### PR TITLE
fix: Use listing asset override

### DIFF
--- a/packages/edition-slices/__tests__/shared-components.base.js
+++ b/packages/edition-slices/__tests__/shared-components.base.js
@@ -6,7 +6,7 @@ import { ArticleSummaryHeadline } from "@times-components/article-summary";
 import { iterator } from "@times-components/test-utils";
 import { mockEditionSlice } from "@times-components/fixture-generator";
 import { TileH } from "../src/tiles";
-import { getCrop, TileLink, TileSummary } from "../src/tiles/shared";
+import { getCrop, TileImage, TileLink, TileSummary } from "../src/tiles/shared";
 
 jest.mock("@times-components/article-flag", () => ({
   ArticleFlags: "ArticleFlags"
@@ -100,7 +100,15 @@ export default () => {
       test: () => {
         const tileWithLeadAssetOverride = {
           article: {
-            ...tile.article
+            ...tile.article,
+            listingAsset: {
+              crop23: {
+                ratio: "2:3",
+                url:
+                  "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fef809506-4b04-11e9-b472-f58a50a13bbb.jpg?crop=620%2C348%2C0%2C23"
+              },
+              id: "ef809506-4b04-11e9-b472-f58a50a13bbb"
+            }
           },
           ...tile,
           leadAsset: {
@@ -119,6 +127,35 @@ export default () => {
 
         expect(output.root.findByType(Image).props.uri).toEqual(
           tileWithLeadAssetOverride.leadAsset.crop23.url
+        );
+      }
+    },
+    {
+      name:
+        "Tile summary displays tile listingAsset override if no tile override is available",
+      test: () => {
+        const tileWithListingAssetOverride = {
+          ...tile,
+          article: {
+            ...tile.article,
+            listingAsset: {
+              crop23: {
+                ratio: "2:3",
+                url:
+                  "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fwf809506-4b04-11e9-b472-f58a50a13bbb.jpg?crop=620%2C348%2C0%2C23"
+              },
+              id: "wf809506-4b04-11e9-b472-f58a50a13bbb"
+            }
+          },
+          leadAsset: null
+        };
+
+        const output = TestRenderer.create(
+          <TileH onPress={() => {}} tile={tileWithListingAssetOverride} />
+        );
+
+        expect(output.root.findByType(TileImage).props.uri).toEqual(
+          tileWithListingAssetOverride.article.listingAsset.crop23.url
         );
       }
     },

--- a/packages/edition-slices/src/tiles/tile-a/index.js
+++ b/packages/edition-slices/src/tiles/tile-a/index.js
@@ -19,7 +19,10 @@ const TileA = ({ onPress, tile }) => (
     <TileImage
       aspectRatio={16 / 9}
       style={styles.imageContainer}
-      uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop169")}
+      uri={getCrop(
+        tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+        "crop169"
+      )}
     />
   </TileLink>
 );

--- a/packages/edition-slices/src/tiles/tile-aa/index.js
+++ b/packages/edition-slices/src/tiles/tile-aa/index.js
@@ -16,7 +16,10 @@ const TileT = ({ onPress, tile }) => (
       <TileImage
         aspectRatio={16 / 9}
         style={styles.imageContainer}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop169")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop169"
+        )}
       />
       <TileSummary
         headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-ab/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/index.js
@@ -23,7 +23,12 @@ const TileH = ({ onPress, tile }) => (
       <View style={styles.imageContainer}>
         <TileImage
           aspectRatio={2 / 3}
-          uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop23")}
+          uri={getCrop(
+            tile.leadAsset ||
+              tile.article.listingAsset ||
+              tile.article.leadAsset,
+            "crop23"
+          )}
         />
       </View>
     </View>

--- a/packages/edition-slices/src/tiles/tile-ac/index.js
+++ b/packages/edition-slices/src/tiles/tile-ac/index.js
@@ -17,7 +17,10 @@ const TileAC = ({ onPress, tile }) => {
       <TileImage
         aspectRatio={16 / 9}
         style={imageContainer}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop169")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop169"
+        )}
       />
       <TileSummary
         headlineStyle={headline}

--- a/packages/edition-slices/src/tiles/tile-ad/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/index.js
@@ -19,7 +19,12 @@ const TileAD = ({ onPress, tile }) => {
         <TileImage
           aspectRatio={3 / 2}
           style={imageContainer}
-          uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop32")}
+          uri={getCrop(
+            tile.leadAsset ||
+              tile.article.listingAsset ||
+              tile.article.leadAsset,
+            "crop32"
+          )}
         />
         <TileSummary
           headlineStyle={headline}

--- a/packages/edition-slices/src/tiles/tile-ah/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/index.js
@@ -30,7 +30,12 @@ class TileAH extends Component {
             aspectRatio={1}
             borderRadius={containerWidth * 0.15}
             style={styles.imageContainer}
-            uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop11")}
+            uri={getCrop(
+              tile.leadAsset ||
+                tile.article.listingAsset ||
+                tile.article.leadAsset,
+              "crop11"
+            )}
           />
           <TileSummary
             byline={tile.article.byline}

--- a/packages/edition-slices/src/tiles/tile-ai/index.js
+++ b/packages/edition-slices/src/tiles/tile-ai/index.js
@@ -10,7 +10,10 @@ const TileAI = ({ onPress, tile }) => (
       <TileImage
         aspectRatio={3 / 2}
         style={styles.imageContainer}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop32")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop32"
+        )}
       />
     </View>
   </TileLink>

--- a/packages/edition-slices/src/tiles/tile-c/index.js
+++ b/packages/edition-slices/src/tiles/tile-c/index.js
@@ -14,7 +14,10 @@ const TileC = ({ onPress, tile }) => (
     <TileImage
       aspectRatio={16 / 9}
       style={styles.imageContainer}
-      uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop169")}
+      uri={getCrop(
+        tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+        "crop169"
+      )}
     />
     <TileSummary headlineStyle={styles.headline} tile={tile} />
   </TileLink>

--- a/packages/edition-slices/src/tiles/tile-d/index.js
+++ b/packages/edition-slices/src/tiles/tile-d/index.js
@@ -16,7 +16,10 @@ const TileD = ({ onPress, tile }) => (
       <TileImage
         aspectRatio={3 / 2}
         style={styles.imageContainer}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop32")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop32"
+        )}
       />
       <TileSummary
         headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-e/index.js
+++ b/packages/edition-slices/src/tiles/tile-e/index.js
@@ -16,7 +16,10 @@ const TileE = ({ onPress, tile }) => (
       <TileImage
         aspectRatio={4 / 5}
         style={styles.imageContainer}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop45")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop45"
+        )}
       />
       <TileSummary
         headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-g/index.js
+++ b/packages/edition-slices/src/tiles/tile-g/index.js
@@ -30,7 +30,12 @@ class TileG extends Component {
             aspectRatio={1}
             borderRadius={containerWidth * 0.15}
             style={styles.imageContainer}
-            uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop11")}
+            uri={getCrop(
+              tile.leadAsset ||
+                tile.article.listingAsset ||
+                tile.article.leadAsset,
+              "crop11"
+            )}
           />
           <TileSummary
             headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-h/index.js
+++ b/packages/edition-slices/src/tiles/tile-h/index.js
@@ -23,7 +23,12 @@ const TileH = ({ onPress, tile }) => (
       <View style={styles.imageContainer}>
         <TileImage
           aspectRatio={2 / 3}
-          uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop23")}
+          uri={getCrop(
+            tile.leadAsset ||
+              tile.article.listingAsset ||
+              tile.article.leadAsset,
+            "crop23"
+          )}
         />
       </View>
     </View>

--- a/packages/edition-slices/src/tiles/tile-i/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/index.js
@@ -14,7 +14,10 @@ const TileI = ({ onPress, tile }) => (
     <TileImage
       aspectRatio={16 / 9}
       style={styles.imageContainer}
-      uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop169")}
+      uri={getCrop(
+        tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+        "crop169"
+      )}
     />
     <TileSummary
       headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-j/index.js
+++ b/packages/edition-slices/src/tiles/tile-j/index.js
@@ -16,7 +16,10 @@ const TileJ = ({ onPress, tile }) => (
       <TileImage
         aspectRatio={3 / 2}
         style={styles.imageContainer}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop32")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop32"
+        )}
       />
       <TileSummary
         headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-n/index.js
+++ b/packages/edition-slices/src/tiles/tile-n/index.js
@@ -17,7 +17,10 @@ const TileN = ({ onPress, tile }) => (
       <TileImage
         aspectRatio={1}
         style={styles.imageContainer}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop11")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop11"
+        )}
       />
       <TileSummary
         flagColour={styles.flagColour}

--- a/packages/edition-slices/src/tiles/tile-p/index.js
+++ b/packages/edition-slices/src/tiles/tile-p/index.js
@@ -30,7 +30,12 @@ class TileP extends Component {
             aspectRatio={1}
             borderRadius={containerWidth * 0.15}
             style={styles.imageContainer}
-            uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop11")}
+            uri={getCrop(
+              tile.leadAsset ||
+                tile.article.listingAsset ||
+                tile.article.leadAsset,
+              "crop11"
+            )}
           />
           <TileSummary
             byline={tile.article.byline}

--- a/packages/edition-slices/src/tiles/tile-q/index.js
+++ b/packages/edition-slices/src/tiles/tile-q/index.js
@@ -10,7 +10,10 @@ const TileQ = ({ onPress, tile }) => (
       <TileImage
         aspectRatio={3 / 2}
         style={styles.imageContainer}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop32")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop32"
+        )}
       />
     </View>
   </TileLink>

--- a/packages/edition-slices/src/tiles/tile-r/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/index.js
@@ -16,7 +16,10 @@ const TileR = ({ onPress, tile }) => (
       <TileSummary headlineStyle={styles.headline} tile={tile} />
       <TileImage
         aspectRatio={16 / 9}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop169")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop169"
+        )}
       />
     </View>
   </TileLink>

--- a/packages/edition-slices/src/tiles/tile-t/index.js
+++ b/packages/edition-slices/src/tiles/tile-t/index.js
@@ -16,7 +16,10 @@ const TileT = ({ onPress, tile }) => (
       <TileImage
         aspectRatio={16 / 9}
         style={styles.imageContainer}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop169")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop169"
+        )}
       />
       <TileSummary
         headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-u/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/index.js
@@ -21,7 +21,10 @@ const TileU = ({ onPress, tile }) => (
       <TileImage
         aspectRatio={3 / 2}
         style={styles.imageContainer}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop32")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop32"
+        )}
       />
     </View>
   </TileLink>

--- a/packages/edition-slices/src/tiles/tile-v/index.js
+++ b/packages/edition-slices/src/tiles/tile-v/index.js
@@ -16,7 +16,10 @@ const TileV = ({ onPress, tile }) => (
       <TileImage
         aspectRatio={16 / 9}
         style={styles.imageContainer}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop169")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop169"
+        )}
       />
       <TileSummary headlineStyle={styles.headline} tile={tile} />
     </View>

--- a/packages/edition-slices/src/tiles/tile-w/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/index.js
@@ -23,7 +23,10 @@ const TileW = ({ onPress, tile }) => (
       <TileImage
         aspectRatio={3 / 2}
         style={styles.imageContainer}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop32")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop32"
+        )}
       />
     </View>
   </TileLink>

--- a/packages/edition-slices/src/tiles/tile-z/index.js
+++ b/packages/edition-slices/src/tiles/tile-z/index.js
@@ -16,7 +16,10 @@ const TileZ = ({ onPress, tile }) => (
       <TileSummary headlineStyle={styles.headline} tile={tile} />
       <TileImage
         aspectRatio={4 / 5}
-        uri={getCrop(tile.leadAsset || tile.article.leadAsset, "crop45")}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop45"
+        )}
       />
     </View>
   </TileLink>

--- a/packages/fixture-generator/src/mock-article.ts
+++ b/packages/fixture-generator/src/mock-article.ts
@@ -30,6 +30,7 @@ class MockArticle {
   constructor() {
     this.article = {
       leadAsset: new MockImage().get(),
+      listingAsset: new MockImage().get(),
       hasVideo: false,
       commentsEnabled: false,
       isBookmarked: false,

--- a/packages/provider-queries/src/section-fragment.js
+++ b/packages/provider-queries/src/section-fragment.js
@@ -1422,6 +1422,24 @@ export default gql`
     }
   }
 
+  fragment listingAsset169 on Media {
+    __typename
+    ... on Video {
+      posterImage {
+        crop169: crop(ratio: "16:9") {
+          ratio
+          url
+        }
+      }
+    }
+    ... on Image {
+      crop169: crop(ratio: "16:9") {
+        ratio
+        url
+      }
+    }
+  }
+
   fragment leadAsset169and32 on Media {
     __typename
     ... on Video {

--- a/packages/provider-queries/src/section-fragment.js
+++ b/packages/provider-queries/src/section-fragment.js
@@ -51,6 +51,9 @@ export default gql`
             leadAsset {
               ...leadAsset11
             }
+            listingAsset {
+              ...listingAsset11
+            }
             summary125: summary(maxCharCount: 125)
           }
           teaser125: teaser(maxCharCount: 125)
@@ -64,6 +67,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset32
+            }
+            listingAsset {
+              ...listingAsset32
             }
           }
         }
@@ -102,6 +108,9 @@ export default gql`
             leadAsset {
               ...leadAsset169
             }
+            listingAsset {
+              ...listingAsset169
+            }
           }
         }
         support1 {
@@ -113,6 +122,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset32
+            }
+            listingAsset {
+              ...listingAsset32
             }
           }
         }
@@ -126,6 +138,9 @@ export default gql`
             leadAsset {
               ...leadAsset32
             }
+            listingAsset {
+              ...listingAsset32
+            }
           }
         }
         support3 {
@@ -138,6 +153,9 @@ export default gql`
             leadAsset {
               ...leadAsset32
             }
+            listingAsset {
+              ...listingAsset32
+            }
           }
         }
         support4 {
@@ -149,6 +167,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset32
+            }
+            listingAsset {
+              ...listingAsset32
             }
           }
         }
@@ -164,6 +185,9 @@ export default gql`
             leadAsset {
               ...leadAsset169and32
             }
+            listingAsset {
+              ...listingAsset169and32
+            }
           }
         }
         support {
@@ -175,6 +199,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
             summary125: summary(maxCharCount: 125)
           }
@@ -191,6 +218,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
           }
         }
@@ -227,6 +257,9 @@ export default gql`
             leadAsset {
               ...leadAsset32
             }
+            listingAsset {
+              ...listingAsset32
+            }
           }
         }
         support2 {
@@ -238,6 +271,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset45
+            }
+            listingAsset {
+              ...listingAsset45
             }
           }
         }
@@ -253,6 +289,9 @@ export default gql`
             leadAsset {
               ...leadAsset169
             }
+            listingAsset {
+              ...listingAsset169
+            }
           }
         }
         secondary2 {
@@ -264,6 +303,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
           }
         }
@@ -277,6 +319,9 @@ export default gql`
             leadAsset {
               ...leadAsset169
             }
+            listingAsset {
+              ...listingAsset169
+            }
           }
         }
         secondary4 {
@@ -288,6 +333,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
           }
         }
@@ -302,6 +350,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169and32
+            }
+            listingAsset {
+              ...listingAsset169and32
             }
             summary125: summary(maxCharCount: 125)
           }
@@ -319,6 +370,9 @@ export default gql`
             leadAsset {
               ...leadAsset169
             }
+            listingAsset {
+              ...listingAsset169
+            }
           }
         }
         columnist {
@@ -330,6 +384,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset23
+            }
+            listingAsset {
+              ...listingAsset23
             }
             summary125: summary(maxCharCount: 125)
           }
@@ -347,6 +404,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset11
+            }
+            listingAsset {
+              ...listingAsset11
             }
           }
         }
@@ -386,6 +446,9 @@ export default gql`
             leadAsset {
               ...leadAsset169
             }
+            listingAsset {
+              ...listingAsset169
+            }
           }
         }
         secondary2 {
@@ -397,6 +460,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
           }
         }
@@ -410,6 +476,9 @@ export default gql`
             leadAsset {
               ...leadAsset11
             }
+            listingAsset {
+              ...listingAsset11
+            }
           }
         }
         support2 {
@@ -421,6 +490,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset11
+            }
+            listingAsset {
+              ...listingAsset11
             }
           }
         }
@@ -452,6 +524,9 @@ export default gql`
             leadAsset {
               ...leadAsset11
             }
+            listingAsset {
+              ...listingAsset11
+            }
           }
         }
         support2 {
@@ -463,6 +538,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset11
+            }
+            listingAsset {
+              ...listingAsset11
             }
           }
         }
@@ -478,6 +556,9 @@ export default gql`
             leadAsset {
               ...leadAsset169
             }
+            listingAsset {
+              ...listingAsset169
+            }
           }
         }
         lead2 {
@@ -489,6 +570,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
           }
         }
@@ -565,6 +649,9 @@ export default gql`
             leadAsset {
               ...leadAsset11
             }
+            listingAsset {
+              ...listingAsset11
+            }
             summary125: summary(maxCharCount: 125)
           }
           teaser125: teaser(maxCharCount: 125)
@@ -578,6 +665,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
           }
         }
@@ -616,6 +706,9 @@ export default gql`
             leadAsset {
               ...leadAsset169
             }
+            listingAsset {
+              ...listingAsset169
+            }
           }
         }
         support1 {
@@ -627,6 +720,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset32
+            }
+            listingAsset {
+              ...listingAsset32
             }
           }
         }
@@ -640,6 +736,9 @@ export default gql`
             leadAsset {
               ...leadAsset32
             }
+            listingAsset {
+              ...listingAsset32
+            }
           }
         }
         support3 {
@@ -652,6 +751,9 @@ export default gql`
             leadAsset {
               ...leadAsset32
             }
+            listingAsset {
+              ...listingAsset32
+            }
           }
         }
         support4 {
@@ -663,6 +765,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset32
+            }
+            listingAsset {
+              ...listingAsset32
             }
           }
         }
@@ -678,6 +783,9 @@ export default gql`
             leadAsset {
               ...leadAsset169and32
             }
+            listingAsset {
+              ...listingAsset169and32
+            }
           }
         }
         support {
@@ -689,6 +797,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
             summary125: summary(maxCharCount: 125)
           }
@@ -705,6 +816,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
           }
         }
@@ -741,6 +855,9 @@ export default gql`
             leadAsset {
               ...leadAsset32
             }
+            listingAsset {
+              ...listingAsset32
+            }
           }
         }
         support2 {
@@ -752,6 +869,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset45
+            }
+            listingAsset {
+              ...listingAsset45
             }
           }
         }
@@ -767,6 +887,9 @@ export default gql`
             leadAsset {
               ...leadAsset169
             }
+            listingAsset {
+              ...listingAsset169
+            }
           }
         }
         secondary2 {
@@ -778,6 +901,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
           }
         }
@@ -791,6 +917,9 @@ export default gql`
             leadAsset {
               ...leadAsset169
             }
+            listingAsset {
+              ...listingAsset169
+            }
           }
         }
         secondary4 {
@@ -802,6 +931,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
           }
         }
@@ -816,6 +948,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169and32
+            }
+            listingAsset {
+              ...listingAsset169and32
             }
             summary125: summary(maxCharCount: 125)
           }
@@ -833,6 +968,9 @@ export default gql`
             leadAsset {
               ...leadAsset169
             }
+            listingAsset {
+              ...listingAsset169
+            }
           }
         }
         columnist {
@@ -844,6 +982,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset23
+            }
+            listingAsset {
+              ...listingAsset23
             }
             summary125: summary(maxCharCount: 125)
           }
@@ -861,6 +1002,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset11
+            }
+            listingAsset {
+              ...listingAsset11
             }
           }
         }
@@ -900,6 +1044,9 @@ export default gql`
             leadAsset {
               ...leadAsset169
             }
+            listingAsset {
+              ...listingAsset169
+            }
           }
         }
         secondary2 {
@@ -911,6 +1058,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
           }
         }
@@ -924,6 +1074,9 @@ export default gql`
             leadAsset {
               ...leadAsset11
             }
+            listingAsset {
+              ...listingAsset11
+            }
           }
         }
         support2 {
@@ -935,6 +1088,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset11
+            }
+            listingAsset {
+              ...listingAsset11
             }
           }
         }
@@ -966,6 +1122,9 @@ export default gql`
             leadAsset {
               ...leadAsset11
             }
+            listingAsset {
+              ...listingAsset11
+            }
           }
         }
         support2 {
@@ -977,6 +1136,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset11
+            }
+            listingAsset {
+              ...listingAsset11
             }
           }
         }
@@ -992,6 +1154,9 @@ export default gql`
             leadAsset {
               ...leadAsset169
             }
+            listingAsset {
+              ...listingAsset169
+            }
           }
         }
         lead2 {
@@ -1003,6 +1168,9 @@ export default gql`
             ...baseArticleProps
             leadAsset {
               ...leadAsset169
+            }
+            listingAsset {
+              ...listingAsset169
             }
           }
         }
@@ -1077,6 +1245,104 @@ export default gql`
       }
     }
     ... on Image {
+      crop169: crop(ratio: "16:9") {
+        ratio
+        url
+      }
+    }
+  }
+
+  fragment listingAsset32 on Media {
+    __typename
+    ... on Video {
+      posterImage {
+        crop32: crop(ratio: "3:2") {
+          ratio
+          url
+        }
+      }
+    }
+    ... on Image {
+      crop32: crop(ratio: "3:2") {
+        ratio
+        url
+      }
+    }
+  }
+
+  fragment listingAsset11 on Media {
+    __typename
+    ... on Video {
+      posterImage {
+        crop11: crop(ratio: "1:1") {
+          ratio
+          url
+        }
+      }
+    }
+    ... on Image {
+      crop11: crop(ratio: "1:1") {
+        ratio
+        url
+      }
+    }
+  }
+
+  fragment listingAsset45 on Media {
+    __typename
+    ... on Video {
+      posterImage {
+        crop45: crop(ratio: "4:5") {
+          ratio
+          url
+        }
+      }
+    }
+    ... on Image {
+      crop45: crop(ratio: "4:5") {
+        ratio
+        url
+      }
+    }
+  }
+
+  fragment listingAsset23 on Media {
+    __typename
+    ... on Video {
+      posterImage {
+        crop23: crop(ratio: "2:3") {
+          ratio
+          url
+        }
+      }
+    }
+    ... on Image {
+      crop23: crop(ratio: "2:3") {
+        ratio
+        url
+      }
+    }
+  }
+
+  fragment listingAsset169and32 on Media {
+    __typename
+    ... on Video {
+      posterImage {
+        crop32: crop(ratio: "3:2") {
+          ratio
+          url
+        }
+        crop169: crop(ratio: "16:9") {
+          ratio
+          url
+        }
+      }
+    }
+    ... on Image {
+      crop32: crop(ratio: "3:2") {
+        ratio
+        url
+      }
       crop169: crop(ratio: "16:9") {
         ratio
         url

--- a/packages/provider-test-tools/fixtures/article.json
+++ b/packages/provider-test-tools/fixtures/article.json
@@ -1028,6 +1028,37 @@
     "title": "Chris Reynolds Gordon at one of his party venues in London",
     "__typename": "Image"
   },
+  "listingAsset": {
+    "caption": "Chris Reynolds Gordon at one of his party venues in London-la",
+    "credits": "Gareth Philips",
+    "crop169": {
+      "ratio": "16:9",
+      "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd67cded0-ca7a-11e8-998e-a6e3c63abd14la.jpg?crop=1600%2C900%2C0%2C0"
+    },
+    "crop32": {
+      "ratio": "3:2",
+      "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46fla.jpg?crop=4272%2C2848%2C0%2C0"
+    },
+    "crop1251": {
+      "ratio": "1.25:1",
+      "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46fla.jpg?crop=3560%2C2848%2C356%2C0"
+    },
+    "crop11": {
+      "ratio": "1:1",
+      "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46fla.jpg?crop=2848%2C2848%2C712%2C0"
+    },
+    "crop45": {
+      "ratio": "4:5",
+      "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46fla.jpg?crop=2278%2C2848%2C997%2C0"
+    },
+    "crop23": {
+      "ratio": "2:3",
+      "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46fla.jpg?crop=1899%2C2848%2C1187%2C0"
+    },
+    "id": "363b03a1-2ce6-4b94-b053-0d35316548c5",
+    "title": "Chris Reynolds Gordon at one of his party venues in London-la",
+    "__typename": "Image"
+  },
   "publicationName": "TIMES",
   "publishedTime": "2015-03-13T18:54:58.000Z",
   "relatedArticleSlice": {

--- a/packages/provider/__tests__/__snapshots__/edition-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/edition-provider.test.js.snap
@@ -67,6 +67,14 @@ Object {
                   "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd67cded0-ca7a-11e8-998e-a6e3c63abd14.jpg?crop=1600%2C900%2C0%2C0",
                 },
               },
+              "listingAsset": Object {
+                "__typename": "Image",
+                "crop169": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd67cded0-ca7a-11e8-998e-a6e3c63abd14la.jpg?crop=1600%2C900%2C0%2C0",
+                },
+              },
               "shortHeadline": "Let's keep A levels but scrap outdated GCSEs",
               "url": "https://www.thetimes.co.uk/edition/news/france-defies-may-over-russia-37b27qd2s",
             },
@@ -143,6 +151,14 @@ Object {
                   "__typename": "Crop",
                   "ratio": "16:9",
                   "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd67cded0-ca7a-11e8-998e-a6e3c63abd14.jpg?crop=1600%2C900%2C0%2C0",
+                },
+              },
+              "listingAsset": Object {
+                "__typename": "Image",
+                "crop169": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd67cded0-ca7a-11e8-998e-a6e3c63abd14la.jpg?crop=1600%2C900%2C0%2C0",
                 },
               },
               "shortHeadline": "Let's keep A levels but scrap outdated GCSEs",

--- a/packages/provider/__tests__/__snapshots__/native-edition-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/native-edition-provider.test.js.snap
@@ -983,6 +983,14 @@ Object {
                   "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd67cded0-ca7a-11e8-998e-a6e3c63abd14.jpg?crop=1600%2C900%2C0%2C0",
                 },
               },
+              "listingAsset": Object {
+                "__typename": "Image",
+                "crop169": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd67cded0-ca7a-11e8-998e-a6e3c63abd14la.jpg?crop=1600%2C900%2C0%2C0",
+                },
+              },
               "shortHeadline": "Let's keep A levels but scrap outdated GCSEs",
               "url": "https://www.thetimes.co.uk/edition/news/france-defies-may-over-russia-37b27qd2s",
             },
@@ -1059,6 +1067,14 @@ Object {
                   "__typename": "Crop",
                   "ratio": "16:9",
                   "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd67cded0-ca7a-11e8-998e-a6e3c63abd14.jpg?crop=1600%2C900%2C0%2C0",
+                },
+              },
+              "listingAsset": Object {
+                "__typename": "Image",
+                "crop169": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd67cded0-ca7a-11e8-998e-a6e3c63abd14la.jpg?crop=1600%2C900%2C0%2C0",
                 },
               },
               "shortHeadline": "Let's keep A levels but scrap outdated GCSEs",


### PR DESCRIPTION
The order or precedence as discussed with backed team is 

tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset