### PR TITLE
fix: pinch to zoom on iOS & alignment

### DIFF
--- a/packages/gestures/src/gestures.js
+++ b/packages/gestures/src/gestures.js
@@ -91,6 +91,9 @@ class Gestures extends Component {
       onPanResponderStart: evt => {
         this.handlePinchStart(evt);
       },
+      // Required for iOS support
+      // https://github.com/facebook/react-native/issues/14295#issuecomment-389971835
+      onPanResponderTerminationRequest: () => false,
       onStartShouldSetPanResponder: (e, { numberActiveTouches }) =>
         numberActiveTouches > 1,
       onStartShouldSetPanResponderCapture: (e, { numberActiveTouches }) =>

--- a/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
@@ -17,7 +17,6 @@ exports[`1. default modal 1`] = `
       <View
         style={
           Object {
-            "display": "flex",
             "flex": 1,
           }
         }

--- a/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
@@ -17,6 +17,7 @@ exports[`1. default modal 1`] = `
       <View
         style={
           Object {
+            "display": "flex",
             "flex": 1,
           }
         }
@@ -24,132 +25,143 @@ exports[`1. default modal 1`] = `
         <View
           style={
             Object {
-              "alignItems": "flex-end",
-              "margin": 16,
-            }
-          }
-        >
-          <View>
-            <Image
-              style={
-                Object {
-                  "height": 24,
-                  "width": 24,
-                }
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Object {
-              "flexGrow": 1,
+              "flex": 1,
+              "position": "relative",
             }
           }
         >
           <View
             style={
               Object {
+                "alignItems": "flex-end",
+                "margin": 16,
+              }
+            }
+          >
+            <View>
+              <Image
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Object {
                 "flexGrow": 1,
-                "justifyContent": "center",
               }
             }
           >
             <View
               style={
                 Object {
-                  "transform": Array [
-                    Object {
-                      "translateX": -0,
-                    },
-                    Object {
-                      "translateY": -0,
-                    },
-                    Object {
-                      "translateX": 0,
-                    },
-                    Object {
-                      "translateY": 0,
-                    },
-                    Object {
-                      "scale": 1,
-                    },
-                    Object {
-                      "translateX": -0,
-                    },
-                    Object {
-                      "translateY": -0,
-                    },
-                    Object {
-                      "translateX": 0,
-                    },
-                    Object {
-                      "translateY": 0,
-                    },
-                    Object {
-                      "rotate": "0 deg",
-                    },
-                    Object {
-                      "perspective": 1000,
-                    },
-                  ],
+                  "flexGrow": 1,
+                  "justifyContent": "center",
                 }
               }
             >
               <View
                 style={
                   Object {
-                    "opacity": 1,
-                    "width": "100%",
+                    "transform": Array [
+                      Object {
+                        "translateX": -0,
+                      },
+                      Object {
+                        "translateY": -0,
+                      },
+                      Object {
+                        "translateX": 0,
+                      },
+                      Object {
+                        "translateY": 0,
+                      },
+                      Object {
+                        "scale": 1,
+                      },
+                      Object {
+                        "translateX": -0,
+                      },
+                      Object {
+                        "translateY": -0,
+                      },
+                      Object {
+                        "translateX": 0,
+                      },
+                      Object {
+                        "translateY": 0,
+                      },
+                      Object {
+                        "rotate": "0 deg",
+                      },
+                      Object {
+                        "perspective": 1000,
+                      },
+                    ],
                   }
                 }
               >
                 <View
                   style={
                     Object {
-                      "flex": 1,
+                      "opacity": 1,
+                      "width": "100%",
                     }
                   }
                 >
-                  <Gradient
+                  <View
                     style={
                       Object {
                         "flex": 1,
                       }
                     }
+                  >
+                    <Gradient
+                      style={
+                        Object {
+                          "flex": 1,
+                        }
+                      }
+                    />
+                  </View>
+                  <Image
+                    style={
+                      Object {
+                        "height": "100%",
+                        "position": "absolute",
+                        "width": "100%",
+                        "zIndex": 1,
+                      }
+                    }
                   />
                 </View>
-                <Image
-                  style={
-                    Object {
-                      "height": "100%",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
               </View>
             </View>
           </View>
-        </View>
-        <View
-          style={
-            Object {
-              "marginBottom": 14,
-              "marginHorizontal": 16,
-            }
-          }
-        >
-          <Text
+          <View
             style={
               Object {
-                "color": "#FFFFFF",
+                "bottom": 14,
+                "left": 16,
+                "position": "absolute",
+                "right": 16,
               }
             }
           >
-            Caption
-          </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                }
+              }
+            >
+              Caption
+            </Text>
+          </View>
         </View>
       </View>
     </View>

--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -10,52 +10,54 @@ exports[`1. modal image 1`] = `
     <View>
       <View>
         <View>
-          <View
-            pointerEvents="box-only"
-          >
-            <Image
-              resizeMode="contain"
-              source={
-                Object {
-                  "testUri": "../../../packages/image/assets/close-button.png",
+          <View>
+            <View
+              pointerEvents="box-only"
+            >
+              <Image
+                resizeMode="contain"
+                source={
+                  Object {
+                    "testUri": "../../../packages/image/assets/close-button.png",
+                  }
                 }
-              }
-            />
+              />
+            </View>
           </View>
-        </View>
-        <View>
           <View>
             <View>
-              <View
-                aspectRatio={1.5}
-              >
-                <View>
-                  <Gradient
-                    degrees={264}
+              <View>
+                <View
+                  aspectRatio={1.5}
+                >
+                  <View>
+                    <Gradient
+                      degrees={264}
+                    />
+                  </View>
+                  <Image
+                    source={
+                      Object {
+                        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
+                      }
+                    }
+                  />
+                  <Image
+                    source={
+                      Object {
+                        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
+                      }
+                    }
                   />
                 </View>
-                <Image
-                  source={
-                    Object {
-                      "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
-                    }
-                  }
-                />
-                <Image
-                  source={
-                    Object {
-                      "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
-                    }
-                  }
-                />
               </View>
             </View>
           </View>
-        </View>
-        <View>
-          <Text>
-            Caption
-          </Text>
+          <View>
+            <Text>
+              Caption
+            </Text>
+          </View>
         </View>
       </View>
     </View>
@@ -93,52 +95,54 @@ exports[`2. modal image with custom highressize 1`] = `
     <View>
       <View>
         <View>
-          <View
-            pointerEvents="box-only"
-          >
-            <Image
-              resizeMode="contain"
-              source={
-                Object {
-                  "testUri": "../../../packages/image/assets/close-button.png",
+          <View>
+            <View
+              pointerEvents="box-only"
+            >
+              <Image
+                resizeMode="contain"
+                source={
+                  Object {
+                    "testUri": "../../../packages/image/assets/close-button.png",
+                  }
                 }
-              }
-            />
+              />
+            </View>
           </View>
-        </View>
-        <View>
           <View>
             <View>
-              <View
-                aspectRatio={1.5}
-              >
-                <View>
-                  <Gradient
-                    degrees={264}
+              <View>
+                <View
+                  aspectRatio={1.5}
+                >
+                  <View>
+                    <Gradient
+                      degrees={264}
+                    />
+                  </View>
+                  <Image
+                    source={
+                      Object {
+                        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
+                      }
+                    }
+                  />
+                  <Image
+                    source={
+                      Object {
+                        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
+                      }
+                    }
                   />
                 </View>
-                <Image
-                  source={
-                    Object {
-                      "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
-                    }
-                  }
-                />
-                <Image
-                  source={
-                    Object {
-                      "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
-                    }
-                  }
-                />
               </View>
             </View>
           </View>
-        </View>
-        <View>
-          <Text>
-            Caption
-          </Text>
+          <View>
+            <Text>
+              Caption
+            </Text>
+          </View>
         </View>
       </View>
     </View>

--- a/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
@@ -17,6 +17,7 @@ exports[`1. default modal 1`] = `
       <RCTSafeAreaView
         style={
           Object {
+            "display": "flex",
             "flex": 1,
           }
         }
@@ -24,140 +25,151 @@ exports[`1. default modal 1`] = `
         <View
           style={
             Object {
-              "marginLeft": 15,
-              "marginTop": 15,
+              "flex": 1,
               "position": "relative",
-              "zIndex": 1,
             }
           }
         >
           <View
             style={
               Object {
-                "opacity": 1,
-              }
-            }
-          >
-            <Image
-              style={
-                Object {
-                  "height": 24,
-                  "width": 24,
-                }
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Object {
-              "flexGrow": 1,
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "flexGrow": 1,
-                "justifyContent": "center",
+                "left": 15,
+                "position": "absolute",
+                "top": 15,
+                "zIndex": 1,
               }
             }
           >
             <View
               style={
                 Object {
-                  "transform": Array [
-                    Object {
-                      "translateX": -0,
-                    },
-                    Object {
-                      "translateY": -0,
-                    },
-                    Object {
-                      "translateX": 0,
-                    },
-                    Object {
-                      "translateY": 0,
-                    },
-                    Object {
-                      "scale": 1,
-                    },
-                    Object {
-                      "translateX": -0,
-                    },
-                    Object {
-                      "translateY": -0,
-                    },
-                    Object {
-                      "translateX": 0,
-                    },
-                    Object {
-                      "translateY": 0,
-                    },
-                    Object {
-                      "rotate": "0 deg",
-                    },
-                    Object {
-                      "perspective": 1000,
-                    },
-                  ],
+                  "opacity": 1,
+                }
+              }
+            >
+              <Image
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "flexGrow": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "flexGrow": 1,
+                  "justifyContent": "center",
                 }
               }
             >
               <View
                 style={
                   Object {
-                    "opacity": 1,
-                    "width": "100%",
+                    "transform": Array [
+                      Object {
+                        "translateX": -0,
+                      },
+                      Object {
+                        "translateY": -0,
+                      },
+                      Object {
+                        "translateX": 0,
+                      },
+                      Object {
+                        "translateY": 0,
+                      },
+                      Object {
+                        "scale": 1,
+                      },
+                      Object {
+                        "translateX": -0,
+                      },
+                      Object {
+                        "translateY": -0,
+                      },
+                      Object {
+                        "translateX": 0,
+                      },
+                      Object {
+                        "translateY": 0,
+                      },
+                      Object {
+                        "rotate": "0 deg",
+                      },
+                      Object {
+                        "perspective": 1000,
+                      },
+                    ],
                   }
                 }
               >
                 <View
                   style={
                     Object {
-                      "flex": 1,
+                      "opacity": 1,
+                      "width": "100%",
                     }
                   }
                 >
-                  <Gradient
+                  <View
                     style={
                       Object {
                         "flex": 1,
                       }
                     }
+                  >
+                    <Gradient
+                      style={
+                        Object {
+                          "flex": 1,
+                        }
+                      }
+                    />
+                  </View>
+                  <Image
+                    style={
+                      Object {
+                        "height": "100%",
+                        "position": "absolute",
+                        "width": "100%",
+                        "zIndex": 1,
+                      }
+                    }
                   />
                 </View>
-                <Image
-                  style={
-                    Object {
-                      "height": "100%",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
               </View>
             </View>
           </View>
-        </View>
-        <View
-          style={
-            Object {
-              "marginBottom": 14,
-              "marginHorizontal": 16,
-            }
-          }
-        >
-          <Text
+          <View
             style={
               Object {
-                "color": "#FFFFFF",
+                "bottom": 14,
+                "left": 16,
+                "position": "absolute",
+                "right": 16,
               }
             }
           >
-            Caption
-          </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                }
+              }
+            >
+              Caption
+            </Text>
+          </View>
         </View>
       </RCTSafeAreaView>
     </View>

--- a/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
@@ -17,7 +17,6 @@ exports[`1. default modal 1`] = `
       <RCTSafeAreaView
         style={
           Object {
-            "display": "flex",
             "flex": 1,
           }
         }

--- a/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
@@ -11,49 +11,51 @@ exports[`1. modal image 1`] = `
       <RCTSafeAreaView>
         <View>
           <View>
-            <Image
-              resizeMode="contain"
-              source={
-                Object {
-                  "testUri": "../../../packages/image/assets/close-button.png",
+            <View>
+              <Image
+                resizeMode="contain"
+                source={
+                  Object {
+                    "testUri": "../../../packages/image/assets/close-button.png",
+                  }
                 }
-              }
-            />
+              />
+            </View>
           </View>
-        </View>
-        <View>
           <View>
             <View>
-              <View
-                aspectRatio={1.5}
-              >
-                <View>
-                  <Gradient
-                    degrees={264}
+              <View>
+                <View
+                  aspectRatio={1.5}
+                >
+                  <View>
+                    <Gradient
+                      degrees={264}
+                    />
+                  </View>
+                  <Image
+                    source={
+                      Object {
+                        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
+                      }
+                    }
+                  />
+                  <Image
+                    source={
+                      Object {
+                        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
+                      }
+                    }
                   />
                 </View>
-                <Image
-                  source={
-                    Object {
-                      "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
-                    }
-                  }
-                />
-                <Image
-                  source={
-                    Object {
-                      "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
-                    }
-                  }
-                />
               </View>
             </View>
           </View>
-        </View>
-        <View>
-          <Text>
-            Caption
-          </Text>
+          <View>
+            <Text>
+              Caption
+            </Text>
+          </View>
         </View>
       </RCTSafeAreaView>
     </View>
@@ -90,49 +92,51 @@ exports[`2. modal image with custom highressize 1`] = `
       <RCTSafeAreaView>
         <View>
           <View>
-            <Image
-              resizeMode="contain"
-              source={
-                Object {
-                  "testUri": "../../../packages/image/assets/close-button.png",
+            <View>
+              <Image
+                resizeMode="contain"
+                source={
+                  Object {
+                    "testUri": "../../../packages/image/assets/close-button.png",
+                  }
                 }
-              }
-            />
+              />
+            </View>
           </View>
-        </View>
-        <View>
           <View>
             <View>
-              <View
-                aspectRatio={1.5}
-              >
-                <View>
-                  <Gradient
-                    degrees={264}
+              <View>
+                <View
+                  aspectRatio={1.5}
+                >
+                  <View>
+                    <Gradient
+                      degrees={264}
+                    />
+                  </View>
+                  <Image
+                    source={
+                      Object {
+                        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
+                      }
+                    }
+                  />
+                  <Image
+                    source={
+                      Object {
+                        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
+                      }
+                    }
                   />
                 </View>
-                <Image
-                  source={
-                    Object {
-                      "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
-                    }
-                  }
-                />
-                <Image
-                  source={
-                    Object {
-                      "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
-                    }
-                  }
-                />
               </View>
             </View>
           </View>
-        </View>
-        <View>
-          <Text>
-            Caption
-          </Text>
+          <View>
+            <Text>
+              Caption
+            </Text>
+          </View>
         </View>
       </RCTSafeAreaView>
     </View>

--- a/packages/image/modal-image.showcase.js
+++ b/packages/image/modal-image.showcase.js
@@ -1,10 +1,17 @@
 /* eslint-disable react/no-danger, react/prop-types */
 import React, { Fragment } from "react";
-import { Text } from "react-native";
+import { Text, View } from "react-native";
 import ModalImage from "./src/modal-image";
 
 const uri =
-  "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7d2fd06c-a460-11e7-8955-1ad2a9a7928d.jpg?crop=1500%2C844%2C0%2C78&resize=685";
+  "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7d2fd06c-a460-11e7-8955-1ad2a9a7928d.jpg?crop=1500%2C844%2C0%2C78";
+
+const Caption = ({ text, style }) => (
+  <View style={style.container}>
+    <Text style={style.text}>{text("Caption: ", "An example caption")}</Text>
+    <Text style={style.text}>{text("Credits: ", "Example credits")}</Text>
+  </View>
+);
 
 export default {
   children: [
@@ -14,12 +21,7 @@ export default {
           <Text>Click on the image to open the modal</Text>
           <ModalImage
             aspectRatio={16 / 9}
-            caption={
-              <Text>
-                {text("Caption: ", "An example caption")}
-                {text("Credits: ", "Example credits")}
-              </Text>
-            }
+            caption={<Caption text={text} />}
             uri={uri}
           />
         </Fragment>

--- a/packages/image/src/modal-image.js
+++ b/packages/image/src/modal-image.js
@@ -54,17 +54,19 @@ class ModalImage extends Component {
         >
           <View style={styles.modal}>
             <SafeAreaView style={styles.safeViewContainer}>
-              <View style={styles.buttonContainer}>
-                <CloseButton onPress={this.hideModal} />
+              <View style={styles.safeViewInnerContainer}>
+                <View style={styles.buttonContainer}>
+                  <CloseButton onPress={this.hideModal} />
+                </View>
+                <Gestures style={styles.imageContainer}>
+                  <Image
+                    {...this.props}
+                    lowResSize={lowResSize}
+                    style={styles.image}
+                  />
+                </Gestures>
+                {captionWithStyles}
               </View>
-              <Gestures style={styles.imageContainer}>
-                <Image
-                  {...this.props}
-                  lowResSize={lowResSize}
-                  style={styles.image}
-                />
-              </Gestures>
-              {captionWithStyles}
             </SafeAreaView>
           </View>
         </Modal>

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -2,9 +2,9 @@ import { colours, spacing } from "@times-components/styleguide";
 
 const styles = {
   buttonContainer: {
-    marginLeft: spacing(3),
-    marginTop: spacing(3),
-    position: "relative",
+    left: spacing(3),
+    position: "absolute",
+    top: spacing(3),
     zIndex: 1
   },
   closeButton: {
@@ -40,14 +40,21 @@ const styles = {
     justifyContent: "center"
   },
   safeViewContainer: {
+    display: "flex",
     flex: 1
+  },
+  safeViewInnerContainer: {
+    flex: 1,
+    position: "relative"
   }
 };
 
 export const captionStyles = {
   container: {
-    marginBottom: 14,
-    marginHorizontal: 16
+    bottom: 14,
+    left: 16,
+    position: "absolute",
+    right: 16
   },
   text: {
     color: colours.functional.white

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -40,7 +40,6 @@ const styles = {
     justifyContent: "center"
   },
   safeViewContainer: {
-    display: "flex",
     flex: 1
   },
   safeViewInnerContainer: {


### PR DESCRIPTION
I've noticed pinch to zoom for modal images is buggy on iOS – seems to be an issue with PanResponder support within Modals. There's a (closed) issue on react native discussing this which has a workaround. https://github.com/facebook/react-native/issues/14295

Also used absolute positioning for modal elements (caption, x button) in order to improve the vertical centring of the image. Sadly, due to SafeAreaView, we can't perfectly centre (as demonstrated with the below image)

![image](https://user-images.githubusercontent.com/719814/53889584-8ff67100-401e-11e9-8276-bdf60db43733.png)


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
