### PR TITLE
feat: Add new params to section clicks

### DIFF
--- a/packages/edition-slices/src/slices/puzzle/index.js
+++ b/packages/edition-slices/src/slices/puzzle/index.js
@@ -7,11 +7,11 @@ import propTypes from "./proptypes";
 import styles from "./styles";
 import withTracking from "./puzzle-tracking-events";
 
-const Puzzle = ({ onPress, slice: { title, url, image } }) => {
+const Puzzle = ({ onPress, slice: { id, title, url, image } }) => {
   const { main, header, headLine, body } = styles;
 
   return (
-    <Link onPress={e => onPress(e, { url })} url={url}>
+    <Link onPress={e => onPress({ id, title, url })} url={url}>
       <View style={main}>
         <View style={header}>
           <ArticleSummaryHeadline headline={title} style={headLine} />

--- a/packages/edition-slices/src/tiles/shared/tile-link.js
+++ b/packages/edition-slices/src/tiles/shared/tile-link.js
@@ -7,10 +7,10 @@ const TileLink = ({
   onPress,
   style,
   tile: {
-    article: { url }
+    article: { id, url }
   }
 }) => (
-  <Link linkStyle={style} onPress={e => onPress(e, { url })} url={url}>
+  <Link linkStyle={style} onPress={e => onPress({ id, url })} url={url}>
     {children}
   </Link>
 );

--- a/packages/pages/src/section/index.js
+++ b/packages/pages/src/section/index.js
@@ -29,8 +29,8 @@ const SectionPage = ({ editionId, publicationName, section, sectionTitle }) => {
     section ? (
       <Section
         analyticsStream={analyticsStream}
-        onArticlePress={(_, { url }) => onArticlePress(url)}
-        onPuzzlePress={(_, { url }) => onPuzzlePress(url)}
+        onArticlePress={({ id, url }) => onArticlePress(url, id)}
+        onPuzzlePress={({ id, title, url }) => onPuzzlePress(url, title, id)}
         publicationName={publicationName}
         section={JSON.parse(section)}
       />


### PR DESCRIPTION
Added a few new params to onArticlePress and onPuzzlePress, as per native teams' requests

- onArticlePress( url, id )
- onPuzzlePress( url, title, id )