### PR TITLE
fix: modal image close button should be in a safe area

### DIFF
--- a/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
@@ -17,132 +17,140 @@ exports[`1. default modal 1`] = `
       <View
         style={
           Object {
-            "alignItems": "flex-end",
-            "margin": 16,
-          }
-        }
-      >
-        <View>
-          <Image
-            style={
-              Object {
-                "height": 24,
-                "width": 24,
-              }
-            }
-          />
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "flexGrow": 1,
+            "flex": 1,
           }
         }
       >
         <View
           style={
             Object {
+              "alignItems": "flex-end",
+              "margin": 16,
+            }
+          }
+        >
+          <View>
+            <Image
+              style={
+                Object {
+                  "height": 24,
+                  "width": 24,
+                }
+              }
+            />
+          </View>
+        </View>
+        <View
+          style={
+            Object {
               "flexGrow": 1,
-              "justifyContent": "center",
             }
           }
         >
           <View
             style={
               Object {
-                "transform": Array [
-                  Object {
-                    "translateX": -0,
-                  },
-                  Object {
-                    "translateY": -0,
-                  },
-                  Object {
-                    "translateX": 0,
-                  },
-                  Object {
-                    "translateY": 0,
-                  },
-                  Object {
-                    "scale": 1,
-                  },
-                  Object {
-                    "translateX": -0,
-                  },
-                  Object {
-                    "translateY": -0,
-                  },
-                  Object {
-                    "translateX": 0,
-                  },
-                  Object {
-                    "translateY": 0,
-                  },
-                  Object {
-                    "rotate": "0 deg",
-                  },
-                  Object {
-                    "perspective": 1000,
-                  },
-                ],
+                "flexGrow": 1,
+                "justifyContent": "center",
               }
             }
           >
             <View
               style={
                 Object {
-                  "opacity": 1,
-                  "width": "100%",
+                  "transform": Array [
+                    Object {
+                      "translateX": -0,
+                    },
+                    Object {
+                      "translateY": -0,
+                    },
+                    Object {
+                      "translateX": 0,
+                    },
+                    Object {
+                      "translateY": 0,
+                    },
+                    Object {
+                      "scale": 1,
+                    },
+                    Object {
+                      "translateX": -0,
+                    },
+                    Object {
+                      "translateY": -0,
+                    },
+                    Object {
+                      "translateX": 0,
+                    },
+                    Object {
+                      "translateY": 0,
+                    },
+                    Object {
+                      "rotate": "0 deg",
+                    },
+                    Object {
+                      "perspective": 1000,
+                    },
+                  ],
                 }
               }
             >
               <View
                 style={
                   Object {
-                    "flex": 1,
+                    "opacity": 1,
+                    "width": "100%",
                   }
                 }
               >
-                <Gradient
+                <View
                   style={
                     Object {
                       "flex": 1,
                     }
                   }
+                >
+                  <Gradient
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  />
+                </View>
+                <Image
+                  style={
+                    Object {
+                      "height": "100%",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
                 />
               </View>
-              <Image
-                style={
-                  Object {
-                    "height": "100%",
-                    "position": "absolute",
-                    "width": "100%",
-                    "zIndex": 1,
-                  }
-                }
-              />
             </View>
           </View>
         </View>
-      </View>
-      <View
-        style={
-          Object {
-            "marginBottom": 14,
-            "marginHorizontal": 16,
-          }
-        }
-      >
-        <Text
+        <View
           style={
             Object {
-              "color": "#FFFFFF",
+              "marginBottom": 14,
+              "marginHorizontal": 16,
             }
           }
         >
-          Caption
-        </Text>
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+              }
+            }
+          >
+            Caption
+          </Text>
+        </View>
       </View>
     </View>
   </Modal>

--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -9,45 +9,47 @@ exports[`1. modal image 1`] = `
   >
     <View>
       <View>
-        <View
-          pointerEvents="box-only"
-        >
-          <Image
-            resizeMode="contain"
-            source={
-              Object {
-                "testUri": "../../../packages/image/assets/close-button.png",
+        <View>
+          <View
+            pointerEvents="box-only"
+          >
+            <Image
+              resizeMode="contain"
+              source={
+                Object {
+                  "testUri": "../../../packages/image/assets/close-button.png",
+                }
               }
-            }
-          />
+            />
+          </View>
         </View>
-      </View>
-      <View>
         <View>
           <View>
-            <View
-              aspectRatio={1.5}
-            >
-              <View>
-                <Gradient
-                  degrees={264}
+            <View>
+              <View
+                aspectRatio={1.5}
+              >
+                <View>
+                  <Gradient
+                    degrees={264}
+                  />
+                </View>
+                <Image
+                  source={
+                    Object {
+                      "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
+                    }
+                  }
                 />
               </View>
-              <Image
-                source={
-                  Object {
-                    "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
-                  }
-                }
-              />
             </View>
           </View>
         </View>
-      </View>
-      <View>
-        <Text>
-          Caption
-        </Text>
+        <View>
+          <Text>
+            Caption
+          </Text>
+        </View>
       </View>
     </View>
   </Modal>

--- a/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
@@ -14,142 +14,150 @@ exports[`1. default modal 1`] = `
         }
       }
     >
-      <View
+      <RCTSafeAreaView
         style={
           Object {
-            "marginLeft": 15,
-            "marginTop": 20,
+            "flex": 1,
           }
         }
       >
         <View
           style={
             Object {
-              "opacity": 1,
-            }
-          }
-        >
-          <Image
-            style={
-              Object {
-                "height": 24,
-                "width": 24,
-              }
-            }
-          />
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "flexGrow": 1,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "flexGrow": 1,
-              "justifyContent": "center",
+              "marginLeft": 15,
+              "marginTop": 15,
             }
           }
         >
           <View
             style={
               Object {
-                "transform": Array [
-                  Object {
-                    "translateX": -0,
-                  },
-                  Object {
-                    "translateY": -0,
-                  },
-                  Object {
-                    "translateX": 0,
-                  },
-                  Object {
-                    "translateY": 0,
-                  },
-                  Object {
-                    "scale": 1,
-                  },
-                  Object {
-                    "translateX": -0,
-                  },
-                  Object {
-                    "translateY": -0,
-                  },
-                  Object {
-                    "translateX": 0,
-                  },
-                  Object {
-                    "translateY": 0,
-                  },
-                  Object {
-                    "rotate": "0 deg",
-                  },
-                  Object {
-                    "perspective": 1000,
-                  },
-                ],
+                "opacity": 1,
+              }
+            }
+          >
+            <Image
+              style={
+                Object {
+                  "height": 24,
+                  "width": 24,
+                }
+              }
+            />
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "flexGrow": 1,
+                "justifyContent": "center",
               }
             }
           >
             <View
               style={
                 Object {
-                  "opacity": 1,
-                  "width": "100%",
+                  "transform": Array [
+                    Object {
+                      "translateX": -0,
+                    },
+                    Object {
+                      "translateY": -0,
+                    },
+                    Object {
+                      "translateX": 0,
+                    },
+                    Object {
+                      "translateY": 0,
+                    },
+                    Object {
+                      "scale": 1,
+                    },
+                    Object {
+                      "translateX": -0,
+                    },
+                    Object {
+                      "translateY": -0,
+                    },
+                    Object {
+                      "translateX": 0,
+                    },
+                    Object {
+                      "translateY": 0,
+                    },
+                    Object {
+                      "rotate": "0 deg",
+                    },
+                    Object {
+                      "perspective": 1000,
+                    },
+                  ],
                 }
               }
             >
               <View
                 style={
                   Object {
-                    "flex": 1,
+                    "opacity": 1,
+                    "width": "100%",
                   }
                 }
               >
-                <Gradient
+                <View
                   style={
                     Object {
                       "flex": 1,
                     }
                   }
+                >
+                  <Gradient
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  />
+                </View>
+                <Image
+                  style={
+                    Object {
+                      "height": "100%",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
                 />
               </View>
-              <Image
-                style={
-                  Object {
-                    "height": "100%",
-                    "position": "absolute",
-                    "width": "100%",
-                    "zIndex": 1,
-                  }
-                }
-              />
             </View>
           </View>
         </View>
-      </View>
-      <View
-        style={
-          Object {
-            "marginBottom": 14,
-            "marginHorizontal": 16,
-          }
-        }
-      >
-        <Text
+        <View
           style={
             Object {
-              "color": "#FFFFFF",
+              "marginBottom": 14,
+              "marginHorizontal": 16,
             }
           }
         >
-          Caption
-        </Text>
-      </View>
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+              }
+            }
+          >
+            Caption
+          </Text>
+        </View>
+      </RCTSafeAreaView>
     </View>
   </Modal>
   <View

--- a/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
@@ -8,45 +8,47 @@ exports[`1. modal image 1`] = `
     visible={false}
   >
     <View>
-      <View>
-        <View>
-          <Image
-            resizeMode="contain"
-            source={
-              Object {
-                "testUri": "../../../packages/image/assets/close-button.png",
-              }
-            }
-          />
-        </View>
-      </View>
-      <View>
+      <RCTSafeAreaView>
         <View>
           <View>
-            <View
-              aspectRatio={1.5}
-            >
-              <View>
-                <Gradient
-                  degrees={264}
+            <Image
+              resizeMode="contain"
+              source={
+                Object {
+                  "testUri": "../../../packages/image/assets/close-button.png",
+                }
+              }
+            />
+          </View>
+        </View>
+        <View>
+          <View>
+            <View>
+              <View
+                aspectRatio={1.5}
+              >
+                <View>
+                  <Gradient
+                    degrees={264}
+                  />
+                </View>
+                <Image
+                  source={
+                    Object {
+                      "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
+                    }
+                  }
                 />
               </View>
-              <Image
-                source={
-                  Object {
-                    "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
-                  }
-                }
-              />
             </View>
           </View>
         </View>
-      </View>
-      <View>
-        <Text>
-          Caption
-        </Text>
-      </View>
+        <View>
+          <Text>
+            Caption
+          </Text>
+        </View>
+      </RCTSafeAreaView>
     </View>
   </Modal>
   <View>

--- a/packages/image/src/modal-image.js
+++ b/packages/image/src/modal-image.js
@@ -43,7 +43,7 @@ class ModalImage extends Component {
           visible={showModal}
         >
           <View style={styles.modal}>
-            <SafeAreaView style={{ flex: 1 }}>
+            <SafeAreaView style={styles.safeViewContainer}>
               <View style={styles.buttonContainer}>
                 <CloseButton onPress={this.hideModal} />
               </View>

--- a/packages/image/src/modal-image.js
+++ b/packages/image/src/modal-image.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Modal, View } from "react-native";
+import { Modal, View, SafeAreaView } from "react-native";
 import Gestures from "@times-components/gestures";
 import Button from "@times-components/link";
 import CloseButton from "./close-button";
@@ -43,13 +43,15 @@ class ModalImage extends Component {
           visible={showModal}
         >
           <View style={styles.modal}>
-            <View style={styles.buttonContainer}>
-              <CloseButton onPress={this.hideModal} />
-            </View>
-            <Gestures style={styles.imageContainer}>
-              <Image {...this.props} style={styles.image} />
-            </Gestures>
-            {captionWithStyles}
+            <SafeAreaView style={{ flex: 1 }}>
+              <View style={styles.buttonContainer}>
+                <CloseButton onPress={this.hideModal} />
+              </View>
+              <Gestures style={styles.imageContainer}>
+                <Image {...this.props} style={styles.image} />
+              </Gestures>
+              {captionWithStyles}
+            </SafeAreaView>
           </View>
         </Modal>
         <Button onPress={this.showModal}>

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -3,7 +3,7 @@ import { colours } from "@times-components/styleguide";
 const styles = {
   buttonContainer: {
     marginLeft: 15,
-    marginTop: 20
+    marginTop: 15
   },
   closeButton: {
     height: 24,

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -1,9 +1,9 @@
-import { colours } from "@times-components/styleguide";
+import { colours, spacing } from "@times-components/styleguide";
 
 const styles = {
   buttonContainer: {
-    marginLeft: 15,
-    marginTop: 15
+    marginLeft: spacing(3),
+    marginTop: spacing(3)
   },
   closeButton: {
     height: 24,

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -36,6 +36,9 @@ const styles = {
   placeholderContainer: {
     alignItems: "center",
     justifyContent: "center"
+  },
+  safeViewContainer: {
+    flex: 1
   }
 };
 


### PR DESCRIPTION
Using RN's `SafeAreaView`, we can ensure the modal exit button is in the correct place across all devices.

<img width="244" alt="screen shot 2019-02-27 at 16 24 17" src="https://user-images.githubusercontent.com/719814/53505656-35a06200-3aac-11e9-8e03-9e12f07b598e.png">


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
