### PR TITLE
Proof of Concept: dummy tile star with context

### DIFF
--- a/packages/edition-slices/src/tiles/shared/tile-star.js
+++ b/packages/edition-slices/src/tiles/shared/tile-star.js
@@ -1,0 +1,31 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Button from "@times-components/button";
+import { SectionContext } from "@times-components/context";
+
+const renderStar = (onSaveStarPress, savedArticles, articleId) => {
+  const isInactive = !savedArticles;
+  const isSaved = savedArticles && savedArticles[articleId];
+  const getTitle = () => {
+    if (isInactive) {
+      return "Inactive";
+    } if (isSaved) {
+      return "Unsave";
+    }
+    return "Save";
+  };
+
+  return (<Button disabled={isInactive} onPress={() => onSaveStarPress(!isSaved, articleId)} style={{ width: 100 }} title={getTitle()} />);
+}
+
+const TileStar = ({ articleId }) => (
+  <SectionContext.Consumer>
+    {({ onSaveStarPress, savedArticles }) => onSaveStarPress ? renderStar(onSaveStarPress, savedArticles, articleId) : null}
+  </SectionContext.Consumer>
+);
+
+TileStar.propTypes = {
+  articleId: PropTypes.string.isRequired
+}
+
+export default TileStar;

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { View } from "react-native";
 import PropTypes from "prop-types";
 import ArticleSummary, {
   ArticleSummaryContent,
@@ -7,11 +8,13 @@ import ArticleSummary, {
 } from "@times-components/article-summary";
 import { ArticleFlags } from "@times-components/article-flag";
 import { colours } from "@times-components/styleguide";
+import TileStar from "./tile-star";
 
 const TileSummary = ({
   tile: {
     headline: tileHeadline,
     article: {
+      id,
       expirableFlags,
       hasVideo,
       headline,
@@ -31,40 +34,43 @@ const TileSummary = ({
   flagColour,
   labelColour
 }) => (
-  <ArticleSummary
-    bylineProps={byline ? { ast: byline, bylineStyle } : null}
-    content={
-      summary
-        ? () => <ArticleSummaryContent ast={summary} style={summaryStyle} />
-        : undefined
-    }
-    flags={() => <ArticleFlags {...flagColour} flags={expirableFlags} />}
-    headline={() => (
-      <ArticleSummaryHeadline
-        headline={tileHeadline || shortHeadline || headline}
-        style={headlineStyle}
+    <View>
+      <ArticleSummary
+        bylineProps={byline ? { ast: byline, bylineStyle } : null}
+        content={
+          summary
+            ? () => <ArticleSummaryContent ast={summary} style={summaryStyle} />
+            : undefined
+        }
+        flags={() => <ArticleFlags {...flagColour} flags={expirableFlags} />}
+        headline={() => (
+          <ArticleSummaryHeadline
+            headline={tileHeadline || shortHeadline || headline}
+            style={headlineStyle}
+          />
+        )}
+        label={label}
+        labelProps={{
+          color:
+            labelColour || (colours.section[section] || colours.section.default),
+          isVideo: hasVideo,
+          title: label
+        }}
+        strapline={
+          strapline
+            ? () => (
+              <ArticleSummaryStrapline
+                strapline={strapline}
+                style={straplineStyle}
+              />
+            )
+            : undefined
+        }
+        style={style}
       />
-    )}
-    label={label}
-    labelProps={{
-      color:
-        labelColour || (colours.section[section] || colours.section.default),
-      isVideo: hasVideo,
-      title: label
-    }}
-    strapline={
-      strapline
-        ? () => (
-            <ArticleSummaryStrapline
-              strapline={strapline}
-              style={straplineStyle}
-            />
-          )
-        : undefined
-    }
-    style={style}
-  />
-);
+      <TileStar articleId={id} />
+    </View>
+  );
 
 TileSummary.propTypes = {
   bylineStyle: PropTypes.shape({}),

--- a/packages/link/src/link.android.js
+++ b/packages/link/src/link.android.js
@@ -8,7 +8,7 @@ const Link = ({ children, linkStyle, onPress }) => (
     onPress={onPress}
     useForeground={TouchableNativeFeedback.canUseNativeForeground()}
   >
-    <View pointerEvents="box-only" style={linkStyle}>
+    <View style={linkStyle}>
       {children}
     </View>
   </TouchableNativeFeedback>


### PR DESCRIPTION
This is a proof of concept, based on saved-star-context work. It consumes SectionContext and renders the button with multiple states

- Hidden: Don't show the star if onSaveStarPress is not implemented on that client
- Inactive: Disable and gray out the star if savedArticles map is not present (this happens while the client is syncing the list of saved articles)
- Saved: Click to unsave
- Unsaved: Click to save