### PR TITLE
feat: secondary 4 tablet

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -13,3 +13,91 @@ exports[`1. lead one full width tablet slice 1`] = `
   <TileR />
 </View>
 `;
+
+exports[`2. secondary four tablet slice 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "marginHorizontal": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "width": "25%",
+        }
+      }
+    >
+      <TileC />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "25%",
+        }
+      }
+    >
+      <TileC />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "25%",
+        }
+      }
+    >
+      <TileC />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "25%",
+        }
+      }
+    >
+      <TileC />
+    </View>
+  </View>
+</View>
+`;

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -5,3 +5,25 @@ exports[`1. lead one full width tablet slice 1`] = `
   <TileR />
 </View>
 `;
+
+exports[`2. secondary four tablet slice 1`] = `
+<View>
+  <View>
+    <View>
+      <TileC />
+    </View>
+    <View />
+    <View>
+      <TileC />
+    </View>
+    <View />
+    <View>
+      <TileC />
+    </View>
+    <View />
+    <View>
+      <TileC />
+    </View>
+  </View>
+</View>
+`;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -13,3 +13,91 @@ exports[`1. lead one full width tablet slice 1`] = `
   <TileR />
 </View>
 `;
+
+exports[`2. secondary four tablet slice 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "marginHorizontal": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "width": "25%",
+        }
+      }
+    >
+      <TileC />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "25%",
+        }
+      }
+    >
+      <TileC />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "25%",
+        }
+      }
+    >
+      <TileC />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "25%",
+        }
+      }
+    >
+      <TileC />
+    </View>
+  </View>
+</View>
+`;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -5,3 +5,25 @@ exports[`1. lead one full width tablet slice 1`] = `
   <TileR />
 </View>
 `;
+
+exports[`2. secondary four tablet slice 1`] = `
+<View>
+  <View>
+    <View>
+      <TileC />
+    </View>
+    <View />
+    <View>
+      <TileC />
+    </View>
+    <View />
+    <View>
+      <TileC />
+    </View>
+    <View />
+    <View>
+      <TileC />
+    </View>
+  </View>
+</View>
+`;

--- a/packages/edition-slices/__tests__/shared-tablet-slices.base.js
+++ b/packages/edition-slices/__tests__/shared-tablet-slices.base.js
@@ -2,16 +2,24 @@ import React from "react";
 import TestRenderer from "react-test-renderer";
 import { iterator } from "@times-components/test-utils";
 import { setDimension } from "@times-components/test-utils/dimensions";
-import { mockLeadOneFullWidthSlice } from "@times-components/fixture-generator";
+import {
+  mockLeadOneFullWidthSlice,
+  mockSecondaryFourSlice
+} from "@times-components/fixture-generator";
 import Responsive from "@times-components/responsive";
 import "./mocks";
-import { LeadOneFullWidthSlice } from "../src/slices";
+import { LeadOneFullWidthSlice, SecondaryFourSlice } from "../src/slices";
 
 const slices = [
   {
     mock: mockLeadOneFullWidthSlice(),
     name: "lead one full width tablet slice",
     Slice: LeadOneFullWidthSlice
+  },
+  {
+    mock: mockSecondaryFourSlice(),
+    name: "secondary four tablet slice",
+    Slice: SecondaryFourSlice
   }
 ];
 

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -211,46 +211,58 @@ exports[`6. secondary four slice 1`] = `
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
 }
+
+.IS11 {
+  -webkit-align-self: center;
+  align-self: center;
+  max-width: 100%;
+  width: 1366px;
+  -ms-flex-item-align: center;
+}
 </style>
 
 <div
-  className="IS10 S1"
+  className="IS11 S1"
 >
   <div
-    className="IS4 S1"
+    className="IS10 S1"
   >
     <div
-      className="IS1 S1"
+      className="IS4 S1"
     >
-      <TileC />
+      <div
+        className="IS1 S1"
+      >
+        <TileC />
+      </div>
+      <div
+        className="IS2"
+      />
+      <div
+        className="IS3 S1"
+      >
+        <TileC />
+      </div>
     </div>
     <div
-      className="IS2"
+      className="IS5 S1"
     />
     <div
-      className="IS3 S1"
+      className="IS9 S1"
     >
-      <TileC />
-    </div>
-  </div>
-  <div
-    className="IS5 S1"
-  />
-  <div
-    className="IS9 S1"
-  >
-    <div
-      className="IS6 S1"
-    >
-      <TileC />
-    </div>
-    <div
-      className="IS7"
-    />
-    <div
-      className="IS8 S1"
-    >
-      <TileC />
+      <div
+        className="IS6 S1"
+      >
+        <TileC />
+      </div>
+      <div
+        className="IS7"
+      />
+      <div
+        className="IS8 S1"
+      >
+        <TileC />
+      </div>
     </div>
   </div>
 </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -44,21 +44,23 @@ exports[`6. secondary four slice 1`] = `
 <div>
   <div>
     <div>
-      <TileC />
+      <div>
+        <TileC />
+      </div>
+      <div />
+      <div>
+        <TileC />
+      </div>
     </div>
     <div />
     <div>
-      <TileC />
-    </div>
-  </div>
-  <div />
-  <div>
-    <div>
-      <TileC />
-    </div>
-    <div />
-    <div>
-      <TileC />
+      <div>
+        <TileC />
+      </div>
+      <div />
+      <div>
+        <TileC />
+      </div>
     </div>
   </div>
 </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -21,3 +21,137 @@ exports[`1. lead one full width tablet slice 1`] = `
   <TileR />
 </div>
 `;
+
+exports[`2. secondary four tablet slice 1`] = `
+<style>
+.S1 {
+  margin-bottom: 0px;
+}
+
+.IS1 {
+  width: 50%;
+}
+
+.IS2 {
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-right-width: 1px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.IS3 {
+  width: 50%;
+}
+
+.IS4 {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+
+.IS5 {
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-bottom-width: 1px;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS6 {
+  width: 50%;
+}
+
+.IS7 {
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-right-width: 1px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.IS8 {
+  width: 50%;
+}
+
+.IS9 {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+
+.IS10 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS11 {
+  -webkit-align-self: center;
+  align-self: center;
+  max-width: 100%;
+  width: 1366px;
+  -ms-flex-item-align: center;
+}
+</style>
+
+<div
+  className="IS11 S1"
+>
+  <div
+    className="IS10 S1"
+  >
+    <div
+      className="IS4 S1"
+    >
+      <div
+        className="IS1 S1"
+      >
+        <TileC />
+      </div>
+      <div
+        className="IS2"
+      />
+      <div
+        className="IS3 S1"
+      >
+        <TileC />
+      </div>
+    </div>
+    <div
+      className="IS5 S1"
+    />
+    <div
+      className="IS9 S1"
+    >
+      <div
+        className="IS6 S1"
+      >
+        <TileC />
+      </div>
+      <div
+        className="IS7"
+      />
+      <div
+        className="IS8 S1"
+      >
+        <TileC />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -5,3 +5,29 @@ exports[`1. lead one full width tablet slice 1`] = `
   <TileR />
 </div>
 `;
+
+exports[`2. secondary four tablet slice 1`] = `
+<div>
+  <div>
+    <div>
+      <div>
+        <TileC />
+      </div>
+      <div />
+      <div>
+        <TileC />
+      </div>
+    </div>
+    <div />
+    <div>
+      <div>
+        <TileC />
+      </div>
+      <div />
+      <div>
+        <TileC />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/edition-slices/src/slices/secondaryfour/index.js
+++ b/packages/edition-slices/src/slices/secondaryfour/index.js
@@ -2,18 +2,26 @@ import React from "react";
 import PropTypes from "prop-types";
 import { SecondaryFourSlice } from "@times-components/slice-layout";
 import { TileC } from "../../tiles";
+import { ResponsiveSlice } from "../shared";
 
 const SecondaryFour = ({
   onPress,
   slice: { secondary1, secondary2, secondary3, secondary4 }
-}) => (
-  <SecondaryFourSlice
-    renderSecondary1={() => <TileC onPress={onPress} tile={secondary1} />}
-    renderSecondary2={() => <TileC onPress={onPress} tile={secondary2} />}
-    renderSecondary3={() => <TileC onPress={onPress} tile={secondary3} />}
-    renderSecondary4={() => <TileC onPress={onPress} tile={secondary4} />}
-  />
-);
+}) => {
+  const renderSlice = breakpoint => (
+    <SecondaryFourSlice
+      breakpoint={breakpoint}
+      renderSecondary1={() => <TileC onPress={onPress} tile={secondary1} />}
+      renderSecondary2={() => <TileC onPress={onPress} tile={secondary2} />}
+      renderSecondary3={() => <TileC onPress={onPress} tile={secondary3} />}
+      renderSecondary4={() => <TileC onPress={onPress} tile={secondary4} />}
+    />
+  );
+
+  return (
+    <ResponsiveSlice renderMedium={renderSlice} renderSmall={renderSlice} />
+  );
+};
 
 SecondaryFour.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/slice-layout/__tests__/android/__snapshots__/sd4-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/sd4-with-style.android.test.js.snap
@@ -100,3 +100,89 @@ exports[`1. four child element 1`] = `
   </View>
 </View>
 `;
+
+exports[`2. tablet - four child element 1`] = `
+<View
+  style={
+    Object {
+      "flexDirection": "row",
+      "marginHorizontal": 10,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  >
+    <Text>
+      secondary-1
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  >
+    <Text>
+      secondary-2
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  >
+    <Text>
+      secondary-3
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  >
+    <Text>
+      secondary-4
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/android/__snapshots__/sd4.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/sd4.android.test.js.snap
@@ -31,3 +31,31 @@ exports[`1. four child element 1`] = `
   </View>
 </View>
 `;
+
+exports[`2. tablet - four child element 1`] = `
+<View>
+  <View>
+    <Text>
+      secondary-1
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      secondary-2
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      secondary-3
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      secondary-4
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/ios/__snapshots__/sd4-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/sd4-with-style.ios.test.js.snap
@@ -100,3 +100,89 @@ exports[`1. four child element 1`] = `
   </View>
 </View>
 `;
+
+exports[`2. tablet - four child element 1`] = `
+<View
+  style={
+    Object {
+      "flexDirection": "row",
+      "marginHorizontal": 10,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  >
+    <Text>
+      secondary-1
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  >
+    <Text>
+      secondary-2
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  >
+    <Text>
+      secondary-3
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  >
+    <Text>
+      secondary-4
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/ios/__snapshots__/sd4.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/sd4.ios.test.js.snap
@@ -31,3 +31,31 @@ exports[`1. four child element 1`] = `
   </View>
 </View>
 `;
+
+exports[`2. tablet - four child element 1`] = `
+<View>
+  <View>
+    <Text>
+      secondary-1
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      secondary-2
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      secondary-3
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      secondary-4
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/sd4.base.js
+++ b/packages/slice-layout/__tests__/sd4.base.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { editionBreakpoints } from "@times-components/styleguide";
 import { iterator } from "@times-components/test-utils";
 import createItem from "./utils";
 import { SecondaryFourSlice } from "../src/slice-layout";
@@ -10,6 +11,22 @@ export default renderComponent => {
       test() {
         const output = renderComponent(
           <SecondaryFourSlice
+            renderSecondary1={() => createItem("secondary-1")}
+            renderSecondary2={() => createItem("secondary-2")}
+            renderSecondary3={() => createItem("secondary-3")}
+            renderSecondary4={() => createItem("secondary-4")}
+          />
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "tablet - four child element",
+      test() {
+        const output = renderComponent(
+          <SecondaryFourSlice
+            breakpoint={editionBreakpoints.medium}
             renderSecondary1={() => createItem("secondary-1")}
             renderSecondary2={() => createItem("secondary-2")}
             renderSecondary3={() => createItem("secondary-3")}

--- a/packages/slice-layout/__tests__/web/__snapshots__/sd4-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/sd4-with-style.web.test.js.snap
@@ -158,3 +158,129 @@ exports[`1. four child element 1`] = `
   </div>
 </div>
 `;
+
+exports[`2. tablet - four child element 1`] = `
+<style>
+.S1 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+}
+</style>
+
+<div
+  className="S1"
+  style={
+    Object {
+      "WebkitBoxDirection": "normal",
+      "WebkitBoxOrient": "horizontal",
+      "WebkitFlexDirection": "row",
+      "flexDirection": "row",
+      "marginLeft": "10px",
+      "marginRight": "10px",
+      "msFlexDirection": "row",
+    }
+  }
+>
+  <div
+    className="S1"
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  >
+    <div
+      className="S1"
+    >
+      secondary-1
+    </div>
+  </div>
+  <div
+    className="S1"
+    style={
+      Object {
+        "borderBottomColor": "rgba(219,219,219,1.00)",
+        "borderLeftColor": "rgba(219,219,219,1.00)",
+        "borderRightColor": "rgba(219,219,219,1.00)",
+        "borderRightWidth": "1px",
+        "borderTopColor": "rgba(219,219,219,1.00)",
+        "marginBottom": "10px",
+        "marginTop": "10px",
+      }
+    }
+  />
+  <div
+    className="S1"
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  >
+    <div
+      className="S1"
+    >
+      secondary-2
+    </div>
+  </div>
+  <div
+    className="S1"
+    style={
+      Object {
+        "borderBottomColor": "rgba(219,219,219,1.00)",
+        "borderLeftColor": "rgba(219,219,219,1.00)",
+        "borderRightColor": "rgba(219,219,219,1.00)",
+        "borderRightWidth": "1px",
+        "borderTopColor": "rgba(219,219,219,1.00)",
+        "marginBottom": "10px",
+        "marginTop": "10px",
+      }
+    }
+  />
+  <div
+    className="S1"
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  >
+    <div
+      className="S1"
+    >
+      secondary-3
+    </div>
+  </div>
+  <div
+    className="S1"
+    style={
+      Object {
+        "borderBottomColor": "rgba(219,219,219,1.00)",
+        "borderLeftColor": "rgba(219,219,219,1.00)",
+        "borderRightColor": "rgba(219,219,219,1.00)",
+        "borderRightWidth": "1px",
+        "borderTopColor": "rgba(219,219,219,1.00)",
+        "marginBottom": "10px",
+        "marginTop": "10px",
+      }
+    }
+  />
+  <div
+    className="S1"
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  >
+    <div
+      className="S1"
+    >
+      secondary-4
+    </div>
+  </div>
+</div>
+`;

--- a/packages/slice-layout/__tests__/web/__snapshots__/sd4.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/sd4.web.test.js.snap
@@ -31,3 +31,31 @@ exports[`1. four child element 1`] = `
   </div>
 </div>
 `;
+
+exports[`2. tablet - four child element 1`] = `
+<div>
+  <div>
+    <div>
+      secondary-1
+    </div>
+  </div>
+  <div />
+  <div>
+    <div>
+      secondary-2
+    </div>
+  </div>
+  <div />
+  <div>
+    <div>
+      secondary-3
+    </div>
+  </div>
+  <div />
+  <div>
+    <div>
+      secondary-4
+    </div>
+  </div>
+</div>
+`;

--- a/packages/slice-layout/src/templates/secondaryfour/index.js
+++ b/packages/slice-layout/src/templates/secondaryfour/index.js
@@ -1,42 +1,60 @@
 import React from "react";
 import { View } from "react-native";
-import styles from "./styles";
-import propTypes from "./proptypes";
+import { editionBreakpoints } from "@times-components/styleguide";
+import styleFactory from "./styles";
+import { propTypes, defaultProps } from "./proptypes";
 import { ItemColSeparator, ItemRowSeparator } from "../shared";
 
 const SecondaryFourSlice = ({
+  breakpoint,
   renderSecondary1,
   renderSecondary2,
   renderSecondary3,
   renderSecondary4
 }) => {
-  const renderRowOne = [renderSecondary1(), renderSecondary2()];
-  const renderRowTwo = [renderSecondary3(), renderSecondary4()];
+  const styles = styleFactory(breakpoint);
+  if (breakpoint === editionBreakpoints.small) {
+    const renderRowOne = [renderSecondary1(), renderSecondary2()];
+    const renderRowTwo = [renderSecondary3(), renderSecondary4()];
+    return (
+      <View style={styles.container}>
+        <View style={styles.itemContainer}>
+          <View key={renderRowOne[0].props.id} style={styles.item}>
+            {renderRowOne[0]}
+          </View>
+          <ItemColSeparator />
+          <View key={renderRowOne[1].props.id} style={styles.item}>
+            {renderRowOne[1]}
+          </View>
+        </View>
+        <ItemRowSeparator />
+        <View style={styles.itemContainer}>
+          <View key={renderRowTwo[0].props.id} style={styles.item}>
+            {renderRowTwo[0]}
+          </View>
+          <ItemColSeparator />
+          <View key={renderRowTwo[1].props.id} style={styles.item}>
+            {renderRowTwo[1]}
+          </View>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
-      <View style={styles.itemContainer}>
-        <View key={renderRowOne[0].props.id} style={styles.item}>
-          {renderRowOne[0]}
-        </View>
-        <ItemColSeparator />
-        <View key={renderRowOne[1].props.id} style={styles.item}>
-          {renderRowOne[1]}
-        </View>
-      </View>
-      <ItemRowSeparator />
-      <View style={styles.itemContainer}>
-        <View key={renderRowTwo[0].props.id} style={styles.item}>
-          {renderRowTwo[0]}
-        </View>
-        <ItemColSeparator />
-        <View key={renderRowTwo[1].props.id} style={styles.item}>
-          {renderRowTwo[1]}
-        </View>
-      </View>
+      <View style={styles.item}>{renderSecondary1()}</View>
+      <ItemColSeparator />
+      <View style={styles.item}>{renderSecondary2()}</View>
+      <ItemColSeparator />
+      <View style={styles.item}>{renderSecondary3()}</View>
+      <ItemColSeparator />
+      <View style={styles.item}>{renderSecondary4()}</View>
     </View>
   );
 };
 
 SecondaryFourSlice.propTypes = propTypes;
+SecondaryFourSlice.defaultProps = defaultProps;
 
 export default SecondaryFourSlice;

--- a/packages/slice-layout/src/templates/secondaryfour/index.js
+++ b/packages/slice-layout/src/templates/secondaryfour/index.js
@@ -41,15 +41,29 @@ const SecondaryFourSlice = ({
     );
   }
 
+  const renderCol = [
+    renderSecondary1(),
+    renderSecondary2(),
+    renderSecondary3(),
+    renderSecondary4()
+  ];
   return (
     <View style={styles.container}>
-      <View style={styles.item}>{renderSecondary1()}</View>
+      <View key={renderCol[0].props.id} style={styles.item}>
+        {renderCol[0]}
+      </View>
       <ItemColSeparator />
-      <View style={styles.item}>{renderSecondary2()}</View>
+      <View key={renderCol[1].props.id} style={styles.item}>
+        {renderCol[1]}
+      </View>
       <ItemColSeparator />
-      <View style={styles.item}>{renderSecondary3()}</View>
+      <View key={renderCol[2].props.id} style={styles.item}>
+        {renderCol[2]}
+      </View>
       <ItemColSeparator />
-      <View style={styles.item}>{renderSecondary4()}</View>
+      <View key={renderCol[3].props.id} style={styles.item}>
+        {renderCol[3]}
+      </View>
     </View>
   );
 };

--- a/packages/slice-layout/src/templates/secondaryfour/proptypes.js
+++ b/packages/slice-layout/src/templates/secondaryfour/proptypes.js
@@ -1,10 +1,16 @@
 import PropTypes from "prop-types";
+import { editionBreakpoints } from "@times-components/styleguide";
 
 const propTypes = {
+  breakpoint: PropTypes.string,
   renderSecondary1: PropTypes.func.isRequired,
   renderSecondary2: PropTypes.func.isRequired,
   renderSecondary3: PropTypes.func.isRequired,
   renderSecondary4: PropTypes.func.isRequired
 };
 
-export default propTypes;
+const defaultProps = {
+  breakpoint: editionBreakpoints.small
+};
+
+export { propTypes, defaultProps };

--- a/packages/slice-layout/src/templates/secondaryfour/styles.js
+++ b/packages/slice-layout/src/templates/secondaryfour/styles.js
@@ -1,6 +1,6 @@
 import { editionBreakpoints, spacing } from "@times-components/styleguide";
 
-const smallStyles = {
+const smallBreakpointStyles = {
   container: {
     flex: 1
   },
@@ -12,7 +12,7 @@ const smallStyles = {
   }
 };
 
-const mediumStyles = {
+const mediumBreakpointStyles = {
   container: { flexDirection: "row", marginHorizontal: spacing(2) },
   item: {
     width: "25%"
@@ -20,4 +20,6 @@ const mediumStyles = {
 };
 
 export default breakpoint =>
-  breakpoint === editionBreakpoints.small ? smallStyles : mediumStyles;
+  breakpoint === editionBreakpoints.small
+    ? smallBreakpointStyles
+    : mediumBreakpointStyles;

--- a/packages/slice-layout/src/templates/secondaryfour/styles.js
+++ b/packages/slice-layout/src/templates/secondaryfour/styles.js
@@ -1,4 +1,6 @@
-const styles = {
+import { editionBreakpoints, spacing } from "@times-components/styleguide";
+
+const smallStyles = {
   container: {
     flex: 1
   },
@@ -10,4 +12,12 @@ const styles = {
   }
 };
 
-export default styles;
+const mediumStyles = {
+  container: { flexDirection: "row", marginHorizontal: spacing(2) },
+  item: {
+    width: "25%"
+  }
+};
+
+export default breakpoint =>
+  breakpoint === editionBreakpoints.small ? smallStyles : mediumStyles;


### PR DESCRIPTION
Secondary 4 tablet layout
- Reuses the same tile
- Passes breakpoint to slice-layout, and lays those slices in a col layout

![screenshot_1550512634](https://user-images.githubusercontent.com/1849590/52968935-aeb20200-33a6-11e9-9086-c1c1dee89302.png)
