### PR TITLE
fix: inappropriate text wrapping during layout calculation

### DIFF
--- a/packages/utils/src/text-layout/styles/index.ios.js
+++ b/packages/utils/src/text-layout/styles/index.ios.js
@@ -10,7 +10,6 @@ export default {
     position: "absolute",
     right: 0,
     top: 0,
-    width: 100,
     zIndex: -1
   }
 };


### PR DESCRIPTION
In some cases, it seems there was an extra line being inserted during drop cap layout calculation on iOS, as seen below. 

![image (1)](https://user-images.githubusercontent.com/719814/54127575-ff46d900-4401-11e9-80e4-a4b28d7a07f1.png)

I spent quite a long time thinking this was an issue in the layout engine, but eventually ruled that out when I noticed that the height of one of the words going into it was double what it needed to be. When I made the layout text elements appear, I noticed one of the words was wrapping inappropriately, which was throwing off the calculations in the layout engine. 

![image (2)](https://user-images.githubusercontent.com/719814/54127686-46cd6500-4402-11e9-8191-f321e33b3238.png)

It seems that the defined width on the iOS container, which I believe was added to cancel an iOS optimisation from preventing `onLayout` from being called, was causing React Native to intermittently attempt to wrap certain words before it gave up. Removing this defined width prevents the inappropriate wrapping, and it also seems we don't need that defined width to ensure `onLayout` is called.

![image (3)](https://user-images.githubusercontent.com/719814/54127842-a0ce2a80-4402-11e9-96e7-e2bf1fbaf209.png)

In terms of the cause of this inappropriate wrapping, I'm not entirely sure what it is, but it seems it could be connected to https://github.com/facebook/react-native/issues/18258

@jmars you may well be particularly interested in this as you may know more about why the defined width was necessary in the first place. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
