### PR TITLE
fix: Add a default value on null for topics

### DIFF
--- a/packages/article-skeleton/src/article-tracking-context.js
+++ b/packages/article-skeleton/src/article-tracking-context.js
@@ -13,9 +13,7 @@ export default Component =>
       referralUrl,
       section: pageSection || get(data, "section", ""),
       template: get(data, "template", "Default"),
-      topics: get(data, "topics", [])
-        .map(topic => topic.name)
-        .join(",")
+      topics: (get(data, "topics", []) || []).map(topic => topic.name).join(",")
     }),
     trackingObjectName: "Article"
   });


### PR DESCRIPTION
Article page is crashing when topics are null. (which happens when there is an api error). Added a default value (lodash only defaults on `undefined`, not `null`)

https://nidigitalsolutions.jira.com/browse/REPLAT-5317