### PR TITLE
fix: Add standfirst to leaders article in case strapline is empty

### DIFF
--- a/packages/edition-slices/src/tiles/tile-m/index.js
+++ b/packages/edition-slices/src/tiles/tile-m/index.js
@@ -7,7 +7,7 @@ import styles from "./styles";
 const TileM = ({ onPress, tile }) => {
   const {
     strapline,
-    article: { shortHeadline }
+    article: { shortHeadline, standfirst }
   } = tile;
   const tileWithoutLabelAndFlags = { article: { shortHeadline } };
 
@@ -16,7 +16,7 @@ const TileM = ({ onPress, tile }) => {
       <View style={styles.container}>
         <TileSummary
           headlineStyle={styles.headline}
-          strapline={strapline}
+          strapline={strapline || standfirst}
           straplineStyle={styles.strapline}
           tile={tileWithoutLabelAndFlags}
         />

--- a/packages/provider-queries/src/section-fragment.js
+++ b/packages/provider-queries/src/section-fragment.js
@@ -74,6 +74,7 @@ export default gql`
           strapline
           article {
             ...baseArticleProps
+            standfirst
           }
         }
         leader2 {
@@ -81,6 +82,7 @@ export default gql`
           strapline
           article {
             ...baseArticleProps
+            standfirst
           }
         }
         leader3 {
@@ -88,6 +90,7 @@ export default gql`
           strapline
           article {
             ...baseArticleProps
+            standfirst
           }
         }
       }

--- a/packages/provider-queries/src/section-fragment.js
+++ b/packages/provider-queries/src/section-fragment.js
@@ -591,6 +591,7 @@ export default gql`
           strapline
           article {
             ...baseArticleProps
+            standfirst
           }
         }
         leader2 {
@@ -598,6 +599,7 @@ export default gql`
           strapline
           article {
             ...baseArticleProps
+            standfirst
           }
         }
         leader3 {
@@ -605,6 +607,7 @@ export default gql`
           strapline
           article {
             ...baseArticleProps
+            standfirst
           }
         }
       }


### PR DESCRIPTION
Strapline on LeadersSlice is usually null, so we are picking standfirst from the article instead.