### PR TITLE
fix: puzzle tiles widths set correctly

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
@@ -1050,8 +1050,32 @@ exports[`15. puzzle 1`] = `
     }
   }
 >
-  <TileAJ />
-  <TileAJ />
-  <TileAJ />
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <TileAJ />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <TileAJ />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <TileAJ />
+  </View>
 </View>
 `;

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
@@ -472,59 +472,65 @@ exports[`14. comment lead and cartoon 1`] = `
 
 exports[`15. puzzle 1`] = `
 <View>
-  <TileAJ
-    id="0"
-    image={
-      Object {
-        "crop11": null,
-        "crop169": null,
-        "crop23": null,
-        "crop32": Object {
-          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-        },
-        "crop45": null,
-        "crops": Array [],
-        "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+  <View>
+    <TileAJ
+      id="0"
+      image={
+        Object {
+          "crop11": null,
+          "crop169": null,
+          "crop23": null,
+          "crop32": Object {
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+          },
+          "crop45": null,
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        }
       }
-    }
-    title="Times Concise medium No 7881"
-    url="/crossword/123"
-  />
-  <TileAJ
-    id="1"
-    image={
-      Object {
-        "crop11": null,
-        "crop169": null,
-        "crop23": null,
-        "crop32": Object {
-          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-        },
-        "crop45": null,
-        "crops": Array [],
-        "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+      title="Times Concise medium No 7881"
+      url="/crossword/123"
+    />
+  </View>
+  <View>
+    <TileAJ
+      id="1"
+      image={
+        Object {
+          "crop11": null,
+          "crop169": null,
+          "crop23": null,
+          "crop32": Object {
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+          },
+          "crop45": null,
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        }
       }
-    }
-    title="Times Concise medium No 7881"
-    url="/crossword/123"
-  />
-  <TileAJ
-    id="2"
-    image={
-      Object {
-        "crop11": null,
-        "crop169": null,
-        "crop23": null,
-        "crop32": Object {
-          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-        },
-        "crop45": null,
-        "crops": Array [],
-        "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+      title="Times Concise medium No 7881"
+      url="/crossword/123"
+    />
+  </View>
+  <View>
+    <TileAJ
+      id="2"
+      image={
+        Object {
+          "crop11": null,
+          "crop169": null,
+          "crop23": null,
+          "crop32": Object {
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+          },
+          "crop45": null,
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        }
       }
-    }
-    title="Times Concise medium No 7881"
-    url="/crossword/123"
-  />
+      title="Times Concise medium No 7881"
+      url="/crossword/123"
+    />
+  </View>
 </View>
 `;

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1017,9 +1017,33 @@ exports[`14. puzzle - medium 1`] = `
       }
     }
   >
-    <TileAK />
-    <TileAK />
-    <TileAK />
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
   </View>
 </View>
 `;
@@ -2041,9 +2065,33 @@ exports[`28. puzzle - wide 1`] = `
       }
     }
   >
-    <TileAK />
-    <TileAK />
-    <TileAK />
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
   </View>
 </View>
 `;
@@ -3065,9 +3113,33 @@ exports[`42. puzzle - huge 1`] = `
       }
     }
   >
-    <TileAK />
-    <TileAK />
-    <TileAK />
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
   </View>
 </View>
 `;

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -358,60 +358,66 @@ exports[`13. secondary two no pic and two - medium 1`] = `
 exports[`14. puzzle - medium 1`] = `
 <View>
   <View>
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <View>
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
+    <View>
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
+    <View>
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
   </View>
 </View>
 `;
@@ -774,60 +780,66 @@ exports[`27. secondary two no pic and two - wide 1`] = `
 exports[`28. puzzle - wide 1`] = `
 <View>
   <View>
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <View>
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
+    <View>
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
+    <View>
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
   </View>
 </View>
 `;
@@ -1190,60 +1202,66 @@ exports[`41. secondary two no pic and two - huge 1`] = `
 exports[`42. puzzle - huge 1`] = `
 <View>
   <View>
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <View>
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
+    <View>
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
+    <View>
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
   </View>
 </View>
 `;

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -1200,7 +1200,7 @@ exports[`31. tile ak 1`] = `
 <Link
   linkStyle={
     Object {
-      "width": "33%",
+      "flex": 1,
     }
   }
   url="/crossword/123"

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
@@ -1050,8 +1050,32 @@ exports[`15. puzzle 1`] = `
     }
   }
 >
-  <TileAJ />
-  <TileAJ />
-  <TileAJ />
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <TileAJ />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <TileAJ />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <TileAJ />
+  </View>
 </View>
 `;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
@@ -472,59 +472,65 @@ exports[`14. comment lead and cartoon 1`] = `
 
 exports[`15. puzzle 1`] = `
 <View>
-  <TileAJ
-    id="0"
-    image={
-      Object {
-        "crop11": null,
-        "crop169": null,
-        "crop23": null,
-        "crop32": Object {
-          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-        },
-        "crop45": null,
-        "crops": Array [],
-        "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+  <View>
+    <TileAJ
+      id="0"
+      image={
+        Object {
+          "crop11": null,
+          "crop169": null,
+          "crop23": null,
+          "crop32": Object {
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+          },
+          "crop45": null,
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        }
       }
-    }
-    title="Times Concise medium No 7881"
-    url="/crossword/123"
-  />
-  <TileAJ
-    id="1"
-    image={
-      Object {
-        "crop11": null,
-        "crop169": null,
-        "crop23": null,
-        "crop32": Object {
-          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-        },
-        "crop45": null,
-        "crops": Array [],
-        "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+      title="Times Concise medium No 7881"
+      url="/crossword/123"
+    />
+  </View>
+  <View>
+    <TileAJ
+      id="1"
+      image={
+        Object {
+          "crop11": null,
+          "crop169": null,
+          "crop23": null,
+          "crop32": Object {
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+          },
+          "crop45": null,
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        }
       }
-    }
-    title="Times Concise medium No 7881"
-    url="/crossword/123"
-  />
-  <TileAJ
-    id="2"
-    image={
-      Object {
-        "crop11": null,
-        "crop169": null,
-        "crop23": null,
-        "crop32": Object {
-          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-        },
-        "crop45": null,
-        "crops": Array [],
-        "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+      title="Times Concise medium No 7881"
+      url="/crossword/123"
+    />
+  </View>
+  <View>
+    <TileAJ
+      id="2"
+      image={
+        Object {
+          "crop11": null,
+          "crop169": null,
+          "crop23": null,
+          "crop32": Object {
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+          },
+          "crop45": null,
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        }
       }
-    }
-    title="Times Concise medium No 7881"
-    url="/crossword/123"
-  />
+      title="Times Concise medium No 7881"
+      url="/crossword/123"
+    />
+  </View>
 </View>
 `;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1017,9 +1017,33 @@ exports[`14. puzzle - medium 1`] = `
       }
     }
   >
-    <TileAK />
-    <TileAK />
-    <TileAK />
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
   </View>
 </View>
 `;
@@ -2041,9 +2065,33 @@ exports[`28. puzzle - wide 1`] = `
       }
     }
   >
-    <TileAK />
-    <TileAK />
-    <TileAK />
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
   </View>
 </View>
 `;
@@ -3065,9 +3113,33 @@ exports[`42. puzzle - huge 1`] = `
       }
     }
   >
-    <TileAK />
-    <TileAK />
-    <TileAK />
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
+    <View
+      style={
+        Object {
+          "width": "33%",
+        }
+      }
+    >
+      <TileAK />
+    </View>
   </View>
 </View>
 `;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -358,60 +358,66 @@ exports[`13. secondary two no pic and two - medium 1`] = `
 exports[`14. puzzle - medium 1`] = `
 <View>
   <View>
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <View>
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
+    <View>
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
+    <View>
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
   </View>
 </View>
 `;
@@ -774,60 +780,66 @@ exports[`27. secondary two no pic and two - wide 1`] = `
 exports[`28. puzzle - wide 1`] = `
 <View>
   <View>
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <View>
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
+    <View>
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
+    <View>
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
   </View>
 </View>
 `;
@@ -1190,60 +1202,66 @@ exports[`41. secondary two no pic and two - huge 1`] = `
 exports[`42. puzzle - huge 1`] = `
 <View>
   <View>
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <View>
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
+    <View>
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
+    <View>
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </View>
   </View>
 </View>
 `;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -1200,7 +1200,7 @@ exports[`31. tile ak 1`] = `
 <Link
   linkStyle={
     Object {
-      "width": "33%",
+      "flex": 1,
     }
   }
   url="/crossword/123"

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -2465,6 +2465,18 @@ exports[`15. puzzle 1`] = `
 }
 
 .IS1 {
+  width: 33%;
+}
+
+.IS2 {
+  width: 33%;
+}
+
+.IS3 {
+  width: 33%;
+}
+
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -2485,7 +2497,7 @@ exports[`15. puzzle 1`] = `
   -webkit-box-direction: normal;
 }
 
-.IS2 {
+.IS5 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -2495,65 +2507,77 @@ exports[`15. puzzle 1`] = `
 </style>
 
 <div
-  className="IS2 S1"
+  className="IS5 S1"
 >
   <div
-    className="IS1 S1"
+    className="IS4 S1"
   >
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <div
+      className="IS1 S1"
+    >
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div
+      className="IS2 S1"
+    >
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div
+      className="IS3 S1"
+    >
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -576,60 +576,66 @@ exports[`14. comment lead and cartoon 1`] = `
 exports[`15. puzzle 1`] = `
 <div>
   <div>
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <div>
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div>
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div>
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1505,6 +1505,18 @@ exports[`14. puzzle - medium 1`] = `
 }
 
 .IS1 {
+  width: 33%;
+}
+
+.IS2 {
+  width: 33%;
+}
+
+.IS3 {
+  width: 33%;
+}
+
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -1525,7 +1537,7 @@ exports[`14. puzzle - medium 1`] = `
   -webkit-box-direction: normal;
 }
 
-.IS2 {
+.IS5 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -1535,65 +1547,77 @@ exports[`14. puzzle - medium 1`] = `
 </style>
 
 <div
-  className="IS2 S1"
+  className="IS5 S1"
 >
   <div
-    className="IS1 S1"
+    className="IS4 S1"
   >
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <div
+      className="IS1 S1"
+    >
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div
+      className="IS2 S1"
+    >
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div
+      className="IS3 S1"
+    >
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -3103,6 +3127,18 @@ exports[`28. puzzle - wide 1`] = `
 }
 
 .IS1 {
+  width: 33%;
+}
+
+.IS2 {
+  width: 33%;
+}
+
+.IS3 {
+  width: 33%;
+}
+
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -3123,7 +3159,7 @@ exports[`28. puzzle - wide 1`] = `
   -webkit-box-direction: normal;
 }
 
-.IS2 {
+.IS5 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -3133,65 +3169,77 @@ exports[`28. puzzle - wide 1`] = `
 </style>
 
 <div
-  className="IS2 S1"
+  className="IS5 S1"
 >
   <div
-    className="IS1 S1"
+    className="IS4 S1"
   >
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <div
+      className="IS1 S1"
+    >
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div
+      className="IS2 S1"
+    >
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div
+      className="IS3 S1"
+    >
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -4701,6 +4749,18 @@ exports[`42. puzzle - huge 1`] = `
 }
 
 .IS1 {
+  width: 33%;
+}
+
+.IS2 {
+  width: 33%;
+}
+
+.IS3 {
+  width: 33%;
+}
+
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -4721,7 +4781,7 @@ exports[`42. puzzle - huge 1`] = `
   -webkit-box-direction: normal;
 }
 
-.IS2 {
+.IS5 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -4731,65 +4791,77 @@ exports[`42. puzzle - huge 1`] = `
 </style>
 
 <div
-  className="IS2 S1"
+  className="IS5 S1"
 >
   <div
-    className="IS1 S1"
+    className="IS4 S1"
   >
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <div
+      className="IS1 S1"
+    >
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div
+      className="IS2 S1"
+    >
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div
+      className="IS3 S1"
+    >
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -342,60 +342,66 @@ exports[`13. secondary two no pic and two - medium 1`] = `
 exports[`14. puzzle - medium 1`] = `
 <div>
   <div>
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <div>
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div>
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div>
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -742,60 +748,66 @@ exports[`27. secondary two no pic and two - wide 1`] = `
 exports[`28. puzzle - wide 1`] = `
 <div>
   <div>
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <div>
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div>
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div>
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -1142,60 +1154,66 @@ exports[`41. secondary two no pic and two - huge 1`] = `
 exports[`42. puzzle - huge 1`] = `
 <div>
   <div>
-    <TileAK
-      id="0"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    <div>
+      <TileAK
+        id="0"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="1"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div>
+      <TileAK
+        id="1"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
-    <TileAK
-      id="2"
-      image={
-        Object {
-          "crop11": null,
-          "crop169": null,
-          "crop23": null,
-          "crop32": Object {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-          },
-          "crop45": null,
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
+    <div>
+      <TileAK
+        id="2"
+        image={
+          Object {
+            "crop11": null,
+            "crop169": null,
+            "crop23": null,
+            "crop32": Object {
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+            },
+            "crop45": null,
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          }
         }
-      }
-      title="Times Concise medium No 7881"
-      url="/crossword/123"
-    />
+        title="Times Concise medium No 7881"
+        url="/crossword/123"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -3341,7 +3341,7 @@ exports[`31. tile ak 1`] = `
 <Link
   linkStyle={
     Object {
-      "width": "33%",
+      "flex": 1,
     }
   }
   url="/crossword/123"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -1200,7 +1200,7 @@ exports[`31. tile ak 1`] = `
 <Link
   linkStyle={
     Object {
-      "width": "33%",
+      "flex": 1,
     }
   }
   url="/crossword/123"

--- a/packages/edition-slices/src/slices/puzzle/index.js
+++ b/packages/edition-slices/src/slices/puzzle/index.js
@@ -8,19 +8,21 @@ import { TileAJ, TileAK } from "../../tiles";
 
 const Puzzle = ({ onPress, slice: { puzzles } }) => {
   const renderPuzzles = (breakpoint = editionBreakpoints.small) => {
-    const { container } = stylesFactory(breakpoint);
+    const { container, tileContainer } = stylesFactory(breakpoint);
     const Tile = breakpoint === editionBreakpoints.small ? TileAJ : TileAK;
 
     return (
       <View style={container}>
         {puzzles.map(({ id, title, url, image }) => (
-          <Tile
-            id={id}
-            image={image}
-            onPress={onPress}
-            title={title}
-            url={url}
-          />
+          <View style={tileContainer}>
+            <Tile
+              id={id}
+              image={image}
+              onPress={onPress}
+              title={title}
+              url={url}
+            />
+          </View>
         ))}
       </View>
     );

--- a/packages/edition-slices/src/slices/puzzle/styles.js
+++ b/packages/edition-slices/src/slices/puzzle/styles.js
@@ -4,6 +4,9 @@ const smallBreakpointStyles = {
   container: {
     flex: 1,
     paddingHorizontal: spacing(2)
+  },
+  tileContainer: {
+    flex: 1
   }
 };
 
@@ -13,6 +16,9 @@ const mediumBreakpointStyles = {
     flexDirection: "row",
     paddingHorizontal: spacing(3),
     paddingTop: spacing(2)
+  },
+  tileContainer: {
+    width: "33%"
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-ak/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ak/styles/index.js
@@ -14,7 +14,7 @@ const styles = {
     width: "85%"
   },
   link: {
-    width: "33%"
+    flex: 1
   },
   puzzleContainer: {
     backgroundColor: colours.functional.border,


### PR DESCRIPTION
Fixing and issue with puzzle tiles not being rendered correctly on mobile.
`Before:`
<img width="448" alt="Screenshot 2019-03-25 at 19 12 58" src="https://user-images.githubusercontent.com/5912453/54939754-0d344800-4f32-11e9-8f57-6959f50fb017.png">

`After:`
<img width="445" alt="Screenshot 2019-03-25 at 19 14 46" src="https://user-images.githubusercontent.com/5912453/54939865-47054e80-4f32-11e9-8689-637fbd32174a.png">

 
