### PR TITLE
fix: Roundel images working across ios and android

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/roundel-image-tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/roundel-image-tiles.test.js.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`1. tile g - layout change 1`] = `
+<Link
+  url="/article/123"
+>
+  <View>
+    <View>
+      <Image
+        aspectRatio={1}
+        borderRadius={105}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+    </View>
+    <View>
+      <View>
+        <Text>
+          LABEL
+        </Text>
+      </View>
+      <Text
+        accessibilityRole="heading"
+        aria-level="3"
+      >
+        Venezuela shows how Corbyn’s socialism works
+      </Text>
+      <View>
+        <ArticleFlags
+          flags={
+            Array [
+              "EXCLUSIVE",
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`2. tile p - layout change 1`] = `
+<Link
+  url="/article/123"
+>
+  <View>
+    <View>
+      <Image
+        aspectRatio={1}
+        borderRadius={105}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+    </View>
+    <View>
+      <View>
+        <Text>
+          LABEL
+        </Text>
+      </View>
+      <Text
+        accessibilityRole="heading"
+        aria-level="3"
+      >
+        Venezuela shows how Corbyn’s socialism works
+      </Text>
+      <Text
+        accessibilityRole="heading"
+        aria-level="4"
+      >
+        The resignation of three Conservative MPs has shown up the divisions in their party that mirror those in Labour. A greater realignment may be needed
+      </Text>
+      <View>
+        <ArticleFlags
+          flags={
+            Array [
+              "EXCLUSIVE",
+            ]
+          }
+        />
+      </View>
+      <Text>
+        <Text>
+          Libby Purves
+        </Text>
+      </Text>
+    </View>
+  </View>
+</Link>
+`;

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -236,7 +236,7 @@ exports[`7. tile g 1`] = `
     <View>
       <Image
         aspectRatio={1}
-        borderRadius={187.5}
+        borderRadius={112.5}
         uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
       />
     </View>
@@ -528,7 +528,7 @@ exports[`15. tile p 1`] = `
     <View>
       <Image
         aspectRatio={1}
-        borderRadius={187.5}
+        borderRadius={112.5}
         uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
       />
     </View>

--- a/packages/edition-slices/__tests__/android/roundel-image-tiles.test.js
+++ b/packages/edition-slices/__tests__/android/roundel-image-tiles.test.js
@@ -1,0 +1,3 @@
+import shared from "../shared-roundel-image-tiles.native";
+
+shared();

--- a/packages/edition-slices/__tests__/ios/__snapshots__/roundel-image-tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/roundel-image-tiles.test.js.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`1. tile g - layout change 1`] = `
+<Link
+  url="/article/123"
+>
+  <View>
+    <View>
+      <Image
+        aspectRatio={1}
+        borderRadius={105}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+    </View>
+    <View>
+      <View>
+        <Text>
+          LABEL
+        </Text>
+      </View>
+      <Text
+        accessibilityRole="heading"
+        aria-level="3"
+      >
+        Venezuela shows how Corbyn’s socialism works
+      </Text>
+      <View>
+        <ArticleFlags
+          flags={
+            Array [
+              "EXCLUSIVE",
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`2. tile p - layout change 1`] = `
+<Link
+  url="/article/123"
+>
+  <View>
+    <View>
+      <Image
+        aspectRatio={1}
+        borderRadius={105}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+    </View>
+    <View>
+      <View>
+        <Text>
+          LABEL
+        </Text>
+      </View>
+      <Text
+        accessibilityRole="heading"
+        aria-level="3"
+      >
+        Venezuela shows how Corbyn’s socialism works
+      </Text>
+      <Text
+        accessibilityRole="heading"
+        aria-level="4"
+      >
+        The resignation of three Conservative MPs has shown up the divisions in their party that mirror those in Labour. A greater realignment may be needed
+      </Text>
+      <View>
+        <ArticleFlags
+          flags={
+            Array [
+              "EXCLUSIVE",
+            ]
+          }
+        />
+      </View>
+      <Text>
+        <Text>
+          Libby Purves
+        </Text>
+      </Text>
+    </View>
+  </View>
+</Link>
+`;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -236,7 +236,7 @@ exports[`7. tile g 1`] = `
     <View>
       <Image
         aspectRatio={1}
-        borderRadius={187.5}
+        borderRadius={112.5}
         uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
       />
     </View>
@@ -528,7 +528,7 @@ exports[`15. tile p 1`] = `
     <View>
       <Image
         aspectRatio={1}
-        borderRadius={187.5}
+        borderRadius={112.5}
         uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
       />
     </View>

--- a/packages/edition-slices/__tests__/ios/roundel-image-tiles.test.js
+++ b/packages/edition-slices/__tests__/ios/roundel-image-tiles.test.js
@@ -1,0 +1,3 @@
+import shared from "../shared-roundel-image-tiles.native";
+
+shared();

--- a/packages/edition-slices/__tests__/shared-roundel-image-tiles.base.js
+++ b/packages/edition-slices/__tests__/shared-roundel-image-tiles.base.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { View } from "react-native";
+import TestRenderer from "react-test-renderer";
+import { iterator } from "@times-components/test-utils";
+import { mockEditionSlice } from "@times-components/fixture-generator";
+
+import { TileG, TileP } from "../src/tiles";
+
+jest.mock("@times-components/article-flag", () => ({
+  ArticleFlags: "ArticleFlags"
+}));
+jest.mock("@times-components/image", () => "Image");
+jest.mock("@times-components/link", () => "Link");
+jest.mock("@times-components/gradient", () => "Gradient");
+
+const tile = mockEditionSlice(1).items[0];
+
+const getLayoutEventForWidth = width => ({
+  nativeEvent: { layout: { width } }
+});
+
+const layoutChange = (Tile, mockTile = tile) => {
+  const output = TestRenderer.create(
+    <Tile onPress={() => {}} tile={mockTile} />
+  );
+
+  output.root.findByType(View).props.onLayout(getLayoutEventForWidth(700));
+
+  expect(output).toMatchSnapshot();
+};
+
+export default () => {
+  const tests = [
+    {
+      name: "tile g - layout change",
+      test: () => layoutChange(TileG)
+    },
+    {
+      name: "tile p - layout change",
+      test: () => layoutChange(TileP)
+    }
+  ];
+
+  iterator(tests);
+};

--- a/packages/edition-slices/__tests__/shared-roundel-image-tiles.native.js
+++ b/packages/edition-slices/__tests__/shared-roundel-image-tiles.native.js
@@ -1,0 +1,28 @@
+import {
+  addSerializers,
+  compose,
+  enzymeRenderedSerializer,
+  minimaliseTransform,
+  minimalNativeTransform,
+  print
+} from "@times-components/jest-serializer";
+import shared from "./shared-roundel-image-tiles.base";
+
+jest.mock("@times-components/image", () => "Image");
+jest.mock("@times-components/gradient", () => "Gradient");
+
+export default () => {
+  addSerializers(
+    expect,
+    enzymeRenderedSerializer(),
+    compose(
+      print,
+      minimalNativeTransform,
+      minimaliseTransform(
+        (value, key) => key === "style" || key.includes("Class")
+      )
+    )
+  );
+
+  shared();
+};

--- a/packages/edition-slices/__tests__/shared-roundel-image-tiles.web.js
+++ b/packages/edition-slices/__tests__/shared-roundel-image-tiles.web.js
@@ -1,0 +1,28 @@
+import { AppRegistry } from "react-native-web";
+import {
+  addSerializers,
+  compose,
+  enzymeTreeSerializer,
+  minimaliseTransform,
+  minimalWebTransform,
+  print,
+  rnwTransform
+} from "@times-components/jest-serializer";
+import shared from "./shared-roundel-image-tiles.base";
+
+export default () => {
+  addSerializers(
+    expect,
+    enzymeTreeSerializer(),
+    compose(
+      print,
+      minimalWebTransform,
+      minimaliseTransform(
+        (value, key) => key === "style" || key === "className"
+      ),
+      rnwTransform(AppRegistry)
+    )
+  );
+
+  shared();
+};

--- a/packages/edition-slices/__tests__/web/__snapshots__/roundel-image-tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/roundel-image-tiles.test.js.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`1. tile g - layout change 1`] = `
+<Link
+  url="/article/123"
+>
+  <div>
+    <div>
+      <Image
+        aspectRatio={1}
+        borderRadius={105}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+    </div>
+    <div>
+      <div>
+        <div>
+          LABEL
+        </div>
+      </div>
+      <h3
+        aria-level="3"
+        role="heading"
+      >
+        Venezuela shows how Corbyn’s socialism works
+      </h3>
+      <div>
+        <ArticleFlags
+          flags={
+            Array [
+              "EXCLUSIVE",
+            ]
+          }
+        />
+      </div>
+    </div>
+  </div>
+</Link>
+`;
+
+exports[`2. tile p - layout change 1`] = `
+<Link
+  url="/article/123"
+>
+  <div>
+    <div>
+      <Image
+        aspectRatio={1}
+        borderRadius={105}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+    </div>
+    <div>
+      <div>
+        <div>
+          LABEL
+        </div>
+      </div>
+      <h3
+        aria-level="3"
+        role="heading"
+      >
+        Venezuela shows how Corbyn’s socialism works
+      </h3>
+      <h4
+        aria-level="4"
+        role="heading"
+      >
+        The resignation of three Conservative MPs has shown up the divisions in their party that mirror those in Labour. A greater realignment may be needed
+      </h4>
+      <div>
+        <ArticleFlags
+          flags={
+            Array [
+              "EXCLUSIVE",
+            ]
+          }
+        />
+      </div>
+      <div>
+        <span>
+          Libby Purves
+        </span>
+      </div>
+    </div>
+  </div>
+</Link>
+`;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -729,7 +729,7 @@ exports[`7. tile g 1`] = `
     >
       <Image
         aspectRatio={1}
-        borderRadius={256}
+        borderRadius={153.6}
         uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
       />
     </div>
@@ -1611,7 +1611,7 @@ exports[`15. tile p 1`] = `
     >
       <Image
         aspectRatio={1}
-        borderRadius={256}
+        borderRadius={153.6}
         uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -236,7 +236,7 @@ exports[`7. tile g 1`] = `
     <div>
       <Image
         aspectRatio={1}
-        borderRadius={256}
+        borderRadius={153.6}
         uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
       />
     </div>
@@ -528,7 +528,7 @@ exports[`15. tile p 1`] = `
     <div>
       <Image
         aspectRatio={1}
-        borderRadius={256}
+        borderRadius={153.6}
         uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/roundel-image-tiles.test.js
+++ b/packages/edition-slices/__tests__/web/roundel-image-tiles.test.js
@@ -1,0 +1,3 @@
+import shared from "../shared-roundel-image-tiles.web";
+
+shared();

--- a/packages/edition-slices/src/tiles/tile-g/index.js
+++ b/packages/edition-slices/src/tiles/tile-g/index.js
@@ -11,12 +11,9 @@ import {
 import styles from "./styles";
 
 class TileG extends Component {
-  constructor() {
-    super();
-    this.state = {
-      containerWidth: Dimensions.get("window").width
-    };
-  }
+  state = {
+    containerWidth: Dimensions.get("window").width
+  };
 
   render() {
     const { onPress, tile } = this.props;

--- a/packages/edition-slices/src/tiles/tile-g/index.js
+++ b/packages/edition-slices/src/tiles/tile-g/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import { Dimensions, View } from "react-native";
 import PropTypes from "prop-types";
 import {
@@ -10,23 +10,41 @@ import {
 } from "../shared";
 import styles from "./styles";
 
-const TileG = ({ onPress, tile }) => (
-  <TileLink onPress={onPress} tile={tile}>
-    <View style={styles.container}>
-      <TileImage
-        aspectRatio={1}
-        borderRadius={Dimensions.get("window").width / 4}
-        style={styles.imageContainer}
-        uri={getCrop(tile.article.leadAsset, "crop11")}
-      />
-      <TileSummary
-        headlineStyle={styles.headline}
-        style={styles.summaryContainer}
-        tile={tile}
-      />
-    </View>
-  </TileLink>
-);
+class TileG extends Component {
+  constructor() {
+    super();
+    this.state = {
+      containerWidth: Dimensions.get("window").width
+    };
+  }
+
+  render() {
+    const { onPress, tile } = this.props;
+    const { containerWidth } = this.state;
+    return (
+      <TileLink onPress={onPress} tile={tile}>
+        <View
+          onLayout={event =>
+            this.setState({ containerWidth: event.nativeEvent.layout.width })
+          }
+          style={styles.container}
+        >
+          <TileImage
+            aspectRatio={1}
+            borderRadius={containerWidth * 0.15}
+            style={styles.imageContainer}
+            uri={getCrop(tile.article.leadAsset, "crop11")}
+          />
+          <TileSummary
+            headlineStyle={styles.headline}
+            style={styles.summaryContainer}
+            tile={tile}
+          />
+        </View>
+      </TileLink>
+    );
+  }
+}
 
 TileG.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/tiles/tile-p/index.js
+++ b/packages/edition-slices/src/tiles/tile-p/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import { Dimensions, View } from "react-native";
 import PropTypes from "prop-types";
 import {
@@ -10,27 +10,45 @@ import {
 } from "../shared";
 import styles from "./styles";
 
-const TileP = ({ onPress, tile }) => (
-  <TileLink onPress={onPress} tile={tile}>
-    <View style={styles.container}>
-      <TileImage
-        aspectRatio={1}
-        borderRadius={Dimensions.get("window").width / 4}
-        style={styles.imageContainer}
-        uri={getCrop(tile.article.leadAsset, "crop11")}
-      />
-      <TileSummary
-        byline={tile.article.byline}
-        bylineStyle={styles.bylineOpinion}
-        headlineStyle={styles.headline}
-        strapline={tile.strapline}
-        straplineStyle={styles.strapline}
-        style={styles.summaryContainer}
-        tile={tile}
-      />
-    </View>
-  </TileLink>
-);
+class TileP extends Component {
+  constructor() {
+    super();
+    this.state = {
+      containerWidth: Dimensions.get("window").width
+    };
+  }
+
+  render() {
+    const { onPress, tile } = this.props;
+    const { containerWidth } = this.state;
+    return (
+      <TileLink onPress={onPress} tile={tile}>
+        <View
+          onLayout={event =>
+            this.setState({ containerWidth: event.nativeEvent.layout.width })
+          }
+          style={styles.container}
+        >
+          <TileImage
+            aspectRatio={1}
+            borderRadius={containerWidth * 0.15}
+            style={styles.imageContainer}
+            uri={getCrop(tile.article.leadAsset, "crop11")}
+          />
+          <TileSummary
+            byline={tile.article.byline}
+            bylineStyle={styles.bylineOpinion}
+            headlineStyle={styles.headline}
+            strapline={tile.strapline}
+            straplineStyle={styles.strapline}
+            style={styles.summaryContainer}
+            tile={tile}
+          />
+        </View>
+      </TileLink>
+    );
+  }
+}
 
 TileP.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/tiles/tile-p/index.js
+++ b/packages/edition-slices/src/tiles/tile-p/index.js
@@ -11,12 +11,9 @@ import {
 import styles from "./styles";
 
 class TileP extends Component {
-  constructor() {
-    super();
-    this.state = {
-      containerWidth: Dimensions.get("window").width
-    };
-  }
+  state = {
+    containerWidth: Dimensions.get("window").width
+  };
 
   render() {
     const { onPress, tile } = this.props;


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/REPLAT-5625

The issue was the tile was using the screen width to calculate the border-radius because the image was a percentage of the width, not a set value. There is no such thing as a proportional border-radius in React Native.

The Tile won't always fill the screen so this is wrong, so we now calculate the size of the container with which the image sits in. Additionally, the calculation was wrong as well assuming `25%` instead of `30%` so I have made this more explicit.

