### PR TITLE
feat: Key line combinations for comments, related articles and topics

### DIFF
--- a/packages/article-comments/__tests__/android/__snapshots__/shared-with-style.android.test.js.snap
+++ b/packages/article-comments/__tests__/android/__snapshots__/shared-with-style.android.test.js.snap
@@ -5,7 +5,10 @@ exports[`comments error 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "marginBottom": 25,
+      "borderStyle": "solid",
+      "borderTopColor": "#DBDBDB",
+      "borderTopWidth": 1,
+      "marginBottom": 50,
       "width": "100%",
     }
   }
@@ -79,7 +82,10 @@ exports[`disabled comments 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "marginBottom": 25,
+      "borderStyle": "solid",
+      "borderTopColor": "#DBDBDB",
+      "borderTopWidth": 1,
+      "marginBottom": 50,
       "width": "100%",
     }
   }
@@ -134,7 +140,10 @@ exports[`enabled comments 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "marginBottom": 25,
+      "borderStyle": "solid",
+      "borderTopColor": "#DBDBDB",
+      "borderTopWidth": 1,
+      "marginBottom": 50,
       "width": "100%",
     }
   }

--- a/packages/article-comments/__tests__/ios/__snapshots__/shared-with-style.ios.test.js.snap
+++ b/packages/article-comments/__tests__/ios/__snapshots__/shared-with-style.ios.test.js.snap
@@ -5,7 +5,10 @@ exports[`comments error 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "marginBottom": 25,
+      "borderStyle": "solid",
+      "borderTopColor": "#DBDBDB",
+      "borderTopWidth": 1,
+      "marginBottom": 50,
       "width": "100%",
     }
   }
@@ -78,7 +81,10 @@ exports[`disabled comments 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "marginBottom": 25,
+      "borderStyle": "solid",
+      "borderTopColor": "#DBDBDB",
+      "borderTopWidth": 1,
+      "marginBottom": 50,
       "width": "100%",
     }
   }
@@ -133,7 +139,10 @@ exports[`enabled comments 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "marginBottom": 25,
+      "borderStyle": "solid",
+      "borderTopColor": "#DBDBDB",
+      "borderTopWidth": 1,
+      "marginBottom": 50,
       "width": "100%",
     }
   }

--- a/packages/article-comments/src/styles/shared.js
+++ b/packages/article-comments/src/styles/shared.js
@@ -9,7 +9,10 @@ const styles = {
   },
   container: {
     alignItems: "center",
-    marginBottom: spacing(5),
+    borderStyle: "solid",
+    borderTopColor: colours.functional.keyline,
+    borderTopWidth: 1,
+    marginBottom: spacing(10),
     width: "100%"
   },
   errorBody: {

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
@@ -35,9 +35,6 @@ exports[`default styles 1`] = `
     <View
       style={
         Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderStyle": "solid",
           "width": "100%",
         }
       }

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
@@ -35,9 +35,6 @@ exports[`default styles 1`] = `
     <View
       style={
         Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderStyle": "solid",
           "width": "100%",
         }
       }

--- a/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
@@ -35,9 +35,6 @@ exports[`default styles 1`] = `
     <View
       style={
         Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderStyle": "solid",
           "width": "100%",
         }
       }

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
@@ -35,9 +35,6 @@ exports[`default styles 1`] = `
     <View
       style={
         Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderStyle": "solid",
           "width": "100%",
         }
       }

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
@@ -35,9 +35,6 @@ exports[`default styles 1`] = `
     <View
       style={
         Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderStyle": "solid",
           "width": "100%",
         }
       }

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
@@ -35,9 +35,6 @@ exports[`default styles 1`] = `
     <View
       style={
         Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderStyle": "solid",
           "width": "100%",
         }
       }

--- a/packages/related-articles/src/related-articles.js
+++ b/packages/related-articles/src/related-articles.js
@@ -95,7 +95,6 @@ class RelatedArticles extends Component {
                   support2.leadAsset
                 );
               }}
-              withSeparators
             />
           );
         case "OpinionOneAndTwoSlice":

--- a/packages/slice-layout/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
@@ -5,9 +5,6 @@ exports[`1. a single child element 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -54,9 +51,6 @@ exports[`2. two child elements 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -125,9 +119,6 @@ exports[`3. three child elements 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }

--- a/packages/slice-layout/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
@@ -5,9 +5,6 @@ exports[`1. a single child element 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -56,9 +53,6 @@ exports[`2. two child elements 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -128,9 +122,6 @@ exports[`3. three child elements 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }

--- a/packages/slice-layout/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
@@ -7,9 +7,6 @@ exports[`2. a single child element 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -56,9 +53,6 @@ exports[`3. two child elements 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -127,9 +121,6 @@ exports[`4. three child elements 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }

--- a/packages/slice-layout/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
@@ -5,9 +5,6 @@ exports[`1. a single child element 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -54,9 +51,6 @@ exports[`2. two child elements 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -125,9 +119,6 @@ exports[`3. three child elements 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }

--- a/packages/slice-layout/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
@@ -5,9 +5,6 @@ exports[`1. a single child element 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -56,9 +53,6 @@ exports[`2. two child elements 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -128,9 +122,6 @@ exports[`3. three child elements 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }

--- a/packages/slice-layout/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
@@ -7,9 +7,6 @@ exports[`2. a single child element 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -56,9 +53,6 @@ exports[`3. two child elements 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -127,9 +121,6 @@ exports[`4. three child elements 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }

--- a/packages/slice-layout/__tests__/la2.base.js
+++ b/packages/slice-layout/__tests__/la2.base.js
@@ -13,7 +13,6 @@ export default renderComponent => {
             renderLead={() => createItem("lead")}
             renderSupport1={() => null}
             renderSupport2={() => null}
-            withSeparators
           />
         );
 
@@ -28,7 +27,6 @@ export default renderComponent => {
             renderLead={() => createItem("lead")}
             renderSupport1={() => createItem("support-1")}
             renderSupport2={() => null}
-            withSeparators
           />
         );
 
@@ -43,7 +41,6 @@ export default renderComponent => {
             renderLead={() => createItem("lead")}
             renderSupport1={() => createItem("support-1")}
             renderSupport2={() => createItem("support-2")}
-            withSeparators
           />
         );
 

--- a/packages/slice-layout/slice-layout.showcase.js
+++ b/packages/slice-layout/slice-layout.showcase.js
@@ -83,7 +83,6 @@ export default {
               />
             )}
             renderSupport={() => <Support1 id="support1" />}
-            withSeparators
           />
         </ScrollView>
       ),
@@ -105,7 +104,6 @@ export default {
             )}
             renderSupport1={() => null}
             renderSupport2={() => null}
-            withSeparators
           />
         </ScrollView>
       ),
@@ -127,7 +125,6 @@ export default {
             )}
             renderSupport1={() => <Support1 id="support1" />}
             renderSupport2={() => null}
-            withSeparators
           />
         </ScrollView>
       ),
@@ -149,7 +146,6 @@ export default {
             )}
             renderSupport1={() => <Support1 id="support1" />}
             renderSupport2={() => <Support2 id="support2" />}
-            withSeparators
           />
         </ScrollView>
       ),

--- a/packages/slice-layout/src/templates/leadoneandtwo/index.js
+++ b/packages/slice-layout/src/templates/leadoneandtwo/index.js
@@ -1,36 +1,33 @@
 import React from "react";
 import { View } from "react-native";
 import { leadConfig, supportConfig } from "./config";
-import { defaultProps, propTypes } from "./proptypes";
+import propTypes from "./proptypes";
 import styles from "../styles";
 
-const LeadOneAndTwoSlice = ({
-  renderLead,
-  renderSupport1,
-  renderSupport2,
-  withSeparators
-}) => {
+const LeadOneAndTwoSlice = ({ renderLead, renderSupport1, renderSupport2 }) => {
   const support1 = renderSupport1(supportConfig);
   const support2 = renderSupport2(supportConfig);
   const supports = [support1, support2];
+  const filteredSupports = supports.filter(support => support);
+
   return (
     <View style={styles.container}>
       <View
         style={
-          withSeparators
-            ? styles.itemContainer
-            : styles.itemContainerWithoutBorders
+          filteredSupports.length === 0
+            ? styles.itemContainerWithoutBorders
+            : styles.itemContainer
         }
       >
         <View style={styles.item}>{renderLead(leadConfig)}</View>
       </View>
-      {supports.filter(support => support).map(support => (
+      {filteredSupports.map((support, index) => (
         <View
           key={support.props.id}
           style={
-            withSeparators
-              ? styles.itemContainer
-              : styles.itemContainerWithoutBorders
+            index === filteredSupports.length - 1
+              ? styles.itemContainerWithoutBorders
+              : styles.itemContainer
           }
         >
           <View style={styles.item}>{support}</View>
@@ -41,6 +38,5 @@ const LeadOneAndTwoSlice = ({
 };
 
 LeadOneAndTwoSlice.propTypes = propTypes;
-LeadOneAndTwoSlice.defaultProps = defaultProps;
 
 export default LeadOneAndTwoSlice;

--- a/packages/slice-layout/src/templates/leadoneandtwo/index.web.js
+++ b/packages/slice-layout/src/templates/leadoneandtwo/index.web.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaultProps, propTypes } from "./proptypes";
+import propTypes from "./proptypes";
 import { getSeparator, SliceContainer } from "../styles/responsive";
 import {
   getContainer,
@@ -58,6 +58,5 @@ const LeadOneAndTwoSlice = ({ renderLead, renderSupport1, renderSupport2 }) => {
 };
 
 LeadOneAndTwoSlice.propTypes = propTypes;
-LeadOneAndTwoSlice.defaultProps = defaultProps;
 
 export default LeadOneAndTwoSlice;

--- a/packages/slice-layout/src/templates/leadoneandtwo/proptypes.js
+++ b/packages/slice-layout/src/templates/leadoneandtwo/proptypes.js
@@ -3,12 +3,7 @@ import PropTypes from "prop-types";
 const propTypes = {
   renderLead: PropTypes.func.isRequired,
   renderSupport1: PropTypes.func.isRequired,
-  renderSupport2: PropTypes.func.isRequired,
-  withSeparators: PropTypes.bool
+  renderSupport2: PropTypes.func.isRequired
 };
 
-const defaultProps = {
-  withSeparators: false
-};
-
-export { propTypes, defaultProps };
+export default propTypes;

--- a/packages/slice-layout/src/templates/opiniononeandtwo/index.js
+++ b/packages/slice-layout/src/templates/opiniononeandtwo/index.js
@@ -13,15 +13,30 @@ const OpinionOneAndTwoSlice = ({
   const support1 = renderSupport1(supportConfig);
   const support2 = renderSupport2(supportConfig);
   const supports = [support1, support2];
+
+  const filteredSupports = supports.filter(support => support);
   return (
     <View style={styles.container}>
-      <View style={styles.itemContainer}>
+      <View
+        style={
+          filteredSupports.length === 0
+            ? styles.itemContainerWithoutBorders
+            : styles.itemContainer
+        }
+      >
         <View style={[styles.item, opinionStyles.opinion]}>
           {renderOpinion(opinionConfig)}
         </View>
       </View>
-      {supports.filter(support => support).map(support => (
-        <View key={support.props.id} style={styles.itemContainer}>
+      {filteredSupports.map((support, index) => (
+        <View
+          key={support.props.id}
+          style={
+            index === filteredSupports.length - 1
+              ? styles.itemContainerWithoutBorders
+              : styles.itemContainer
+          }
+        >
           <View style={styles.item}>{support}</View>
         </View>
       ))}

--- a/packages/slice-layout/src/templates/standard/index.js
+++ b/packages/slice-layout/src/templates/standard/index.js
@@ -11,8 +11,15 @@ const StandardSlice = ({ itemCount, renderItems }) => {
 
   return (
     <View style={styles.container}>
-      {renderItems(config({ itemCount })).map(item => (
-        <View key={item.props.id} style={styles.itemContainer}>
+      {renderItems(config({ itemCount })).map((item, index) => (
+        <View
+          key={item.props.id}
+          style={
+            index === itemCount - 1
+              ? styles.itemContainerWithoutBorders
+              : styles.itemContainer
+          }
+        >
           <View style={styles.item}>{item}</View>
         </View>
       ))}


### PR DESCRIPTION
Where there were no related articles, above comments would be missing a key line. To deal with optional topics and related articles, and keeping the complexity to a minimum, it made sense to remove the last keyline from related article slices and add this to the top of comments.

Additionally, within `leadoneandtwo`, there was a `withSeperators` prop that was never used. I removed this for simplicity.

![screenshot 2019-02-14 at 16 37 09](https://user-images.githubusercontent.com/935975/52802296-932dbb00-3077-11e9-8efd-69a9658a4e3c.png)

===

![screenshot 2019-02-14 at 16 38 19](https://user-images.githubusercontent.com/935975/52802311-97f26f00-3077-11e9-9f31-2b3eb8596ab4.png)
