### PR TITLE
feat: Additional ad sizes for larger widths

### DIFF
--- a/packages/ad/src/utils/sizes.js
+++ b/packages/ad/src/utils/sizes.js
@@ -53,6 +53,16 @@ const sizes = {
       height: 250,
       sizes: [[300, 250]],
       width: 300
+    },
+    {
+      height: 90,
+      sizes: [leaderboard],
+      width: 728
+    },
+    {
+      height: 250,
+      sizes: [billboard],
+      width: 970
     }
   ],
   pixel: [


### PR DESCRIPTION
Within the ad package, you can add more sizes to a particular slot. This has been done now to support billboard and leaderboard.

Please note: billboard seems to give inconsistent results and often shows a leaderboard. This might be due to ad inventory? I would ask that someone with better knowledge on ads can advise?