### PR TITLE
feat: Short Headline to be the primary headline for List Pages and Slices

### DIFF
--- a/packages/article-list/__tests__/android/utils.android.test.js
+++ b/packages/article-list/__tests__/android/utils.android.test.js
@@ -1,0 +1,4 @@
+import { getHeadline } from "../../src/utils";
+import shared from "../shared-utils";
+
+shared({ getHeadline });

--- a/packages/article-list/__tests__/ios/utils.ios.test.js
+++ b/packages/article-list/__tests__/ios/utils.ios.test.js
@@ -1,0 +1,4 @@
+import { getHeadline } from "../../src/utils";
+import shared from "../shared-utils";
+
+shared({ getHeadline });

--- a/packages/article-list/__tests__/shared-utils.js
+++ b/packages/article-list/__tests__/shared-utils.js
@@ -1,0 +1,26 @@
+import { iterator } from "@times-components/test-utils";
+
+const headline = "I am a long headline used in Articles";
+const shortHeadline = "Short Headline";
+
+export default ({ getHeadline }) => {
+  const tests = [
+    {
+      name:
+        "getHeadline returns a shortHeadline before a headline if its provided",
+      test: () => {
+        const headlineToUse = getHeadline(headline, shortHeadline);
+        expect(headlineToUse).toEqual(shortHeadline);
+      }
+    },
+    {
+      name: "getHeadline returns a headline if shortHeadline is unavailable",
+      test: () => {
+        const headlineToUse = getHeadline(headline, null);
+        expect(headlineToUse).toEqual(headline);
+      }
+    }
+  ];
+
+  iterator(tests);
+};

--- a/packages/article-list/__tests__/web/utils.web.test.js
+++ b/packages/article-list/__tests__/web/utils.web.test.js
@@ -1,0 +1,4 @@
+import { getHeadline } from "../../src/utils";
+import shared from "../shared-utils";
+
+shared({ getHeadline });

--- a/packages/article-list/src/utils/index-base.js
+++ b/packages/article-list/src/utils/index-base.js
@@ -7,6 +7,6 @@ const getImageUri = item =>
     get(item, "leadAsset.posterImage.crop.url", null)
   );
 
-const getHeadline = (headline, shortHeadline) => headline || shortHeadline;
+const getHeadline = (headline, shortHeadline) => shortHeadline || headline;
 
 export { getImageUri, getHeadline };

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -45,7 +45,7 @@ exports[`1. tile a 1`] = `
         }
       }
     >
-      Venezuela shows how Corbyn’s socialism works
+      Driving Off
     </Text>
     <View
       style={
@@ -115,7 +115,7 @@ exports[`2. tile b 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -207,7 +207,7 @@ exports[`3. tile c 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -286,7 +286,7 @@ exports[`4. tile d 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -365,7 +365,7 @@ exports[`5. tile e 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -427,7 +427,7 @@ exports[`6. tile f 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -542,7 +542,7 @@ exports[`7. tile g 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -612,7 +612,7 @@ exports[`8. tile h 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -733,7 +733,7 @@ exports[`9. tile i 1`] = `
         }
       }
     >
-      Venezuela shows how Corbyn’s socialism works
+      Driving Off
     </Text>
     <View
       style={
@@ -812,7 +812,7 @@ exports[`10. tile j 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -874,7 +874,7 @@ exports[`11. tile l 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -1007,7 +1007,7 @@ exports[`13. tile n 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -1084,7 +1084,7 @@ exports[`14. tile o 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -1168,7 +1168,7 @@ exports[`15. tile p 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -1286,7 +1286,7 @@ exports[`17. tile r 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -1477,7 +1477,7 @@ exports[`19. tile t 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -1547,7 +1547,7 @@ exports[`20. tile u 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -1629,7 +1629,7 @@ exports[`21. tile v 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -1700,7 +1700,7 @@ exports[`22. tile w 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -1789,7 +1789,7 @@ exports[`23. tile x 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -1882,7 +1882,7 @@ exports[`24. tile y 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -1961,7 +1961,7 @@ exports[`25. tile z 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -14,7 +14,7 @@ exports[`1. tile a 1`] = `
       accessibilityRole="heading"
       aria-level="3"
     >
-      Venezuela shows how Corbyn’s socialism works
+      Driving Off
     </Text>
     <View>
       <ArticleFlags
@@ -50,7 +50,7 @@ exports[`2. tile b 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text>
         <Text>
@@ -94,7 +94,7 @@ exports[`3. tile c 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -131,7 +131,7 @@ exports[`4. tile d 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -168,7 +168,7 @@ exports[`5. tile e 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -199,7 +199,7 @@ exports[`6. tile f 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         accessibilityRole="heading"
@@ -250,7 +250,7 @@ exports[`7. tile g 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -281,7 +281,7 @@ exports[`8. tile h 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text>
         <Text>
@@ -337,7 +337,7 @@ exports[`9. tile i 1`] = `
       accessibilityRole="heading"
       aria-level="3"
     >
-      Venezuela shows how Corbyn’s socialism works
+      Driving Off
     </Text>
     <View>
       <ArticleFlags
@@ -373,7 +373,7 @@ exports[`10. tile j 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -404,7 +404,7 @@ exports[`11. tile l 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -465,7 +465,7 @@ exports[`13. tile n 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         accessibilityRole="heading"
@@ -503,7 +503,7 @@ exports[`14. tile o 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -542,7 +542,7 @@ exports[`15. tile p 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         accessibilityRole="heading"
@@ -599,7 +599,7 @@ exports[`17. tile r 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -680,7 +680,7 @@ exports[`19. tile t 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -711,7 +711,7 @@ exports[`20. tile u 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -754,7 +754,7 @@ exports[`21. tile v 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -785,7 +785,7 @@ exports[`22. tile w 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text>
         <Text>
@@ -829,7 +829,7 @@ exports[`23. tile x 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         accessibilityRole="heading"
@@ -873,7 +873,7 @@ exports[`24. tile y 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text>
         <Text>
@@ -911,7 +911,7 @@ exports[`25. tile z 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags

--- a/packages/edition-slices/__tests__/android/shared-components.test.js
+++ b/packages/edition-slices/__tests__/android/shared-components.test.js
@@ -1,0 +1,3 @@
+import shared from "../shared-components.base";
+
+shared();

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -45,7 +45,7 @@ exports[`1. tile a 1`] = `
         }
       }
     >
-      Venezuela shows how Corbyn’s socialism works
+      Driving Off
     </Text>
     <View
       style={
@@ -115,7 +115,7 @@ exports[`2. tile b 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -207,7 +207,7 @@ exports[`3. tile c 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -286,7 +286,7 @@ exports[`4. tile d 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -365,7 +365,7 @@ exports[`5. tile e 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -427,7 +427,7 @@ exports[`6. tile f 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -542,7 +542,7 @@ exports[`7. tile g 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -612,7 +612,7 @@ exports[`8. tile h 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -733,7 +733,7 @@ exports[`9. tile i 1`] = `
         }
       }
     >
-      Venezuela shows how Corbyn’s socialism works
+      Driving Off
     </Text>
     <View
       style={
@@ -812,7 +812,7 @@ exports[`10. tile j 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -874,7 +874,7 @@ exports[`11. tile l 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -1007,7 +1007,7 @@ exports[`13. tile n 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -1084,7 +1084,7 @@ exports[`14. tile o 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -1168,7 +1168,7 @@ exports[`15. tile p 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -1286,7 +1286,7 @@ exports[`17. tile r 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -1477,7 +1477,7 @@ exports[`19. tile t 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -1547,7 +1547,7 @@ exports[`20. tile u 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -1629,7 +1629,7 @@ exports[`21. tile v 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={
@@ -1700,7 +1700,7 @@ exports[`22. tile w 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -1789,7 +1789,7 @@ exports[`23. tile x 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -1882,7 +1882,7 @@ exports[`24. tile y 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         style={
@@ -1961,7 +1961,7 @@ exports[`25. tile z 1`] = `
           }
         }
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View
         style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -14,7 +14,7 @@ exports[`1. tile a 1`] = `
       accessibilityRole="heading"
       aria-level="3"
     >
-      Venezuela shows how Corbyn’s socialism works
+      Driving Off
     </Text>
     <View>
       <ArticleFlags
@@ -50,7 +50,7 @@ exports[`2. tile b 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text>
         <Text>
@@ -94,7 +94,7 @@ exports[`3. tile c 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -131,7 +131,7 @@ exports[`4. tile d 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -168,7 +168,7 @@ exports[`5. tile e 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -199,7 +199,7 @@ exports[`6. tile f 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         accessibilityRole="heading"
@@ -250,7 +250,7 @@ exports[`7. tile g 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -281,7 +281,7 @@ exports[`8. tile h 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text>
         <Text>
@@ -337,7 +337,7 @@ exports[`9. tile i 1`] = `
       accessibilityRole="heading"
       aria-level="3"
     >
-      Venezuela shows how Corbyn’s socialism works
+      Driving Off
     </Text>
     <View>
       <ArticleFlags
@@ -373,7 +373,7 @@ exports[`10. tile j 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -404,7 +404,7 @@ exports[`11. tile l 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -465,7 +465,7 @@ exports[`13. tile n 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         accessibilityRole="heading"
@@ -503,7 +503,7 @@ exports[`14. tile o 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -542,7 +542,7 @@ exports[`15. tile p 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         accessibilityRole="heading"
@@ -599,7 +599,7 @@ exports[`17. tile r 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -680,7 +680,7 @@ exports[`19. tile t 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -711,7 +711,7 @@ exports[`20. tile u 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -754,7 +754,7 @@ exports[`21. tile v 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags
@@ -785,7 +785,7 @@ exports[`22. tile w 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text>
         <Text>
@@ -829,7 +829,7 @@ exports[`23. tile x 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text
         accessibilityRole="heading"
@@ -873,7 +873,7 @@ exports[`24. tile y 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <Text>
         <Text>
@@ -911,7 +911,7 @@ exports[`25. tile z 1`] = `
         accessibilityRole="heading"
         aria-level="3"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </Text>
       <View>
         <ArticleFlags

--- a/packages/edition-slices/__tests__/ios/shared-components.test.js
+++ b/packages/edition-slices/__tests__/ios/shared-components.test.js
@@ -1,0 +1,3 @@
+import shared from "../shared-components.base";
+
+shared();

--- a/packages/edition-slices/__tests__/shared-components.base.js
+++ b/packages/edition-slices/__tests__/shared-components.base.js
@@ -1,0 +1,41 @@
+import React from "react";
+import TestRenderer from "react-test-renderer";
+import { ArticleSummaryHeadline } from "@times-components/article-summary";
+import { iterator } from "@times-components/test-utils";
+import { mockEditionSlice } from "@times-components/fixture-generator";
+
+import TileSummary from "../src/tiles/shared/tile-summary";
+
+jest.mock("@times-components/article-flag", () => ({
+  ArticleFlags: "ArticleFlags"
+}));
+
+const tile = mockEditionSlice(1).items[0];
+
+export default () => {
+  const tests = [
+    {
+      name:
+        "Tile summary falls back to headline if shortHeadline is unavailable",
+      test: () => {
+        const tileWithoutShortHeadline = {
+          ...tile,
+          article: {
+            ...tile.article,
+            shortHeadline: ""
+          }
+        };
+
+        const output = TestRenderer.create(
+          <TileSummary tile={tileWithoutShortHeadline} />
+        );
+
+        expect(
+          output.root.findByType(ArticleSummaryHeadline).props.headline
+        ).toEqual(tileWithoutShortHeadline.article.headline);
+      }
+    }
+  ];
+
+  iterator(tests);
+};

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -65,7 +65,7 @@ exports[`1. tile a 1`] = `
       className="IS2 S3"
       role="heading"
     >
-      Venezuela shows how Corbyn’s socialism works
+      Driving Off
     </h3>
     <div
       className="S4"
@@ -176,7 +176,7 @@ exports[`2. tile b 1`] = `
         className="IS2 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S5"
@@ -283,7 +283,7 @@ exports[`3. tile c 1`] = `
         className="IS3 S4"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S1"
@@ -390,7 +390,7 @@ exports[`4. tile d 1`] = `
         className="IS3 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S4"
@@ -497,7 +497,7 @@ exports[`5. tile e 1`] = `
         className="IS3 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S4"
@@ -610,7 +610,7 @@ exports[`6. tile f 1`] = `
         className="IS2 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <h4
         aria-level="4"
@@ -750,7 +750,7 @@ exports[`7. tile g 1`] = `
         className="IS3 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S4"
@@ -891,7 +891,7 @@ exports[`8. tile h 1`] = `
         className="IS2 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S5"
@@ -1021,7 +1021,7 @@ exports[`9. tile i 1`] = `
       className="IS3 S3"
       role="heading"
     >
-      Venezuela shows how Corbyn’s socialism works
+      Driving Off
     </h3>
     <div
       className="S4"
@@ -1121,7 +1121,7 @@ exports[`10. tile j 1`] = `
         className="IS3 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S4"
@@ -1203,7 +1203,7 @@ exports[`11. tile l 1`] = `
         className="IS2 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S4"
@@ -1382,7 +1382,7 @@ exports[`13. tile n 1`] = `
         className="IS3 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <h4
         aria-level="4"
@@ -1474,7 +1474,7 @@ exports[`14. tile o 1`] = `
         className="IS2 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S4"
@@ -1632,7 +1632,7 @@ exports[`15. tile p 1`] = `
         className="IS3 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <h4
         aria-level="4"
@@ -1772,7 +1772,7 @@ exports[`17. tile r 1`] = `
         className="IS2 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S4"
@@ -1991,7 +1991,7 @@ exports[`19. tile t 1`] = `
         className="IS3 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S4"
@@ -2084,7 +2084,7 @@ exports[`20. tile u 1`] = `
         className="IS2 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S4"
@@ -2187,7 +2187,7 @@ exports[`21. tile v 1`] = `
         className="IS3 S4"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S1"
@@ -2301,7 +2301,7 @@ exports[`22. tile w 1`] = `
         className="IS2 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S5"
@@ -2436,7 +2436,7 @@ exports[`23. tile x 1`] = `
         className="IS2 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <h4
         aria-level="4"
@@ -2558,7 +2558,7 @@ exports[`24. tile y 1`] = `
         className="IS2 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S5"
@@ -2651,7 +2651,7 @@ exports[`25. tile z 1`] = `
         className="IS2 S3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div
         className="S4"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -14,7 +14,7 @@ exports[`1. tile a 1`] = `
       aria-level="3"
       role="heading"
     >
-      Venezuela shows how Corbyn’s socialism works
+      Driving Off
     </h3>
     <div>
       <ArticleFlags
@@ -50,7 +50,7 @@ exports[`2. tile b 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <span>
@@ -94,7 +94,7 @@ exports[`3. tile c 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <ArticleFlags
@@ -131,7 +131,7 @@ exports[`4. tile d 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <ArticleFlags
@@ -168,7 +168,7 @@ exports[`5. tile e 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <ArticleFlags
@@ -199,7 +199,7 @@ exports[`6. tile f 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <h4
         aria-level="4"
@@ -250,7 +250,7 @@ exports[`7. tile g 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <ArticleFlags
@@ -281,7 +281,7 @@ exports[`8. tile h 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <span>
@@ -337,7 +337,7 @@ exports[`9. tile i 1`] = `
       aria-level="3"
       role="heading"
     >
-      Venezuela shows how Corbyn’s socialism works
+      Driving Off
     </h3>
     <div>
       <ArticleFlags
@@ -373,7 +373,7 @@ exports[`10. tile j 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <ArticleFlags
@@ -404,7 +404,7 @@ exports[`11. tile l 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <ArticleFlags
@@ -465,7 +465,7 @@ exports[`13. tile n 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <h4
         aria-level="4"
@@ -503,7 +503,7 @@ exports[`14. tile o 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <ArticleFlags
@@ -542,7 +542,7 @@ exports[`15. tile p 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <h4
         aria-level="4"
@@ -599,7 +599,7 @@ exports[`17. tile r 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <ArticleFlags
@@ -680,7 +680,7 @@ exports[`19. tile t 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <ArticleFlags
@@ -711,7 +711,7 @@ exports[`20. tile u 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <ArticleFlags
@@ -754,7 +754,7 @@ exports[`21. tile v 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <ArticleFlags
@@ -785,7 +785,7 @@ exports[`22. tile w 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <span>
@@ -829,7 +829,7 @@ exports[`23. tile x 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <h4
         aria-level="4"
@@ -873,7 +873,7 @@ exports[`24. tile y 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <span>
@@ -911,7 +911,7 @@ exports[`25. tile z 1`] = `
         aria-level="3"
         role="heading"
       >
-        Venezuela shows how Corbyn’s socialism works
+        Driving Off
       </h3>
       <div>
         <ArticleFlags

--- a/packages/edition-slices/__tests__/web/shared-components.test.js
+++ b/packages/edition-slices/__tests__/web/shared-components.test.js
@@ -1,0 +1,3 @@
+import shared from "../shared-components.base";
+
+shared();

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -33,7 +33,7 @@ const TileSummary = ({
     flags={() => <ArticleFlags {...flagColour} flags={flags} />}
     headline={() => (
       <ArticleSummaryHeadline
-        headline={headline || shortHeadline}
+        headline={shortHeadline || headline}
         style={headlineStyle}
       />
     )}


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/REPLAT-5646

We were using the longer headline. This PR rectifies this.

It also adds a test for these as well as setting up testing for the shared components of `Tiles` and utils of `ArticleList`. These areas could use some more tests following this PR.