### PR TITLE
feat: Removing section colours for indepth template

### DIFF
--- a/packages/styleguide/src/theme/theme-factory.js
+++ b/packages/styleguide/src/theme/theme-factory.js
@@ -5,10 +5,7 @@ const sectionColourPicker = (
   template = "mainstandard"
 ) => {
   const config = {
-    indepth: {
-      ...sectionColours,
-      ...secondarySectionColours
-    },
+    indepth: {},
     magazinecomment: {
       ...sectionColours,
       ...secondarySectionColours


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/REPLAT-5452.

Pull quotes, Dropcap and Key Facts on an In-Depth template require no change of colours. The feedback from design that the contrasting colours to the background colour of the header were too much. This, therefore, covers further components being added. As a result, its a simple change for in-depth templates to not have access to other section colours.