### PR TITLE
chore: add myself to the code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # The following people are responsible for this project and its live instances:
-*    neha.srivastava1@news.co.uk tunca.ulubilge@news.co.uk nathaniel.higgins@news.co.uk james.miller@news.co.uk aron.shamash@news.co.uk jaye.marshall@news.co.uk
+*    neha.srivastava1@news.co.uk tunca.ulubilge@news.co.uk nathaniel.higgins@news.co.uk james.miller@news.co.uk aron.shamash@news.co.uk jaye.marshall@news.co.uk valentin.georgiev@news.co.uk


### PR DESCRIPTION
I am adding myself to the code owners

Reasons:
1. No need to ask someone to merge my PR or any already approved PRs
2. Added as a default reviewer