### PR TITLE
fix: Interactives now display on tablets

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -494,9 +494,9 @@ exports[`4. an article skeleton with responsive items 1`] = `
               Object {
                 "alignSelf": "center",
                 "marginBottom": 20,
-                "maxWidth": 660,
                 "paddingLeft": 10,
                 "paddingRight": 10,
+                "width": 660,
               }
             }
           >

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -494,9 +494,9 @@ exports[`4. an article skeleton with responsive items 1`] = `
               Object {
                 "alignSelf": "center",
                 "marginBottom": 20,
-                "maxWidth": 660,
                 "paddingLeft": 10,
                 "paddingRight": 10,
+                "width": 660,
               }
             }
           >

--- a/packages/article-skeleton/src/styles/article-body/shared.js
+++ b/packages/article-skeleton/src/styles/article-body/shared.js
@@ -47,7 +47,7 @@ const sharedStyles = scale => {
     },
     interactiveContainerTablet: {
       alignSelf: "center",
-      maxWidth: tabletWidth
+      width: tabletWidth
     },
     leadAsset: {
       marginBottom: spacing(2)


### PR DESCRIPTION
With a `maxWidth`, the interactives were not displaying. This was down to the webview needing specific widths (I believe)

![screenshot 2019-02-21 at 14 43 26](https://user-images.githubusercontent.com/935975/53177055-3dad5d00-35e7-11e9-9711-091273f90bbf.png)
![screenshot 2019-02-21 at 14 43 48](https://user-images.githubusercontent.com/935975/53177048-3b4b0300-35e7-11e9-80e3-294b3f9ec9d5.png)

Please note: Poor screenshots!
