### PR TITLE
fix: Fragment name conflicts

### DIFF
--- a/packages/provider-queries/src/article-fragment.js
+++ b/packages/provider-queries/src/article-fragment.js
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
 
 export default gql`
-  fragment article on Article {
+  fragment articlePageProps on Article {
     bylines {
       ... on Byline {
         byline

--- a/packages/provider-queries/src/article.js
+++ b/packages/provider-queries/src/article.js
@@ -6,7 +6,7 @@ export default addTypenameToDocument(
   gql`
     query ArticleQuery($id: ID!) {
       article(id: $id) {
-        ...article
+        ...articlePageProps
       }
     }
 

--- a/packages/provider-queries/src/native-edition.js
+++ b/packages/provider-queries/src/native-edition.js
@@ -1,0 +1,44 @@
+import { addTypenameToDocument } from "apollo-utilities";
+import gql from "graphql-tag";
+import articleFragment from "./article-fragment";
+import sectionFragment from "./section-fragment";
+
+export default addTypenameToDocument(
+  gql`
+    query EditionQuery($id: ID!) {
+      edition(id: $id) {
+        id
+        sections: sections {
+          id
+          title
+          ...sectionPageProps
+        }
+        nativeSections: sections {
+          id
+          ... on StandardSection {
+            id
+            title
+            slices {
+              ... on ArticleSlice {
+                items {
+                  articles: article {
+                    id
+                    ...articlePageProps
+                  }
+                  nativeArticles: article {
+                    id
+                    headline
+                    url
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    ${articleFragment}
+    ${sectionFragment}
+  `
+);

--- a/packages/provider-queries/src/provider-queries.js
+++ b/packages/provider-queries/src/provider-queries.js
@@ -4,6 +4,7 @@ import * as authorArticlesNoImagesQuery from "./author-articles-no-images";
 import * as authorArticlesWithImagesQuery from "./author-articles-with-images";
 import authorQuery from "./author";
 import editionQuery from "./edition";
+import nativeEditionQuery from "./native-edition";
 import topicQuery from "./topic";
 import * as topicArticlesQuery from "./topic-articles";
 
@@ -17,6 +18,7 @@ export const authorArticlesWithImagesPTV =
   authorArticlesWithImagesQuery.propsToVariables;
 export const author = authorQuery;
 export const edition = editionQuery;
+export const nativeEdition = nativeEditionQuery;
 export const topic = topicQuery;
 export const topicArticles = topicArticlesQuery.default;
 export const topicArticlesPTV = topicArticlesQuery.propsToVariables;

--- a/packages/provider-queries/src/section-fragment.js
+++ b/packages/provider-queries/src/section-fragment.js
@@ -597,35 +597,44 @@ export default gql`
     leadAsset {
       ... on Video {
         posterImage {
-          ...imageProps
+          ...sectionImageProps
         }
       }
       ... on Image {
-        ...imageProps
+        ...sectionImageProps
       }
     }
     strapline
     article {
-      ...article
+      ...sectionArticle
     }
   }
 
-  fragment article on Article {
+  fragment sectionArticle on Article {
+    byline
     flags
+    hasVideo
+    headline
+    id
+    label
     leadAsset {
       ... on Video {
         posterImage {
-          ...imageProps
+          ...sectionImageProps
         }
       }
       ... on Image {
-        ...imageProps
+        ...sectionImageProps
       }
     }
-    ...articleProps
+    publicationName
+    section
+    shortHeadline
+    summary125: summary(maxCharCount: 125)
+    url
   }
 
-  fragment imageProps on Image {
+  fragment sectionImageProps on Image {
     crop169: crop(ratio: "16:9") {
       ratio
       url
@@ -642,23 +651,6 @@ export default gql`
       ratio
       url
     }
-  }
-
-  fragment articleProps on Article {
-    ...summaries
-    byline
-    hasVideo
-    headline
-    id
-    label
-    publicationName
-    section
-    shortHeadline
-    url
-  }
-
-  fragment summaries on Article {
-    summary125: summary(maxCharCount: 125)
   }
 
   fragment teasers on Tile {

--- a/packages/provider-test-tools/src/index.js
+++ b/packages/provider-test-tools/src/index.js
@@ -12,6 +12,7 @@ import generateQueries from "./generate-queries";
 import mm from "./make-mocks";
 import MockedProvider from "./mocked-provider";
 import MockFixture, { schemaToMocks } from "./mock-fixture";
+import nativeEdition from "./native-edition";
 import providerTester from "./provider-tester";
 import topic from "./topic";
 import topicArticles from "./fixtures/topic-articles.json";
@@ -42,6 +43,7 @@ export {
   makeMocks,
   MockedProvider,
   MockFixture,
+  nativeEdition,
   providerTester,
   schemaToMocks,
   topic

--- a/packages/provider-test-tools/src/native-edition.js
+++ b/packages/provider-test-tools/src/native-edition.js
@@ -1,0 +1,91 @@
+import { MockList } from "graphql-tools";
+import { mockEditionSlice } from "@times-components/fixture-generator";
+import { nativeEdition as nativeEditionQuery } from "@times-components/provider-queries";
+import article from "../fixtures/article.json";
+
+const getMediaUrl = (obj, ratio) => {
+  const crop = obj[`crop${ratio.replace(":", "")}`];
+  const ratios = {
+    "3:2": "300/200",
+    "16:9": "320/180"
+  };
+
+  return {
+    url: crop
+      ? crop.url
+      : `https://placeimg.com/${ratios[ratio] || "100/100"}/tech`
+  };
+};
+
+export default ({ variables = () => {} } = {}) => {
+  const queryVariables = variables();
+
+  return [
+    {
+      defaults: {
+        types: {
+          Article: () => article,
+          ArticleSlice: () => ({
+            __typename: "StandardSlice",
+            items: new MockList(1)
+          }),
+          Crop: (parent, { ratio }) => {
+            if (parent.posterImage) {
+              return getMediaUrl(parent.posterImage, ratio);
+            }
+
+            return getMediaUrl(parent, ratio);
+          },
+          DateTime: () => "2018-10-25",
+          LeadOneFullWidthSlice: () => ({
+            __typename: "LeadOneFullWidthSlice",
+            items: mockEditionSlice(1)
+          }),
+          Markup: (parent, { maxCharCount }) => {
+            if (maxCharCount) {
+              return parent[`summary${maxCharCount}`] || {};
+            }
+
+            // this oddly returns the provided fixture
+            return {};
+          },
+          Media: () => ({ __typename: "Image" }),
+          Ratio: () => "16:9",
+          Section: () => ({
+            __typename: "StandardSection",
+            slices: new MockList(1)
+          }),
+          Slug: () => "some-slug",
+          StandardSection: () => ({
+            colour: {
+              rgba: {
+                alpha: 1,
+                blue: 255,
+                green: 255,
+                red: 255
+              }
+            },
+            id: "dummy-section-id",
+            slices: [mockEditionSlice(1)],
+            slug: "dummy-section-slug",
+            title: "News"
+          }),
+          StandardSectionSlice: () => ({
+            __typename: "LeadOneFullWidthSlice",
+            items: new MockList(1)
+          }),
+          StandardSlice: () => ({
+            __typename: "StandardSlice",
+            items: []
+          }),
+          Tile: () => ({}),
+          URL: () => "https://test.io",
+          UUID: () => "a-u-u-i-d"
+        }
+      },
+      error: null,
+      query: nativeEditionQuery,
+      variables: queryVariables
+    }
+  ];
+};

--- a/packages/provider/.jestlint
+++ b/packages/provider/.jestlint
@@ -1,5 +1,5 @@
 {
-  "maxFileSize": 18587,
-  "maxLines": 422
+  "maxFileSize": 52806,
+  "maxLines": 1128
 }
 

--- a/packages/provider/__tests__/__snapshots__/native-edition-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/native-edition-provider.test.js.snap
@@ -1,0 +1,1130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Native Edition provider returns query result 1`] = `
+Object {
+  "__typename": "Edition",
+  "id": "a-u-u-i-d",
+  "nativeSections": Array [
+    Object {
+      "__typename": "StandardSection",
+      "id": "dummy-section-id",
+      "slices": Array [
+        Object {
+          "__typename": "LeadOneFullWidthSlice",
+          "items": Array [
+            Object {
+              "__typename": "Tile",
+              "articles": Object {
+                "__typename": "Article",
+                "backgroundColour": Object {
+                  "__typename": "Colour",
+                  "rgba": Object {
+                    "__typename": "RGBA",
+                    "alpha": 1,
+                    "blue": 255,
+                    "green": 255,
+                    "red": 255,
+                  },
+                },
+                "byline": Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "inline markup",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ],
+                "bylines": Array [],
+                "content": Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "paragraph",
+                  },
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "paragraph",
+                  },
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "paragraph",
+                  },
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [],
+                    "name": "ad",
+                  },
+                ],
+                "dropcapsDisabled": false,
+                "flags": Array [
+                  "EXCLUSIVE",
+                ],
+                "hasVideo": false,
+                "headline": "Venezuela shows how Corbyn’s socialism works",
+                "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                "keywords": Array [
+                  "keyword",
+                ],
+                "label": "label",
+                "leadAsset": Object {
+                  "__typename": "Image",
+                  "caption": "Hello World",
+                  "credits": "Hello World",
+                  "crop11": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "crop1251": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "crop169": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "crop2251": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "crop23": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "crop32": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "crop45": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                  "title": "Rise of centenarian drivers as elderly push on",
+                },
+                "publicationName": "TIMES",
+                "publishedTime": String {
+                  "0": "2",
+                  "1": "0",
+                  "2": "1",
+                  "3": "8",
+                  "4": "-",
+                  "5": "1",
+                  "6": "0",
+                  "7": "-",
+                  "8": "2",
+                  "9": "5",
+                },
+                "relatedArticleSlice": Object {
+                  "__typename": "StandardSlice",
+                  "items": Array [
+                    Object {
+                      "__typename": "Tile",
+                      "article": Object {
+                        "__typename": "Article",
+                        "byline": Array [
+                          Object {
+                            "attributes": Object {},
+                            "children": Array [
+                              Object {
+                                "attributes": Object {
+                                  "value": "inline markup",
+                                },
+                                "children": Array [],
+                                "name": "text",
+                              },
+                            ],
+                            "name": "inline",
+                          },
+                        ],
+                        "hasVideo": false,
+                        "headline": "Venezuela shows how Corbyn’s socialism works",
+                        "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                        "label": "label",
+                        "leadAsset": Object {
+                          "__typename": "Image",
+                          "crop169": Object {
+                            "__typename": "Crop",
+                            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                          },
+                          "crop32": Object {
+                            "__typename": "Crop",
+                            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                          },
+                          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                          "title": "Rise of centenarian drivers as elderly push on",
+                        },
+                        "publicationName": "TIMES",
+                        "publishedTime": String {
+                          "0": "2",
+                          "1": "0",
+                          "2": "1",
+                          "3": "8",
+                          "4": "-",
+                          "5": "1",
+                          "6": "0",
+                          "7": "-",
+                          "8": "2",
+                          "9": "5",
+                        },
+                        "section": "business",
+                        "shortHeadline": "shortheadline - Venezuela shows how Corbyn’s socialism work",
+                        "shortIdentifier": "37b27qd2s",
+                        "slug": "british-trio-stopped-on-the-way-to-join-isis",
+                        "summary125": Array [
+                          Array [
+                            Object {
+                              "attributes": Object {},
+                              "children": Array [
+                                Object {
+                                  "attributes": Object {
+                                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                                  },
+                                  "children": Array [],
+                                  "name": "text",
+                                },
+                              ],
+                              "name": "paragraph",
+                            },
+                          ],
+                        ],
+                        "url": "/article/123",
+                      },
+                      "leadAsset": Object {
+                        "__typename": "Image",
+                        "crop169": Object {
+                          "__typename": "Crop",
+                          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                        },
+                        "crop32": Object {
+                          "__typename": "Crop",
+                          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                        },
+                        "id": "6c1c108e-ed63-47af-df1d-46c63be16627",
+                        "title": "TMS: Pratchett’s law of the jungle",
+                      },
+                    },
+                    Object {
+                      "__typename": "Tile",
+                      "article": Object {
+                        "__typename": "Article",
+                        "byline": Array [
+                          Object {
+                            "attributes": Object {},
+                            "children": Array [
+                              Object {
+                                "attributes": Object {
+                                  "value": "inline markup",
+                                },
+                                "children": Array [],
+                                "name": "text",
+                              },
+                            ],
+                            "name": "inline",
+                          },
+                        ],
+                        "hasVideo": false,
+                        "headline": "Venezuela shows how Corbyn’s socialism works",
+                        "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                        "label": "label",
+                        "leadAsset": Object {
+                          "__typename": "Image",
+                          "crop169": Object {
+                            "__typename": "Crop",
+                            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                          },
+                          "crop32": Object {
+                            "__typename": "Crop",
+                            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                          },
+                          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                          "title": "Rise of centenarian drivers as elderly push on",
+                        },
+                        "publicationName": "TIMES",
+                        "publishedTime": String {
+                          "0": "2",
+                          "1": "0",
+                          "2": "1",
+                          "3": "8",
+                          "4": "-",
+                          "5": "1",
+                          "6": "0",
+                          "7": "-",
+                          "8": "2",
+                          "9": "5",
+                        },
+                        "section": "business",
+                        "shortHeadline": "shortheadline - Venezuela shows how Corbyn’s socialism work",
+                        "shortIdentifier": "37b27qd2s",
+                        "slug": "british-trio-stopped-on-the-way-to-join-isis",
+                        "summary125": Array [
+                          Array [
+                            Object {
+                              "attributes": Object {},
+                              "children": Array [
+                                Object {
+                                  "attributes": Object {
+                                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                                  },
+                                  "children": Array [],
+                                  "name": "text",
+                                },
+                              ],
+                              "name": "paragraph",
+                            },
+                          ],
+                        ],
+                        "url": "/article/123",
+                      },
+                      "leadAsset": Object {
+                        "__typename": "Image",
+                        "crop169": Object {
+                          "__typename": "Crop",
+                          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                        },
+                        "crop32": Object {
+                          "__typename": "Crop",
+                          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                        },
+                        "id": "6c1c108e-ed63-47af-df1d-46c63be16627",
+                        "title": "TMS: Pratchett’s law of the jungle",
+                      },
+                    },
+                    Object {
+                      "__typename": "Tile",
+                      "article": Object {
+                        "__typename": "Article",
+                        "byline": Array [
+                          Object {
+                            "attributes": Object {},
+                            "children": Array [
+                              Object {
+                                "attributes": Object {
+                                  "value": "inline markup",
+                                },
+                                "children": Array [],
+                                "name": "text",
+                              },
+                            ],
+                            "name": "inline",
+                          },
+                        ],
+                        "hasVideo": false,
+                        "headline": "Venezuela shows how Corbyn’s socialism works",
+                        "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                        "label": "label",
+                        "leadAsset": Object {
+                          "__typename": "Image",
+                          "crop169": Object {
+                            "__typename": "Crop",
+                            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                          },
+                          "crop32": Object {
+                            "__typename": "Crop",
+                            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                          },
+                          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                          "title": "Rise of centenarian drivers as elderly push on",
+                        },
+                        "publicationName": "TIMES",
+                        "publishedTime": String {
+                          "0": "2",
+                          "1": "0",
+                          "2": "1",
+                          "3": "8",
+                          "4": "-",
+                          "5": "1",
+                          "6": "0",
+                          "7": "-",
+                          "8": "2",
+                          "9": "5",
+                        },
+                        "section": "business",
+                        "shortHeadline": "shortheadline - Venezuela shows how Corbyn’s socialism work",
+                        "shortIdentifier": "37b27qd2s",
+                        "slug": "british-trio-stopped-on-the-way-to-join-isis",
+                        "summary125": Array [
+                          Array [
+                            Object {
+                              "attributes": Object {},
+                              "children": Array [
+                                Object {
+                                  "attributes": Object {
+                                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                                  },
+                                  "children": Array [],
+                                  "name": "text",
+                                },
+                              ],
+                              "name": "paragraph",
+                            },
+                          ],
+                        ],
+                        "url": "/article/123",
+                      },
+                      "leadAsset": Object {
+                        "__typename": "Image",
+                        "crop169": Object {
+                          "__typename": "Crop",
+                          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fe251dcc0-d7df-11e8-9c20-5eb2e7b96a26.jpg?crop=5022%2C2825%2C0%2C262",
+                        },
+                        "crop32": Object {
+                          "__typename": "Crop",
+                          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fe251dcc0-d7df-11e8-9c20-5eb2e7b96a26.jpg?crop=5022%2C2825%2C0%2C262",
+                        },
+                        "id": "a-u-u-i-d",
+                        "title": "Hello World",
+                      },
+                    },
+                  ],
+                },
+                "section": "business",
+                "shortHeadline": "shortheadline - Venezuela shows how Corbyn’s socialism work",
+                "shortIdentifier": "37b27qd2s",
+                "slug": "british-trio-stopped-on-the-way-to-join-isis",
+                "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
+                "template": "mainstandard",
+                "textColour": Object {
+                  "__typename": "Colour",
+                  "rgba": Object {
+                    "__typename": "RGBA",
+                    "alpha": 1,
+                    "blue": 0,
+                    "green": 0,
+                    "red": 0,
+                  },
+                },
+                "topics": Array [
+                  Object {
+                    "__typename": "Topic",
+                    "name": "Islington",
+                    "slug": "islington",
+                  },
+                  Object {
+                    "__typename": "Topic",
+                    "name": "Chelsea",
+                    "slug": "chelsea",
+                  },
+                ],
+                "url": "/article/123",
+              },
+              "nativeArticles": Object {
+                "__typename": "Article",
+                "headline": "Venezuela shows how Corbyn’s socialism works",
+                "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                "url": "/article/123",
+              },
+            },
+          ],
+        },
+      ],
+      "title": "News",
+    },
+    Object {
+      "__typename": "StandardSection",
+      "id": "dummy-section-id",
+      "slices": Array [
+        Object {
+          "__typename": "LeadOneFullWidthSlice",
+          "items": Array [
+            Object {
+              "__typename": "Tile",
+              "articles": Object {
+                "__typename": "Article",
+                "backgroundColour": Object {
+                  "__typename": "Colour",
+                  "rgba": Object {
+                    "__typename": "RGBA",
+                    "alpha": 1,
+                    "blue": 255,
+                    "green": 255,
+                    "red": 255,
+                  },
+                },
+                "byline": Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "inline markup",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ],
+                "bylines": Array [],
+                "content": Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "paragraph",
+                  },
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "paragraph",
+                  },
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "paragraph",
+                  },
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [],
+                    "name": "ad",
+                  },
+                ],
+                "dropcapsDisabled": false,
+                "flags": Array [
+                  "EXCLUSIVE",
+                ],
+                "hasVideo": false,
+                "headline": "Venezuela shows how Corbyn’s socialism works",
+                "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                "keywords": Array [
+                  "keyword",
+                ],
+                "label": "label",
+                "leadAsset": Object {
+                  "__typename": "Image",
+                  "caption": "Hello World",
+                  "credits": "Hello World",
+                  "crop11": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "crop1251": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "crop169": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "crop2251": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "crop23": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "crop32": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "crop45": Object {
+                    "__typename": "Crop",
+                    "ratio": "16:9",
+                    "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                  },
+                  "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                  "title": "Rise of centenarian drivers as elderly push on",
+                },
+                "publicationName": "TIMES",
+                "publishedTime": String {
+                  "0": "2",
+                  "1": "0",
+                  "2": "1",
+                  "3": "8",
+                  "4": "-",
+                  "5": "1",
+                  "6": "0",
+                  "7": "-",
+                  "8": "2",
+                  "9": "5",
+                },
+                "relatedArticleSlice": Object {
+                  "__typename": "StandardSlice",
+                  "items": Array [
+                    Object {
+                      "__typename": "Tile",
+                      "article": Object {
+                        "__typename": "Article",
+                        "byline": Array [
+                          Object {
+                            "attributes": Object {},
+                            "children": Array [
+                              Object {
+                                "attributes": Object {
+                                  "value": "inline markup",
+                                },
+                                "children": Array [],
+                                "name": "text",
+                              },
+                            ],
+                            "name": "inline",
+                          },
+                        ],
+                        "hasVideo": false,
+                        "headline": "Venezuela shows how Corbyn’s socialism works",
+                        "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                        "label": "label",
+                        "leadAsset": Object {
+                          "__typename": "Image",
+                          "crop169": Object {
+                            "__typename": "Crop",
+                            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                          },
+                          "crop32": Object {
+                            "__typename": "Crop",
+                            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                          },
+                          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                          "title": "Rise of centenarian drivers as elderly push on",
+                        },
+                        "publicationName": "TIMES",
+                        "publishedTime": String {
+                          "0": "2",
+                          "1": "0",
+                          "2": "1",
+                          "3": "8",
+                          "4": "-",
+                          "5": "1",
+                          "6": "0",
+                          "7": "-",
+                          "8": "2",
+                          "9": "5",
+                        },
+                        "section": "business",
+                        "shortHeadline": "shortheadline - Venezuela shows how Corbyn’s socialism work",
+                        "shortIdentifier": "37b27qd2s",
+                        "slug": "british-trio-stopped-on-the-way-to-join-isis",
+                        "summary125": Array [
+                          Array [
+                            Object {
+                              "attributes": Object {},
+                              "children": Array [
+                                Object {
+                                  "attributes": Object {
+                                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                                  },
+                                  "children": Array [],
+                                  "name": "text",
+                                },
+                              ],
+                              "name": "paragraph",
+                            },
+                          ],
+                        ],
+                        "url": "/article/123",
+                      },
+                      "leadAsset": Object {
+                        "__typename": "Image",
+                        "crop169": Object {
+                          "__typename": "Crop",
+                          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                        },
+                        "crop32": Object {
+                          "__typename": "Crop",
+                          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                        },
+                        "id": "6c1c108e-ed63-47af-df1d-46c63be16627",
+                        "title": "TMS: Pratchett’s law of the jungle",
+                      },
+                    },
+                    Object {
+                      "__typename": "Tile",
+                      "article": Object {
+                        "__typename": "Article",
+                        "byline": Array [
+                          Object {
+                            "attributes": Object {},
+                            "children": Array [
+                              Object {
+                                "attributes": Object {
+                                  "value": "inline markup",
+                                },
+                                "children": Array [],
+                                "name": "text",
+                              },
+                            ],
+                            "name": "inline",
+                          },
+                        ],
+                        "hasVideo": false,
+                        "headline": "Venezuela shows how Corbyn’s socialism works",
+                        "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                        "label": "label",
+                        "leadAsset": Object {
+                          "__typename": "Image",
+                          "crop169": Object {
+                            "__typename": "Crop",
+                            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                          },
+                          "crop32": Object {
+                            "__typename": "Crop",
+                            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                          },
+                          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                          "title": "Rise of centenarian drivers as elderly push on",
+                        },
+                        "publicationName": "TIMES",
+                        "publishedTime": String {
+                          "0": "2",
+                          "1": "0",
+                          "2": "1",
+                          "3": "8",
+                          "4": "-",
+                          "5": "1",
+                          "6": "0",
+                          "7": "-",
+                          "8": "2",
+                          "9": "5",
+                        },
+                        "section": "business",
+                        "shortHeadline": "shortheadline - Venezuela shows how Corbyn’s socialism work",
+                        "shortIdentifier": "37b27qd2s",
+                        "slug": "british-trio-stopped-on-the-way-to-join-isis",
+                        "summary125": Array [
+                          Array [
+                            Object {
+                              "attributes": Object {},
+                              "children": Array [
+                                Object {
+                                  "attributes": Object {
+                                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                                  },
+                                  "children": Array [],
+                                  "name": "text",
+                                },
+                              ],
+                              "name": "paragraph",
+                            },
+                          ],
+                        ],
+                        "url": "/article/123",
+                      },
+                      "leadAsset": Object {
+                        "__typename": "Image",
+                        "crop169": Object {
+                          "__typename": "Crop",
+                          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                        },
+                        "crop32": Object {
+                          "__typename": "Crop",
+                          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                        },
+                        "id": "6c1c108e-ed63-47af-df1d-46c63be16627",
+                        "title": "TMS: Pratchett’s law of the jungle",
+                      },
+                    },
+                    Object {
+                      "__typename": "Tile",
+                      "article": Object {
+                        "__typename": "Article",
+                        "byline": Array [
+                          Object {
+                            "attributes": Object {},
+                            "children": Array [
+                              Object {
+                                "attributes": Object {
+                                  "value": "inline markup",
+                                },
+                                "children": Array [],
+                                "name": "text",
+                              },
+                            ],
+                            "name": "inline",
+                          },
+                        ],
+                        "hasVideo": false,
+                        "headline": "Venezuela shows how Corbyn’s socialism works",
+                        "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                        "label": "label",
+                        "leadAsset": Object {
+                          "__typename": "Image",
+                          "crop169": Object {
+                            "__typename": "Crop",
+                            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                          },
+                          "crop32": Object {
+                            "__typename": "Crop",
+                            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+                          },
+                          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                          "title": "Rise of centenarian drivers as elderly push on",
+                        },
+                        "publicationName": "TIMES",
+                        "publishedTime": String {
+                          "0": "2",
+                          "1": "0",
+                          "2": "1",
+                          "3": "8",
+                          "4": "-",
+                          "5": "1",
+                          "6": "0",
+                          "7": "-",
+                          "8": "2",
+                          "9": "5",
+                        },
+                        "section": "business",
+                        "shortHeadline": "shortheadline - Venezuela shows how Corbyn’s socialism work",
+                        "shortIdentifier": "37b27qd2s",
+                        "slug": "british-trio-stopped-on-the-way-to-join-isis",
+                        "summary125": Array [
+                          Array [
+                            Object {
+                              "attributes": Object {},
+                              "children": Array [
+                                Object {
+                                  "attributes": Object {
+                                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                                  },
+                                  "children": Array [],
+                                  "name": "text",
+                                },
+                              ],
+                              "name": "paragraph",
+                            },
+                          ],
+                        ],
+                        "url": "/article/123",
+                      },
+                      "leadAsset": Object {
+                        "__typename": "Image",
+                        "crop169": Object {
+                          "__typename": "Crop",
+                          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fe251dcc0-d7df-11e8-9c20-5eb2e7b96a26.jpg?crop=5022%2C2825%2C0%2C262",
+                        },
+                        "crop32": Object {
+                          "__typename": "Crop",
+                          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fe251dcc0-d7df-11e8-9c20-5eb2e7b96a26.jpg?crop=5022%2C2825%2C0%2C262",
+                        },
+                        "id": "a-u-u-i-d",
+                        "title": "Hello World",
+                      },
+                    },
+                  ],
+                },
+                "section": "business",
+                "shortHeadline": "shortheadline - Venezuela shows how Corbyn’s socialism work",
+                "shortIdentifier": "37b27qd2s",
+                "slug": "british-trio-stopped-on-the-way-to-join-isis",
+                "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
+                "template": "mainstandard",
+                "textColour": Object {
+                  "__typename": "Colour",
+                  "rgba": Object {
+                    "__typename": "RGBA",
+                    "alpha": 1,
+                    "blue": 0,
+                    "green": 0,
+                    "red": 0,
+                  },
+                },
+                "topics": Array [
+                  Object {
+                    "__typename": "Topic",
+                    "name": "Islington",
+                    "slug": "islington",
+                  },
+                  Object {
+                    "__typename": "Topic",
+                    "name": "Chelsea",
+                    "slug": "chelsea",
+                  },
+                ],
+                "url": "/article/123",
+              },
+              "nativeArticles": Object {
+                "__typename": "Article",
+                "headline": "Venezuela shows how Corbyn’s socialism works",
+                "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+                "url": "/article/123",
+              },
+            },
+          ],
+        },
+      ],
+      "title": "News",
+    },
+  ],
+  "sections": Array [
+    Object {
+      "__typename": "StandardSection",
+      "colour": Object {
+        "__typename": "Colour",
+        "rgba": Object {
+          "__typename": "RGBA",
+          "alpha": 1,
+          "blue": 255,
+          "green": 255,
+          "red": 255,
+        },
+      },
+      "id": "dummy-section-id",
+      "name": "StandardSection",
+      "slices": Array [
+        Object {
+          "__typename": "LeadOneFullWidthSlice",
+          "lead": Object {
+            "__typename": "Tile",
+            "article": Object {
+              "__typename": "Article",
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Rick Broadbent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "flags": Array [
+                "NEW",
+                "EXCLUSIVE",
+              ],
+              "hasVideo": true,
+              "headline": "Exclusive interview: the cyclist Geraint Thomas on Welsh pride, drugs cheats and winning the Tour de France",
+              "id": "a-u-u-i-d",
+              "label": "Random label",
+              "leadAsset": Object {
+                "__typename": "Image",
+                "crop11": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46f.jpg?crop=2848%2C2848%2C712%2C0",
+                },
+                "crop169": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd67cded0-ca7a-11e8-998e-a6e3c63abd14.jpg?crop=1600%2C900%2C0%2C0",
+                },
+                "crop32": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46f.jpg?crop=4272%2C2848%2C0%2C0",
+                },
+                "crop45": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46f.jpg?crop=2278%2C2848%2C997%2C0",
+                },
+              },
+              "publicationName": "TIMES",
+              "section": "business",
+              "shortHeadline": "Let's keep A levels but scrap outdated GCSEs",
+              "summary125": Object {},
+              "url": "https://www.thetimes.co.uk/edition/news/france-defies-may-over-russia-37b27qd2s",
+            },
+            "headline": "Hello World",
+            "leadAsset": Object {
+              "__typename": "Image",
+              "crop11": Object {
+                "__typename": "Crop",
+                "ratio": "16:9",
+                "url": "https://placeimg.com/100/100/tech",
+              },
+              "crop169": Object {
+                "__typename": "Crop",
+                "ratio": "16:9",
+                "url": "https://placeimg.com/320/180/tech",
+              },
+              "crop32": Object {
+                "__typename": "Crop",
+                "ratio": "16:9",
+                "url": "https://placeimg.com/300/200/tech",
+              },
+              "crop45": Object {
+                "__typename": "Crop",
+                "ratio": "16:9",
+                "url": "https://placeimg.com/100/100/tech",
+              },
+            },
+            "strapline": "Hello World",
+            "teaser125": Object {},
+          },
+          "name": "LeadOneFullWidthSlice",
+        },
+      ],
+      "title": "News",
+    },
+    Object {
+      "__typename": "StandardSection",
+      "colour": Object {
+        "__typename": "Colour",
+        "rgba": Object {
+          "__typename": "RGBA",
+          "alpha": 1,
+          "blue": 255,
+          "green": 255,
+          "red": 255,
+        },
+      },
+      "id": "dummy-section-id",
+      "name": "StandardSection",
+      "slices": Array [
+        Object {
+          "__typename": "LeadOneFullWidthSlice",
+          "lead": Object {
+            "__typename": "Tile",
+            "article": Object {
+              "__typename": "Article",
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Rick Broadbent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "flags": Array [
+                "NEW",
+                "EXCLUSIVE",
+              ],
+              "hasVideo": true,
+              "headline": "Exclusive interview: the cyclist Geraint Thomas on Welsh pride, drugs cheats and winning the Tour de France",
+              "id": "a-u-u-i-d",
+              "label": "Random label",
+              "leadAsset": Object {
+                "__typename": "Image",
+                "crop11": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46f.jpg?crop=2848%2C2848%2C712%2C0",
+                },
+                "crop169": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd67cded0-ca7a-11e8-998e-a6e3c63abd14.jpg?crop=1600%2C900%2C0%2C0",
+                },
+                "crop32": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46f.jpg?crop=4272%2C2848%2C0%2C0",
+                },
+                "crop45": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46f.jpg?crop=2278%2C2848%2C997%2C0",
+                },
+              },
+              "publicationName": "TIMES",
+              "section": "business",
+              "shortHeadline": "Let's keep A levels but scrap outdated GCSEs",
+              "summary125": Object {},
+              "url": "https://www.thetimes.co.uk/edition/news/france-defies-may-over-russia-37b27qd2s",
+            },
+            "headline": "Hello World",
+            "leadAsset": Object {
+              "__typename": "Image",
+              "crop11": Object {
+                "__typename": "Crop",
+                "ratio": "16:9",
+                "url": "https://placeimg.com/100/100/tech",
+              },
+              "crop169": Object {
+                "__typename": "Crop",
+                "ratio": "16:9",
+                "url": "https://placeimg.com/320/180/tech",
+              },
+              "crop32": Object {
+                "__typename": "Crop",
+                "ratio": "16:9",
+                "url": "https://placeimg.com/300/200/tech",
+              },
+              "crop45": Object {
+                "__typename": "Crop",
+                "ratio": "16:9",
+                "url": "https://placeimg.com/100/100/tech",
+              },
+            },
+            "strapline": "Hello World",
+            "teaser125": Object {},
+          },
+          "name": "LeadOneFullWidthSlice",
+        },
+      ],
+      "title": "News",
+    },
+  ],
+}
+`;

--- a/packages/provider/__tests__/native-edition-provider.test.js
+++ b/packages/provider/__tests__/native-edition-provider.test.js
@@ -1,0 +1,45 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { nativeEdition } from "@times-components/provider-queries";
+import {
+  nativeEdition as makeNativeEditionParams,
+  MockedProvider,
+  MockFixture
+} from "@times-components/provider-test-tools";
+import connectGraphql from "../src/connect";
+
+const NativeEditionProvider = connectGraphql(nativeEdition);
+
+const renderComponent = child => {
+  const id = "2b6e462c-225f-11e9-b782-40e94f317da5";
+
+  return renderer.create(
+    <MockFixture
+      params={makeNativeEditionParams({
+        variables: () => ({
+          id
+        })
+      })}
+      render={mocks => (
+        <MockedProvider mocks={mocks}>
+          <NativeEditionProvider debounceTimeMs={0} id={id}>
+            {child}
+          </NativeEditionProvider>
+        </MockedProvider>
+      )}
+    />
+  );
+};
+
+describe("Native Edition provider", () => {
+  it("returns query result", done => {
+    renderComponent(({ isLoading, edition }) => {
+      if (!isLoading) {
+        expect(edition).toMatchSnapshot();
+        done();
+      }
+
+      return null;
+    });
+  });
+});

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,9 +33,9 @@
   "devDependencies": {
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/jest-configurator": "2.2.6",
+    "@times-components/jest-configurator": "2.2.7",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/test-utils": "2.1.15",
+    "@times-components/test-utils": "2.1.16",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
@@ -51,7 +51,7 @@
     "webpack-cli": "2.1.4"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.20.1",
+    "@times-components/styleguide": "3.20.2",
     "lodash.omitby": "4.6.0",
     "prop-types": "15.6.2",
     "react-native": "0.55.4"

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -38,10 +38,10 @@
   "devDependencies": {
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/jest-configurator": "2.2.6",
+    "@times-components/jest-configurator": "2.2.7",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/storybook": "3.3.8",
-    "@times-components/test-utils": "2.1.15",
+    "@times-components/storybook": "3.3.9",
+    "@times-components/test-utils": "2.1.16",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-plugin-add-react-displayname": "0.0.5",
@@ -59,8 +59,8 @@
     "webpack-cli": "2.1.4"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.20.1",
-    "@times-components/svgs": "2.3.6",
+    "@times-components/styleguide": "3.20.2",
+    "@times-components/svgs": "2.3.7",
     "prop-types": "15.6.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
We were using the same fragment names within section fragment and article fragment, which causes an issue when we use both fragments within the same query. Prefixed section fragments with `section...` to avoid conflicts.

Addresses the pr comment by Christian: https://github.com/newsuk/times-components/pull/1685#discussion_r256454533

+ Also added a native-edition-query for test purposes only, to check how it'll work in the native app when we use both fragments