### PR TITLE
fix: update max width so that gutters do not show on landscape iPad Pro 11"

### DIFF
--- a/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
@@ -133,7 +133,7 @@ exports[`3. mobile fullwidth image with caption and credits 1`] = `
   style={
     Object {
       "marginBottom": 10,
-      "maxWidth": 1180,
+      "maxWidth": 1194,
     }
   }
 >
@@ -206,7 +206,7 @@ exports[`4. tablet fullwidth image with caption and credits 1`] = `
   style={
     Object {
       "marginBottom": 10,
-      "maxWidth": 1180,
+      "maxWidth": 1194,
     }
   }
 >

--- a/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
+++ b/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
@@ -133,7 +133,7 @@ exports[`3. mobile fullwidth image with caption and credits 1`] = `
   style={
     Object {
       "marginBottom": 10,
-      "maxWidth": 1180,
+      "maxWidth": 1194,
     }
   }
 >
@@ -206,7 +206,7 @@ exports[`4. tablet fullwidth image with caption and credits 1`] = `
   style={
     Object {
       "marginBottom": 10,
-      "maxWidth": 1180,
+      "maxWidth": 1194,
     }
   }
 >

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-images-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-images-with-style.android.test.js.snap
@@ -17,7 +17,7 @@ exports[`1. a secondary image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -29,7 +29,7 @@ exports[`1. a secondary image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -45,7 +45,7 @@ exports[`1. a secondary image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -57,7 +57,7 @@ exports[`1. a secondary image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -86,7 +86,7 @@ exports[`2. an inline image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -98,7 +98,7 @@ exports[`2. an inline image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -114,7 +114,7 @@ exports[`2. an inline image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -126,7 +126,7 @@ exports[`2. an inline image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -17,7 +17,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -29,7 +29,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -45,7 +45,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -69,7 +69,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -85,7 +85,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -101,7 +101,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -117,7 +117,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -145,7 +145,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -161,7 +161,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -187,7 +187,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -205,7 +205,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -274,7 +274,7 @@ exports[`2. an article with no content 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -286,7 +286,7 @@ exports[`2. an article with no content 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -311,7 +311,7 @@ exports[`2. an article with no content 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -327,7 +327,7 @@ exports[`2. an article with no content 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -356,7 +356,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -368,7 +368,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -392,7 +392,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -416,7 +416,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -428,7 +428,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -457,7 +457,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -469,7 +469,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -485,7 +485,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -511,7 +511,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -527,7 +527,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -543,7 +543,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -559,7 +559,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -587,7 +587,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -603,7 +603,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -629,7 +629,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -654,7 +654,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-images-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-images-with-style.ios.test.js.snap
@@ -17,7 +17,7 @@ exports[`1. a secondary image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -29,7 +29,7 @@ exports[`1. a secondary image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -45,7 +45,7 @@ exports[`1. a secondary image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -57,7 +57,7 @@ exports[`1. a secondary image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -86,7 +86,7 @@ exports[`2. an inline image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -98,7 +98,7 @@ exports[`2. an inline image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -114,7 +114,7 @@ exports[`2. an inline image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -126,7 +126,7 @@ exports[`2. an inline image 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-scaling.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-scaling.ios.test.js.snap
@@ -17,7 +17,7 @@ exports[`1. scaled medium full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -29,7 +29,7 @@ exports[`1. scaled medium full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -45,7 +45,7 @@ exports[`1. scaled medium full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -72,7 +72,7 @@ exports[`1. scaled medium full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -96,7 +96,7 @@ exports[`1. scaled medium full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -125,7 +125,7 @@ exports[`2. scaled large full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -137,7 +137,7 @@ exports[`2. scaled large full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -153,7 +153,7 @@ exports[`2. scaled large full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -180,7 +180,7 @@ exports[`2. scaled large full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -204,7 +204,7 @@ exports[`2. scaled large full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -233,7 +233,7 @@ exports[`3. scaled xlarge full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -245,7 +245,7 @@ exports[`3. scaled xlarge full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -261,7 +261,7 @@ exports[`3. scaled xlarge full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -288,7 +288,7 @@ exports[`3. scaled xlarge full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -312,7 +312,7 @@ exports[`3. scaled xlarge full article 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -17,7 +17,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -29,7 +29,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -45,7 +45,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -69,7 +69,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -85,7 +85,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -101,7 +101,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -117,7 +117,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -145,7 +145,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -161,7 +161,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -187,7 +187,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -205,7 +205,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -274,7 +274,7 @@ exports[`2. an article with no content 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -286,7 +286,7 @@ exports[`2. an article with no content 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -311,7 +311,7 @@ exports[`2. an article with no content 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -327,7 +327,7 @@ exports[`2. an article with no content 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -356,7 +356,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -368,7 +368,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -392,7 +392,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -416,7 +416,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -428,7 +428,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -457,7 +457,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         />
@@ -469,7 +469,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -485,7 +485,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -511,7 +511,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -527,7 +527,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -543,7 +543,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -559,7 +559,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -587,7 +587,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -603,7 +603,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -629,7 +629,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >
@@ -654,7 +654,7 @@ exports[`4. an article skeleton with responsive items 1`] = `
               "alignSelf": "center",
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "width": 1180,
+              "width": 1194,
             }
           }
         >

--- a/packages/styleguide/src/breakpoints/index.js
+++ b/packages/styleguide/src/breakpoints/index.js
@@ -25,7 +25,7 @@ export default {
   huge: 1320,
   medium: 768,
   nativeTablet: 660,
-  nativeTabletWide: 1180,
+  nativeTabletWide: 1194,
   small: 520,
   wide: 1024
 };


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/719814/54137343-6752ea80-4415-11e9-8c9d-8e9063abd0a0.png)

After:

![image](https://user-images.githubusercontent.com/719814/54137389-805b9b80-4415-11e9-9c35-5b476692efcf.png)

Update the max width so that the tiny gutters currently present on the 11" iPad are no longer present. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
