### PR TITLE
chore: Adding knobs to slice layout stories

### DIFF
--- a/packages/jest-configurator/package.json
+++ b/packages/jest-configurator/package.json
@@ -55,7 +55,7 @@
     ]
   },
   "dependencies": {
-    "@times-components/test-utils": "2.2.6",
+    "@times-components/test-utils": "2.2.7",
     "babel-core": "6.26.0",
     "babel-jest": "23.4.2",
     "babel-plugin-istanbul": "4.1.6",

--- a/packages/lazy-load/package.json
+++ b/packages/lazy-load/package.json
@@ -38,7 +38,7 @@
     "@times-components/jest-configurator": "2.3.0",
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/storybook": "3.4.1",
-    "@times-components/test-utils": "2.2.6",
+    "@times-components/test-utils": "2.2.7",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "enzyme": "3.6.0",

--- a/packages/markup-forest/package.json
+++ b/packages/markup-forest/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.3.0",
-    "@times-components/test-utils": "2.2.6",
+    "@times-components/test-utils": "2.2.7",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "eslint": "5.9.0",

--- a/packages/provider-test-tools/package.json
+++ b/packages/provider-test-tools/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/test-utils": "2.2.6",
+    "@times-components/test-utils": "2.2.7",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -39,7 +39,7 @@
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/provider-test-tools": "1.13.17",
     "@times-components/storybook": "3.4.1",
-    "@times-components/test-utils": "2.2.6",
+    "@times-components/test-utils": "2.2.7",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/test-utils": "2.2.6",
+    "@times-components/test-utils": "2.2.7",
     "eslint": "5.9.0",
     "prettier": "1.14.3",
     "rimraf": "2.6.1"

--- a/packages/slice-layout/package.json
+++ b/packages/slice-layout/package.json
@@ -41,7 +41,7 @@
     "@times-components/jest-configurator": "2.3.0",
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/storybook": "3.4.1",
-    "@times-components/styleguide": "3.24.0",
+    "@times-components/styleguide": "3.25.0",
     "@times-components/test-utils": "2.2.7",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/slice-layout/slice-layout.showcase.js
+++ b/packages/slice-layout/slice-layout.showcase.js
@@ -1,6 +1,8 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { ScrollView, View } from "react-native";
+import { editionBreakpoints } from "@times-components/styleguide";
+
 import {
   CommentLeadAndCartoon,
   LeadOneAndFourSlice,
@@ -54,12 +56,16 @@ const Support4 = () => (
   <View style={[{ minHeight: 150 }, { backgroundColor: "blue" }]} />
 );
 
+const breakpointSelect = select =>
+  select("Breakpoints:", editionBreakpoints, "small");
+
 export default {
   children: [
     {
-      component: () => (
+      component: ({ select }) => (
         <ScrollView>
           <LeadOneAndFourSlice
+            breakpoint={breakpointSelect(select)}
             renderLead={() => <Support3 id="support1" />}
             renderSupport1={() => <Support1 id="support2" />}
             renderSupport2={() => <Support2 id="support3" />}
@@ -72,9 +78,10 @@ export default {
       type: "story"
     },
     {
-      component: () => (
+      component: ({ select }) => (
         <ScrollView>
           <LeadOneAndOneSlice
+            breakpoint={breakpointSelect(select)}
             renderLead={() => (
               <View
                 id="lead"
@@ -218,9 +225,10 @@ export default {
       type: "story"
     },
     {
-      component: () => (
+      component: ({ select }) => (
         <ScrollView>
           <SecondaryFourSlice
+            breakpoint={breakpointSelect(select)}
             renderSecondary1={() => <Support1 id="support1" />}
             renderSecondary2={() => <Support2 id="support2" />}
             renderSecondary3={() => <Support3 id="support3" />}
@@ -232,9 +240,10 @@ export default {
       type: "story"
     },
     {
-      component: () => (
+      component: ({ select }) => (
         <ScrollView>
           <SecondaryTwoAndTwoSlice
+            breakpoint={breakpointSelect(select)}
             renderSecondary1={() => <Support1 id="support1" />}
             renderSecondary2={() => <Support2 id="support2" />}
             renderSupport1={() => <Support3 id="support3" />}
@@ -248,9 +257,10 @@ export default {
       type: "story"
     },
     {
-      component: () => (
+      component: ({ select }) => (
         <ScrollView>
           <SecondaryOneAndFourSlice
+            breakpoint={breakpointSelect(select)}
             renderSecondary={() => <Support1 id="support1" />}
             renderSupport1={() => <Support2 id="support2" />}
             renderSupport2={() => <Support3 id="support3" />}
@@ -263,9 +273,10 @@ export default {
       type: "story"
     },
     {
-      component: () => (
+      component: ({ select }) => (
         <ScrollView>
           <SecondaryTwoNoPicAndTwoSlice
+            breakpoint={breakpointSelect(select)}
             renderSecondary1={() => <Support1 id="support1" />}
             renderSecondary2={() => <Support2 id="support2" />}
             renderSupport1={() => <Support3 id="support3" />}
@@ -277,9 +288,10 @@ export default {
       type: "story"
     },
     {
-      component: () => (
+      component: ({ select }) => (
         <ScrollView>
           <LeadTwoNoPicAndTwoSlice
+            breakpoint={breakpointSelect(select)}
             renderLead1={() => <Support1 id="support1" />}
             renderLead2={() => <Support2 id="support2" />}
             renderSupport1={() => <Support3 id="support3" />}
@@ -291,9 +303,10 @@ export default {
       type: "story"
     },
     {
-      component: () => (
+      component: ({ select }) => (
         <ScrollView>
           <ListTwoAndSixNoPic
+            breakpoint={breakpointSelect(select)}
             renderLead1={() => <Support3 id="support1" />}
             renderLead2={() => <Support4 id="support2" />}
             renderSupport1={() => <Support1 id="support3" />}
@@ -309,9 +322,10 @@ export default {
       type: "story"
     },
     {
-      component: () => (
+      component: ({ select }) => (
         <ScrollView>
           <Leaders
+            breakpoint={breakpointSelect(select)}
             renderLeader1={() => <Support1 id="support1" />}
             renderLeader2={() => <Support2 id="support2" />}
             renderLeader3={() => <Support3 id="support3" />}
@@ -322,9 +336,10 @@ export default {
       type: "story"
     },
     {
-      component: () => (
+      component: ({ select }) => (
         <ScrollView>
           <CommentLeadAndCartoon
+            breakpoint={breakpointSelect(select)}
             renderCartoon={() => <Support2 id="support2" />}
             renderLead={() => <Support1 id="support1" />}
           />

--- a/packages/svgs/package.json
+++ b/packages/svgs/package.json
@@ -42,7 +42,7 @@
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.3.0",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/test-utils": "2.2.6",
+    "@times-components/test-utils": "2.2.7",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",

--- a/packages/tealium/package.json
+++ b/packages/tealium/package.json
@@ -28,7 +28,7 @@
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.3.0",
-    "@times-components/test-utils": "2.2.6",
+    "@times-components/test-utils": "2.2.7",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-plugin-add-react-displayname": "0.0.5",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,7 +35,7 @@
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.3.0",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/test-utils": "2.2.6",
+    "@times-components/test-utils": "2.2.7",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
@@ -51,7 +51,7 @@
     "webpack-cli": "2.1.4"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.24.0",
+    "@times-components/styleguide": "3.25.0",
     "lodash.omitby": "4.6.0",
     "prop-types": "15.6.2",
     "react-native": "0.55.4"

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -41,7 +41,7 @@
     "@times-components/jest-configurator": "2.3.0",
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/storybook": "3.4.1",
-    "@times-components/test-utils": "2.2.6",
+    "@times-components/test-utils": "2.2.7",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-plugin-add-react-displayname": "0.0.5",
@@ -59,7 +59,7 @@
     "webpack-cli": "2.1.4"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.24.0",
+    "@times-components/styleguide": "3.25.0",
     "@times-components/svgs": "2.5.0",
     "prop-types": "15.6.2"
   },


### PR DESCRIPTION
With the recent responsive slice work, there wasn't a way in storybook to test the slice layouts at different breakpoints.