### PR TITLE
fix: drop caps not always rendering on ios

### DIFF
--- a/packages/utils/src/text-layout/styles/index.js
+++ b/packages/utils/src/text-layout/styles/index.js
@@ -4,6 +4,7 @@ export default {
   ...shared,
   container: {
     ...shared.container,
-    height: 100
+    height: 100,
+    width: 100
   }
 };


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
fixes ios dropcaps sometimes not rendering when swiping articles