### PR TITLE
chore: Improve Article Label coverage in templates

### DIFF
--- a/packages/article-in-depth/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
@@ -11,18 +11,27 @@ exports[`1. article standfirst with content 1`] = `
 
 exports[`2. article standfirst with no content 1`] = `null`;
 
-exports[`3. article label uses default section colour 1`] = `
+exports[`3. article label uses a colour if override is provided 1`] = `
 <View>
   <ArticleLabel
-    color="#FFFFFF"
+    color="#000000"
     title="Random Label"
   />
 </View>
 `;
 
-exports[`4. article label renders null if there is no text 1`] = `null`;
+exports[`4. article label uses the video label when isvideo is truthy 1`] = `
+<View>
+  <VideoLabel
+    color="#1D1D1B"
+    title="Random Label"
+  />
+</View>
+`;
 
-exports[`5. article meta uses default section colour 1`] = `
+exports[`5. article label renders null if there is no text 1`] = `null`;
+
+exports[`6. article meta uses default section colour 1`] = `
 <View>
   <View>
     <ArticleBylineWithLinks

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
@@ -11,18 +11,27 @@ exports[`1. article standfirst with content 1`] = `
 
 exports[`2. article standfirst with no content 1`] = `null`;
 
-exports[`3. article label uses default section colour 1`] = `
+exports[`3. article label uses a colour if override is provided 1`] = `
 <View>
   <ArticleLabel
-    color="#FFFFFF"
+    color="#000000"
     title="Random Label"
   />
 </View>
 `;
 
-exports[`4. article label renders null if there is no text 1`] = `null`;
+exports[`4. article label uses the video label when isvideo is truthy 1`] = `
+<View>
+  <VideoLabel
+    color="#1D1D1B"
+    title="Random Label"
+  />
+</View>
+`;
 
-exports[`5. article meta uses default section colour 1`] = `
+exports[`5. article label renders null if there is no text 1`] = `null`;
+
+exports[`6. article meta uses default section colour 1`] = `
 <View>
   <View>
     <ArticleBylineWithLinks

--- a/packages/article-in-depth/__tests__/mocks.native.js
+++ b/packages/article-in-depth/__tests__/mocks.native.js
@@ -32,4 +32,6 @@ jest.mock("@times-components/pull-quote", () => "PullQuote");
 jest.mock("@times-components/related-articles", () => "RelatedArticles");
 jest.mock("@times-components/watermark", () => "Watermark");
 jest.mock("@times-components/video", () => "Video");
+jest.mock("@times-components/video-label", () => "VideoLabel");
+
 mockNativeModules();

--- a/packages/article-in-depth/__tests__/mocks.web.js
+++ b/packages/article-in-depth/__tests__/mocks.web.js
@@ -14,3 +14,4 @@ jest.mock("@times-components/image", () => "Image");
 jest.mock("@times-components/link", () => "Link");
 jest.mock("@times-components/pull-quote", () => "PullQuote");
 jest.mock("@times-components/related-articles", () => "RelatedArticles");
+jest.mock("@times-components/video-label", () => "VideoLabel");

--- a/packages/article-in-depth/__tests__/shared-internal-components.base.js
+++ b/packages/article-in-depth/__tests__/shared-internal-components.base.js
@@ -30,8 +30,7 @@ const snapshotTests = renderComponent => [
     name: "article label uses a colour if override is provided",
     test() {
       const output = renderComponent(
-
-          <Label label="Random Label" color="#000000" />
+        <Label color="#000000" label="Random Label" />
       );
 
       expect(output).toMatchSnapshot();
@@ -40,9 +39,7 @@ const snapshotTests = renderComponent => [
   {
     name: "article label uses the video label when isVideo is truthy",
     test() {
-      const output = renderComponent(
-          <Label label="Random Label" isVideo />
-      );
+      const output = renderComponent(<Label isVideo label="Random Label" />);
 
       expect(output).toMatchSnapshot();
     }

--- a/packages/article-in-depth/__tests__/shared-internal-components.base.js
+++ b/packages/article-in-depth/__tests__/shared-internal-components.base.js
@@ -27,16 +27,21 @@ const snapshotTests = renderComponent => [
     }
   },
   {
-    name: "article label uses default section colour",
+    name: "article label uses a colour if override is provided",
     test() {
       const output = renderComponent(
-        <Context.Provider
-          value={{
-            theme: { sectionColour: null }
-          }}
-        >
-          <Label label="Random Label" />
-        </Context.Provider>
+
+          <Label label="Random Label" color="#000000" />
+      );
+
+      expect(output).toMatchSnapshot();
+    }
+  },
+  {
+    name: "article label uses the video label when isVideo is truthy",
+    test() {
+      const output = renderComponent(
+          <Label label="Random Label" isVideo />
       );
 
       expect(output).toMatchSnapshot();

--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-internal-components.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-internal-components.web.test.js.snap
@@ -11,7 +11,7 @@ exports[`1. article standfirst with content 1`] = `
 
 exports[`2. article standfirst with no content 1`] = `null`;
 
-exports[`3. article label uses default section colour 1`] = `
+exports[`3. article label uses a colour if override is provided 1`] = `
 <div>
   <div>
     RANDOM LABEL
@@ -19,9 +19,18 @@ exports[`3. article label uses default section colour 1`] = `
 </div>
 `;
 
-exports[`4. article label renders null if there is no text 1`] = `null`;
+exports[`4. article label uses the video label when isvideo is truthy 1`] = `
+<div>
+  <VideoLabel
+    color="#1D1D1B"
+    title="Random Label"
+  />
+</div>
+`;
 
-exports[`5. article meta uses default section colour 1`] = `
+exports[`5. article label renders null if there is no text 1`] = `null`;
+
+exports[`6. article meta uses default section colour 1`] = `
 <div>
   <div>
     <ArticleBylineWithLinks

--- a/packages/article-in-depth/src/article-label/article-label-prop-types.js
+++ b/packages/article-in-depth/src/article-label/article-label-prop-types.js
@@ -8,7 +8,7 @@ const articleLabelPropTypes = {
 };
 
 const articleLabelDefaultProps = {
-  color: colours.functional.white,
+  color: colours.section.default,
   isVideo: false,
   label: null
 };

--- a/packages/article-in-depth/src/article-label/article-label.js
+++ b/packages/article-in-depth/src/article-label/article-label.js
@@ -17,7 +17,7 @@ const HeaderLabel = ({ color, isVideo, label }) => {
 
   return (
     <View style={styles.label}>
-      <Label color={color || colours.section.default} title={label} />
+      <Label color={color} title={label} />
     </View>
   );
 };

--- a/packages/article-in-depth/src/article-label/article-label.js
+++ b/packages/article-in-depth/src/article-label/article-label.js
@@ -2,7 +2,6 @@ import React from "react";
 import { View } from "react-native";
 import ArticleLabel from "@times-components/article-label";
 import VideoLabel from "@times-components/video-label";
-import { colours } from "@times-components/styleguide";
 
 import {
   articleLabelPropTypes,

--- a/packages/article-magazine-comment/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
@@ -22,7 +22,16 @@ exports[`3. article label uses default section colour 1`] = `
 
 exports[`4. article label renders null if there is no text 1`] = `null`;
 
-exports[`5. article meta 1`] = `
+exports[`5. article label shows video label is isvideo is truthy 1`] = `
+<View>
+  <VideoLabel
+    color="#1D1D1B"
+    title="Random Label"
+  />
+</View>
+`;
+
+exports[`6. article meta 1`] = `
 <View>
   <View>
     <ArticleBylineWithLinks

--- a/packages/article-magazine-comment/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
@@ -22,7 +22,16 @@ exports[`3. article label uses default section colour 1`] = `
 
 exports[`4. article label renders null if there is no text 1`] = `null`;
 
-exports[`5. article meta 1`] = `
+exports[`5. article label shows video label is isvideo is truthy 1`] = `
+<View>
+  <VideoLabel
+    color="#1D1D1B"
+    title="Random Label"
+  />
+</View>
+`;
+
+exports[`6. article meta 1`] = `
 <View>
   <View>
     <ArticleBylineWithLinks

--- a/packages/article-magazine-comment/__tests__/mocks.native.js
+++ b/packages/article-magazine-comment/__tests__/mocks.native.js
@@ -32,4 +32,6 @@ jest.mock("@times-components/pull-quote", () => "PullQuote");
 jest.mock("@times-components/related-articles", () => "RelatedArticles");
 jest.mock("@times-components/watermark", () => "Watermark");
 jest.mock("@times-components/video", () => "Video");
+jest.mock("@times-components/video-label", () => "VideoLabel");
+
 mockNativeModules();

--- a/packages/article-magazine-comment/__tests__/mocks.web.js
+++ b/packages/article-magazine-comment/__tests__/mocks.web.js
@@ -19,3 +19,4 @@ jest.mock("@times-components/image", () => "Image");
 jest.mock("@times-components/link", () => "Link");
 jest.mock("@times-components/pull-quote", () => "PullQuote");
 jest.mock("@times-components/related-articles", () => "RelatedArticles");
+jest.mock("@times-components/video-label", () => "VideoLabel");

--- a/packages/article-magazine-comment/__tests__/shared-internal-components.base.js
+++ b/packages/article-magazine-comment/__tests__/shared-internal-components.base.js
@@ -51,6 +51,14 @@ const snapshotTests = renderComponent => [
     }
   },
   {
+    name: "article label shows video label is isVideo is truthy",
+    test() {
+      const output = renderComponent(<Label label="Random Label" isVideo />);
+
+      expect(output).toMatchSnapshot();
+    }
+  },
+  {
     name: "article meta",
     test() {
       const output = renderComponent(

--- a/packages/article-magazine-comment/__tests__/shared-internal-components.base.js
+++ b/packages/article-magazine-comment/__tests__/shared-internal-components.base.js
@@ -53,7 +53,7 @@ const snapshotTests = renderComponent => [
   {
     name: "article label shows video label is isVideo is truthy",
     test() {
-      const output = renderComponent(<Label label="Random Label" isVideo />);
+      const output = renderComponent(<Label isVideo label="Random Label" />);
 
       expect(output).toMatchSnapshot();
     }

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-internal-components.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-internal-components.web.test.js.snap
@@ -21,7 +21,16 @@ exports[`3. article label uses default section colour 1`] = `
 
 exports[`4. article label renders null if there is no text 1`] = `null`;
 
-exports[`5. article meta 1`] = `
+exports[`5. article label shows video label is isvideo is truthy 1`] = `
+<div>
+  <VideoLabel
+    color="#1D1D1B"
+    title="Random Label"
+  />
+</div>
+`;
+
+exports[`6. article meta 1`] = `
 <div>
   <div>
     <ArticleBylineWithLinks

--- a/packages/article-magazine-standard/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
@@ -22,7 +22,16 @@ exports[`3. article label uses default section colour 1`] = `
 
 exports[`4. article label renders null if there is no text 1`] = `null`;
 
-exports[`5. article meta uses default section colour 1`] = `
+exports[`5. article label shows video label is isvideo is truthy 1`] = `
+<View>
+  <VideoLabel
+    color="#1D1D1B"
+    title="Random Label"
+  />
+</View>
+`;
+
+exports[`6. article meta uses default section colour 1`] = `
 <View>
   <View>
     <ArticleBylineWithLinks

--- a/packages/article-magazine-standard/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
@@ -22,7 +22,16 @@ exports[`3. article label uses default section colour 1`] = `
 
 exports[`4. article label renders null if there is no text 1`] = `null`;
 
-exports[`5. article meta uses default section colour 1`] = `
+exports[`5. article label shows video label is isvideo is truthy 1`] = `
+<View>
+  <VideoLabel
+    color="#1D1D1B"
+    title="Random Label"
+  />
+</View>
+`;
+
+exports[`6. article meta uses default section colour 1`] = `
 <View>
   <View>
     <ArticleBylineWithLinks

--- a/packages/article-magazine-standard/__tests__/mocks.native.js
+++ b/packages/article-magazine-standard/__tests__/mocks.native.js
@@ -36,4 +36,6 @@ jest.mock("@times-components/pull-quote", () => "PullQuote");
 jest.mock("@times-components/related-articles", () => "RelatedArticles");
 jest.mock("@times-components/watermark", () => "Watermark");
 jest.mock("@times-components/video", () => "Video");
+jest.mock("@times-components/video-label", () => "VideoLabel");
+
 mockNativeModules();

--- a/packages/article-magazine-standard/__tests__/mocks.web.js
+++ b/packages/article-magazine-standard/__tests__/mocks.web.js
@@ -19,3 +19,4 @@ jest.mock("@times-components/image", () => "Image");
 jest.mock("@times-components/link", () => "Link");
 jest.mock("@times-components/pull-quote", () => "PullQuote");
 jest.mock("@times-components/related-articles", () => "RelatedArticles");
+jest.mock("@times-components/video-label", () => "VideoLabel");

--- a/packages/article-magazine-standard/__tests__/shared-internal-components.base.js
+++ b/packages/article-magazine-standard/__tests__/shared-internal-components.base.js
@@ -51,6 +51,14 @@ const snapshotTests = renderComponent => [
     }
   },
   {
+    name: "article label shows video label is isVideo is truthy",
+    test() {
+      const output = renderComponent(<Label label="Random Label" isVideo />);
+
+      expect(output).toMatchSnapshot();
+    }
+  },
+  {
     name: "article meta uses default section colour",
     test() {
       const output = renderComponent(

--- a/packages/article-magazine-standard/__tests__/shared-internal-components.base.js
+++ b/packages/article-magazine-standard/__tests__/shared-internal-components.base.js
@@ -53,7 +53,7 @@ const snapshotTests = renderComponent => [
   {
     name: "article label shows video label is isVideo is truthy",
     test() {
-      const output = renderComponent(<Label label="Random Label" isVideo />);
+      const output = renderComponent(<Label isVideo label="Random Label" />);
 
       expect(output).toMatchSnapshot();
     }

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-internal-components.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-internal-components.web.test.js.snap
@@ -21,7 +21,16 @@ exports[`3. article label uses default section colour 1`] = `
 
 exports[`4. article label renders null if there is no text 1`] = `null`;
 
-exports[`5. article meta uses default section colour 1`] = `
+exports[`5. article label shows video label is isvideo is truthy 1`] = `
+<div>
+  <VideoLabel
+    color="#1D1D1B"
+    title="Random Label"
+  />
+</div>
+`;
+
+exports[`6. article meta uses default section colour 1`] = `
 <div>
   <div>
     <ArticleBylineWithLinks

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
@@ -22,7 +22,16 @@ exports[`3. article label uses default section colour 1`] = `
 
 exports[`4. article label renders null if there is no text 1`] = `null`;
 
-exports[`5. article meta 1`] = `
+exports[`5. article label shows video label is isvideo is truthy 1`] = `
+<View>
+  <VideoLabel
+    color="#1D1D1B"
+    title="Random Label"
+  />
+</View>
+`;
+
+exports[`6. article meta 1`] = `
 <View>
   <View>
     <ArticleBylineWithLinks

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
@@ -22,7 +22,16 @@ exports[`3. article label uses default section colour 1`] = `
 
 exports[`4. article label renders null if there is no text 1`] = `null`;
 
-exports[`5. article meta 1`] = `
+exports[`5. article label shows video label is isvideo is truthy 1`] = `
+<View>
+  <VideoLabel
+    color="#1D1D1B"
+    title="Random Label"
+  />
+</View>
+`;
+
+exports[`6. article meta 1`] = `
 <View>
   <View>
     <ArticleBylineWithLinks

--- a/packages/article-main-comment/__tests__/mocks.native.js
+++ b/packages/article-main-comment/__tests__/mocks.native.js
@@ -27,4 +27,6 @@ jest.mock("@times-components/pull-quote", () => "PullQuote");
 jest.mock("@times-components/related-articles", () => "RelatedArticles");
 jest.mock("@times-components/watermark", () => "Watermark");
 jest.mock("@times-components/video", () => "Video");
+jest.mock("@times-components/video-label", () => "VideoLabel");
+
 mockNativeModules();

--- a/packages/article-main-comment/__tests__/mocks.web.js
+++ b/packages/article-main-comment/__tests__/mocks.web.js
@@ -15,3 +15,4 @@ jest.mock("@times-components/image", () => "Image");
 jest.mock("@times-components/link", () => "Link");
 jest.mock("@times-components/pull-quote", () => "PullQuote");
 jest.mock("@times-components/related-articles", () => "RelatedArticles");
+jest.mock("@times-components/video-label", () => "VideoLabel");

--- a/packages/article-main-comment/__tests__/shared-internal-components.base.js
+++ b/packages/article-main-comment/__tests__/shared-internal-components.base.js
@@ -51,6 +51,14 @@ const snapshotTests = renderComponent => [
     }
   },
   {
+    name: "article label shows video label is isVideo is truthy",
+    test() {
+      const output = renderComponent(<Label label="Random Label" isVideo />);
+
+      expect(output).toMatchSnapshot();
+    }
+  },
+  {
     name: "article meta",
     test() {
       const output = renderComponent(

--- a/packages/article-main-comment/__tests__/shared-internal-components.base.js
+++ b/packages/article-main-comment/__tests__/shared-internal-components.base.js
@@ -53,7 +53,7 @@ const snapshotTests = renderComponent => [
   {
     name: "article label shows video label is isVideo is truthy",
     test() {
-      const output = renderComponent(<Label label="Random Label" isVideo />);
+      const output = renderComponent(<Label isVideo label="Random Label" />);
 
       expect(output).toMatchSnapshot();
     }

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-internal-components.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-internal-components.web.test.js.snap
@@ -21,7 +21,16 @@ exports[`3. article label uses default section colour 1`] = `
 
 exports[`4. article label renders null if there is no text 1`] = `null`;
 
-exports[`5. article meta 1`] = `
+exports[`5. article label shows video label is isvideo is truthy 1`] = `
+<div>
+  <VideoLabel
+    color="#1D1D1B"
+    title="Random Label"
+  />
+</div>
+`;
+
+exports[`6. article meta 1`] = `
 <div>
   <div>
     <ArticleBylineWithLinks

--- a/packages/slice-layout/package.json
+++ b/packages/slice-layout/package.json
@@ -41,7 +41,7 @@
     "@times-components/jest-configurator": "2.3.2",
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/storybook": "3.4.3",
-    "@times-components/styleguide": "3.25.2",
+    "@times-components/styleguide": "3.25.3",
     "@times-components/test-utils": "2.2.10",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",


### PR DESCRIPTION
Non-default templates are not covering everything for their article labels.

Ideally with the Design Review PR this should increase the coverage by a fair bit.