### PR TITLE
feat: section perf improvements

### DIFF
--- a/packages/edition-slices/src/slices/commentleadandcartoon/index.js
+++ b/packages/edition-slices/src/slices/commentleadandcartoon/index.js
@@ -1,23 +1,23 @@
-import React from "react";
+import React, { Component } from "react";
 import { CommentLeadAndCartoon } from "@times-components/slice-layout";
 import PropTypes from "prop-types";
 import { TileP, TileQ, TileAH, TileAI } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-const CommentLeadAndCartoonSlice = ({ onPress, slice: { lead, cartoon } }) => (
-  <ResponsiveSlice
-    renderMedium={editionBreakpoint => (
-      <CommentLeadAndCartoon
-        breakpoint={editionBreakpoint}
-        renderCartoon={() => (
-          <TileAI onPress={onPress} tile={cartoon} tileName="cartoon" />
-        )}
-        renderLead={() => (
-          <TileAH onPress={onPress} tile={lead} tileName="lead" />
-        )}
-      />
-    )}
-    renderSmall={editionBreakpoint => (
+class CommentLeadAndCartoonSlice extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSmall = this.renderSmall.bind(this);
+    this.renderMedium = this.renderMedium.bind(this);
+  }
+
+  renderSmall(editionBreakpoint) {
+    const {
+      onPress,
+      slice: { lead, cartoon }
+    } = this.props;
+
+    return (
       <CommentLeadAndCartoon
         breakpoint={editionBreakpoint}
         renderCartoon={() => (
@@ -27,9 +27,37 @@ const CommentLeadAndCartoonSlice = ({ onPress, slice: { lead, cartoon } }) => (
           <TileP onPress={onPress} tile={lead} tileName="lead" />
         )}
       />
-    )}
-  />
-);
+    );
+  }
+
+  renderMedium(editionBreakpoint) {
+    const {
+      onPress,
+      slice: { lead, cartoon }
+    } = this.props;
+
+    return (
+      <CommentLeadAndCartoon
+        breakpoint={editionBreakpoint}
+        renderCartoon={() => (
+          <TileAI onPress={onPress} tile={cartoon} tileName="cartoon" />
+        )}
+        renderLead={() => (
+          <TileAH onPress={onPress} tile={lead} tileName="lead" />
+        )}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderMedium}
+        renderSmall={this.renderSmall}
+      />
+    );
+  }
+}
 
 CommentLeadAndCartoonSlice.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/dailyregisterleadfour/index.js
+++ b/packages/edition-slices/src/slices/dailyregisterleadfour/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import { View, Text } from "react-native";
 import PropTypes from "prop-types";
 import { ItemRowSeparator } from "@times-components/slice-layout";
@@ -7,11 +7,18 @@ import { TileS } from "../../tiles";
 import styleFactory from "./styles";
 import Logo from "./logo";
 
-const DailyRegisterLeadFour = ({
-  slice: { birthdaysToday, briefing, natureNotes, onThisDay }
-}) => {
-  const renderSlice = breakpoint => {
+class DailyRegisterLeadFour extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSlice = this.renderSlice.bind(this);
+  }
+
+  renderSlice(breakpoint) {
+    const {
+      slice: { birthdaysToday, briefing, natureNotes, onThisDay }
+    } = this.props;
     const styles = styleFactory(breakpoint);
+
     return (
       <View style={styles.container}>
         <Logo
@@ -42,17 +49,19 @@ const DailyRegisterLeadFour = ({
         <TileS tile={birthdaysToday} />
       </View>
     );
-  };
+  }
 
-  return (
-    <ResponsiveSlice
-      renderHuge={renderSlice}
-      renderMedium={renderSlice}
-      renderSmall={renderSlice}
-      renderWide={renderSlice}
-    />
-  );
-};
+  render() {
+    return (
+      <ResponsiveSlice
+        renderHuge={this.renderSlice}
+        renderMedium={this.renderSlice}
+        renderSmall={this.renderSlice}
+        renderWide={this.renderSlice}
+      />
+    );
+  }
+}
 
 DailyRegisterLeadFour.propTypes = {
   slice: PropTypes.shape({

--- a/packages/edition-slices/src/slices/leaders/index.js
+++ b/packages/edition-slices/src/slices/leaders/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import { View, Text } from "react-native";
 import { SectionContext } from "@times-components/context";
 import { Leaders } from "@times-components/slice-layout";
@@ -8,62 +8,85 @@ import styles from "./styles";
 import { ResponsiveSlice } from "../shared";
 import MastHead from "./masthead";
 
-const renderHead = publicationName => (
-  <View style={styles.mastheadContainer}>
-    <MastHead publicationName={publicationName} />
-    <View style={styles.headingContainer}>
-      <Text style={[styles.heading, styles.text]}> Leading Articles </Text>
-    </View>
-  </View>
+const renderHead = () => (
+  <SectionContext.Consumer>
+    {({ publicationName }) => (
+      <View style={styles.mastheadContainer}>
+        <MastHead publicationName={publicationName} />
+        <View style={styles.headingContainer}>
+          <Text style={[styles.heading, styles.text]}> Leading Articles </Text>
+        </View>
+      </View>
+    )}
+  </SectionContext.Consumer>
 );
 
-const LeadersSlice = ({ onPress, slice: { leader1, leader2, leader3 } }) => {
-  const renderSmallSlice = breakpoint => (
-    <Leaders
-      breakpoint={breakpoint}
-      renderLeader1={() => (
-        <TileM onPress={onPress} tile={leader1} tileName="leader1" />
-      )}
-      renderLeader2={() => (
-        <TileM onPress={onPress} tile={leader2} tileName="leader2" />
-      )}
-      renderLeader3={() => (
-        <TileM onPress={onPress} tile={leader3} tileName="leader3" />
-      )}
-    />
-  );
+class LeadersSlice extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSmall = this.renderSmall.bind(this);
+    this.renderHuge = this.renderHuge.bind(this);
+  }
 
-  const renderHugeSlice = breakpoint => (
-    <Leaders
-      breakpoint={breakpoint}
-      renderLeader1={() => (
-        <TileAG onPress={onPress} tile={leader1} tileName="leader1" />
-      )}
-      renderLeader2={() => (
-        <TileAG onPress={onPress} tile={leader2} tileName="leader2" />
-      )}
-      renderLeader3={() => (
-        <TileAG onPress={onPress} tile={leader3} tileName="leader3" />
-      )}
-    />
-  );
+  renderSmall(breakpoint) {
+    const {
+      onPress,
+      slice: { leader1, leader2, leader3 }
+    } = this.props;
 
-  return (
-    <SectionContext.Consumer>
-      {({ publicationName }) => (
-        <View style={styles.container}>
-          {renderHead(publicationName)}
-          <ResponsiveSlice
-            renderHuge={renderHugeSlice}
-            renderMedium={renderSmallSlice}
-            renderSmall={renderSmallSlice}
-            renderWide={renderHugeSlice}
-          />
-        </View>
-      )}
-    </SectionContext.Consumer>
-  );
-};
+    return (
+      <Leaders
+        breakpoint={breakpoint}
+        renderLeader1={() => (
+          <TileM onPress={onPress} tile={leader1} tileName="leader1" />
+        )}
+        renderLeader2={() => (
+          <TileM onPress={onPress} tile={leader2} tileName="leader2" />
+        )}
+        renderLeader3={() => (
+          <TileM onPress={onPress} tile={leader3} tileName="leader3" />
+        )}
+      />
+    );
+  }
+
+  renderHuge(breakpoint) {
+    const {
+      onPress,
+      slice: { leader1, leader2, leader3 }
+    } = this.props;
+
+    return (
+      <Leaders
+        breakpoint={breakpoint}
+        renderLeader1={() => (
+          <TileAG onPress={onPress} tile={leader1} tileName="leader1" />
+        )}
+        renderLeader2={() => (
+          <TileAG onPress={onPress} tile={leader2} tileName="leader2" />
+        )}
+        renderLeader3={() => (
+          <TileAG onPress={onPress} tile={leader3} tileName="leader3" />
+        )}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        {renderHead()}
+        <ResponsiveSlice
+          renderHuge={this.renderHuge}
+          renderMedium={this.renderSmall}
+          renderSmall={this.renderSmall}
+          renderWide={this.renderHuge}
+        />
+      </View>
+    );
+  }
+}
+
 LeadersSlice.propTypes = {
   onPress: PropTypes.func.isRequired,
   slice: PropTypes.shape({

--- a/packages/edition-slices/src/slices/leadoneandfour/index.js
+++ b/packages/edition-slices/src/slices/leadoneandfour/index.js
@@ -1,35 +1,23 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { LeadOneAndFourSlice } from "@times-components/slice-layout";
 import { TileAC, TileAD, TileI, TileJ } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-const LeadOneAndFour = ({
-  onPress,
-  slice: { lead, support1, support2, support3, support4 }
-}) => (
-  <ResponsiveSlice
-    renderMedium={breakpoint => (
-      <LeadOneAndFourSlice
-        breakpoint={breakpoint}
-        renderLead={() => (
-          <TileAC onPress={onPress} tile={lead} tileName="lead" />
-        )}
-        renderSupport1={() => (
-          <TileAD onPress={onPress} tile={support1} tileName="support1" />
-        )}
-        renderSupport2={() => (
-          <TileAD onPress={onPress} tile={support2} tileName="support2" />
-        )}
-        renderSupport3={() => (
-          <TileAD onPress={onPress} tile={support3} tileName="support3" />
-        )}
-        renderSupport4={() => (
-          <TileAD onPress={onPress} tile={support4} tileName="support4" />
-        )}
-      />
-    )}
-    renderSmall={breakpoint => (
+class LeadOneAndFour extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSmall = this.renderSmall.bind(this);
+    this.renderMedium = this.renderMedium.bind(this);
+  }
+
+  renderSmall(breakpoint) {
+    const {
+      onPress,
+      slice: { lead, support1, support2, support3, support4 }
+    } = this.props;
+
+    return (
       <LeadOneAndFourSlice
         breakpoint={breakpoint}
         renderLead={() => (
@@ -48,9 +36,46 @@ const LeadOneAndFour = ({
           <TileJ onPress={onPress} tile={support4} tileName="support4" />
         )}
       />
-    )}
-  />
-);
+    );
+  }
+
+  renderMedium(breakpoint) {
+    const {
+      onPress,
+      slice: { lead, support1, support2, support3, support4 }
+    } = this.props;
+
+    return (
+      <LeadOneAndFourSlice
+        breakpoint={breakpoint}
+        renderLead={() => (
+          <TileAC onPress={onPress} tile={lead} tileName="lead" />
+        )}
+        renderSupport1={() => (
+          <TileAD onPress={onPress} tile={support1} tileName="support1" />
+        )}
+        renderSupport2={() => (
+          <TileAD onPress={onPress} tile={support2} tileName="support2" />
+        )}
+        renderSupport3={() => (
+          <TileAD onPress={onPress} tile={support3} tileName="support3" />
+        )}
+        renderSupport4={() => (
+          <TileAD onPress={onPress} tile={support4} tileName="support4" />
+        )}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderMedium}
+        renderSmall={this.renderSmall}
+      />
+    );
+  }
+}
 
 LeadOneAndFour.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/leadoneandone/index.js
+++ b/packages/edition-slices/src/slices/leadoneandone/index.js
@@ -1,25 +1,24 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { LeadOneAndOneSlice } from "@times-components/slice-layout";
 import { TileA, TileB, TileC, TileU } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-const LeadOneAndOne = ({ onPress, slice: { lead, support } }) => (
-  <ResponsiveSlice
-    renderMedium={editionBreakpoint => (
+class LeadOneAndOne extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSmall = this.renderSmall.bind(this);
+    this.renderMedium = this.renderMedium.bind(this);
+  }
+
+  renderSmall(breakpoint) {
+    const {
+      onPress,
+      slice: { lead, support }
+    } = this.props;
+    return (
       <LeadOneAndOneSlice
-        breakpoint={editionBreakpoint}
-        renderLead={() => (
-          <TileU onPress={onPress} tile={lead} tileName="lead" />
-        )}
-        renderSupport={() => (
-          <TileC onPress={onPress} tile={support} tileName="support" />
-        )}
-      />
-    )}
-    renderSmall={editionBreakpoint => (
-      <LeadOneAndOneSlice
-        breakpoint={editionBreakpoint}
+        breakpoint={breakpoint}
         renderLead={() => (
           <TileA onPress={onPress} tile={lead} tileName="lead" />
         )}
@@ -27,9 +26,36 @@ const LeadOneAndOne = ({ onPress, slice: { lead, support } }) => (
           <TileB onPress={onPress} tile={support} tileName="support" />
         )}
       />
-    )}
-  />
-);
+    );
+  }
+
+  renderMedium(breakpoint) {
+    const {
+      onPress,
+      slice: { lead, support }
+    } = this.props;
+    return (
+      <LeadOneAndOneSlice
+        breakpoint={breakpoint}
+        renderLead={() => (
+          <TileU onPress={onPress} tile={lead} tileName="lead" />
+        )}
+        renderSupport={() => (
+          <TileC onPress={onPress} tile={support} tileName="support" />
+        )}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderMedium}
+        renderSmall={this.renderSmall}
+      />
+    );
+  }
+}
 
 LeadOneAndOne.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/leadonefullwidth/index.js
+++ b/packages/edition-slices/src/slices/leadonefullwidth/index.js
@@ -1,14 +1,40 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { TileA, TileR } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-const LeadOneFullWidthSlice = ({ slice: { lead }, onPress }) => (
-  <ResponsiveSlice
-    renderMedium={() => <TileR onPress={onPress} tile={lead} tileName="lead" />}
-    renderSmall={() => <TileA onPress={onPress} tile={lead} tileName="lead" />}
-  />
-);
+class LeadOneFullWidthSlice extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSmall = this.renderSmall.bind(this);
+    this.renderMedium = this.renderMedium.bind(this);
+  }
+
+  renderSmall() {
+    const {
+      slice: { lead },
+      onPress
+    } = this.props;
+    return <TileA onPress={onPress} tile={lead} tileName="lead" />;
+  }
+
+  renderMedium() {
+    const {
+      slice: { lead },
+      onPress
+    } = this.props;
+    return <TileR onPress={onPress} tile={lead} tileName="lead" />;
+  }
+
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderMedium}
+        renderSmall={this.renderSmall}
+      />
+    );
+  }
+}
 
 LeadOneFullWidthSlice.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/leadtwonopicandtwo/index.js
+++ b/packages/edition-slices/src/slices/leadtwonopicandtwo/index.js
@@ -1,34 +1,24 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { LeadTwoNoPicAndTwoSlice } from "@times-components/slice-layout";
 import { TileB, TileD, TileE, TileF, TileX, TileY, TileZ } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-const LeadTwoNoPicAndTwo = ({
-  onPress,
-  slice: { lead1, lead2, support1, support2 }
-}) => (
-  <ResponsiveSlice
-    renderMedium={editionBreakpoint => (
+class LeadTwoNoPicAndTwo extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSmall = this.renderSmall.bind(this);
+    this.renderMedium = this.renderMedium.bind(this);
+  }
+
+  renderSmall(breakpoint) {
+    const {
+      onPress,
+      slice: { lead1, lead2, support1, support2 }
+    } = this.props;
+    return (
       <LeadTwoNoPicAndTwoSlice
-        breakpoint={editionBreakpoint}
-        renderLead1={() => (
-          <TileX onPress={onPress} tile={lead1} tileName="lead1" />
-        )}
-        renderLead2={() => (
-          <TileY onPress={onPress} tile={lead2} tileName="lead2" />
-        )}
-        renderSupport1={() => (
-          <TileD onPress={onPress} tile={support1} tileName="support1" />
-        )}
-        renderSupport2={() => (
-          <TileZ onPress={onPress} tile={support2} tileName="support2" />
-        )}
-      />
-    )}
-    renderSmall={editionBreakpoint => (
-      <LeadTwoNoPicAndTwoSlice
-        breakpoint={editionBreakpoint}
+        breakpoint={breakpoint}
         renderLead1={() => (
           <TileF onPress={onPress} tile={lead1} tileName="lead1" />
         )}
@@ -42,9 +32,42 @@ const LeadTwoNoPicAndTwo = ({
           <TileE onPress={onPress} tile={support2} tileName="support2" />
         )}
       />
-    )}
-  />
-);
+    );
+  }
+
+  renderMedium(breakpoint) {
+    const {
+      onPress,
+      slice: { lead1, lead2, support1, support2 }
+    } = this.props;
+    return (
+      <LeadTwoNoPicAndTwoSlice
+        breakpoint={breakpoint}
+        renderLead1={() => (
+          <TileX onPress={onPress} tile={lead1} tileName="lead1" />
+        )}
+        renderLead2={() => (
+          <TileY onPress={onPress} tile={lead2} tileName="lead2" />
+        )}
+        renderSupport1={() => (
+          <TileD onPress={onPress} tile={support1} tileName="support1" />
+        )}
+        renderSupport2={() => (
+          <TileZ onPress={onPress} tile={support2} tileName="support2" />
+        )}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderMedium}
+        renderSmall={this.renderSmall}
+      />
+    );
+  }
+}
 
 LeadTwoNoPicAndTwo.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/listtwoandsixnopic/index.js
+++ b/packages/edition-slices/src/slices/listtwoandsixnopic/index.js
@@ -1,56 +1,70 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { ListTwoAndSixNoPic } from "@times-components/slice-layout";
 import { ResponsiveSlice } from "../shared";
 import { TileL, TileC } from "../../tiles";
 
-const ListTwoAndSixNoPicSlice = ({
-  onPress,
-  slice: {
-    lead1,
-    lead2,
-    support1,
-    support2,
-    support3,
-    support4,
-    support5,
-    support6
+class ListTwoAndSixNoPicSlice extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSlice = this.renderSlice.bind(this);
   }
-}) => {
-  const renderSlice = breakpoint => (
-    <ListTwoAndSixNoPic
-      breakpoint={breakpoint}
-      renderLead1={() => (
-        <TileC onPress={onPress} tile={lead1} tileName="lead1" />
-      )}
-      renderLead2={() => (
-        <TileC onPress={onPress} tile={lead2} tileName="lead2" />
-      )}
-      renderSupport1={() => (
-        <TileL onPress={onPress} tile={support1} tileName="support1" />
-      )}
-      renderSupport2={() => (
-        <TileL onPress={onPress} tile={support2} tileName="support2" />
-      )}
-      renderSupport3={() => (
-        <TileL onPress={onPress} tile={support3} tileName="support3" />
-      )}
-      renderSupport4={() => (
-        <TileL onPress={onPress} tile={support4} tileName="support4" />
-      )}
-      renderSupport5={() => (
-        <TileL onPress={onPress} tile={support5} tileName="support5" />
-      )}
-      renderSupport6={() => (
-        <TileL onPress={onPress} tile={support6} tileName="support6" />
-      )}
-    />
-  );
 
-  return (
-    <ResponsiveSlice renderMedium={renderSlice} renderSmall={renderSlice} />
-  );
-};
+  renderSlice(breakpoint) {
+    const {
+      onPress,
+      slice: {
+        lead1,
+        lead2,
+        support1,
+        support2,
+        support3,
+        support4,
+        support5,
+        support6
+      }
+    } = this.props;
+
+    return (
+      <ListTwoAndSixNoPic
+        breakpoint={breakpoint}
+        renderLead1={() => (
+          <TileC onPress={onPress} tile={lead1} tileName="lead1" />
+        )}
+        renderLead2={() => (
+          <TileC onPress={onPress} tile={lead2} tileName="lead2" />
+        )}
+        renderSupport1={() => (
+          <TileL onPress={onPress} tile={support1} tileName="support1" />
+        )}
+        renderSupport2={() => (
+          <TileL onPress={onPress} tile={support2} tileName="support2" />
+        )}
+        renderSupport3={() => (
+          <TileL onPress={onPress} tile={support3} tileName="support3" />
+        )}
+        renderSupport4={() => (
+          <TileL onPress={onPress} tile={support4} tileName="support4" />
+        )}
+        renderSupport5={() => (
+          <TileL onPress={onPress} tile={support5} tileName="support5" />
+        )}
+        renderSupport6={() => (
+          <TileL onPress={onPress} tile={support6} tileName="support6" />
+        )}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderSlice}
+        renderSmall={this.renderSlice}
+      />
+    );
+  }
+}
 
 ListTwoAndSixNoPicSlice.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/puzzle/index.js
+++ b/packages/edition-slices/src/slices/puzzle/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import { View } from "react-native";
 import { editionBreakpoints } from "@times-components/styleguide";
 import propTypes from "./proptypes";
@@ -6,8 +6,17 @@ import stylesFactory from "./styles";
 import { ResponsiveSlice } from "../shared";
 import { TileAJ, TileAK } from "../../tiles";
 
-const Puzzle = ({ onPress, slice: { puzzles } }) => {
-  const renderPuzzles = (breakpoint = editionBreakpoints.small) => {
+class Puzzle extends Component {
+  constructor(props) {
+    super(props);
+    this.renderPuzzles = this.renderPuzzles.bind(this);
+  }
+
+  renderPuzzles(breakpoint) {
+    const {
+      onPress,
+      slice: { puzzles }
+    } = this.props;
     const { container, tileContainer } = stylesFactory(breakpoint);
     const Tile = breakpoint === editionBreakpoints.small ? TileAJ : TileAK;
 
@@ -26,15 +35,17 @@ const Puzzle = ({ onPress, slice: { puzzles } }) => {
         ))}
       </View>
     );
-  };
+  }
 
-  return (
-    <ResponsiveSlice
-      renderMedium={breakpoint => renderPuzzles(breakpoint)}
-      renderSmall={breakpoint => renderPuzzles(breakpoint)}
-    />
-  );
-};
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderPuzzles}
+        renderSmall={this.renderPuzzles}
+      />
+    );
+  }
+}
 
 Puzzle.propTypes = propTypes;
 

--- a/packages/edition-slices/src/slices/secondaryfour/index.js
+++ b/packages/edition-slices/src/slices/secondaryfour/index.js
@@ -1,35 +1,49 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { SecondaryFourSlice } from "@times-components/slice-layout";
 import { TileC } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-const SecondaryFour = ({
-  onPress,
-  slice: { secondary1, secondary2, secondary3, secondary4 }
-}) => {
-  const renderSlice = breakpoint => (
-    <SecondaryFourSlice
-      breakpoint={breakpoint}
-      renderSecondary1={() => (
-        <TileC onPress={onPress} tile={secondary1} tileName="secondary1" />
-      )}
-      renderSecondary2={() => (
-        <TileC onPress={onPress} tile={secondary2} tileName="secondary2" />
-      )}
-      renderSecondary3={() => (
-        <TileC onPress={onPress} tile={secondary3} tileName="secondary3" />
-      )}
-      renderSecondary4={() => (
-        <TileC onPress={onPress} tile={secondary4} tileName="secondary4" />
-      )}
-    />
-  );
+class SecondaryFour extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSlice = this.renderSlice.bind(this);
+  }
 
-  return (
-    <ResponsiveSlice renderMedium={renderSlice} renderSmall={renderSlice} />
-  );
-};
+  renderSlice(breakpoint) {
+    const {
+      onPress,
+      slice: { secondary1, secondary2, secondary3, secondary4 }
+    } = this.props;
+
+    return (
+      <SecondaryFourSlice
+        breakpoint={breakpoint}
+        renderSecondary1={() => (
+          <TileC onPress={onPress} tile={secondary1} tileName="secondary1" />
+        )}
+        renderSecondary2={() => (
+          <TileC onPress={onPress} tile={secondary2} tileName="secondary2" />
+        )}
+        renderSecondary3={() => (
+          <TileC onPress={onPress} tile={secondary3} tileName="secondary3" />
+        )}
+        renderSecondary4={() => (
+          <TileC onPress={onPress} tile={secondary4} tileName="secondary4" />
+        )}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderSlice}
+        renderSmall={this.renderSlice}
+      />
+    );
+  }
+}
 
 SecondaryFour.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/secondaryone/index.js
+++ b/packages/edition-slices/src/slices/secondaryone/index.js
@@ -1,18 +1,40 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { TileA, TileW } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-const SecondaryOneSlice = ({ onPress, slice: { secondary } }) => (
-  <ResponsiveSlice
-    renderMedium={() => (
-      <TileW onPress={onPress} tile={secondary} tileName="secondary" />
-    )}
-    renderSmall={() => (
-      <TileA onPress={onPress} tile={secondary} tileName="secondary" />
-    )}
-  />
-);
+class SecondaryOneSlice extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSmall = this.renderSmall.bind(this);
+    this.renderMedium = this.renderMedium.bind(this);
+  }
+
+  renderSmall() {
+    const {
+      onPress,
+      slice: { secondary }
+    } = this.props;
+    return <TileA onPress={onPress} tile={secondary} tileName="secondary" />;
+  }
+
+  renderMedium() {
+    const {
+      onPress,
+      slice: { secondary }
+    } = this.props;
+    return <TileW onPress={onPress} tile={secondary} tileName="secondary" />;
+  }
+
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderMedium}
+        renderSmall={this.renderSmall}
+      />
+    );
+  }
+}
 
 SecondaryOneSlice.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/secondaryoneandcolumnist/index.js
+++ b/packages/edition-slices/src/slices/secondaryoneandcolumnist/index.js
@@ -1,26 +1,22 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { SecondaryOneAndColumnistSlice } from "@times-components/slice-layout";
 import { TileH, TileT, TileAA, TileAB } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-const SecondaryOneAndColumnist = ({
-  onPress,
-  slice: { columnist, secondary }
-}) => (
-  <ResponsiveSlice
-    renderMedium={breakpoint => (
-      <SecondaryOneAndColumnistSlice
-        breakpoint={breakpoint}
-        renderColumnist={() => (
-          <TileAB onPress={onPress} tile={columnist} tileName="columnist" />
-        )}
-        renderSecondary={() => (
-          <TileAA onPress={onPress} tile={secondary} tileName="secondary" />
-        )}
-      />
-    )}
-    renderSmall={breakpoint => (
+class SecondaryOneAndColumnist extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSmall = this.renderSmall.bind(this);
+    this.renderMedium = this.renderMedium.bind(this);
+  }
+
+  renderSmall(breakpoint) {
+    const {
+      onPress,
+      slice: { columnist, secondary }
+    } = this.props;
+    return (
       <SecondaryOneAndColumnistSlice
         breakpoint={breakpoint}
         renderColumnist={() => (
@@ -30,9 +26,36 @@ const SecondaryOneAndColumnist = ({
           <TileT onPress={onPress} tile={secondary} tileName="secondary" />
         )}
       />
-    )}
-  />
-);
+    );
+  }
+
+  renderMedium(breakpoint) {
+    const {
+      onPress,
+      slice: { columnist, secondary }
+    } = this.props;
+    return (
+      <SecondaryOneAndColumnistSlice
+        breakpoint={breakpoint}
+        renderColumnist={() => (
+          <TileAB onPress={onPress} tile={columnist} tileName="columnist" />
+        )}
+        renderSecondary={() => (
+          <TileAA onPress={onPress} tile={secondary} tileName="secondary" />
+        )}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderMedium}
+        renderSmall={this.renderSmall}
+      />
+    );
+  }
+}
 
 SecondaryOneAndColumnist.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/secondaryoneandfour/index.js
+++ b/packages/edition-slices/src/slices/secondaryoneandfour/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import { View } from "react-native";
 import PropTypes from "prop-types";
 import { SectionContext } from "@times-components/context";
@@ -11,11 +11,18 @@ import { TileO, TileN } from "../../tiles";
 import styleFactory from "./styles";
 import { ResponsiveSlice } from "../shared";
 
-const SecondaryOneAndFour = ({
-  onPress,
-  slice: { secondary, support1, support2, support3, support4 }
-}) => {
-  const renderSlice = breakpoint => {
+class SecondaryOneAndFour extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSlice = this.renderSlice.bind(this);
+  }
+
+  renderSlice(breakpoint) {
+    const {
+      onPress,
+      slice: { secondary, support1, support2, support3, support4 }
+    } = this.props;
+
     const styles = styleFactory(breakpoint);
     return (
       <SectionContext.Consumer>
@@ -55,12 +62,17 @@ const SecondaryOneAndFour = ({
         )}
       </SectionContext.Consumer>
     );
-  };
+  }
 
-  return (
-    <ResponsiveSlice renderMedium={renderSlice} renderSmall={renderSlice} />
-  );
-};
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderSlice}
+        renderSmall={this.renderSlice}
+      />
+    );
+  }
+}
 
 SecondaryOneAndFour.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/secondarytwoandtwo/index.js
+++ b/packages/edition-slices/src/slices/secondarytwoandtwo/index.js
@@ -1,32 +1,23 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { SecondaryTwoAndTwoSlice } from "@times-components/slice-layout";
 import { TileC, TileG, TileV } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-const SecondaryTwoAndTwo = ({
-  onPress,
-  slice: { secondary1, secondary2, support1, support2 }
-}) => (
-  <ResponsiveSlice
-    renderMedium={breakpoint => (
-      <SecondaryTwoAndTwoSlice
-        breakpoint={breakpoint}
-        renderSecondary1={() => (
-          <TileV onPress={onPress} tile={secondary1} tileName="secondary1" />
-        )}
-        renderSecondary2={() => (
-          <TileV onPress={onPress} tile={secondary2} tileName="secondary2" />
-        )}
-        renderSupport1={() => (
-          <TileG onPress={onPress} tile={support1} tileName="support1" />
-        )}
-        renderSupport2={() => (
-          <TileG onPress={onPress} tile={support2} tileName="support2" />
-        )}
-      />
-    )}
-    renderSmall={breakpoint => (
+class SecondaryTwoAndTwo extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSmall = this.renderSmall.bind(this);
+    this.renderMedium = this.renderMedium.bind(this);
+  }
+
+  renderSmall(breakpoint) {
+    const {
+      onPress,
+      slice: { secondary1, secondary2, support1, support2 }
+    } = this.props;
+
+    return (
       <SecondaryTwoAndTwoSlice
         breakpoint={breakpoint}
         renderSecondary1={() => (
@@ -42,9 +33,43 @@ const SecondaryTwoAndTwo = ({
           <TileG onPress={onPress} tile={support2} tileName="support2" />
         )}
       />
-    )}
-  />
-);
+    );
+  }
+
+  renderMedium(breakpoint) {
+    const {
+      onPress,
+      slice: { secondary1, secondary2, support1, support2 }
+    } = this.props;
+
+    return (
+      <SecondaryTwoAndTwoSlice
+        breakpoint={breakpoint}
+        renderSecondary1={() => (
+          <TileV onPress={onPress} tile={secondary1} tileName="secondary1" />
+        )}
+        renderSecondary2={() => (
+          <TileV onPress={onPress} tile={secondary2} tileName="secondary2" />
+        )}
+        renderSupport1={() => (
+          <TileG onPress={onPress} tile={support1} tileName="support1" />
+        )}
+        renderSupport2={() => (
+          <TileG onPress={onPress} tile={support2} tileName="support2" />
+        )}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderMedium}
+        renderSmall={this.renderSmall}
+      />
+    );
+  }
+}
 
 SecondaryTwoAndTwo.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/secondarytwonopicandtwo/index.js
+++ b/packages/edition-slices/src/slices/secondarytwonopicandtwo/index.js
@@ -1,34 +1,25 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { SecondaryTwoNoPicAndTwoSlice } from "@times-components/slice-layout";
 import { TileAE, TileB, TileG } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-const SecondaryTwoNoPicAndTwo = ({
-  onPress,
-  slice: { secondary1, secondary2, support1, support2 }
-}) => (
-  <ResponsiveSlice
-    renderMedium={editionBreakpoint => (
+class SecondaryTwoNoPicAndTwo extends Component {
+  constructor(props) {
+    super(props);
+    this.renderSmall = this.renderSmall.bind(this);
+    this.renderMedium = this.renderMedium.bind(this);
+  }
+
+  renderSmall(breakpoint) {
+    const {
+      onPress,
+      slice: { secondary1, secondary2, support1, support2 }
+    } = this.props;
+
+    return (
       <SecondaryTwoNoPicAndTwoSlice
-        breakpoint={editionBreakpoint}
-        renderSecondary1={() => (
-          <TileAE onPress={onPress} tile={secondary1} tileName="secondary1" />
-        )}
-        renderSecondary2={() => (
-          <TileAE onPress={onPress} tile={secondary2} tileName="secondary2" />
-        )}
-        renderSupport1={() => (
-          <TileG onPress={onPress} tile={support1} tileName="support1" />
-        )}
-        renderSupport2={() => (
-          <TileG onPress={onPress} tile={support2} tileName="support2" />
-        )}
-      />
-    )}
-    renderSmall={editionBreakpoint => (
-      <SecondaryTwoNoPicAndTwoSlice
-        breakpoint={editionBreakpoint}
+        breakpoint={breakpoint}
         renderSecondary1={() => (
           <TileB onPress={onPress} tile={secondary1} tileName="secondary1" />
         )}
@@ -42,9 +33,43 @@ const SecondaryTwoNoPicAndTwo = ({
           <TileG onPress={onPress} tile={support2} tileName="support2" />
         )}
       />
-    )}
-  />
-);
+    );
+  }
+
+  renderMedium(breakpoint) {
+    const {
+      onPress,
+      slice: { secondary1, secondary2, support1, support2 }
+    } = this.props;
+
+    return (
+      <SecondaryTwoNoPicAndTwoSlice
+        breakpoint={breakpoint}
+        renderSecondary1={() => (
+          <TileAE onPress={onPress} tile={secondary1} tileName="secondary1" />
+        )}
+        renderSecondary2={() => (
+          <TileAE onPress={onPress} tile={secondary2} tileName="secondary2" />
+        )}
+        renderSupport1={() => (
+          <TileG onPress={onPress} tile={support1} tileName="support1" />
+        )}
+        renderSupport2={() => (
+          <TileG onPress={onPress} tile={support2} tileName="support2" />
+        )}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <ResponsiveSlice
+        renderMedium={this.renderMedium}
+        renderSmall={this.renderSmall}
+      />
+    );
+  }
+}
 
 SecondaryTwoNoPicAndTwo.propTypes = {
   onPress: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ArticleSummary, {
   ArticleSummaryContent,
@@ -8,63 +8,95 @@ import ArticleSummary, {
 import { ArticleFlags } from "@times-components/article-flag";
 import { colours } from "@times-components/styleguide";
 
-const TileSummary = ({
-  tile: {
-    headline: tileHeadline,
-    article: {
-      expirableFlags,
-      hasVideo,
-      headline,
-      label,
-      section,
-      shortHeadline
-    }
-  },
-  byline,
-  bylineStyle,
-  headlineStyle,
-  strapline,
-  straplineStyle,
-  style,
-  summary,
-  summaryStyle,
-  flagColour,
-  labelColour
-}) => (
-  <ArticleSummary
-    bylineProps={byline ? { ast: byline, bylineStyle } : null}
-    content={
-      summary
-        ? () => <ArticleSummaryContent ast={summary} style={summaryStyle} />
-        : undefined
-    }
-    flags={() => <ArticleFlags {...flagColour} flags={expirableFlags} />}
-    headline={() => (
+class TileSummary extends Component {
+  constructor(props) {
+    super(props);
+    this.renderContent = this.renderContent.bind(this);
+    this.renderFlags = this.renderFlags.bind(this);
+    this.renderHeadline = this.renderHeadline.bind(this);
+    this.renderStrapline = this.renderStrapline.bind(this);
+  }
+
+  renderContent() {
+    const { summary, summaryStyle } = this.props;
+
+    return summary
+      ? () => <ArticleSummaryContent ast={summary} style={summaryStyle} />
+      : undefined;
+  }
+
+  renderFlags() {
+    const {
+      tile: {
+        article: { expirableFlags }
+      },
+      flagColour
+    } = this.props;
+
+    return <ArticleFlags {...flagColour} flags={expirableFlags} />;
+  }
+
+  renderHeadline() {
+    const {
+      tile: {
+        headline: tileHeadline,
+        article: { headline, shortHeadline }
+      },
+      headlineStyle
+    } = this.props;
+
+    return (
       <ArticleSummaryHeadline
         headline={tileHeadline || shortHeadline || headline}
         style={headlineStyle}
       />
-    )}
-    label={label}
-    labelProps={{
-      color:
-        labelColour || (colours.section[section] || colours.section.default),
-      isVideo: hasVideo,
-      title: label
-    }}
-    strapline={
-      strapline
-        ? () => (
-            <ArticleSummaryStrapline
-              strapline={strapline}
-              style={straplineStyle}
-            />
-          )
-        : undefined
-    }
-    style={style}
-  />
-);
+    );
+  }
+
+  renderStrapline() {
+    const { strapline, straplineStyle } = this.props;
+
+    return strapline
+      ? () => (
+          <ArticleSummaryStrapline
+            strapline={strapline}
+            style={straplineStyle}
+          />
+        )
+      : undefined;
+  }
+
+  render() {
+    const {
+      tile: {
+        article: { hasVideo, label, section }
+      },
+      byline,
+      bylineStyle,
+      style,
+      labelColour
+    } = this.props;
+
+    return (
+      <ArticleSummary
+        bylineProps={byline ? { ast: byline, bylineStyle } : null}
+        content={this.renderContent}
+        flags={this.renderFlags}
+        headline={this.renderHeadline}
+        label={label}
+        labelProps={{
+          color:
+            labelColour ||
+            (colours.section[section] || colours.section.default),
+          isVideo: hasVideo,
+          title: label
+        }}
+        strapline={this.renderStrapline}
+        style={style}
+      />
+    );
+  }
+}
 
 TileSummary.propTypes = {
   bylineStyle: PropTypes.shape({}),

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -20,9 +20,7 @@ class TileSummary extends Component {
   renderContent() {
     const { summary, summaryStyle } = this.props;
 
-    return summary
-      ? () => <ArticleSummaryContent ast={summary} style={summaryStyle} />
-      : undefined;
+    return <ArticleSummaryContent ast={summary} style={summaryStyle} />;
   }
 
   renderFlags() {
@@ -56,14 +54,9 @@ class TileSummary extends Component {
   renderStrapline() {
     const { strapline, straplineStyle } = this.props;
 
-    return strapline
-      ? () => (
-          <ArticleSummaryStrapline
-            strapline={strapline}
-            style={straplineStyle}
-          />
-        )
-      : undefined;
+    return (
+      <ArticleSummaryStrapline strapline={strapline} style={straplineStyle} />
+    );
   }
 
   render() {
@@ -73,14 +66,16 @@ class TileSummary extends Component {
       },
       byline,
       bylineStyle,
+      strapline,
       style,
+      summary,
       labelColour
     } = this.props;
 
     return (
       <ArticleSummary
         bylineProps={byline ? { ast: byline, bylineStyle } : null}
-        content={this.renderContent}
+        content={summary ? this.renderContent : undefined}
         flags={this.renderFlags}
         headline={this.renderHeadline}
         label={label}
@@ -91,7 +86,7 @@ class TileSummary extends Component {
           isVideo: hasVideo,
           title: label
         }}
-        strapline={this.renderStrapline}
+        strapline={strapline ? this.renderStrapline : undefined}
         style={style}
       />
     );

--- a/packages/section/__tests__/android/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/android/__snapshots__/section.test.js.snap
@@ -145,48 +145,13 @@ exports[`section page 1`] = `
         />
       </View>
     </View>
-    <View>
-      <SecondaryOneSlice />
-      <View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#DBDBDB",
-              "height": 1,
-            }
-          }
-        />
-      </View>
-    </View>
-    <View>
-      <SecondaryFourSlice />
-      <View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#DBDBDB",
-              "height": 1,
-            }
-          }
-        />
-      </View>
-    </View>
-    <View>
-      <SecondaryTwoNoPicAndTwoSlice />
-      <View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#DBDBDB",
-              "height": 1,
-            }
-          }
-        />
-      </View>
-    </View>
-    <View>
-      <ListTwoAndSixNoPicSlice />
-    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;

--- a/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
@@ -145,48 +145,13 @@ exports[`section page 1`] = `
         />
       </View>
     </View>
-    <View>
-      <SecondaryOneSlice />
-      <View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#DBDBDB",
-              "height": 1,
-            }
-          }
-        />
-      </View>
-    </View>
-    <View>
-      <SecondaryFourSlice />
-      <View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#DBDBDB",
-              "height": 1,
-            }
-          }
-        />
-      </View>
-    </View>
-    <View>
-      <SecondaryTwoNoPicAndTwoSlice />
-      <View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#DBDBDB",
-              "height": 1,
-            }
-          }
-        />
-      </View>
-    </View>
-    <View>
-      <ListTwoAndSixNoPicSlice />
-    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;

--- a/packages/section/src/section.js
+++ b/packages/section/src/section.js
@@ -65,7 +65,7 @@ class Section extends Component {
       <Responsive>
         <FlatList
           data={data}
-          initialNumToRender={3}
+          initialNumToRender={5}
           ItemSeparatorComponent={
             !isPuzzle &&
             (() => (
@@ -80,7 +80,7 @@ class Section extends Component {
           }
           onViewableItemsChanged={onViewed ? this.onViewableItemsChanged : null}
           renderItem={this.renderItem}
-          windowSize={3}
+          windowSize={5}
         />
       </Responsive>
     );

--- a/packages/section/src/section.js
+++ b/packages/section/src/section.js
@@ -65,6 +65,7 @@ class Section extends Component {
       <Responsive>
         <FlatList
           data={data}
+          initialNumToRender={3}
           ItemSeparatorComponent={
             !isPuzzle &&
             (() => (
@@ -79,6 +80,7 @@ class Section extends Component {
           }
           onViewableItemsChanged={onViewed ? this.onViewableItemsChanged : null}
           renderItem={this.renderItem}
+          windowSize={3}
         />
       </Responsive>
     );


### PR DESCRIPTION
Round 1 of section perf improvements (more coming soon, in a separate PR):

- Changed windowSize and initialNumToRender on section FlatList. Defaults are 20 items, which is huge for our use case.
- Got rid of inline function declarations in edition-slices and in tile-summary. However, we still got a million more to inline function declarations in slice-layout, but that'll be the next PR