### PR TITLE
fix: portrait images in modals

### DIFF
--- a/packages/article-image/__tests__/web/__snapshots__/article-image.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image.web.test.js.snap
@@ -32,9 +32,7 @@ Array [
           alt=""
           src="https://img/someImage"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>,
@@ -75,9 +73,7 @@ Array [
           alt=""
           src="https://img/someImage"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>,
@@ -111,9 +107,7 @@ Array [
           alt=""
           src="https://img/someImage?resize=50"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>,

--- a/packages/article-list/__tests__/web/__snapshots__/article-list-error-with-styles.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list-error-with-styles.web.test.js.snap
@@ -80,28 +80,6 @@ exports[`1. page error 1`] = `
   align-items: stretch;
   border-top-width: 0px;
   border-bottom-width: 0px;
-  -ms-flex-direction: column;
-  -webkit-box-direction: normal;
-  -webkit-box-orient: vertical;
-  -webkit-flex-direction: column;
-  flex-direction: column;
-  margin-top: 0px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  min-height: 0px;
-  padding-top: 0px;
-  padding-bottom: 0px;
-  position: relative;
-}
-
-.S2 {
-  -ms-flex-align: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  align-items: stretch;
-  border-top-width: 0px;
-  border-bottom-width: 0px;
   bottom: 0px;
   -ms-flex-direction: column;
   -webkit-box-direction: normal;
@@ -117,6 +95,28 @@ exports[`1. page error 1`] = `
   padding-bottom: 0px;
   position: absolute;
   right: 0px;
+}
+
+.S2 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  min-height: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  position: relative;
 }
 
 .S3 {
@@ -154,6 +154,16 @@ exports[`1. page error 1`] = `
 
 .IS1 {
   background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 
 .IS2 {
@@ -171,13 +181,13 @@ exports[`1. page error 1`] = `
 </style>
 
 <div
-  className="c0 S1"
+  className="c0 S2"
 >
   <div
-    className="c1 S1"
+    className="c1 S2"
   >
     <div
-      className="S1"
+      className="S2"
     >
       <div
         className="IS2"
@@ -186,17 +196,13 @@ exports[`1. page error 1`] = `
           className="c2"
         />
         <div
-          className="S2"
-        >
-          <div
-            className="S1 IS1"
-          />
-        </div>
+          className="S1 IS1"
+        />
       </div>
     </div>
   </div>
   <div
-    className="c3 S1"
+    className="c3 S2"
   >
     <div
       className="S3"

--- a/packages/article-list/__tests__/web/__snapshots__/article-list-error.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list-error.web.test.js.snap
@@ -9,9 +9,7 @@ exports[`1. page error 1`] = `
           alt=""
           src="2d7dffcd8e7f3cde3e959c364dc3d432"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>

--- a/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
@@ -150,10 +150,22 @@ exports[`1. card loading state 1`] = `
 }
 
 .IS2 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
   flex: 1;
 }
 
 .IS3 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
   flex: 1;
 }
 
@@ -490,10 +502,22 @@ exports[`2. card with reversed loading state 1`] = `
 }
 
 .IS14 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
   flex: 1;
 }
 
 .IS15 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
   flex: 1;
 }
 

--- a/packages/card/__tests__/web/__snapshots__/card-render-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-render-style.test.js.snap
@@ -100,10 +100,22 @@ exports[`card with default layout 1`] = `
 }
 
 .IS2 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
   flex: 1;
 }
 
 .IS3 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
   flex: 1;
 }
 

--- a/packages/card/__tests__/web/__snapshots__/card-reverse-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-reverse-style.test.js.snap
@@ -101,10 +101,22 @@ exports[`card with reversed layout 1`] = `
 }
 
 .IS2 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
   flex: 1;
 }
 
 .IS3 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
   flex: 1;
 }
 

--- a/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
@@ -227,9 +227,7 @@ exports[`11. card should not re-render when imageratio prop is changed 1`] = `
           alt=""
           src="https://img.io/img?resize=50"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>
@@ -254,9 +252,7 @@ exports[`11. card should not re-render when imageratio prop is changed 2`] = `
           alt=""
           src="https://img.io/img?resize=50"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>
@@ -281,9 +277,7 @@ exports[`12. card should re-render when image uri changes 1`] = `
           alt=""
           src="https://img.io/img?resize=50"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>
@@ -308,9 +302,7 @@ exports[`12. card should re-render when image uri changes 2`] = `
           alt=""
           src="http://foo?resize=50"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>
@@ -335,9 +327,7 @@ exports[`13. card should re-render when low res size changes 1`] = `
           alt=""
           src="https://img.io/img?resize=50"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>
@@ -358,9 +348,7 @@ exports[`13. card should re-render when low res size changes 2`] = `
           alt=""
           src="https://img.io/img?resize=360"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>
@@ -385,9 +373,7 @@ exports[`14. card should re-render when high res size changes 1`] = `
           alt=""
           src="https://img.io/img?resize=50"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>
@@ -408,9 +394,7 @@ exports[`14. card should re-render when high res size changes 2`] = `
           alt=""
           src="https://img.io/img?resize=50"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>
@@ -436,9 +420,7 @@ exports[`15. card should re-render when loading state changes 1`] = `
             alt=""
             src="https://img.io/img?resize=50"
           />
-          <div>
-            <div />
-          </div>
+          <div />
         </div>
       </div>
     </div>
@@ -465,9 +447,7 @@ exports[`15. card should re-render when loading state changes 2`] = `
           alt=""
           src="https://img.io/img?resize=50"
         />
-        <div>
-          <div />
-        </div>
+        <div />
       </div>
     </div>
   </div>

--- a/packages/gradient/__tests__/android/__snapshots__/gradient-with-style.android.test.js.snap
+++ b/packages/gradient/__tests__/android/__snapshots__/gradient-with-style.android.test.js.snap
@@ -4,6 +4,7 @@ exports[`1. gradient using prop styles 1`] = `
 <View
   style={
     Object {
+      "backgroundColor": "#F9F9F9",
       "flex": 1,
       "height": 200,
       "width": 200,
@@ -32,6 +33,7 @@ exports[`2. gradient using array prop styles 1`] = `
 <View
   style={
     Object {
+      "backgroundColor": "#F9F9F9",
       "flex": 1,
       "height": 300,
       "width": 400,
@@ -60,6 +62,7 @@ exports[`3. gradient using stylesheets 1`] = `
 <View
   style={
     Object {
+      "backgroundColor": "#F9F9F9",
       "flex": 1,
       "height": 200,
       "margin": 10,

--- a/packages/gradient/__tests__/ios/__snapshots__/gradient-with-style.ios.test.js.snap
+++ b/packages/gradient/__tests__/ios/__snapshots__/gradient-with-style.ios.test.js.snap
@@ -4,6 +4,7 @@ exports[`1. gradient using prop styles 1`] = `
 <View
   style={
     Object {
+      "backgroundColor": "#F9F9F9",
       "flex": 1,
       "height": 200,
       "width": 200,
@@ -32,6 +33,7 @@ exports[`2. gradient using array prop styles 1`] = `
 <View
   style={
     Object {
+      "backgroundColor": "#F9F9F9",
       "flex": 1,
       "height": 300,
       "width": 400,
@@ -60,6 +62,7 @@ exports[`3. gradient using stylesheets 1`] = `
 <View
   style={
     Object {
+      "backgroundColor": "#F9F9F9",
       "flex": 1,
       "height": 200,
       "margin": 10,

--- a/packages/gradient/__tests__/shared.base.js
+++ b/packages/gradient/__tests__/shared.base.js
@@ -1,6 +1,5 @@
 import React from "react";
-import { Text } from "react-native";
-import { shallow } from "enzyme";
+import { ART, Text } from "react-native";
 import { iterator } from "@times-components/test-utils";
 import Gradient, { OverlayGradient } from "../src/gradient";
 import GradientBase from "../src/gradient.base";
@@ -53,20 +52,63 @@ export default renderMethod => {
       }
     },
     {
-      name:
-        "when receiving a width and height from native, the state is correctly set",
+      name: "gradient defaults to size of its container",
       test: () => {
-        const component = shallow(
+        const testRenderer = renderMethod(
           <GradientBase endColour="#FFFFFF" startColour="#000000" />
         );
-        component.instance().onLayout(
+        const testInstance = testRenderer.root;
+        const view = testInstance.find(child => !!child.props.onLayout);
+
+        view.props.onLayout(
           makeMessageEvent({
             height: 100,
             width: 100
           })
         );
-        expect(component.state().width).toEqual(100);
-        expect(component.state().height).toEqual(100);
+        const surface = testInstance.findByType(ART.Surface);
+
+        expect(surface.props).toEqual(
+          expect.objectContaining({ height: 100, width: 100 })
+        );
+      }
+    },
+    {
+      name: "can override gradient size with custom width and height",
+      test: () => {
+        const testRenderer = renderMethod(
+          <GradientBase
+            endColour="#FFFFFF"
+            height={200}
+            startColour="#000000"
+            width={300}
+          />
+        );
+        const testInstance = testRenderer.root;
+        const surface = testInstance.findByType(ART.Surface);
+
+        expect(surface.props).toEqual(
+          expect.objectContaining({ height: 200, width: 300 })
+        );
+      }
+    },
+    {
+      name: "does not use onLayout when custom width and height passed",
+      test: () => {
+        const testRenderer = renderMethod(
+          <GradientBase
+            endColour="#FFFFFF"
+            height={200}
+            startColour="#000000"
+            width={300}
+          />
+        );
+        const testInstance = testRenderer.root;
+        const onLayoutViews = testInstance.findAll(
+          child => !!child.props.onLayout
+        );
+
+        expect(onLayoutViews).toHaveLength(0);
       }
     }
   ];

--- a/packages/gradient/src/gradient-prop-types-shared.js
+++ b/packages/gradient/src/gradient-prop-types-shared.js
@@ -1,0 +1,19 @@
+import PropTypes from "prop-types";
+import { ViewPropTypes } from "react-native";
+
+const { style: ViewPropTypesStyle } = ViewPropTypes;
+
+export const propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.arrayOf(PropTypes.element)
+  ]),
+  degrees: PropTypes.number,
+  style: ViewPropTypesStyle
+};
+
+export const defaultProps = {
+  children: null,
+  degrees: 265,
+  style: null
+};

--- a/packages/gradient/src/gradient-prop-types.js
+++ b/packages/gradient/src/gradient-prop-types.js
@@ -1,19 +1,17 @@
 import PropTypes from "prop-types";
-import { ViewPropTypes } from "react-native";
-
-const { style: ViewPropTypesStyle } = ViewPropTypes;
+import {
+  propTypes as sharedPropTypes,
+  defaultProps as sharedDefaultProps
+} from "./gradient-prop-types-shared";
 
 export const propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.arrayOf(PropTypes.element)
-  ]),
-  degrees: PropTypes.number,
-  style: ViewPropTypesStyle
+  ...sharedPropTypes,
+  height: PropTypes.number,
+  width: PropTypes.number
 };
 
 export const defaultProps = {
-  children: null,
-  degrees: 265,
-  style: null
+  ...sharedDefaultProps,
+  height: 0,
+  width: 0
 };

--- a/packages/gradient/src/gradient-prop-types.web.js
+++ b/packages/gradient/src/gradient-prop-types.web.js
@@ -1,0 +1,1 @@
+export { propTypes, defaultProps } from "./gradient-prop-types-shared";

--- a/packages/gradient/src/gradient.base.js
+++ b/packages/gradient/src/gradient.base.js
@@ -53,7 +53,10 @@ class GradientBase extends Component {
     const onLayoutProps = height && width ? {} : { onLayout: this.onLayout };
 
     return (
-      <View {...onLayoutProps} style={[styles.container, style]}>
+      <View
+        {...onLayoutProps}
+        style={[{ backgroundColor: startColour }, styles.container, style]}
+      >
         <Surface height={height} style={styles.surface} width={width}>
           <Shape
             d={d}

--- a/packages/gradient/src/gradient.base.js
+++ b/packages/gradient/src/gradient.base.js
@@ -10,8 +10,7 @@ class GradientBase extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      height: 0,
-      width: 0
+      dimensions: null
     };
   }
 
@@ -21,13 +20,26 @@ class GradientBase extends Component {
     }
   }) => {
     this.setState({
-      height,
-      width
+      dimensions: {
+        height,
+        width
+      }
     });
   };
 
+  getDimensions() {
+    const { dimensions } = this.state;
+    const { height, width } = this.props;
+
+    if (dimensions) {
+      return dimensions;
+    }
+
+    return { height, width };
+  }
+
   render() {
-    const { height, width } = this.state;
+    const { height, width } = this.getDimensions();
     const { children, degrees, startColour, endColour, style } = this.props;
 
     const { start, end } = angleToPoints(((degrees + 90) / 180) * Math.PI);
@@ -38,8 +50,10 @@ class GradientBase extends Component {
       .line(-width, 0)
       .line(0, -height);
 
+    const onLayoutProps = height && width ? {} : { onLayout: this.onLayout };
+
     return (
-      <View onLayout={this.onLayout} style={[styles.container, style]}>
+      <View {...onLayoutProps} style={[styles.container, style]}>
         <Surface height={height} style={styles.surface} width={width}>
           <Shape
             d={d}

--- a/packages/gradient/src/gradient.js
+++ b/packages/gradient/src/gradient.js
@@ -3,15 +3,12 @@ import { colours } from "@times-components/styleguide";
 import { defaultProps, propTypes } from "./gradient-prop-types";
 import GradientBase from "./gradient.base";
 
-const Gradient = ({ children, degrees, style }) => (
+const Gradient = props => (
   <GradientBase
-    degrees={degrees}
+    {...props}
     endColour={colours.functional.backgroundSecondary}
     startColour={colours.functional.backgroundPrimary}
-    style={style}
-  >
-    {children}
-  </GradientBase>
+  />
 );
 
 Gradient.propTypes = propTypes;

--- a/packages/image/.jestlint
+++ b/packages/image/.jestlint
@@ -1,3 +1,5 @@
 {
-  "maxAttributeStringLength": 64
+  "maxAttributeStringLength": 64,
+  "maxDepth": 13,
+  "maxFileSize": 12000
 }

--- a/packages/image/__tests__/android/__snapshots__/image-with-style.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image-with-style.android.test.js.snap
@@ -2,21 +2,13 @@
 
 exports[`1. default image 1`] = `
 <View>
-  <View
+  <Gradient
     style={
       Object {
         "flex": 1,
       }
     }
-  >
-    <Gradient
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    />
-  </View>
+  />
   <Image
     style={
       Object {

--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -4,11 +4,32 @@ exports[`1. default layout 1`] = `
 <View
   aspectRatio={1.5}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+  <Gradient
+    degrees={264}
+    height={350}
+    width={700}
+  >
+    <View>
+      <Svg
+        height={191.87817258883248}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={191.87817258883248}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
   <Image
     source={
       Object {
@@ -21,68 +42,70 @@ exports[`1. default layout 1`] = `
 
 exports[`2. default layout without uri 1`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+  <Gradient
+    degrees={264}
+    height={350}
+    width={700}
+  >
+    <View>
+      <Svg
+        height={191.87817258883248}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={191.87817258883248}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
   <Image
     source={null}
   />
 </View>
 `;
 
-exports[`3. handle layout change 1`] = `
+exports[`3. prepend https schema 1`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    >
-      <View>
-        <Svg
-          height={164.46700507614213}
-          version="1.1"
-          viewBox="145 50 108 120"
-          width={164.46700507614213}
+  <Gradient
+    degrees={264}
+    height={350}
+    width={700}
+  >
+    <View>
+      <Svg
+        height={191.87817258883248}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={191.87817258883248}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
         >
-          <G
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
-          >
-            <Path
-              d="6a6c07166e9c40e4f62e57af2b507822"
-              fill="#FFFFFF"
-            />
-          </G>
-        </Svg>
-      </View>
-    </Gradient>
-  </View>
-  <Image
-    source={
-      Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
-      }
-    }
-  />
-</View>
-`;
-
-exports[`4. prepend https schema 1`] = `
-<View
-  aspectRatio={1.5}
->
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
   <Image
     source={
       Object {
@@ -93,15 +116,36 @@ exports[`4. prepend https schema 1`] = `
 </View>
 `;
 
-exports[`5. handle onload event 1`] = `
+exports[`4. handle onload event 1`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+  <Gradient
+    degrees={264}
+    height={350}
+    width={700}
+  >
+    <View>
+      <Svg
+        height={191.87817258883248}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={191.87817258883248}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
   <Image
     source={
       Object {
@@ -112,9 +156,9 @@ exports[`5. handle onload event 1`] = `
 </View>
 `;
 
-exports[`5. handle onload event 2`] = `
+exports[`4. handle onload event 2`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
   <Image
     source={
@@ -126,15 +170,36 @@ exports[`5. handle onload event 2`] = `
 </View>
 `;
 
-exports[`7. uses highressize if it exists 1`] = `
+exports[`6. uses highressize if it exists 1`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+  <Gradient
+    degrees={264}
+    height={350}
+    width={700}
+  >
+    <View>
+      <Svg
+        height={191.87817258883248}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={191.87817258883248}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
   <Image
     source={
       Object {
@@ -145,15 +210,15 @@ exports[`7. uses highressize if it exists 1`] = `
 </View>
 `;
 
-exports[`9. image with borderradius 1`] = `
+exports[`8. image with borderradius 1`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+  <Gradient
+    degrees={264}
+    height={null}
+    width={null}
+  />
   <Image
     borderRadius={10}
     source={
@@ -165,17 +230,16 @@ exports[`9. image with borderradius 1`] = `
 </View>
 `;
 
-exports[`10. uses lowressize image as placeholder if passed 1`] = `
+exports[`9. uses lowressize image as placeholder if passed 1`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+  <Gradient
+    degrees={264}
+    height={null}
+    width={null}
+  />
   <Image
-    borderRadius={10}
     source={
       Object {
         "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
@@ -183,10 +247,49 @@ exports[`10. uses lowressize image as placeholder if passed 1`] = `
     }
   />
   <Image
-    borderRadius={10}
     source={
       Object {
         "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=2308",
+      }
+    }
+  />
+</View>
+`;
+
+exports[`11. handle layout change 1`] = `
+<View
+  aspectRatio={2}
+>
+  <Gradient
+    degrees={264}
+    height={300}
+    width={600}
+  >
+    <View>
+      <Svg
+        height={164.46700507614213}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={164.46700507614213}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
+  <Image
+    source={
+      Object {
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
       }
     }
   />

--- a/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. default modal 1`] = `
+exports[`1. landscape default modal 1`] = `
 <View>
   <Modal>
     <View
@@ -58,6 +58,7 @@ exports[`1. default modal 1`] = `
             <View
               style={
                 Object {
+                  "alignItems": "center",
                   "flexGrow": 1,
                   "justifyContent": "center",
                 }
@@ -108,25 +109,38 @@ exports[`1. default modal 1`] = `
                   style={
                     Object {
                       "opacity": 1,
+                      "overflow": "hidden",
                       "width": "100%",
                     }
                   }
                 >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <Gradient
+                  <Gradient>
+                    <View
                       style={
                         Object {
+                          "alignItems": "center",
                           "flex": 1,
+                          "justifyContent": "center",
                         }
                       }
-                    />
-                  </View>
+                    >
+                      <Svg>
+                        <G>
+                          <Path />
+                        </G>
+                      </Svg>
+                    </View>
+                  </Gradient>
+                  <Image
+                    style={
+                      Object {
+                        "height": "100%",
+                        "position": "absolute",
+                        "width": "100%",
+                        "zIndex": 1,
+                      }
+                    }
+                  />
                   <Image
                     style={
                       Object {
@@ -167,6 +181,52 @@ exports[`1. default modal 1`] = `
   </Modal>
   <View>
     <View>
+      <Gradient>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Svg>
+            <G>
+              <Path />
+            </G>
+          </Svg>
+        </View>
+      </Gradient>
+      <Image
+        style={
+          Object {
+            "height": "100%",
+            "position": "absolute",
+            "width": "100%",
+            "zIndex": 1,
+          }
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`2. portrait default modal 1`] = `
+<View>
+  <Modal>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#1D1D1B",
+          "flexDirection": "column",
+          "height": "100%",
+          "justifyContent": "space-between",
+          "width": "100%",
+        }
+      }
+    >
       <View
         style={
           Object {
@@ -174,14 +234,183 @@ exports[`1. default modal 1`] = `
           }
         }
       >
-        <Gradient
+        <View
           style={
             Object {
               "flex": 1,
+              "position": "relative",
             }
           }
-        />
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "flex-end",
+                "margin": 16,
+              }
+            }
+          >
+            <View>
+              <Image
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "flexGrow": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "transform": Array [
+                      Object {
+                        "translateX": -0,
+                      },
+                      Object {
+                        "translateY": -0,
+                      },
+                      Object {
+                        "translateX": 0,
+                      },
+                      Object {
+                        "translateY": 0,
+                      },
+                      Object {
+                        "scale": 1,
+                      },
+                      Object {
+                        "translateX": -0,
+                      },
+                      Object {
+                        "translateY": -0,
+                      },
+                      Object {
+                        "translateX": 0,
+                      },
+                      Object {
+                        "translateY": 0,
+                      },
+                      Object {
+                        "rotate": "0 deg",
+                      },
+                      Object {
+                        "perspective": 1000,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "height": "100%",
+                      "opacity": 1,
+                      "overflow": "hidden",
+                    }
+                  }
+                >
+                  <Gradient>
+                    <View
+                      style={
+                        Object {
+                          "alignItems": "center",
+                          "flex": 1,
+                          "justifyContent": "center",
+                        }
+                      }
+                    >
+                      <Svg>
+                        <G>
+                          <Path />
+                        </G>
+                      </Svg>
+                    </View>
+                  </Gradient>
+                  <Image
+                    style={
+                      Object {
+                        "height": "100%",
+                        "position": "absolute",
+                        "width": "100%",
+                        "zIndex": 1,
+                      }
+                    }
+                  />
+                  <Image
+                    style={
+                      Object {
+                        "height": "100%",
+                        "position": "absolute",
+                        "width": "100%",
+                        "zIndex": 1,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "bottom": 14,
+                "left": 16,
+                "position": "absolute",
+                "right": 16,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                }
+              }
+            >
+              Caption
+            </Text>
+          </View>
+        </View>
       </View>
+    </View>
+  </Modal>
+  <View>
+    <View>
+      <Gradient>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Svg>
+            <G>
+              <Path />
+            </G>
+          </Svg>
+        </View>
+      </Gradient>
       <Image
         style={
           Object {

--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -30,11 +30,32 @@ exports[`1. modal image 1`] = `
                 <View
                   aspectRatio={1.5}
                 >
-                  <View>
-                    <Gradient
-                      degrees={264}
-                    />
-                  </View>
+                  <Gradient
+                    degrees={264}
+                    height={350}
+                    width={700}
+                  >
+                    <View>
+                      <Svg
+                        height={191.87817258883248}
+                        version="1.1"
+                        viewBox="145 50 108 120"
+                        width={191.87817258883248}
+                      >
+                        <G
+                          fill="none"
+                          fillRule="evenodd"
+                          stroke="none"
+                          strokeWidth="1"
+                        >
+                          <Path
+                            d="6a6c07166e9c40e4f62e57af2b507822"
+                            fill="#FFFFFF"
+                          />
+                        </G>
+                      </Svg>
+                    </View>
+                  </Gradient>
                   <Image
                     source={
                       Object {
@@ -68,11 +89,32 @@ exports[`1. modal image 1`] = `
     <View
       aspectRatio={1.5}
     >
-      <View>
-        <Gradient
-          degrees={264}
-        />
-      </View>
+      <Gradient
+        degrees={264}
+        height={350}
+        width={700}
+      >
+        <View>
+          <Svg
+            height={191.87817258883248}
+            version="1.1"
+            viewBox="145 50 108 120"
+            width={191.87817258883248}
+          >
+            <G
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <Path
+                d="6a6c07166e9c40e4f62e57af2b507822"
+                fill="#FFFFFF"
+              />
+            </G>
+          </Svg>
+        </View>
+      </Gradient>
       <Image
         source={
           Object {
@@ -115,11 +157,32 @@ exports[`2. modal image with custom highressize 1`] = `
                 <View
                   aspectRatio={1.5}
                 >
-                  <View>
-                    <Gradient
-                      degrees={264}
-                    />
-                  </View>
+                  <Gradient
+                    degrees={264}
+                    height={350}
+                    width={700}
+                  >
+                    <View>
+                      <Svg
+                        height={191.87817258883248}
+                        version="1.1"
+                        viewBox="145 50 108 120"
+                        width={191.87817258883248}
+                      >
+                        <G
+                          fill="none"
+                          fillRule="evenodd"
+                          stroke="none"
+                          strokeWidth="1"
+                        >
+                          <Path
+                            d="6a6c07166e9c40e4f62e57af2b507822"
+                            fill="#FFFFFF"
+                          />
+                        </G>
+                      </Svg>
+                    </View>
+                  </Gradient>
                   <Image
                     source={
                       Object {
@@ -153,11 +216,32 @@ exports[`2. modal image with custom highressize 1`] = `
     <View
       aspectRatio={1.5}
     >
-      <View>
-        <Gradient
-          degrees={264}
-        />
-      </View>
+      <Gradient
+        degrees={264}
+        height={350}
+        width={700}
+      >
+        <View>
+          <Svg
+            height={191.87817258883248}
+            version="1.1"
+            viewBox="145 50 108 120"
+            width={191.87817258883248}
+          >
+            <G
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <Path
+                d="6a6c07166e9c40e4f62e57af2b507822"
+                fill="#FFFFFF"
+              />
+            </G>
+          </Svg>
+        </View>
+      </Gradient>
       <Image
         source={
           Object {

--- a/packages/image/__tests__/ios/__snapshots__/image-with-style.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image-with-style.ios.test.js.snap
@@ -2,21 +2,13 @@
 
 exports[`1. default image 1`] = `
 <View>
-  <View
+  <Gradient
     style={
       Object {
         "flex": 1,
       }
     }
-  >
-    <Gradient
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    />
-  </View>
+  />
   <Image
     style={
       Object {

--- a/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
@@ -4,11 +4,32 @@ exports[`1. default layout 1`] = `
 <View
   aspectRatio={1.5}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+  <Gradient
+    degrees={264}
+    height={350}
+    width={700}
+  >
+    <View>
+      <Svg
+        height={191.87817258883248}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={191.87817258883248}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
   <Image
     source={
       Object {
@@ -21,68 +42,70 @@ exports[`1. default layout 1`] = `
 
 exports[`2. default layout without uri 1`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+  <Gradient
+    degrees={264}
+    height={350}
+    width={700}
+  >
+    <View>
+      <Svg
+        height={191.87817258883248}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={191.87817258883248}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
   <Image
     source={null}
   />
 </View>
 `;
 
-exports[`3. handle layout change 1`] = `
+exports[`3. prepend https schema 1`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    >
-      <View>
-        <Svg
-          height={164.46700507614213}
-          version="1.1"
-          viewBox="145 50 108 120"
-          width={164.46700507614213}
+  <Gradient
+    degrees={264}
+    height={350}
+    width={700}
+  >
+    <View>
+      <Svg
+        height={191.87817258883248}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={191.87817258883248}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
         >
-          <G
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
-          >
-            <Path
-              d="6a6c07166e9c40e4f62e57af2b507822"
-              fill="#FFFFFF"
-            />
-          </G>
-        </Svg>
-      </View>
-    </Gradient>
-  </View>
-  <Image
-    source={
-      Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
-      }
-    }
-  />
-</View>
-`;
-
-exports[`4. prepend https schema 1`] = `
-<View
-  aspectRatio={1.5}
->
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
   <Image
     source={
       Object {
@@ -93,15 +116,36 @@ exports[`4. prepend https schema 1`] = `
 </View>
 `;
 
-exports[`5. handle onload event 1`] = `
+exports[`4. handle onload event 1`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+  <Gradient
+    degrees={264}
+    height={350}
+    width={700}
+  >
+    <View>
+      <Svg
+        height={191.87817258883248}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={191.87817258883248}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
   <Image
     source={
       Object {
@@ -112,9 +156,9 @@ exports[`5. handle onload event 1`] = `
 </View>
 `;
 
-exports[`5. handle onload event 2`] = `
+exports[`4. handle onload event 2`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
   <Image
     source={
@@ -126,15 +170,36 @@ exports[`5. handle onload event 2`] = `
 </View>
 `;
 
-exports[`7. uses highressize if it exists 1`] = `
+exports[`6. uses highressize if it exists 1`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+  <Gradient
+    degrees={264}
+    height={350}
+    width={700}
+  >
+    <View>
+      <Svg
+        height={191.87817258883248}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={191.87817258883248}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
   <Image
     source={
       Object {
@@ -145,15 +210,15 @@ exports[`7. uses highressize if it exists 1`] = `
 </View>
 `;
 
-exports[`9. image with borderradius 1`] = `
+exports[`8. image with borderradius 1`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+  <Gradient
+    degrees={264}
+    height={null}
+    width={null}
+  />
   <Image
     borderRadius={10}
     source={
@@ -165,17 +230,16 @@ exports[`9. image with borderradius 1`] = `
 </View>
 `;
 
-exports[`10. uses lowressize image as placeholder if passed 1`] = `
+exports[`9. uses lowressize image as placeholder if passed 1`] = `
 <View
-  aspectRatio={1.5}
+  aspectRatio={2}
 >
-  <View>
-    <Gradient
-      degrees={264}
-    />
-  </View>
+  <Gradient
+    degrees={264}
+    height={null}
+    width={null}
+  />
   <Image
-    borderRadius={10}
     source={
       Object {
         "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
@@ -183,10 +247,49 @@ exports[`10. uses lowressize image as placeholder if passed 1`] = `
     }
   />
   <Image
-    borderRadius={10}
     source={
       Object {
         "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=2308",
+      }
+    }
+  />
+</View>
+`;
+
+exports[`11. handle layout change 1`] = `
+<View
+  aspectRatio={2}
+>
+  <Gradient
+    degrees={264}
+    height={300}
+    width={600}
+  >
+    <View>
+      <Svg
+        height={164.46700507614213}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={164.46700507614213}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
+  <Image
+    source={
+      Object {
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
       }
     }
   />

--- a/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. default modal 1`] = `
+exports[`1. landscape default modal 1`] = `
 <View>
   <Modal>
     <View
@@ -66,6 +66,7 @@ exports[`1. default modal 1`] = `
             <View
               style={
                 Object {
+                  "alignItems": "center",
                   "flexGrow": 1,
                   "justifyContent": "center",
                 }
@@ -116,25 +117,38 @@ exports[`1. default modal 1`] = `
                   style={
                     Object {
                       "opacity": 1,
+                      "overflow": "hidden",
                       "width": "100%",
                     }
                   }
                 >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <Gradient
+                  <Gradient>
+                    <View
                       style={
                         Object {
+                          "alignItems": "center",
                           "flex": 1,
+                          "justifyContent": "center",
                         }
                       }
-                    />
-                  </View>
+                    >
+                      <Svg>
+                        <G>
+                          <Path />
+                        </G>
+                      </Svg>
+                    </View>
+                  </Gradient>
+                  <Image
+                    style={
+                      Object {
+                        "height": "100%",
+                        "position": "absolute",
+                        "width": "100%",
+                        "zIndex": 1,
+                      }
+                    }
+                  />
                   <Image
                     style={
                       Object {
@@ -181,21 +195,250 @@ exports[`1. default modal 1`] = `
     }
   >
     <View>
-      <View
+      <Gradient>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Svg>
+            <G>
+              <Path />
+            </G>
+          </Svg>
+        </View>
+      </Gradient>
+      <Image
+        style={
+          Object {
+            "height": "100%",
+            "position": "absolute",
+            "width": "100%",
+            "zIndex": 1,
+          }
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`2. portrait default modal 1`] = `
+<View>
+  <Modal>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#1D1D1B",
+          "flexDirection": "column",
+          "height": "100%",
+          "justifyContent": "space-between",
+          "width": "100%",
+        }
+      }
+    >
+      <RCTSafeAreaView
         style={
           Object {
             "flex": 1,
           }
         }
       >
-        <Gradient
+        <View
           style={
             Object {
               "flex": 1,
+              "position": "relative",
             }
           }
-        />
-      </View>
+        >
+          <View
+            style={
+              Object {
+                "left": 15,
+                "position": "absolute",
+                "top": 15,
+                "zIndex": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <Image
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "flexGrow": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "transform": Array [
+                      Object {
+                        "translateX": -0,
+                      },
+                      Object {
+                        "translateY": -0,
+                      },
+                      Object {
+                        "translateX": 0,
+                      },
+                      Object {
+                        "translateY": 0,
+                      },
+                      Object {
+                        "scale": 1,
+                      },
+                      Object {
+                        "translateX": -0,
+                      },
+                      Object {
+                        "translateY": -0,
+                      },
+                      Object {
+                        "translateX": 0,
+                      },
+                      Object {
+                        "translateY": 0,
+                      },
+                      Object {
+                        "rotate": "0 deg",
+                      },
+                      Object {
+                        "perspective": 1000,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "height": "100%",
+                      "opacity": 1,
+                      "overflow": "hidden",
+                    }
+                  }
+                >
+                  <Gradient>
+                    <View
+                      style={
+                        Object {
+                          "alignItems": "center",
+                          "flex": 1,
+                          "justifyContent": "center",
+                        }
+                      }
+                    >
+                      <Svg>
+                        <G>
+                          <Path />
+                        </G>
+                      </Svg>
+                    </View>
+                  </Gradient>
+                  <Image
+                    style={
+                      Object {
+                        "height": "100%",
+                        "position": "absolute",
+                        "width": "100%",
+                        "zIndex": 1,
+                      }
+                    }
+                  />
+                  <Image
+                    style={
+                      Object {
+                        "height": "100%",
+                        "position": "absolute",
+                        "width": "100%",
+                        "zIndex": 1,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "bottom": 14,
+                "left": 16,
+                "position": "absolute",
+                "right": 16,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                }
+              }
+            >
+              Caption
+            </Text>
+          </View>
+        </View>
+      </RCTSafeAreaView>
+    </View>
+  </Modal>
+  <View
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+  >
+    <View>
+      <Gradient>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Svg>
+            <G>
+              <Path />
+            </G>
+          </Svg>
+        </View>
+      </Gradient>
       <Image
         style={
           Object {

--- a/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
@@ -28,11 +28,32 @@ exports[`1. modal image 1`] = `
                 <View
                   aspectRatio={1.5}
                 >
-                  <View>
-                    <Gradient
-                      degrees={264}
-                    />
-                  </View>
+                  <Gradient
+                    degrees={264}
+                    height={350}
+                    width={700}
+                  >
+                    <View>
+                      <Svg
+                        height={191.87817258883248}
+                        version="1.1"
+                        viewBox="145 50 108 120"
+                        width={191.87817258883248}
+                      >
+                        <G
+                          fill="none"
+                          fillRule="evenodd"
+                          stroke="none"
+                          strokeWidth="1"
+                        >
+                          <Path
+                            d="6a6c07166e9c40e4f62e57af2b507822"
+                            fill="#FFFFFF"
+                          />
+                        </G>
+                      </Svg>
+                    </View>
+                  </Gradient>
                   <Image
                     source={
                       Object {
@@ -64,11 +85,32 @@ exports[`1. modal image 1`] = `
     <View
       aspectRatio={1.5}
     >
-      <View>
-        <Gradient
-          degrees={264}
-        />
-      </View>
+      <Gradient
+        degrees={264}
+        height={350}
+        width={700}
+      >
+        <View>
+          <Svg
+            height={191.87817258883248}
+            version="1.1"
+            viewBox="145 50 108 120"
+            width={191.87817258883248}
+          >
+            <G
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <Path
+                d="6a6c07166e9c40e4f62e57af2b507822"
+                fill="#FFFFFF"
+              />
+            </G>
+          </Svg>
+        </View>
+      </Gradient>
       <Image
         source={
           Object {
@@ -109,11 +151,32 @@ exports[`2. modal image with custom highressize 1`] = `
                 <View
                   aspectRatio={1.5}
                 >
-                  <View>
-                    <Gradient
-                      degrees={264}
-                    />
-                  </View>
+                  <Gradient
+                    degrees={264}
+                    height={350}
+                    width={700}
+                  >
+                    <View>
+                      <Svg
+                        height={191.87817258883248}
+                        version="1.1"
+                        viewBox="145 50 108 120"
+                        width={191.87817258883248}
+                      >
+                        <G
+                          fill="none"
+                          fillRule="evenodd"
+                          stroke="none"
+                          strokeWidth="1"
+                        >
+                          <Path
+                            d="6a6c07166e9c40e4f62e57af2b507822"
+                            fill="#FFFFFF"
+                          />
+                        </G>
+                      </Svg>
+                    </View>
+                  </Gradient>
                   <Image
                     source={
                       Object {
@@ -145,11 +208,32 @@ exports[`2. modal image with custom highressize 1`] = `
     <View
       aspectRatio={1.5}
     >
-      <View>
-        <Gradient
-          degrees={264}
-        />
-      </View>
+      <Gradient
+        degrees={264}
+        height={350}
+        width={700}
+      >
+        <View>
+          <Svg
+            height={191.87817258883248}
+            version="1.1"
+            viewBox="145 50 108 120"
+            width={191.87817258883248}
+          >
+            <G
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <Path
+                d="6a6c07166e9c40e4f62e57af2b507822"
+                fill="#FFFFFF"
+              />
+            </G>
+          </Svg>
+        </View>
+      </Gradient>
       <Image
         source={
           Object {

--- a/packages/image/__tests__/modal-shared-with-style.native.js
+++ b/packages/image/__tests__/modal-shared-with-style.native.js
@@ -11,7 +11,7 @@ import {
 } from "@times-components/jest-serializer";
 import { iterator } from "@times-components/test-utils";
 import "./mocks";
-import { ModalImage } from "../src";
+import Image, { ModalImage } from "../src";
 
 // eslint-disable-next-line react/prop-types
 const MockCaption = ({ style: { text, container } }) => (
@@ -21,7 +21,6 @@ const MockCaption = ({ style: { text, container } }) => (
 );
 
 const props = {
-  aspectRatio: 3 / 2,
   caption: <MockCaption />,
   uri: "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0"
 };
@@ -39,9 +38,33 @@ export default () => {
 
   const tests = [
     {
-      name: "default modal",
+      name: "landscape default modal",
       test: () => {
-        const testInstance = TestRenderer.create(<ModalImage {...props} />);
+        const testInstance = TestRenderer.create(
+          <ModalImage {...props} aspectRatio={2} />
+        );
+
+        testInstance.root.findAllByType(Image).forEach(img =>
+          img.children[0].props.onLayout({
+            nativeEvent: { layout: { height: 350, width: 700 } }
+          })
+        );
+
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "portrait default modal",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ModalImage {...props} aspectRatio={0.5} />
+        );
+
+        testInstance.root.findAllByType(Image).forEach(img =>
+          img.children[0].props.onLayout({
+            nativeEvent: { layout: { height: 700, width: 350 } }
+          })
+        );
 
         expect(testInstance).toMatchSnapshot();
       }

--- a/packages/image/__tests__/modal-shared.native.js
+++ b/packages/image/__tests__/modal-shared.native.js
@@ -48,7 +48,7 @@ export default () => {
 
         testInstance.root.findAllByType(Image).forEach(img =>
           img.children[0].props.onLayout({
-            nativeEvent: { layout: { width: 700 } }
+            nativeEvent: { layout: { height: 350, width: 700 } }
           })
         );
 
@@ -64,7 +64,7 @@ export default () => {
 
         testInstance.root.findAllByType(Image).forEach(img =>
           img.children[0].props.onLayout({
-            nativeEvent: { layout: { width: 700 } }
+            nativeEvent: { layout: { height: 350, width: 700 } }
           })
         );
 

--- a/packages/image/__tests__/shared.base.js
+++ b/packages/image/__tests__/shared.base.js
@@ -1,10 +1,9 @@
 import React from "react";
 import { iterator } from "@times-components/test-utils";
 import Image from "../src";
-import Placeholder from "../src/placeholder";
 
 const props = {
-  aspectRatio: 3 / 2,
+  aspectRatio: 2,
   highResSize: 800,
   uri: "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0"
 };
@@ -27,25 +26,11 @@ export default (renderComponent, platformTests = []) => {
     {
       name: "default layout without uri",
       test: () => {
-        const output = renderComponent(<Image aspectRatio={3 / 2} />);
-
-        expect(output).toMatchSnapshot();
-      }
-    },
-    {
-      name: "handle layout change",
-      test() {
-        const testInstance = renderComponent(<Image {...props} />);
-
-        const placeholder = testInstance.root.find(
-          node => node.type === Placeholder
+        const output = renderComponent(
+          <Image aspectRatio={props.aspectRatio} />
         );
 
-        placeholder.instance.handleLayout({
-          nativeEvent: { layout: { width: 600 } }
-        });
-
-        expect(testInstance).toMatchSnapshot();
+        expect(output).toMatchSnapshot();
       }
     },
     ...platformTests

--- a/packages/image/__tests__/shared.native.js
+++ b/packages/image/__tests__/shared.native.js
@@ -15,7 +15,7 @@ import Image from "../src";
 import shared from "./shared.base";
 
 const getLayoutEventForWidth = width => ({
-  nativeEvent: { layout: { width } }
+  nativeEvent: { layout: { height: width / 2, width } }
 });
 
 export default () => {
@@ -32,7 +32,7 @@ export default () => {
   );
 
   const props = {
-    aspectRatio: 3 / 2,
+    aspectRatio: 2,
     highResSize: 900,
     uri: "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0"
   };
@@ -112,7 +112,7 @@ export default () => {
         const uri =
           "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=100";
         const testInstance = TestRenderer.create(
-          <Image aspectRatio={3 / 2} highResSize={999} uri={uri} />
+          <Image {...props} uri={uri} />
         );
 
         testInstance.root.children[0].props.onLayout(
@@ -129,12 +129,7 @@ export default () => {
       name: "image with borderRadius",
       test: () => {
         const testInstance = TestRenderer.create(
-          <Image
-            aspectRatio={3 / 2}
-            borderRadius={10}
-            highResSize={1000}
-            uri="http://example.com/image.jpg?crop=1016%2C677%2C0%2C0"
-          />
+          <Image {...props} borderRadius={10} />
         );
         expect(testInstance).toMatchSnapshot();
       }
@@ -143,13 +138,7 @@ export default () => {
       name: "uses lowResSize image as placeholder if passed",
       test: () => {
         const testInstance = TestRenderer.create(
-          <Image
-            aspectRatio={3 / 2}
-            borderRadius={10}
-            highResSize={2000}
-            lowResSize={800}
-            uri="http://example.com/image.jpg?crop=1016%2C677%2C0%2C0"
-          />
+          <Image {...props} highResSize={2000} lowResSize={800} />
         );
         expect(testInstance).toMatchSnapshot();
       }
@@ -165,6 +154,16 @@ export default () => {
 
         testInstance.root.children[0].props.onLayout(mockEvt);
         expect(mockOnLayout).toHaveBeenCalledWith(mockEvt);
+      }
+    },
+    {
+      name: "handle layout change",
+      test() {
+        const testRenderer = TestRenderer.create(<Image {...props} />);
+
+        testRenderer.getInstance().onImageLayout(getLayoutEventForWidth(600));
+
+        expect(testRenderer).toMatchSnapshot();
       }
     }
   ];

--- a/packages/image/__tests__/shared.web.js
+++ b/packages/image/__tests__/shared.web.js
@@ -11,9 +11,9 @@ import {
   replacePropTransform
 } from "@times-components/jest-serializer";
 import { hash } from "@times-components/test-utils";
+import "./mocks";
 import Image from "../src";
 import Placeholder from "../src/placeholder";
-import "./mocks";
 import shared from "./shared.base";
 
 export default () => {
@@ -37,7 +37,7 @@ export default () => {
       name: "an invalid uri",
       test: () => {
         const testRenderer = TestRenderer.create(
-          <Image aspectRatio={3 / 2} highResSize={1400} uri="not-valid" />
+          <Image aspectRatio={2} highResSize={1400} uri="not-valid" />
         );
 
         expect(testRenderer).toMatchSnapshot();
@@ -51,7 +51,7 @@ export default () => {
         delete window.URL;
 
         const testInstance = TestRenderer.create(
-          <Image aspectRatio={3 / 2} highResSize={1400} uri="not-valid" />
+          <Image aspectRatio={2} highResSize={1400} uri="not-valid" />
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -63,11 +63,7 @@ export default () => {
       name: "with existing URL params",
       test: () => {
         const testRenderer = TestRenderer.create(
-          <Image
-            aspectRatio={3 / 2}
-            highResSize={1400}
-            uri="https://image.io"
-          />
+          <Image aspectRatio={2} highResSize={1400} uri="https://image.io" />
         );
 
         expect(testRenderer).toMatchSnapshot();
@@ -79,7 +75,7 @@ export default () => {
       test: () => {
         const testRenderer = TestRenderer.create(
           <Image
-            aspectRatio={3 / 2}
+            aspectRatio={2}
             highResSize={1400}
             lowResSize={200}
             uri="https://image.io"
@@ -101,7 +97,7 @@ export default () => {
       name: "only a low res image",
       test: () => {
         const testRenderer = TestRenderer.create(
-          <Image aspectRatio={3 / 2} lowResSize={200} uri="https://image.io" />
+          <Image aspectRatio={2} lowResSize={200} uri="https://image.io" />
         );
 
         expect(testRenderer).toMatchSnapshot();
@@ -112,7 +108,7 @@ export default () => {
       test: () => {
         const testRenderer = TestRenderer.create(
           <Image
-            aspectRatio={3 / 2}
+            aspectRatio={2}
             fadeImageIn
             lowResSize={200}
             uri="https://image.io"
@@ -133,7 +129,7 @@ export default () => {
       test: () => {
         const testRenderer = TestRenderer.create(
           <Image
-            aspectRatio={3 / 2}
+            aspectRatio={2}
             highResSize={900}
             lowResSize={200}
             uri="https://image.io"
@@ -147,7 +143,7 @@ export default () => {
       name: "high res image should hide placeholder after loading",
       test: () => {
         const testRenderer = TestRenderer.create(
-          <Image aspectRatio={3 / 2} highResSize={900} uri="https://image.io" />
+          <Image aspectRatio={2} highResSize={900} uri="https://image.io" />
         );
 
         let numberOfPlaceholders = testRenderer.root.findAllByType(Placeholder)
@@ -166,7 +162,7 @@ export default () => {
       name: "low res image should hide placeholder after loading",
       test: () => {
         const testRenderer = TestRenderer.create(
-          <Image aspectRatio={3 / 2} lowResSize={200} uri="https://image.io" />
+          <Image aspectRatio={2} lowResSize={200} uri="https://image.io" />
         );
 
         let numberOfPlaceholders = testRenderer.root.findAllByType(Placeholder)

--- a/packages/image/__tests__/web/__snapshots__/image-with-style.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image-with-style.web.test.js.snap
@@ -17,30 +17,6 @@ exports[`1. default image 1`] = `
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   align-items: stretch;
-  bottom: 0px;
-  display: flex;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -ms-flex-direction: column;
-  -webkit-box-direction: normal;
-  -webkit-box-orient: vertical;
-  -webkit-flex-direction: column;
-  flex-direction: column;
-  left: 0px;
-  padding-bottom: 0px;
-  position: absolute;
-  right: 0px;
-  top: 0px;
-  z-index: 0;
-}
-
-.S2 {
-  -ms-flex-align: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  align-items: stretch;
   display: flex;
   -ms-flex-direction: column;
   -webkit-box-direction: normal;
@@ -53,6 +29,12 @@ exports[`1. default image 1`] = `
 }
 
 .IS1 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
   flex: 1;
 }
 
@@ -65,7 +47,7 @@ exports[`1. default image 1`] = `
 </style>
 
 <div
-  className="S2"
+  className="S1"
 >
   <div
     className="IS2"
@@ -73,13 +55,9 @@ exports[`1. default image 1`] = `
     <img
       className="c0"
     />
-    <div
-      className="S1"
-    >
-      <Gradient
-        className="IS1"
-      />
-    </div>
+    <Gradient
+      className="IS1"
+    />
   </div>
 </div>
 `;
@@ -101,30 +79,6 @@ exports[`2. default modal 1`] = `
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   align-items: stretch;
-  bottom: 0px;
-  display: flex;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -ms-flex-direction: column;
-  -webkit-box-direction: normal;
-  -webkit-box-orient: vertical;
-  -webkit-flex-direction: column;
-  flex-direction: column;
-  left: 0px;
-  padding-bottom: 0px;
-  position: absolute;
-  right: 0px;
-  top: 0px;
-  z-index: 0;
-}
-
-.S2 {
-  -ms-flex-align: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  align-items: stretch;
   display: flex;
   -ms-flex-direction: column;
   -webkit-box-direction: normal;
@@ -137,6 +91,12 @@ exports[`2. default modal 1`] = `
 }
 
 .IS1 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
   flex: 1;
 }
 
@@ -149,7 +109,7 @@ exports[`2. default modal 1`] = `
 </style>
 
 <div
-  className="S2"
+  className="S1"
 >
   <div
     className="IS2"
@@ -157,13 +117,9 @@ exports[`2. default modal 1`] = `
     <img
       className="c0"
     />
-    <div
-      className="S1"
-    >
-      <Gradient
-        className="IS1"
-      />
-    </div>
+    <Gradient
+      className="IS1"
+    />
   </div>
 </div>
 `;

--- a/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
@@ -17,9 +17,11 @@ exports[`1. default layout 1`] = `
       alt=""
       src="http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1000"
     />
-    <div>
-      <div />
-    </div>
+    <Gradient
+      degrees={264}
+      height={null}
+      width={null}
+    />
   </div>
 </div>
 `;
@@ -41,59 +43,16 @@ exports[`2. default layout without uri 1`] = `
       alt=""
       src={null}
     />
-    <div>
-      <div />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`3. handle layout change 1`] = `
-.c0 {
-  display: block;
-  opacity: 0;
-  position: absolute;
-  -webkit-transition: opacity 0.3s ease-in-out;
-  transition: opacity 0.3s ease-in-out;
-  width: 100%;
-  z-index: 2;
-}
-
-<div>
-  <div>
-    <img
-      alt=""
-      src="http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800"
+    <Gradient
+      degrees={264}
+      height={null}
+      width={null}
     />
-    <div>
-      <div>
-        <div>
-          <svg
-            height={164.46700507614213}
-            version="1.1"
-            viewBox="145 50 108 120"
-            width={164.46700507614213}
-          >
-            <g
-              fill="none"
-              fillRule="evenodd"
-              stroke="none"
-              strokeWidth="1"
-            >
-              <path
-                d="6a6c07166e9c40e4f62e57af2b507822"
-                fill="#FFFFFF"
-              />
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
   </div>
 </div>
 `;
 
-exports[`4. an invalid uri 1`] = `
+exports[`3. an invalid uri 1`] = `
 .c0 {
   display: block;
   opacity: 0;
@@ -110,14 +69,16 @@ exports[`4. an invalid uri 1`] = `
       alt=""
       src="not-valid"
     />
-    <div>
-      <div />
-    </div>
+    <Gradient
+      degrees={264}
+      height={null}
+      width={null}
+    />
   </div>
 </div>
 `;
 
-exports[`5. no url in environment 1`] = `
+exports[`4. no url in environment 1`] = `
 .c0 {
   display: block;
   opacity: 0;
@@ -134,14 +95,16 @@ exports[`5. no url in environment 1`] = `
       alt=""
       src="not-valid?resize=1400"
     />
-    <div>
-      <div />
-    </div>
+    <Gradient
+      degrees={264}
+      height={null}
+      width={null}
+    />
   </div>
 </div>
 `;
 
-exports[`6. with existing url params 1`] = `
+exports[`5. with existing url params 1`] = `
 .c0 {
   display: block;
   opacity: 0;
@@ -158,14 +121,16 @@ exports[`6. with existing url params 1`] = `
       alt=""
       src="https://image.io?resize=1400"
     />
-    <div>
-      <div />
-    </div>
+    <Gradient
+      degrees={264}
+      height={null}
+      width={null}
+    />
   </div>
 </div>
 `;
 
-exports[`7. remove the low res image after the high res image has transitioned in 1`] = `
+exports[`6. remove the low res image after the high res image has transitioned in 1`] = `
 .c1 {
   display: block;
   opacity: 1;
@@ -200,7 +165,7 @@ exports[`7. remove the low res image after the high res image has transitioned i
 </div>
 `;
 
-exports[`7. remove the low res image after the high res image has transitioned in 2`] = `
+exports[`6. remove the low res image after the high res image has transitioned in 2`] = `
 .c0 {
   display: block;
   opacity: 1;
@@ -221,7 +186,7 @@ exports[`7. remove the low res image after the high res image has transitioned i
 </div>
 `;
 
-exports[`8. only a low res image 1`] = `
+exports[`7. only a low res image 1`] = `
 .c0 {
   display: block;
   opacity: 1;
@@ -238,14 +203,16 @@ exports[`8. only a low res image 1`] = `
       alt=""
       src="https://image.io?resize=200"
     />
-    <div>
-      <div />
-    </div>
+    <Gradient
+      degrees={264}
+      height={null}
+      width={null}
+    />
   </div>
 </div>
 `;
 
-exports[`9. fade in the low res image 1`] = `
+exports[`8. fade in the low res image 1`] = `
 .c0 {
   display: block;
   opacity: 0;
@@ -262,14 +229,16 @@ exports[`9. fade in the low res image 1`] = `
       alt=""
       src="https://image.io?resize=200"
     />
-    <div>
-      <div />
-    </div>
+    <Gradient
+      degrees={264}
+      height={null}
+      width={null}
+    />
   </div>
 </div>
 `;
 
-exports[`9. fade in the low res image 2`] = `
+exports[`8. fade in the low res image 2`] = `
 .c0 {
   display: block;
   opacity: 1;
@@ -290,7 +259,7 @@ exports[`9. fade in the low res image 2`] = `
 </div>
 `;
 
-exports[`10. both high and low res sizes 1`] = `
+exports[`9. both high and low res sizes 1`] = `
 .c0 {
   display: block;
   opacity: 0;
@@ -321,9 +290,11 @@ exports[`10. both high and low res sizes 1`] = `
       alt=""
       src="https://image.io?resize=200"
     />
-    <div>
-      <div />
-    </div>
+    <Gradient
+      degrees={264}
+      height={null}
+      width={null}
+    />
   </div>
 </div>
 `;

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -32,6 +32,7 @@ class TimesImage extends Component {
     super(props);
 
     this.state = {
+      height: null,
       isLoaded: false,
       width: null
     };
@@ -41,8 +42,9 @@ class TimesImage extends Component {
 
   onImageLayout(evt) {
     const { onLayout } = this.props;
+    const { height, width } = evt.nativeEvent.layout;
 
-    this.setState({ width: evt.nativeEvent.layout.width });
+    this.setState({ height, width });
 
     if (onLayout) {
       onLayout(evt);
@@ -62,7 +64,7 @@ class TimesImage extends Component {
       style,
       uri
     } = this.props;
-    const { isLoaded, width } = this.state;
+    const { isLoaded, width, height } = this.state;
     const renderedRes = highResSize || width;
     const srcUri = getUriAtRes(uri, renderedRes);
 
@@ -74,7 +76,7 @@ class TimesImage extends Component {
       >
         {isLoaded ? null : (
           <Fragment>
-            <Placeholder />
+            <Placeholder height={height} width={width} />
             {lowResSize ? (
               <Image
                 borderRadius={borderRadius}

--- a/packages/image/src/image.web.js
+++ b/packages/image/src/image.web.js
@@ -11,15 +11,29 @@ class TimesImage extends Component {
     super(props);
 
     this.state = {
+      height: null,
       highResIsLoaded: false,
       highResIsVisible: false,
       imageIsLoaded: false,
-      lowResIsLoaded: !props.fadeImageIn
+      lowResIsLoaded: !props.fadeImageIn,
+      width: null
     };
 
     this.handleHighResOnLoad = this.handleHighResOnLoad.bind(this);
     this.handleLowResOnLoad = this.handleLowResOnLoad.bind(this);
     this.onHighResTransitionEnd = this.onHighResTransitionEnd.bind(this);
+    this.onImageLayout = this.onImageLayout.bind(this);
+  }
+
+  onImageLayout(evt) {
+    const { onLayout } = this.props;
+    const { height, width } = evt.nativeEvent.layout;
+
+    this.setState({ height, width });
+
+    if (onLayout) {
+      onLayout(evt);
+    }
   }
 
   onHighResTransitionEnd() {
@@ -79,7 +93,7 @@ class TimesImage extends Component {
 
   render() {
     const { aspectRatio, highResSize, lowResSize, style, uri } = this.props;
-    const { imageIsLoaded } = this.state;
+    const { height, imageIsLoaded, width } = this.state;
     const url = addMissingProtocol(uri);
 
     const styles = StyleSheet.create({
@@ -100,11 +114,17 @@ class TimesImage extends Component {
     });
 
     return (
-      <View style={style}>
+      <View onLayout={this.onImageLayout} style={style}>
         <div style={StyleSheet.flatten(styles.wrapper)}>
           {this.highResImage({ highResSize, lowResSize, url })}
           {this.lowResImage({ lowResSize, url })}
-          {imageIsLoaded ? null : <Placeholder style={styles.placeholder} />}
+          {imageIsLoaded ? null : (
+            <Placeholder
+              height={height}
+              style={styles.placeholder}
+              width={width}
+            />
+          )}
         </div>
       </View>
     );

--- a/packages/image/src/modal-image.js
+++ b/packages/image/src/modal-image.js
@@ -36,7 +36,7 @@ class ModalImage extends Component {
   }
 
   render() {
-    const { caption, highResSize } = this.props;
+    const { caption, highResSize, aspectRatio } = this.props;
     const { showModal, lowResImageWidth } = this.state;
     const lowResSize = highResSize || lowResImageWidth;
     const captionWithStyles =
@@ -62,7 +62,12 @@ class ModalImage extends Component {
                   <Image
                     {...this.props}
                     lowResSize={lowResSize}
-                    style={styles.image}
+                    style={[
+                      styles.image,
+                      aspectRatio >= 1
+                        ? styles.imageFullWidth
+                        : styles.imageFullHeight
+                    ]}
                   />
                 </Gestures>
                 {captionWithStyles}

--- a/packages/image/src/placeholder.js
+++ b/packages/image/src/placeholder.js
@@ -8,14 +8,15 @@ import T from "./t";
 const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 function Placeholder({ height, style, width }) {
+  const hasDimensions = width !== null && height !== null;
   return (
     <Gradient
       degrees={264}
       height={height}
-      style={[style, !width && !height && { flex: 1 }]}
+      style={[style, !hasDimensions && { flex: 1 }]}
       width={width}
     >
-      {width ? (
+      {width !== null ? (
         <View style={[styles.container, styles.placeholderContainer]}>
           <T width={width} />
         </View>

--- a/packages/image/src/placeholder.js
+++ b/packages/image/src/placeholder.js
@@ -1,4 +1,5 @@
-import React, { Component } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { View, ViewPropTypes } from "react-native";
 import Gradient from "@times-components/gradient";
 import styles from "./styles/index";
@@ -6,48 +7,33 @@ import T from "./t";
 
 const { style: ViewPropTypesStyle } = ViewPropTypes;
 
-class Placeholder extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {};
-    this.handleLayout = this.handleLayout.bind(this);
-  }
-
-  handleLayout({
-    nativeEvent: {
-      layout: { width }
-    }
-  }) {
-    this.setState({
-      width
-    });
-  }
-
-  render() {
-    const { style } = this.props;
-    const { width } = this.state;
-
-    return (
-      <View onLayout={this.handleLayout} style={[styles.container, style]}>
-        <Gradient degrees={264} style={styles.container}>
-          {width ? (
-            <View style={[styles.container, styles.placeholderContainer]}>
-              <T width={width} />
-            </View>
-          ) : null}
-        </Gradient>
-      </View>
-    );
-  }
+function Placeholder({ height, style, width }) {
+  return (
+    <Gradient
+      degrees={264}
+      height={height}
+      style={[style, !width && !height && { flex: 1 }]}
+      width={width}
+    >
+      {width ? (
+        <View style={[styles.container, styles.placeholderContainer]}>
+          <T width={width} />
+        </View>
+      ) : null}
+    </Gradient>
+  );
 }
 
 Placeholder.propTypes = {
-  style: ViewPropTypesStyle
+  height: PropTypes.number,
+  style: ViewPropTypesStyle,
+  width: PropTypes.number
 };
 
 Placeholder.defaultProps = {
-  style: null
+  height: null,
+  style: null,
+  width: null
 };
 
 export default Placeholder;

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -16,7 +16,12 @@ const styles = {
   },
   image: {
     opacity: 1,
-    width: "100%"
+    /*
+     * Due to our use of SafeAreaView, on layout is called multiple times meaning
+     * the placeholder may appear outside of the bounds of the image momentarily
+     * causing a white flash. This prevents that from occurring
+     */
+    overflow: "hidden"
   },
   imageBackground: {
     height: "100%",
@@ -25,9 +30,12 @@ const styles = {
     zIndex: 1
   },
   imageContainer: {
+    alignItems: "center",
     flexGrow: 1,
     justifyContent: "center"
   },
+  imageFullHeight: { height: "100%" },
+  imageFullWidth: { width: "100%" },
   modal: {
     backgroundColor: colours.functional.brandColour,
     flexDirection: "column",


### PR DESCRIPTION
Portrait images should appear at full height in modals rather than full width.

<img width="691" alt="Screen Shot 2019-03-13 at 14 37 06" src="https://user-images.githubusercontent.com/719814/54287439-8ed4bf00-459d-11e9-8a37-c62395d8e0b5.png">

Also some associated fixes around reducing the number of onLayout calculations during image load so that there are less loading states and "flashes" during image load. 

Other changes:

- Gradient can now take a specified width and height to display at instead of the size of its container
- Gradient will now use the startColour as a placeholder on native for the gradient as it loads 


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
