### PR TITLE
fix: lead 1 and 1 slice title in storybook

### DIFF
--- a/packages/edition-slices/edition-slices.showcase.js
+++ b/packages/edition-slices/edition-slices.showcase.js
@@ -55,7 +55,7 @@ const sliceStories = [
   },
   {
     mock: mockLeadOneAndOneSlice(),
-    name: "Lead One And One (AB)",
+    name: "Lead One And One (Mobile: AB, Tablet: UC)",
     Slice: LeadOneAndOneSlice
   },
   {


### PR DESCRIPTION
- minor update to slice showcase title