### PR TITLE
fix: articles should not be larger than screen width

### DIFF
--- a/packages/article-list/src/article-list.js
+++ b/packages/article-list/src/article-list.js
@@ -3,7 +3,10 @@ import { ActivityIndicator, FlatList, View } from "react-native";
 import Button from "@times-components/button";
 import { colours, tabletWidth } from "@times-components/styleguide";
 import { withTrackScrollDepth } from "@times-components/tracking";
-import { normaliseWidth, screenWidthInPixels } from "@times-components/utils";
+import {
+  normaliseWidthForAssetRequestCache,
+  screenWidthInPixels
+} from "@times-components/utils";
 import ArticleListError from "./article-list-error";
 import ArticleListItemWithError from "./article-list-item-with-error";
 import ArticleListItemSeparator from "./article-list-item-separator";
@@ -25,7 +28,7 @@ class ArticleList extends Component {
     this.state = {
       loadingMore: false,
       loadMoreError: null,
-      width: normaliseWidth(screenWidthInPixels())
+      width: normaliseWidthForAssetRequestCache(screenWidthInPixels())
     };
   }
 

--- a/packages/article-list/src/article-list.web.js
+++ b/packages/article-list/src/article-list.web.js
@@ -6,7 +6,7 @@ import Button from "@times-components/button";
 import ErrorView from "@times-components/error-view";
 import { spacing } from "@times-components/styleguide";
 import { withTrackScrollDepth } from "@times-components/tracking";
-import { normaliseWidth } from "@times-components/utils";
+import { normaliseWidthForAssetRequestCache } from "@times-components/utils";
 import LazyLoad from "@times-components/lazy-load";
 import { scrollUpToPaging } from "./utils/index.web";
 import ArticleListError from "./article-list-error";
@@ -24,7 +24,7 @@ class ArticleList extends Component {
       return null;
     }
 
-    return node ? normaliseWidth(node.clientWidth) : null;
+    return node ? normaliseWidthForAssetRequestCache(node.clientWidth) : null;
   }
 
   constructor(props) {

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
@@ -6,7 +6,7 @@ exports[`1. article with header 1`] = `
     ListHeaderComponent={
       <Gutter>
         <Header
-          width={1180}
+          width={750}
         />
       </Gutter>
     }

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-images-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-images-with-style.android.test.js.snap
@@ -16,6 +16,7 @@ exports[`1. a secondary image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -27,6 +28,7 @@ exports[`1. a secondary image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -42,6 +44,7 @@ exports[`1. a secondary image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -53,6 +56,7 @@ exports[`1. a secondary image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -81,6 +85,7 @@ exports[`2. an inline image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -92,6 +97,7 @@ exports[`2. an inline image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -107,6 +113,7 @@ exports[`2. an inline image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -118,6 +125,7 @@ exports[`2. an inline image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-images.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-images.android.test.js.snap
@@ -6,7 +6,7 @@ exports[`1. a secondary image 1`] = `
     ListHeaderComponent={
       <Gutter>
         <Header
-          width={1180}
+          width={750}
         />
       </Gutter>
     }
@@ -68,7 +68,7 @@ exports[`2. an inline image 1`] = `
     ListHeaderComponent={
       <Gutter>
         <Header
-          width={1180}
+          width={750}
         />
       </Gutter>
     }

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -16,6 +16,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -27,6 +28,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -42,6 +44,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -65,6 +68,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -80,6 +84,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -95,6 +100,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -110,6 +116,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -137,6 +144,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -152,6 +160,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -177,6 +186,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -194,6 +204,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -262,6 +273,7 @@ exports[`2. an article with no content 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -273,6 +285,7 @@ exports[`2. an article with no content 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -297,6 +310,7 @@ exports[`2. an article with no content 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -312,6 +326,7 @@ exports[`2. an article with no content 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -340,6 +355,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -351,6 +367,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -374,6 +391,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -397,6 +415,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -408,6 +427,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -436,6 +456,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -447,6 +468,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -462,6 +484,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -487,6 +510,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -502,6 +526,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -517,6 +542,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -532,6 +558,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -559,6 +586,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -574,6 +602,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -599,6 +628,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -623,6 +653,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -6,7 +6,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
     ListHeaderComponent={
       <Gutter>
         <Header
-          width={1180}
+          width={750}
         />
       </Gutter>
     }
@@ -224,7 +224,7 @@ exports[`2. an article with no content 1`] = `
     ListHeaderComponent={
       <Gutter>
         <Header
-          width={1180}
+          width={750}
         />
       </Gutter>
     }
@@ -328,7 +328,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
     ListHeaderComponent={
       <Gutter>
         <Header
-          width={1180}
+          width={750}
         />
       </Gutter>
     }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-header-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-header-with-style.ios.test.js.snap
@@ -6,7 +6,7 @@ exports[`1. article with header 1`] = `
     ListHeaderComponent={
       <Gutter>
         <Header
-          width={1180}
+          width={750}
         />
       </Gutter>
     }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-images-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-images-with-style.ios.test.js.snap
@@ -16,6 +16,7 @@ exports[`1. a secondary image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -27,6 +28,7 @@ exports[`1. a secondary image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -42,6 +44,7 @@ exports[`1. a secondary image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -53,6 +56,7 @@ exports[`1. a secondary image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -81,6 +85,7 @@ exports[`2. an inline image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -92,6 +97,7 @@ exports[`2. an inline image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -107,6 +113,7 @@ exports[`2. an inline image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -118,6 +125,7 @@ exports[`2. an inline image 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-images.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-images.ios.test.js.snap
@@ -6,7 +6,7 @@ exports[`1. a secondary image 1`] = `
     ListHeaderComponent={
       <Gutter>
         <Header
-          width={1180}
+          width={750}
         />
       </Gutter>
     }
@@ -68,7 +68,7 @@ exports[`2. an inline image 1`] = `
     ListHeaderComponent={
       <Gutter>
         <Header
-          width={1180}
+          width={750}
         />
       </Gutter>
     }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-scaling.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-scaling.ios.test.js.snap
@@ -16,6 +16,7 @@ exports[`1. scaled medium full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -27,6 +28,7 @@ exports[`1. scaled medium full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -42,6 +44,7 @@ exports[`1. scaled medium full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -68,6 +71,7 @@ exports[`1. scaled medium full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -91,6 +95,7 @@ exports[`1. scaled medium full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -119,6 +124,7 @@ exports[`2. scaled large full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -130,6 +136,7 @@ exports[`2. scaled large full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -145,6 +152,7 @@ exports[`2. scaled large full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -171,6 +179,7 @@ exports[`2. scaled large full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -194,6 +203,7 @@ exports[`2. scaled large full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -222,6 +232,7 @@ exports[`3. scaled xlarge full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -233,6 +244,7 @@ exports[`3. scaled xlarge full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -248,6 +260,7 @@ exports[`3. scaled xlarge full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -274,6 +287,7 @@ exports[`3. scaled xlarge full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -297,6 +311,7 @@ exports[`3. scaled xlarge full article 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -16,6 +16,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -27,6 +28,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -42,6 +44,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -65,6 +68,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -80,6 +84,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -95,6 +100,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -110,6 +116,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -137,6 +144,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -152,6 +160,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -177,6 +186,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -194,6 +204,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -262,6 +273,7 @@ exports[`2. an article with no content 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -273,6 +285,7 @@ exports[`2. an article with no content 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -297,6 +310,7 @@ exports[`2. an article with no content 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -312,6 +326,7 @@ exports[`2. an article with no content 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -340,6 +355,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -351,6 +367,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -374,6 +391,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -397,6 +415,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -408,6 +427,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -436,6 +456,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -447,6 +468,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -462,6 +484,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -487,6 +510,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -502,6 +526,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -517,6 +542,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -532,6 +558,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -559,6 +586,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -574,6 +602,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -599,6 +628,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }
@@ -623,6 +653,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
             Object {
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
               "width": 1180,
             }
           }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -6,7 +6,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
     ListHeaderComponent={
       <Gutter>
         <Header
-          width={1180}
+          width={750}
         />
       </Gutter>
     }
@@ -224,7 +224,7 @@ exports[`2. an article with no content 1`] = `
     ListHeaderComponent={
       <Gutter>
         <Header
-          width={1180}
+          width={750}
         />
       </Gutter>
     }
@@ -328,7 +328,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
     ListHeaderComponent={
       <Gutter>
         <Header
-          width={1180}
+          width={750}
         />
       </Gutter>
     }

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -8,7 +8,7 @@ import { AdComposer } from "@times-components/ad";
 import RelatedArticles from "@times-components/related-articles";
 import Responsive, { ResponsiveContext } from "@times-components/responsive";
 import { withTrackScrollDepth } from "@times-components/tracking";
-import { normaliseWidth, screenWidthInPixels } from "@times-components/utils";
+import { screenWidth } from "@times-components/utils";
 import ArticleRow from "./article-body/article-body-row";
 import ArticleTopics from "./article-topics";
 import {
@@ -101,7 +101,7 @@ class ArticleSkeleton extends Component {
     if (props.data) {
       this.state = {
         dataSource: props.data,
-        width: normaliseWidth(screenWidthInPixels())
+        width: screenWidth()
       };
     } else {
       this.state = {

--- a/packages/article-skeleton/src/styles/shared.js
+++ b/packages/article-skeleton/src/styles/shared.js
@@ -12,6 +12,7 @@ const globalStyle = {
   gutter: {
     alignSelf: "center",
     backgroundColor: "#ffffff",
+    maxWidth: "100%",
     width: maxWidth
   },
   relatedArticlesTablet: {

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { View } from "react-native";
 import {
   addMissingProtocol,
-  normaliseWidth,
+  normaliseWidthForAssetRequestCache,
   convertToPixels
 } from "@times-components/utils";
 import LazyLoadingImage from "./lazy-loading-image";
@@ -29,7 +29,7 @@ class TimesImage extends Component {
     }
   }) {
     const { highResSize } = this.props;
-    const imageRes = normaliseWidth(
+    const imageRes = normaliseWidthForAssetRequestCache(
       convertToPixels(highResSize ? Math.min(width, highResSize) : width)
     );
 

--- a/packages/utils/__tests__/screen.test.js
+++ b/packages/utils/__tests__/screen.test.js
@@ -2,23 +2,27 @@
 import {
   acceptedWidths,
   convertToPixels,
-  normaliseWidth,
+  normaliseWidthForAssetRequestCache,
   screenWidth,
   screenWidthInPixels
 } from "../src";
 
 describe("screen utilities", () => {
-  context("normaliseWidth", () => {
+  context("normaliseWidthForAssetRequestCache", () => {
     it("should return the next highest value from the acceptedWidths array", () => {
       const firstAcceptedWidthItem = acceptedWidths[0];
       const width = firstAcceptedWidthItem - 1;
-      expect(normaliseWidth(width)).toEqual(firstAcceptedWidthItem);
+      expect(normaliseWidthForAssetRequestCache(width)).toEqual(
+        firstAcceptedWidthItem
+      );
     });
 
     it("should return the last highest value from the acceptedWidths array", () => {
       const lastAcceptedWidthItem = acceptedWidths[acceptedWidths.length - 1];
       const width = lastAcceptedWidthItem + 1;
-      expect(normaliseWidth(width)).toEqual(lastAcceptedWidthItem);
+      expect(normaliseWidthForAssetRequestCache(width)).toEqual(
+        lastAcceptedWidthItem
+      );
     });
   });
 

--- a/packages/utils/src/screen.base.js
+++ b/packages/utils/src/screen.base.js
@@ -1,22 +1,17 @@
 import { Dimensions } from "react-native";
-import {
-  tabletRowPadding,
-  tabletWidth,
-  tabletWidthMax
-} from "@times-components/styleguide";
+import { tabletRowPadding, tabletWidth } from "@times-components/styleguide";
 
 export const acceptedWidths = [
   320,
   440,
-  tabletWidth,
+  660,
   800,
   1080,
-  tabletWidthMax,
+  1280,
   1440,
   1670,
   1920,
-  2308,
-  2736
+  2308
 ];
 
 export const normaliseWidth = width => {

--- a/packages/utils/src/screen.base.js
+++ b/packages/utils/src/screen.base.js
@@ -14,8 +14,11 @@ export const acceptedWidths = [
   2308
 ];
 
-export const normaliseWidth = width => {
-  const nWidth = acceptedWidths.find(w => width <= w);
+// We want to ensure a small number of caches that are more frequently "warm"
+// so we limit the number of resolutions we will request for assets
+// across devices to a common set
+export const normaliseWidthForAssetRequestCache = widthInPixels => {
+  const nWidth = acceptedWidths.find(w => widthInPixels <= w);
 
   return nWidth || acceptedWidths[acceptedWidths.length - 1];
 };

--- a/packages/utils/src/screen.js
+++ b/packages/utils/src/screen.js
@@ -1,8 +1,12 @@
 import { PixelRatio } from "react-native";
 
-import { acceptedWidths, normaliseWidth, screenWidth } from "./screen.base.js";
+import {
+  acceptedWidths,
+  normaliseWidthForAssetRequestCache,
+  screenWidth
+} from "./screen.base.js";
 
-export { acceptedWidths, normaliseWidth, screenWidth };
+export { acceptedWidths, normaliseWidthForAssetRequestCache, screenWidth };
 
 export const convertToPixels = points =>
   PixelRatio.getPixelSizeForLayoutSize(points);

--- a/packages/utils/src/screen.web.js
+++ b/packages/utils/src/screen.web.js
@@ -1,3 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 
-export { normaliseWidth, screenWidth } from "./screen.base.js";
+export {
+  normaliseWidthForAssetRequestCache,
+  screenWidth
+} from "./screen.base.js";


### PR DESCRIPTION
https://github.com/newsuk/times-components/pull/1704 introduced a regression where on devices smaller than 1180 pixels wide, the article would be wider than the screen width. This fixes that regression.

It also renames `normaliseWidth` to `normaliseWidthForAssetRequestCache`, and its arguments, to make its purpose more clear. 

It also removes the duplicated points-pixels conversation and normalisation as it is handled by TimesImage. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
