### PR TITLE
Feat/lead 2 no pic and 2 tablet

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -235,6 +235,7 @@ exports[`5. lead two no pic and two - medium 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "justifyContent": "center",
         "paddingHorizontal": 10,
       }
     }
@@ -1284,6 +1285,7 @@ exports[`19. lead two no pic and two - wide 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "justifyContent": "center",
         "paddingHorizontal": 10,
       }
     }
@@ -1291,7 +1293,7 @@ exports[`19. lead two no pic and two - wide 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "42%",
         }
       }
     >
@@ -1321,21 +1323,29 @@ exports[`19. lead two no pic and two - wide 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "16%",
         }
       }
     >
-      <TileD />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
-          }
+      <TileAL />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
         }
-      />
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "42%",
+        }
+      }
+    >
       <TileZ />
     </View>
   </View>
@@ -2333,6 +2343,7 @@ exports[`33. lead two no pic and two - huge 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "justifyContent": "center",
         "paddingHorizontal": 10,
       }
     }
@@ -2340,7 +2351,7 @@ exports[`33. lead two no pic and two - huge 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "36%",
         }
       }
     >
@@ -2370,21 +2381,29 @@ exports[`33. lead two no pic and two - huge 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "14%",
         }
       }
     >
-      <TileD />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
-          }
+      <TileAL />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
         }
-      />
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "36%",
+        }
+      }
+    >
       <TileZ />
     </View>
   </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -521,10 +521,12 @@ exports[`19. lead two no pic and two - wide 1`] = `
     </View>
     <View />
     <View>
-      <TileD
+      <TileAL
         tileName="support1"
       />
-      <View />
+    </View>
+    <View />
+    <View>
       <TileZ
         tileName="support2"
       />
@@ -943,10 +945,12 @@ exports[`33. lead two no pic and two - huge 1`] = `
     </View>
     <View />
     <View>
-      <TileD
+      <TileAL
         tileName="support1"
       />
-      <View />
+    </View>
+    <View />
+    <View>
       <TileZ
         tileName="support2"
       />

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -2385,3 +2385,94 @@ exports[`31. tile ak 1`] = `
   </View>
 </Link>
 `;
+
+exports[`32. tile al 1`] = `
+<Link>
+  <View
+    style={
+      Object {
+        "flexDirection": "column",
+        "paddingHorizontal": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "paddingVertical": 10,
+          "width": "100%",
+        }
+      }
+    >
+      <Image />
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "marginBottom": 5,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#005B8D",
+              "fontFamily": "GillSansMTStd-Medium",
+              "fontSize": 12,
+              "fontWeight": "400",
+              "letterSpacing": 1.2,
+              "lineHeight": 14,
+              "marginBottom": 0,
+            }
+          }
+        >
+          LABEL
+        </Text>
+      </View>
+      <Text
+        style={
+          Object {
+            "color": "#333333",
+            "fontFamily": "TimesModern-Bold",
+            "fontSize": 22,
+            "fontWeight": "400",
+            "lineHeight": 27,
+            "marginBottom": 0,
+          }
+        }
+      >
+        This is tile headline
+      </Text>
+      <Text
+        style={
+          Object {
+            "color": "#696969",
+            "flexWrap": "wrap",
+            "fontFamily": "TimesDigitalW04-Regular",
+            "fontSize": 14,
+            "lineHeight": undefined,
+            "marginBottom": 10,
+            "width": "100%",
+          }
+        }
+      >
+        <Text>
+          
+          Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+          ...
+        </Text>
+      </Text>
+      <View
+        style={
+          Object {
+            "marginBottom": 10,
+          }
+        }
+      >
+        <ArticleFlags />
+      </View>
+    </View>
+  </View>
+</Link>
+`;

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -1227,3 +1227,50 @@ exports[`31. tile ak 1`] = `
   </View>
 </Link>
 `;
+
+exports[`32. tile al 1`] = `
+<Link
+  url="/article/123"
+>
+  <View>
+    <View>
+      <Image
+        aspectRatio={1.5}
+        uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+      />
+    </View>
+    <View>
+      <View>
+        <Text>
+          LABEL
+        </Text>
+      </View>
+      <Text
+        accessibilityRole="heading"
+        aria-level="3"
+      >
+        This is tile headline
+      </Text>
+      <Text>
+        <Text>
+          
+          Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+          ...
+        </Text>
+      </Text>
+      <View>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -235,6 +235,7 @@ exports[`5. lead two no pic and two - medium 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "justifyContent": "center",
         "paddingHorizontal": 10,
       }
     }
@@ -1284,6 +1285,7 @@ exports[`19. lead two no pic and two - wide 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "justifyContent": "center",
         "paddingHorizontal": 10,
       }
     }
@@ -1291,7 +1293,7 @@ exports[`19. lead two no pic and two - wide 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "42%",
         }
       }
     >
@@ -1321,21 +1323,29 @@ exports[`19. lead two no pic and two - wide 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "16%",
         }
       }
     >
-      <TileD />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
-          }
+      <TileAL />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
         }
-      />
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "42%",
+        }
+      }
+    >
       <TileZ />
     </View>
   </View>
@@ -2333,6 +2343,7 @@ exports[`33. lead two no pic and two - huge 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "justifyContent": "center",
         "paddingHorizontal": 10,
       }
     }
@@ -2340,7 +2351,7 @@ exports[`33. lead two no pic and two - huge 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "36%",
         }
       }
     >
@@ -2370,21 +2381,29 @@ exports[`33. lead two no pic and two - huge 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "14%",
         }
       }
     >
-      <TileD />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
-          }
+      <TileAL />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
         }
-      />
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "36%",
+        }
+      }
+    >
       <TileZ />
     </View>
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -521,10 +521,12 @@ exports[`19. lead two no pic and two - wide 1`] = `
     </View>
     <View />
     <View>
-      <TileD
+      <TileAL
         tileName="support1"
       />
-      <View />
+    </View>
+    <View />
+    <View>
       <TileZ
         tileName="support2"
       />
@@ -943,10 +945,12 @@ exports[`33. lead two no pic and two - huge 1`] = `
     </View>
     <View />
     <View>
-      <TileD
+      <TileAL
         tileName="support1"
       />
-      <View />
+    </View>
+    <View />
+    <View>
       <TileZ
         tileName="support2"
       />

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -2385,3 +2385,94 @@ exports[`31. tile ak 1`] = `
   </View>
 </Link>
 `;
+
+exports[`32. tile al 1`] = `
+<Link>
+  <View
+    style={
+      Object {
+        "flexDirection": "column",
+        "paddingHorizontal": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "paddingVertical": 10,
+          "width": "100%",
+        }
+      }
+    >
+      <Image />
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "marginBottom": 0,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#005B8D",
+              "fontFamily": "GillSansMTStd-Medium",
+              "fontSize": 12,
+              "fontWeight": "400",
+              "letterSpacing": 1.2,
+              "lineHeight": 14,
+              "marginBottom": 0,
+            }
+          }
+        >
+          LABEL
+        </Text>
+      </View>
+      <Text
+        style={
+          Object {
+            "color": "#333333",
+            "fontFamily": "TimesModern-Bold",
+            "fontSize": 22,
+            "fontWeight": "900",
+            "lineHeight": 27,
+            "marginBottom": 0,
+          }
+        }
+      >
+        This is tile headline
+      </Text>
+      <Text
+        style={
+          Object {
+            "color": "#696969",
+            "flexWrap": "wrap",
+            "fontFamily": "TimesDigitalW04-Regular",
+            "fontSize": 14,
+            "lineHeight": undefined,
+            "marginBottom": 10,
+            "width": "100%",
+          }
+        }
+      >
+        <Text>
+          
+          Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+          ...
+        </Text>
+      </Text>
+      <View
+        style={
+          Object {
+            "marginBottom": 10,
+          }
+        }
+      >
+        <ArticleFlags />
+      </View>
+    </View>
+  </View>
+</Link>
+`;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -1227,3 +1227,50 @@ exports[`31. tile ak 1`] = `
   </View>
 </Link>
 `;
+
+exports[`32. tile al 1`] = `
+<Link
+  url="/article/123"
+>
+  <View>
+    <View>
+      <Image
+        aspectRatio={1.5}
+        uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+      />
+    </View>
+    <View>
+      <View>
+        <Text>
+          LABEL
+        </Text>
+      </View>
+      <Text
+        accessibilityRole="heading"
+        aria-level="3"
+      >
+        This is tile headline
+      </Text>
+      <Text>
+        <Text>
+          
+          Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+          ...
+        </Text>
+      </Text>
+      <View>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;

--- a/packages/edition-slices/__tests__/shared-tiles.base.js
+++ b/packages/edition-slices/__tests__/shared-tiles.base.js
@@ -38,7 +38,8 @@ import {
   TileAB,
   TileAG,
   TileAJ,
-  TileAK
+  TileAK,
+  TileAL
 } from "../src/tiles";
 
 jest.mock("@times-components/article-flag", () => ({
@@ -197,6 +198,10 @@ export default () => {
     {
       name: "tile ak",
       test: () => testPuzzleTile(TileAK)
+    },
+    {
+      name: "tile al",
+      test: () => testTile(TileAL)
     }
   ];
 

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -1108,7 +1108,7 @@ exports[`5. lead two no pic and two 1`] = `
 }
 
 .IS2 {
-  width: 50%;
+  width: 42%;
 }
 
 .IS3 {
@@ -1122,30 +1122,38 @@ exports[`5. lead two no pic and two 1`] = `
 }
 
 .IS4 {
-  border-bottom-width: 1px;
+  width: 16%;
+}
+
+.IS5 {
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-bottom-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
-  margin-right: 10px;
-  margin-left: 10px;
-}
-
-.IS5 {
-  width: 50%;
+  border-right-width: 1px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 .IS6 {
+  width: 42%;
+}
+
+.IS7 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-justify-content: center;
+  justify-content: center;
   padding-right: 10px;
   padding-left: 10px;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
 }
 
-.IS7 {
+.IS8 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -1155,10 +1163,10 @@ exports[`5. lead two no pic and two 1`] = `
 </style>
 
 <div
-  className="IS7 S1"
+  className="IS8 S1"
 >
   <div
-    className="IS6 S1"
+    className="IS7 S1"
   >
     <div
       className="IS2 S1"
@@ -1177,14 +1185,18 @@ exports[`5. lead two no pic and two 1`] = `
       className="IS3"
     />
     <div
-      className="IS5 S1"
+      className="IS4 S1"
     >
-      <TileD
+      <TileAL
         tileName="support1"
       />
-      <div
-        className="IS4 S1"
-      />
+    </div>
+    <div
+      className="IS5"
+    />
+    <div
+      className="IS6 S1"
+    >
       <TileZ
         tileName="support2"
       />

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -275,10 +275,12 @@ exports[`5. lead two no pic and two 1`] = `
     </div>
     <div />
     <div>
-      <TileD
+      <TileAL
         tileName="support1"
       />
-      <div />
+    </div>
+    <div />
+    <div>
       <TileZ
         tileName="support2"
       />

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -344,7 +344,7 @@ exports[`5. lead two no pic and two - medium 1`] = `
 }
 
 .IS2 {
-  width: 50%;
+  width: 42%;
 }
 
 .IS3 {
@@ -358,30 +358,38 @@ exports[`5. lead two no pic and two - medium 1`] = `
 }
 
 .IS4 {
-  border-bottom-width: 1px;
+  width: 16%;
+}
+
+.IS5 {
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-bottom-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
-  margin-right: 10px;
-  margin-left: 10px;
-}
-
-.IS5 {
-  width: 50%;
+  border-right-width: 1px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 .IS6 {
+  width: 42%;
+}
+
+.IS7 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-justify-content: center;
+  justify-content: center;
   padding-right: 10px;
   padding-left: 10px;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
 }
 
-.IS7 {
+.IS8 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -391,10 +399,10 @@ exports[`5. lead two no pic and two - medium 1`] = `
 </style>
 
 <div
-  className="IS7 S1"
+  className="IS8 S1"
 >
   <div
-    className="IS6 S1"
+    className="IS7 S1"
   >
     <div
       className="IS2 S1"
@@ -413,14 +421,18 @@ exports[`5. lead two no pic and two - medium 1`] = `
       className="IS3"
     />
     <div
-      className="IS5 S1"
+      className="IS4 S1"
     >
-      <TileD
+      <TileAL
         tileName="support1"
       />
-      <div
-        className="IS4 S1"
-      />
+    </div>
+    <div
+      className="IS5"
+    />
+    <div
+      className="IS6 S1"
+    >
       <TileZ
         tileName="support2"
       />
@@ -1968,7 +1980,7 @@ exports[`19. lead two no pic and two - wide 1`] = `
 }
 
 .IS2 {
-  width: 50%;
+  width: 42%;
 }
 
 .IS3 {
@@ -1982,30 +1994,38 @@ exports[`19. lead two no pic and two - wide 1`] = `
 }
 
 .IS4 {
-  border-bottom-width: 1px;
+  width: 16%;
+}
+
+.IS5 {
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-bottom-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
-  margin-right: 10px;
-  margin-left: 10px;
-}
-
-.IS5 {
-  width: 50%;
+  border-right-width: 1px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 .IS6 {
+  width: 42%;
+}
+
+.IS7 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-justify-content: center;
+  justify-content: center;
   padding-right: 10px;
   padding-left: 10px;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
 }
 
-.IS7 {
+.IS8 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -2015,10 +2035,10 @@ exports[`19. lead two no pic and two - wide 1`] = `
 </style>
 
 <div
-  className="IS7 S1"
+  className="IS8 S1"
 >
   <div
-    className="IS6 S1"
+    className="IS7 S1"
   >
     <div
       className="IS2 S1"
@@ -2037,14 +2057,18 @@ exports[`19. lead two no pic and two - wide 1`] = `
       className="IS3"
     />
     <div
-      className="IS5 S1"
+      className="IS4 S1"
     >
-      <TileD
+      <TileAL
         tileName="support1"
       />
-      <div
-        className="IS4 S1"
-      />
+    </div>
+    <div
+      className="IS5"
+    />
+    <div
+      className="IS6 S1"
+    >
       <TileZ
         tileName="support2"
       />
@@ -3592,7 +3616,7 @@ exports[`33. lead two no pic and two - huge 1`] = `
 }
 
 .IS2 {
-  width: 50%;
+  width: 42%;
 }
 
 .IS3 {
@@ -3606,30 +3630,38 @@ exports[`33. lead two no pic and two - huge 1`] = `
 }
 
 .IS4 {
-  border-bottom-width: 1px;
+  width: 16%;
+}
+
+.IS5 {
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-bottom-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
-  margin-right: 10px;
-  margin-left: 10px;
-}
-
-.IS5 {
-  width: 50%;
+  border-right-width: 1px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 .IS6 {
+  width: 42%;
+}
+
+.IS7 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-justify-content: center;
+  justify-content: center;
   padding-right: 10px;
   padding-left: 10px;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
 }
 
-.IS7 {
+.IS8 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -3639,10 +3671,10 @@ exports[`33. lead two no pic and two - huge 1`] = `
 </style>
 
 <div
-  className="IS7 S1"
+  className="IS8 S1"
 >
   <div
-    className="IS6 S1"
+    className="IS7 S1"
   >
     <div
       className="IS2 S1"
@@ -3661,14 +3693,18 @@ exports[`33. lead two no pic and two - huge 1`] = `
       className="IS3"
     />
     <div
-      className="IS5 S1"
+      className="IS4 S1"
     >
-      <TileD
+      <TileAL
         tileName="support1"
       />
-      <div
-        className="IS4 S1"
-      />
+    </div>
+    <div
+      className="IS5"
+    />
+    <div
+      className="IS6 S1"
+    >
       <TileZ
         tileName="support2"
       />

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -87,10 +87,12 @@ exports[`5. lead two no pic and two - medium 1`] = `
     </div>
     <div />
     <div>
-      <TileD
+      <TileAL
         tileName="support1"
       />
-      <div />
+    </div>
+    <div />
+    <div>
       <TileZ
         tileName="support2"
       />
@@ -493,10 +495,12 @@ exports[`19. lead two no pic and two - wide 1`] = `
     </div>
     <div />
     <div>
-      <TileD
+      <TileAL
         tileName="support1"
       />
-      <div />
+    </div>
+    <div />
+    <div>
       <TileZ
         tileName="support2"
       />
@@ -899,10 +903,12 @@ exports[`33. lead two no pic and two - huge 1`] = `
     </div>
     <div />
     <div>
-      <TileD
+      <TileAL
         tileName="support1"
       />
-      <div />
+    </div>
+    <div />
+    <div>
       <TileZ
         tileName="support2"
       />

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -3375,3 +3375,133 @@ exports[`31. tile ak 1`] = `
   </div>
 </Link>
 `;
+
+exports[`32. tile al 1`] = `
+<style>
+.S1 {
+  margin-bottom: 0px;
+}
+
+.S2 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 14px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 27px;
+  margin-bottom: 0px;
+}
+
+.S4 {
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-bottom: 0px;
+}
+
+.S5 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-size: 14px;
+  font-weight: inherit;
+  margin-bottom: 10px;
+}
+
+.S6 {
+  margin-bottom: 10px;
+}
+
+.IS1 {
+  padding-top: 10px;
+  width: 100%;
+}
+
+.IS2 {
+  color: rgba(0,91,141,1.00);
+}
+
+.IS3 {
+  font-family: TimesDigitalW04-Regular;
+  width: 100%;
+}
+
+.IS4 {
+  padding-right: 10px;
+  padding-left: 10px;
+}
+</style>
+
+<Link
+  url="/article/123"
+>
+  <div
+    className="IS4 S1"
+  >
+    <div
+      className="IS1 S1"
+    >
+      <Image
+        aspectRatio={1.5}
+        uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+      />
+    </div>
+    <div
+      className="S1"
+    >
+      <div
+        className="S1"
+      >
+        <div
+          className="IS2 S2"
+        >
+          LABEL
+        </div>
+      </div>
+      <h3
+        aria-level="3"
+        className="S3"
+        role="heading"
+      >
+        This is tile headline
+      </h3>
+      <div
+        className="IS3 S5"
+      >
+        <span
+          className="S4"
+        >
+          
+          Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+          ...
+        </span>
+      </div>
+      <div
+        className="S6"
+      >
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </div>
+    </div>
+  </div>
+</Link>
+`;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -1227,3 +1227,50 @@ exports[`31. tile ak 1`] = `
   </div>
 </Link>
 `;
+
+exports[`32. tile al 1`] = `
+<Link
+  url="/article/123"
+>
+  <div>
+    <div>
+      <Image
+        aspectRatio={1.5}
+        uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+      />
+    </div>
+    <div>
+      <div>
+        <div>
+          LABEL
+        </div>
+      </div>
+      <h3
+        aria-level="3"
+        role="heading"
+      >
+        This is tile headline
+      </h3>
+      <div>
+        <span>
+          
+          Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+          ...
+        </span>
+      </div>
+      <div>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </div>
+    </div>
+  </div>
+</Link>
+`;

--- a/packages/edition-slices/edition-tiles.showcase.js
+++ b/packages/edition-slices/edition-tiles.showcase.js
@@ -38,7 +38,8 @@ import {
   TileAB,
   TileAG,
   TileAH,
-  TileAI
+  TileAI,
+  TileAL
 } from "./src/tiles";
 
 const tile = mockEditionSlice(1).items[0];
@@ -112,6 +113,11 @@ const tileStories = [
     name:
       "Tile AD - Horizontal, image left of article summary with 2:3 ratio. Font size 20",
     Tile: TileAD
+  },
+  {
+    name:
+      "Tile AL - Vertical, top image with 2:3 ratio, 22pt headline, centered aligned summary",
+    Tile: TileAL
   },
   {
     name: "Tile L - No image, 22pt headline, no teaser",

--- a/packages/edition-slices/src/slices/leadtwonopicandtwo/index.js
+++ b/packages/edition-slices/src/slices/leadtwonopicandtwo/index.js
@@ -1,7 +1,16 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { LeadTwoNoPicAndTwoSlice } from "@times-components/slice-layout";
-import { TileB, TileD, TileE, TileF, TileX, TileY, TileZ } from "../../tiles";
+import {
+  TileB,
+  TileD,
+  TileE,
+  TileF,
+  TileX,
+  TileY,
+  TileZ,
+  TileAL
+} from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
 class LeadTwoNoPicAndTwo extends Component {
@@ -9,6 +18,7 @@ class LeadTwoNoPicAndTwo extends Component {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);
     this.renderMedium = this.renderMedium.bind(this);
+    this.renderWide = this.renderWide.bind(this);
   }
 
   renderSmall(breakpoint) {
@@ -30,6 +40,30 @@ class LeadTwoNoPicAndTwo extends Component {
         )}
         renderSupport2={() => (
           <TileE onPress={onPress} tile={support2} tileName="support2" />
+        )}
+      />
+    );
+  }
+
+  renderWide(breakpoint) {
+    const {
+      onPress,
+      slice: { lead1, lead2, support1, support2 }
+    } = this.props;
+    return (
+      <LeadTwoNoPicAndTwoSlice
+        breakpoint={breakpoint}
+        renderLead1={() => (
+          <TileX onPress={onPress} tile={lead1} tileName="lead1" />
+        )}
+        renderLead2={() => (
+          <TileY onPress={onPress} tile={lead2} tileName="lead2" />
+        )}
+        renderSupport1={() => (
+          <TileAL onPress={onPress} tile={support1} tileName="support1" />
+        )}
+        renderSupport2={() => (
+          <TileZ onPress={onPress} tile={support2} tileName="support2" />
         )}
       />
     );
@@ -62,8 +96,10 @@ class LeadTwoNoPicAndTwo extends Component {
   render() {
     return (
       <ResponsiveSlice
+        renderHuge={this.renderWide}
         renderMedium={this.renderMedium}
         renderSmall={this.renderSmall}
+        renderWide={this.renderWide}
       />
     );
   }

--- a/packages/edition-slices/src/tiles/index.js
+++ b/packages/edition-slices/src/tiles/index.js
@@ -4,6 +4,7 @@ export { default as TileAD } from "./tile-ad";
 export { default as TileAE } from "./tile-ae";
 export { default as TileAJ } from "./tile-aj";
 export { default as TileAK } from "./tile-ak";
+export { default as TileAL } from "./tile-al";
 export { default as TileB } from "./tile-b";
 export { default as TileC } from "./tile-c";
 export { default as TileD } from "./tile-d";

--- a/packages/edition-slices/src/tiles/tile-al/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/index.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { View } from "react-native";
+import PropTypes from "prop-types";
+import {
+  getCrop,
+  TileImage,
+  TileLink,
+  TileSummary,
+  withTileTracking
+} from "../shared";
+import styles from "./styles";
+
+const TileAL = ({ onPress, tile }) => (
+  <TileLink onPress={onPress} tile={tile}>
+    <View style={styles.container}>
+      <TileImage
+        aspectRatio={3 / 2}
+        style={styles.imageContainer}
+        uri={getCrop(
+          tile.leadAsset || tile.article.listingAsset || tile.article.leadAsset,
+          "crop32"
+        )}
+      />
+      <TileSummary
+        headlineStyle={styles.headline}
+        summary={tile.teaser125 || tile.article.summary125}
+        summaryStyle={styles.summaryContainer}
+        tile={tile}
+      />
+    </View>
+  </TileLink>
+);
+
+TileAL.propTypes = {
+  onPress: PropTypes.func.isRequired,
+  tile: PropTypes.shape({}).isRequired
+};
+
+export default withTileTracking(TileAL);

--- a/packages/edition-slices/src/tiles/tile-al/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/styles/index.js
@@ -1,0 +1,29 @@
+import { fontFactory, spacing } from "@times-components/styleguide";
+
+const styles = {
+  container: {
+    flexDirection: "column",
+    paddingHorizontal: spacing(2)
+  },
+  headline: {
+    marginBottom: 0,
+    ...fontFactory({
+      font: "headline",
+      fontSize: "smallHeadline"
+    })
+  },
+  imageContainer: {
+    paddingVertical: spacing(2),
+    width: "100%"
+  },
+  summaryContainer: {
+    lineHeight: 1.43,
+    width: "100%",
+    ...fontFactory({
+      font: "bodyRegular",
+      fontSize: "teaser"
+    })
+  }
+};
+
+export default styles;

--- a/packages/slice-layout/__tests__/android/__snapshots__/l2np2-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/l2np2-with-style.android.test.js.snap
@@ -52,6 +52,7 @@ exports[`2. lead two no pic and two - medium 1`] = `
   style={
     Object {
       "flexDirection": "row",
+      "justifyContent": "center",
       "paddingHorizontal": 10,
     }
   }
@@ -110,6 +111,164 @@ exports[`2. lead two no pic and two - medium 1`] = `
         }
       }
     />
+    <Text>
+      support-2
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`3. lead two no pic and two - wide 1`] = `
+<View
+  style={
+    Object {
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "paddingHorizontal": 10,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "width": "42%",
+      }
+    }
+  >
+    <Text>
+      lead-1
+    </Text>
+    <View
+      style={
+        Object {
+          "borderBottomWidth": 1,
+          "borderColor": "#DBDBDB",
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+        }
+      }
+    />
+    <Text>
+      lead-2
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "16%",
+      }
+    }
+  >
+    <Text>
+      support-1
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "42%",
+      }
+    }
+  >
+    <Text>
+      support-2
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`4. lead two no pic and two - huge 1`] = `
+<View
+  style={
+    Object {
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "paddingHorizontal": 10,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "width": "36%",
+      }
+    }
+  >
+    <Text>
+      lead-1
+    </Text>
+    <View
+      style={
+        Object {
+          "borderBottomWidth": 1,
+          "borderColor": "#DBDBDB",
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+        }
+      }
+    />
+    <Text>
+      lead-2
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "14%",
+      }
+    }
+  >
+    <Text>
+      support-1
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "36%",
+      }
+    }
+  >
     <Text>
       support-2
     </Text>

--- a/packages/slice-layout/__tests__/android/__snapshots__/l2np2.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/l2np2.android.test.js.snap
@@ -43,3 +43,55 @@ exports[`2. lead two no pic and two - medium 1`] = `
   </View>
 </View>
 `;
+
+exports[`3. lead two no pic and two - wide 1`] = `
+<View>
+  <View>
+    <Text>
+      lead-1
+    </Text>
+    <View />
+    <Text>
+      lead-2
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-1
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-2
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`4. lead two no pic and two - huge 1`] = `
+<View>
+  <View>
+    <Text>
+      lead-1
+    </Text>
+    <View />
+    <Text>
+      lead-2
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-1
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-2
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/ios/__snapshots__/l2np2-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/l2np2-with-style.ios.test.js.snap
@@ -52,6 +52,7 @@ exports[`2. lead two no pic and two - medium 1`] = `
   style={
     Object {
       "flexDirection": "row",
+      "justifyContent": "center",
       "paddingHorizontal": 10,
     }
   }
@@ -110,6 +111,164 @@ exports[`2. lead two no pic and two - medium 1`] = `
         }
       }
     />
+    <Text>
+      support-2
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`3. lead two no pic and two - wide 1`] = `
+<View
+  style={
+    Object {
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "paddingHorizontal": 10,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "width": "42%",
+      }
+    }
+  >
+    <Text>
+      lead-1
+    </Text>
+    <View
+      style={
+        Object {
+          "borderBottomWidth": 1,
+          "borderColor": "#DBDBDB",
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+        }
+      }
+    />
+    <Text>
+      lead-2
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "16%",
+      }
+    }
+  >
+    <Text>
+      support-1
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "42%",
+      }
+    }
+  >
+    <Text>
+      support-2
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`4. lead two no pic and two - huge 1`] = `
+<View
+  style={
+    Object {
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "paddingHorizontal": 10,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "width": "36%",
+      }
+    }
+  >
+    <Text>
+      lead-1
+    </Text>
+    <View
+      style={
+        Object {
+          "borderBottomWidth": 1,
+          "borderColor": "#DBDBDB",
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+        }
+      }
+    />
+    <Text>
+      lead-2
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "14%",
+      }
+    }
+  >
+    <Text>
+      support-1
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "36%",
+      }
+    }
+  >
     <Text>
       support-2
     </Text>

--- a/packages/slice-layout/__tests__/ios/__snapshots__/l2np2.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/l2np2.ios.test.js.snap
@@ -43,3 +43,55 @@ exports[`2. lead two no pic and two - medium 1`] = `
   </View>
 </View>
 `;
+
+exports[`3. lead two no pic and two - wide 1`] = `
+<View>
+  <View>
+    <Text>
+      lead-1
+    </Text>
+    <View />
+    <Text>
+      lead-2
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-1
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-2
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`4. lead two no pic and two - huge 1`] = `
+<View>
+  <View>
+    <Text>
+      lead-1
+    </Text>
+    <View />
+    <Text>
+      lead-2
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-1
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-2
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/l2np2.base.js
+++ b/packages/slice-layout/__tests__/l2np2.base.js
@@ -36,6 +36,38 @@ export default renderComponent => {
 
         expect(output).toMatchSnapshot();
       }
+    },
+    {
+      name: "lead two no pic and two - wide",
+      test() {
+        const output = renderComponent(
+          <LeadTwoNoPicAndTwoSlice
+            breakpoint={editionBreakpoints.wide}
+            renderLead1={() => createItem("lead-1")}
+            renderLead2={() => createItem("lead-2")}
+            renderSupport1={() => createItem("support-1")}
+            renderSupport2={() => createItem("support-2")}
+          />
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "lead two no pic and two - huge",
+      test() {
+        const output = renderComponent(
+          <LeadTwoNoPicAndTwoSlice
+            breakpoint={editionBreakpoints.huge}
+            renderLead1={() => createItem("lead-1")}
+            renderLead2={() => createItem("lead-2")}
+            renderSupport1={() => createItem("support-1")}
+            renderSupport2={() => createItem("support-2")}
+          />
+        );
+
+        expect(output).toMatchSnapshot();
+      }
     }
   ];
 

--- a/packages/slice-layout/__tests__/web/__snapshots__/l2np2-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/l2np2-with-style.web.test.js.snap
@@ -116,9 +116,13 @@ exports[`2. lead two no pic and two - medium 1`] = `
     Object {
       "WebkitBoxDirection": "normal",
       "WebkitBoxOrient": "horizontal",
+      "WebkitBoxPack": "center",
       "WebkitFlexDirection": "row",
+      "WebkitJustifyContent": "center",
       "flexDirection": "row",
+      "justifyContent": "center",
       "msFlexDirection": "row",
+      "msFlexPack": "center",
       "paddingLeft": "10px",
       "paddingRight": "10px",
     }
@@ -198,6 +202,274 @@ exports[`2. lead two no pic and two - medium 1`] = `
         }
       }
     />
+    <div
+      className="S1"
+    >
+      support-2
+    </div>
+  </div>
+</div>
+`;
+
+exports[`3. lead two no pic and two - wide 1`] = `
+<style>
+.S1 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+}
+
+.S2 {
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+}
+
+.S3 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+</style>
+
+<div
+  className="S3"
+  style={
+    Object {
+      "WebkitBoxDirection": "normal",
+      "WebkitBoxOrient": "horizontal",
+      "WebkitBoxPack": "center",
+      "WebkitFlexDirection": "row",
+      "WebkitJustifyContent": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "msFlexDirection": "row",
+      "msFlexPack": "center",
+      "paddingLeft": "10px",
+      "paddingRight": "10px",
+    }
+  }
+>
+  <div
+    className="S1"
+    style={
+      Object {
+        "width": "42%",
+      }
+    }
+  >
+    <div
+      className="S1"
+    >
+      lead-1
+    </div>
+    <div
+      className="S2"
+      style={
+        Object {
+          "borderBottomColor": "rgba(219,219,219,1.00)",
+          "borderBottomWidth": "1px",
+          "borderLeftColor": "rgba(219,219,219,1.00)",
+          "borderRightColor": "rgba(219,219,219,1.00)",
+          "borderTopColor": "rgba(219,219,219,1.00)",
+          "marginLeft": "10px",
+          "marginRight": "10px",
+        }
+      }
+    />
+    <div
+      className="S1"
+    >
+      lead-2
+    </div>
+  </div>
+  <div
+    className="S1"
+    style={
+      Object {
+        "borderBottomColor": "rgba(219,219,219,1.00)",
+        "borderLeftColor": "rgba(219,219,219,1.00)",
+        "borderRightColor": "rgba(219,219,219,1.00)",
+        "borderRightWidth": "1px",
+        "borderTopColor": "rgba(219,219,219,1.00)",
+        "marginBottom": "10px",
+        "marginTop": "10px",
+      }
+    }
+  />
+  <div
+    className="S1"
+    style={
+      Object {
+        "width": "16%",
+      }
+    }
+  >
+    <div
+      className="S1"
+    >
+      support-1
+    </div>
+  </div>
+  <div
+    className="S1"
+    style={
+      Object {
+        "borderBottomColor": "rgba(219,219,219,1.00)",
+        "borderLeftColor": "rgba(219,219,219,1.00)",
+        "borderRightColor": "rgba(219,219,219,1.00)",
+        "borderRightWidth": "1px",
+        "borderTopColor": "rgba(219,219,219,1.00)",
+        "marginBottom": "10px",
+        "marginTop": "10px",
+      }
+    }
+  />
+  <div
+    className="S1"
+    style={
+      Object {
+        "width": "42%",
+      }
+    }
+  >
+    <div
+      className="S1"
+    >
+      support-2
+    </div>
+  </div>
+</div>
+`;
+
+exports[`4. lead two no pic and two - huge 1`] = `
+<style>
+.S1 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+}
+
+.S2 {
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+}
+
+.S3 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+</style>
+
+<div
+  className="S3"
+  style={
+    Object {
+      "WebkitBoxDirection": "normal",
+      "WebkitBoxOrient": "horizontal",
+      "WebkitBoxPack": "center",
+      "WebkitFlexDirection": "row",
+      "WebkitJustifyContent": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "msFlexDirection": "row",
+      "msFlexPack": "center",
+      "paddingLeft": "10px",
+      "paddingRight": "10px",
+    }
+  }
+>
+  <div
+    className="S1"
+    style={
+      Object {
+        "width": "36%",
+      }
+    }
+  >
+    <div
+      className="S1"
+    >
+      lead-1
+    </div>
+    <div
+      className="S2"
+      style={
+        Object {
+          "borderBottomColor": "rgba(219,219,219,1.00)",
+          "borderBottomWidth": "1px",
+          "borderLeftColor": "rgba(219,219,219,1.00)",
+          "borderRightColor": "rgba(219,219,219,1.00)",
+          "borderTopColor": "rgba(219,219,219,1.00)",
+          "marginLeft": "10px",
+          "marginRight": "10px",
+        }
+      }
+    />
+    <div
+      className="S1"
+    >
+      lead-2
+    </div>
+  </div>
+  <div
+    className="S1"
+    style={
+      Object {
+        "borderBottomColor": "rgba(219,219,219,1.00)",
+        "borderLeftColor": "rgba(219,219,219,1.00)",
+        "borderRightColor": "rgba(219,219,219,1.00)",
+        "borderRightWidth": "1px",
+        "borderTopColor": "rgba(219,219,219,1.00)",
+        "marginBottom": "10px",
+        "marginTop": "10px",
+      }
+    }
+  />
+  <div
+    className="S1"
+    style={
+      Object {
+        "width": "14%",
+      }
+    }
+  >
+    <div
+      className="S1"
+    >
+      support-1
+    </div>
+  </div>
+  <div
+    className="S1"
+    style={
+      Object {
+        "borderBottomColor": "rgba(219,219,219,1.00)",
+        "borderLeftColor": "rgba(219,219,219,1.00)",
+        "borderRightColor": "rgba(219,219,219,1.00)",
+        "borderRightWidth": "1px",
+        "borderTopColor": "rgba(219,219,219,1.00)",
+        "marginBottom": "10px",
+        "marginTop": "10px",
+      }
+    }
+  />
+  <div
+    className="S1"
+    style={
+      Object {
+        "width": "36%",
+      }
+    }
+  >
     <div
       className="S1"
     >

--- a/packages/slice-layout/__tests__/web/__snapshots__/l2np2.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/l2np2.web.test.js.snap
@@ -43,3 +43,55 @@ exports[`2. lead two no pic and two - medium 1`] = `
   </div>
 </div>
 `;
+
+exports[`3. lead two no pic and two - wide 1`] = `
+<div>
+  <div>
+    <div>
+      lead-1
+    </div>
+    <div />
+    <div>
+      lead-2
+    </div>
+  </div>
+  <div />
+  <div>
+    <div>
+      support-1
+    </div>
+  </div>
+  <div />
+  <div>
+    <div>
+      support-2
+    </div>
+  </div>
+</div>
+`;
+
+exports[`4. lead two no pic and two - huge 1`] = `
+<div>
+  <div>
+    <div>
+      lead-1
+    </div>
+    <div />
+    <div>
+      lead-2
+    </div>
+  </div>
+  <div />
+  <div>
+    <div>
+      support-1
+    </div>
+  </div>
+  <div />
+  <div>
+    <div>
+      support-2
+    </div>
+  </div>
+</div>
+`;

--- a/packages/slice-layout/src/templates/leadtwonopicandtwo/index.js
+++ b/packages/slice-layout/src/templates/leadtwonopicandtwo/index.js
@@ -5,7 +5,7 @@ import { editionBreakpoints } from "@times-components/styleguide";
 import Column from "../column";
 import { ItemColSeparator } from "../shared";
 import { propTypes, defaultProps } from "./proptypes";
-import styles from "./styles";
+import styleFactory from "./styles";
 
 const LeadTwoNoPicAndTwoSlice = ({
   breakpoint,
@@ -14,6 +14,32 @@ const LeadTwoNoPicAndTwoSlice = ({
   renderSupport1,
   renderSupport2
 }) => {
+  const styles = styleFactory(breakpoint);
+
+  if (breakpoint === editionBreakpoints.huge) {
+    return (
+      <View style={styles.container}>
+        <Column style={styles.column} tiles={[renderLead1, renderLead2]} />
+        <ItemColSeparator />
+        <View style={styles.middleTile}>{renderSupport1()}</View>
+        <ItemColSeparator />
+        <View style={styles.column}>{renderSupport2()}</View>
+      </View>
+    );
+  }
+
+  if (breakpoint === editionBreakpoints.wide) {
+    return (
+      <View style={styles.container}>
+        <Column style={styles.column} tiles={[renderLead1, renderLead2]} />
+        <ItemColSeparator />
+        <View style={styles.middleTile}>{renderSupport1()}</View>
+        <ItemColSeparator />
+        <View style={styles.column}>{renderSupport2()}</View>
+      </View>
+    );
+  }
+
   if (breakpoint === editionBreakpoints.small) {
     return (
       <Column

--- a/packages/slice-layout/src/templates/leadtwonopicandtwo/styles.js
+++ b/packages/slice-layout/src/templates/leadtwonopicandtwo/styles.js
@@ -1,13 +1,40 @@
 import { spacing } from "@times-components/styleguide";
 
-const styles = {
+const main = {
   column: {
     width: "50%"
   },
   container: {
     flexDirection: "row",
+    justifyContent: "center",
     paddingHorizontal: spacing(2)
   }
 };
 
-export default styles;
+const stylesWide = {
+  column: {
+    width: "42%"
+  },
+  middleTile: {
+    width: "16%"
+  }
+};
+
+const stylesHuge = {
+  column: {
+    width: "36%"
+  },
+  middleTile: {
+    width: "14%"
+  }
+};
+
+const stylesResolver = {
+  huge: stylesHuge,
+  wide: stylesWide
+};
+
+export default breakpoint => ({
+  ...main,
+  ...(stylesResolver[breakpoint] || {})
+});


### PR DESCRIPTION
Implement LeadTwoNoPicAndTwo for wide and huge tablet breakpoints.
New tile (TileAL) added.

TileAL:
![image](https://user-images.githubusercontent.com/7889661/55170901-10247800-5180-11e9-897b-0acd8a0609ba.png)

Wide: 
![image](https://user-images.githubusercontent.com/7889661/55170521-5fb67400-517f-11e9-8d7a-d2ff6c41dfb2.png)

Huge:
![image](https://user-images.githubusercontent.com/7889661/55170709-aefca480-517f-11e9-952e-088bf44bb509.png)
