### PR TITLE
fix: pull quotes captions should not change colour based on section

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -176,7 +176,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           <View>
             <PullQuote
               caption="AName"
-              captionColour="#FF0000"
               quoteColour="#FF0000"
               text="a text"
               twitter="@AName"

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -176,7 +176,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           <View>
             <PullQuote
               caption="AName"
-              captionColour="#FF0000"
               quoteColour="#FF0000"
               text="a text"
               twitter="@AName"

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -115,7 +115,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
         <div>
           <PullQuote
             caption="AName"
-            captionColour="#FF0000"
             quoteColour="#FF0000"
             text="a text"
             twitter="@AName"

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -148,7 +148,6 @@ const ArticleRow = ({
                   <View style={isTablet && styles.containerTablet}>
                     <PullQuote
                       caption={name}
-                      captionColour={sectionColour}
                       font={pullQuoteFont}
                       onTwitterLinkPress={onTwitterLinkPress}
                       quoteColour={sectionColour}

--- a/packages/article-skeleton/src/article-body/article-body.web.js
+++ b/packages/article-skeleton/src/article-body/article-body.web.js
@@ -150,7 +150,6 @@ const renderers = ({ observed, registerNode }) => ({
               <PullQuoteResp>
                 <PullQuote
                   caption={name}
-                  captionColour={sectionColour}
                   font={pullQuoteFont}
                   quoteColour={sectionColour}
                   text={text}

--- a/packages/markup-forest/package.json
+++ b/packages/markup-forest/package.json
@@ -37,8 +37,8 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/jest-configurator": "2.2.10",
-    "@times-components/test-utils": "2.2.3",
+    "@times-components/jest-configurator": "2.2.11",
+    "@times-components/test-utils": "2.2.4",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "eslint": "5.9.0",

--- a/packages/pull-quote/README.md
+++ b/packages/pull-quote/README.md
@@ -7,8 +7,7 @@ which is the quote itself, and two optional strings called `caption` and
 `twitter`, which are typically used to attriute the citation (or quote) to a
 person, including their (optional) twitter handle.
 
-The colour props `captionColour` and `quoteColour` handle the colour of the
-`caption` text and the colour of the quotation marks, respectively.
+The colour prop `quoteColour` handle the colour of the colour of the quotation marks.
 
 ## Contributing
 

--- a/packages/pull-quote/README.md
+++ b/packages/pull-quote/README.md
@@ -7,7 +7,7 @@ which is the quote itself, and two optional strings called `caption` and
 `twitter`, which are typically used to attriute the citation (or quote) to a
 person, including their (optional) twitter handle.
 
-The colour prop `quoteColour` handle the colour of the colour of the quotation marks.
+The colour prop `quoteColour` handles the colour of the colour of the quotation marks.
 
 ## Contributing
 

--- a/packages/pull-quote/__tests__/android/__snapshots__/pull-quotes-with-style.android.test.js.snap
+++ b/packages/pull-quote/__tests__/android/__snapshots__/pull-quotes-with-style.android.test.js.snap
@@ -50,7 +50,7 @@ exports[`different colours 1`] = `
     <Text
       style={
         Object {
-          "color": "#850029",
+          "color": "#696969",
           "fontFamily": "GillSansMTStd-Medium",
           "fontSize": 13,
           "lineHeight": 13,

--- a/packages/pull-quote/__tests__/ios/__snapshots__/pull-quotes-with-style.ios.test.js.snap
+++ b/packages/pull-quote/__tests__/ios/__snapshots__/pull-quotes-with-style.ios.test.js.snap
@@ -52,7 +52,7 @@ exports[`different colours 1`] = `
     <Text
       style={
         Object {
-          "color": "#850029",
+          "color": "#696969",
           "fontFamily": "GillSansMTStd-Medium",
           "fontSize": 13,
           "lineHeight": 13,

--- a/packages/pull-quote/__tests__/shared-with-style.base.js
+++ b/packages/pull-quote/__tests__/shared-with-style.base.js
@@ -10,7 +10,6 @@ export default renderComponent => {
     const output = renderComponent(
       <PullQuotes
         caption={caption}
-        captionColour="#850029"
         onTwitterLinkPress={() => null}
         quoteColour="#850029"
         twitter={twitter}

--- a/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes-with-style.test.js.snap
+++ b/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes-with-style.test.js.snap
@@ -40,18 +40,6 @@ exports[`different colours 1`] = `
 
 .S3 {
   border-left-width: 0px;
-  display: inline;
-  font-family: GillSansMTStd-Medium;
-  font-size: 13px;
-  line-height: 13px;
-  margin-top: 0px;
-  margin-left: 0px;
-  margin-bottom: 0px;
-  padding-left: 0px;
-}
-
-.S4 {
-  border-left-width: 0px;
   color: rgba(105,105,105,1.00);
   display: inline;
   font-family: GillSansMTStd-Medium;
@@ -63,7 +51,7 @@ exports[`different colours 1`] = `
   padding-left: 0px;
 }
 
-.S5 {
+.S4 {
   -ms-flex-align: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -83,7 +71,7 @@ exports[`different colours 1`] = `
   padding-left: 7px;
 }
 
-.S6 {
+.S5 {
   -ms-flex-align: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -102,7 +90,7 @@ exports[`different colours 1`] = `
   padding-left: 0px;
 }
 
-.S7 {
+.S6 {
   -ms-flex-align: stretch;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -128,10 +116,6 @@ exports[`different colours 1`] = `
 }
 
 .IS2 {
-  color: rgba(133,0,41,1.00);
-}
-
-.IS3 {
   font-family: GillSansMTStd-Medium;
   font-size: 13;
   line-height: 13;
@@ -145,7 +129,7 @@ exports[`different colours 1`] = `
   url="https://twitter.com/@twitter"
 >
   <div
-    className="S7"
+    className="S6"
   >
     <div
       className="IS1 S1"
@@ -160,27 +144,27 @@ exports[`different colours 1`] = `
       </cite>
     </div>
     <div
-      className="S6"
+      className="S5"
     >
       <div
-        className="IS2 S3"
+        className="S3"
       >
         A caption
       </div>
       <div
-        className="S4"
+        className="S3"
       >
         
       </div>
       <div
-        className="S5"
+        className="S4"
       >
         <IconTwitter
           height={10}
           width={12}
         />
         <TextLink
-          className="IS3"
+          className="IS2"
           target="_blank"
           url="https://twitter.com/@twitter"
         >

--- a/packages/pull-quote/__tests__/web/__snapshots__/themes-with-style.web.test.js.snap
+++ b/packages/pull-quote/__tests__/web/__snapshots__/themes-with-style.web.test.js.snap
@@ -39,18 +39,6 @@ exports[`1. pull quote in culture magazine 1`] = `
 
 .S3 {
   border-left-width: 0px;
-  display: inline;
-  font-family: GillSansMTStd-Medium;
-  font-size: 13px;
-  line-height: 13px;
-  margin-top: 0px;
-  margin-left: 0px;
-  margin-bottom: 0px;
-  padding-left: 0px;
-}
-
-.S4 {
-  border-left-width: 0px;
   color: rgba(105,105,105,1.00);
   display: inline;
   font-family: GillSansMTStd-Medium;
@@ -62,7 +50,7 @@ exports[`1. pull quote in culture magazine 1`] = `
   padding-left: 0px;
 }
 
-.S5 {
+.S4 {
   -ms-flex-align: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -81,7 +69,7 @@ exports[`1. pull quote in culture magazine 1`] = `
   padding-left: 0px;
 }
 
-.S6 {
+.S5 {
   -ms-flex-align: stretch;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -106,17 +94,13 @@ exports[`1. pull quote in culture magazine 1`] = `
   margin-bottom: -40px;
   margin-left: -3px;
 }
-
-.IS2 {
-  color: rgba(105,105,105,1.00);
-}
 </style>
 
 <blockquote
   url=""
 >
   <div
-    className="S6"
+    className="S5"
   >
     <div
       className="IS1 S1"
@@ -131,15 +115,15 @@ exports[`1. pull quote in culture magazine 1`] = `
       </cite>
     </div>
     <div
-      className="S5"
+      className="S4"
     >
       <div
-        className="IS2 S3"
+        className="S3"
       >
         A caption
       </div>
       <div
-        className="S4"
+        className="S3"
       >
         , Some extra text
       </div>

--- a/packages/pull-quote/pull-quote.showcase.js
+++ b/packages/pull-quote/pull-quote.showcase.js
@@ -27,7 +27,6 @@ export default {
         return (
           <PullQuotes
             caption={text("Caption: ", caption)}
-            captionColour={color("Caption Colour: ", "#850029")}
             font={theme.pullQuoteFont}
             onTwitterLinkPress={preventDefaultedAction(decorateAction)(
               "onTwitterLinkPress"

--- a/packages/pull-quote/src/pull-quote-prop-types.js
+++ b/packages/pull-quote/src/pull-quote-prop-types.js
@@ -7,7 +7,6 @@ import {
 
 export const propTypes = {
   caption: PropTypes.string,
-  captionColour: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
   font: PropTypes.string,
   onTwitterLinkPress: twitterPropTypes.onTwitterLinkPress,
@@ -18,7 +17,6 @@ export const propTypes = {
 
 export const defaultProps = {
   caption: "",
-  captionColour: colours.functional.secondary,
   font: null,
   quoteColour: colours.functional.secondary,
   text: "",

--- a/packages/pull-quote/src/pull-quote.base.js
+++ b/packages/pull-quote/src/pull-quote.base.js
@@ -8,7 +8,6 @@ import quoteStyleFactory from "./styles/quotes";
 
 const PullQuotes = ({
   caption,
-  captionColour,
   children,
   font,
   onTwitterLinkPress,
@@ -22,7 +21,7 @@ const PullQuotes = ({
     </Text>
     <PullQuoteContent>{children}</PullQuoteContent>
     <View style={styles.captionContainer}>
-      <Text style={[styles.caption, { color: captionColour }]}>{caption}</Text>
+      <Text style={[styles.caption]}>{caption}</Text>
       <Text style={styles.text}>{caption && text ? `, ${text}` : text}</Text>
       <PullQuoteTwitterLink
         onTwitterLinkPress={onTwitterLinkPress}

--- a/packages/pull-quote/src/styles/shared.js
+++ b/packages/pull-quote/src/styles/shared.js
@@ -7,6 +7,7 @@ const sharedStyles = {
       font: "supporting",
       fontSize: "caption"
     }),
+    color: "#696969",
     marginBottom: 0
   },
   captionContainer: {

--- a/packages/slice-layout/package.json
+++ b/packages/slice-layout/package.json
@@ -41,7 +41,7 @@
     "@times-components/jest-configurator": "2.2.11",
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/storybook": "3.4.0",
-    "@times-components/styleguide": "3.22.1",
+    "@times-components/styleguide": "3.22.2",
     "@times-components/test-utils": "2.2.4",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/svgs/package.json
+++ b/packages/svgs/package.json
@@ -40,9 +40,9 @@
   "devDependencies": {
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/jest-configurator": "2.2.10",
+    "@times-components/jest-configurator": "2.2.11",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/test-utils": "2.2.3",
+    "@times-components/test-utils": "2.2.4",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",

--- a/packages/tealium/package.json
+++ b/packages/tealium/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/jest-configurator": "2.2.10",
-    "@times-components/test-utils": "2.2.3",
+    "@times-components/jest-configurator": "2.2.11",
+    "@times-components/test-utils": "2.2.4",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-plugin-add-react-displayname": "0.0.5",

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -37,9 +37,9 @@
   "devDependencies": {
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/jest-configurator": "2.2.10",
+    "@times-components/jest-configurator": "2.2.11",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/storybook": "3.3.12",
+    "@times-components/storybook": "3.4.0",
     "@times-components/tealium-utils": "0.7.24",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,9 +33,9 @@
   "devDependencies": {
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/jest-configurator": "2.2.10",
+    "@times-components/jest-configurator": "2.2.11",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/test-utils": "2.2.3",
+    "@times-components/test-utils": "2.2.4",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
@@ -51,7 +51,7 @@
     "webpack-cli": "2.1.4"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.22.1",
+    "@times-components/styleguide": "3.22.2",
     "lodash.omitby": "4.6.0",
     "prop-types": "15.6.2",
     "react-native": "0.55.4"

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -38,10 +38,10 @@
   "devDependencies": {
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/jest-configurator": "2.2.10",
+    "@times-components/jest-configurator": "2.2.11",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/storybook": "3.3.12",
-    "@times-components/test-utils": "2.2.3",
+    "@times-components/storybook": "3.4.0",
+    "@times-components/test-utils": "2.2.4",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-plugin-add-react-displayname": "0.0.5",
@@ -59,7 +59,7 @@
     "webpack-cli": "2.1.4"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.22.1",
+    "@times-components/styleguide": "3.22.2",
     "@times-components/svgs": "2.4.1",
     "prop-types": "15.6.2"
   },


### PR DESCRIPTION

<img width="1164" alt="screen shot 2019-02-20 at 11 54 37" src="https://user-images.githubusercontent.com/719814/53090117-52fe8a80-3506-11e9-945e-64302a51a0f9.png">

The caption on the pull quote (the author's name) should be a static grey colour, not depending on the section colour. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
