### PR TITLE
fix: Handle null aspect ratio case in images

### DIFF
--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -76,7 +76,45 @@ exports[`2. default layout without uri 1`] = `
 </View>
 `;
 
-exports[`3. prepend https schema 1`] = `
+exports[`3. default layout without aspect ratio 1`] = `
+<View>
+  <Gradient
+    degrees={264}
+    height={350}
+    width={700}
+  >
+    <View>
+      <Svg
+        height={191}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={191}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
+  <Image
+    source={
+      Object {
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
+      }
+    }
+  />
+</View>
+`;
+
+exports[`4. prepend https schema 1`] = `
 <View
   aspectRatio={2}
 >
@@ -116,7 +154,7 @@ exports[`3. prepend https schema 1`] = `
 </View>
 `;
 
-exports[`4. handle onload event 1`] = `
+exports[`5. handle onload event 1`] = `
 <View
   aspectRatio={2}
 >
@@ -156,7 +194,7 @@ exports[`4. handle onload event 1`] = `
 </View>
 `;
 
-exports[`4. handle onload event 2`] = `
+exports[`5. handle onload event 2`] = `
 <View
   aspectRatio={2}
 >
@@ -170,7 +208,7 @@ exports[`4. handle onload event 2`] = `
 </View>
 `;
 
-exports[`6. uses highressize if it exists 1`] = `
+exports[`7. uses highressize if it exists 1`] = `
 <View
   aspectRatio={2}
 >
@@ -210,7 +248,7 @@ exports[`6. uses highressize if it exists 1`] = `
 </View>
 `;
 
-exports[`8. image with borderradius 1`] = `
+exports[`9. image with borderradius 1`] = `
 <View
   aspectRatio={2}
 >
@@ -225,7 +263,7 @@ exports[`8. image with borderradius 1`] = `
 </View>
 `;
 
-exports[`9. uses lowressize image as placeholder if passed 1`] = `
+exports[`10. uses lowressize image as placeholder if passed 1`] = `
 <View
   aspectRatio={2}
 >
@@ -246,7 +284,7 @@ exports[`9. uses lowressize image as placeholder if passed 1`] = `
 </View>
 `;
 
-exports[`11. handle layout change 1`] = `
+exports[`12. handle layout change 1`] = `
 <View
   aspectRatio={2}
 >

--- a/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
@@ -76,7 +76,45 @@ exports[`2. default layout without uri 1`] = `
 </View>
 `;
 
-exports[`3. prepend https schema 1`] = `
+exports[`3. default layout without aspect ratio 1`] = `
+<View>
+  <Gradient
+    degrees={264}
+    height={350}
+    width={700}
+  >
+    <View>
+      <Svg
+        height={191}
+        version="1.1"
+        viewBox="145 50 108 120"
+        width={191}
+      >
+        <G
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <Path
+            d="6a6c07166e9c40e4f62e57af2b507822"
+            fill="#FFFFFF"
+          />
+        </G>
+      </Svg>
+    </View>
+  </Gradient>
+  <Image
+    source={
+      Object {
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
+      }
+    }
+  />
+</View>
+`;
+
+exports[`4. prepend https schema 1`] = `
 <View
   aspectRatio={2}
 >
@@ -116,7 +154,7 @@ exports[`3. prepend https schema 1`] = `
 </View>
 `;
 
-exports[`4. handle onload event 1`] = `
+exports[`5. handle onload event 1`] = `
 <View
   aspectRatio={2}
 >
@@ -156,7 +194,7 @@ exports[`4. handle onload event 1`] = `
 </View>
 `;
 
-exports[`4. handle onload event 2`] = `
+exports[`5. handle onload event 2`] = `
 <View
   aspectRatio={2}
 >
@@ -170,7 +208,7 @@ exports[`4. handle onload event 2`] = `
 </View>
 `;
 
-exports[`6. uses highressize if it exists 1`] = `
+exports[`7. uses highressize if it exists 1`] = `
 <View
   aspectRatio={2}
 >
@@ -210,7 +248,7 @@ exports[`6. uses highressize if it exists 1`] = `
 </View>
 `;
 
-exports[`8. image with borderradius 1`] = `
+exports[`9. image with borderradius 1`] = `
 <View
   aspectRatio={2}
 >
@@ -225,7 +263,7 @@ exports[`8. image with borderradius 1`] = `
 </View>
 `;
 
-exports[`9. uses lowressize image as placeholder if passed 1`] = `
+exports[`10. uses lowressize image as placeholder if passed 1`] = `
 <View
   aspectRatio={2}
 >
@@ -246,7 +284,7 @@ exports[`9. uses lowressize image as placeholder if passed 1`] = `
 </View>
 `;
 
-exports[`11. handle layout change 1`] = `
+exports[`12. handle layout change 1`] = `
 <View
   aspectRatio={2}
 >

--- a/packages/image/__tests__/shared.base.js
+++ b/packages/image/__tests__/shared.base.js
@@ -33,6 +33,16 @@ export default (renderComponent, platformTests = []) => {
         expect(output).toMatchSnapshot();
       }
     },
+    {
+      name: "default layout without aspect ratio",
+      test: () => {
+        const output = renderComponent(
+          <Image uri="http://example.com/image.jpg?crop=1016%2C677%2C0%2C0" />
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
     ...platformTests
   ];
 

--- a/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
@@ -94,7 +94,54 @@ exports[`2. default layout without uri 1`] = `
 </div>
 `;
 
-exports[`3. an invalid uri 1`] = `
+exports[`3. default layout without aspect ratio 1`] = `
+.c0 {
+  display: block;
+  opacity: 0;
+  position: absolute;
+  -webkit-transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out;
+  width: 100%;
+  z-index: 2;
+}
+
+<div>
+  <div>
+    <img
+      alt=""
+      src="http://example.com/image.jpg?crop=1016%2C677%2C0%2C0"
+    />
+    <Gradient
+      degrees={264}
+      height={400}
+      width={800}
+    >
+      <div>
+        <Svg
+          height={219}
+          version="1.1"
+          viewBox="145 50 108 120"
+          width={219}
+        >
+          <G
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1"
+          >
+            <Path
+              d="6a6c07166e9c40e4f62e57af2b507822"
+              fill="#FFFFFF"
+            />
+          </G>
+        </Svg>
+      </div>
+    </Gradient>
+  </div>
+</div>
+`;
+
+exports[`4. an invalid uri 1`] = `
 .c0 {
   display: block;
   opacity: 0;
@@ -141,7 +188,7 @@ exports[`3. an invalid uri 1`] = `
 </div>
 `;
 
-exports[`4. no url in environment 1`] = `
+exports[`5. no url in environment 1`] = `
 .c0 {
   display: block;
   opacity: 0;
@@ -188,7 +235,7 @@ exports[`4. no url in environment 1`] = `
 </div>
 `;
 
-exports[`5. with existing url params 1`] = `
+exports[`6. with existing url params 1`] = `
 .c0 {
   display: block;
   opacity: 0;
@@ -235,7 +282,7 @@ exports[`5. with existing url params 1`] = `
 </div>
 `;
 
-exports[`6. remove the low res image after the high res image has transitioned in 1`] = `
+exports[`7. remove the low res image after the high res image has transitioned in 1`] = `
 .c1 {
   display: block;
   opacity: 1;
@@ -270,7 +317,7 @@ exports[`6. remove the low res image after the high res image has transitioned i
 </div>
 `;
 
-exports[`6. remove the low res image after the high res image has transitioned in 2`] = `
+exports[`7. remove the low res image after the high res image has transitioned in 2`] = `
 .c0 {
   display: block;
   opacity: 1;
@@ -291,7 +338,7 @@ exports[`6. remove the low res image after the high res image has transitioned i
 </div>
 `;
 
-exports[`7. only a low res image 1`] = `
+exports[`8. only a low res image 1`] = `
 .c0 {
   display: block;
   opacity: 1;
@@ -338,7 +385,7 @@ exports[`7. only a low res image 1`] = `
 </div>
 `;
 
-exports[`8. fade in the low res image 1`] = `
+exports[`9. fade in the low res image 1`] = `
 .c0 {
   display: block;
   opacity: 0;
@@ -385,7 +432,7 @@ exports[`8. fade in the low res image 1`] = `
 </div>
 `;
 
-exports[`8. fade in the low res image 2`] = `
+exports[`9. fade in the low res image 2`] = `
 .c0 {
   display: block;
   opacity: 1;
@@ -406,7 +453,7 @@ exports[`8. fade in the low res image 2`] = `
 </div>
 `;
 
-exports[`9. both high and low res sizes 1`] = `
+exports[`10. both high and low res sizes 1`] = `
 .c0 {
   display: block;
   opacity: 0;

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -47,7 +47,7 @@ class TimesImage extends Component {
       layout.width,
       layout.height,
       layout.width,
-      layout.width / aspectRatio
+      aspectRatio ? layout.width / aspectRatio : layout.height
     );
 
     this.setState({ dimensions: { height, width } });

--- a/packages/video/__tests__/android/__snapshots__/video.android.test.js.snap
+++ b/packages/video/__tests__/android/__snapshots__/video.android.test.js.snap
@@ -6,6 +6,7 @@ exports[`1. video 1`] = `
   testID="splash-component"
 >
   <Image
+    aspectRatio={1.5}
     uri="b9a31d3949b1882a09ed2f8508d538f3"
   />
   <View>
@@ -94,6 +95,7 @@ exports[`3. sky sports video 1`] = `
     />
   </View>
   <Image
+    aspectRatio={1.5}
     uri="b9a31d3949b1882a09ed2f8508d538f3"
   />
   <View>
@@ -135,6 +137,7 @@ exports[`4. 360 video 1`] = `
   testID="splash-component"
 >
   <Image
+    aspectRatio={1.5}
     uri="b9a31d3949b1882a09ed2f8508d538f3"
   />
   <View>

--- a/packages/video/__tests__/ios/__snapshots__/video.ios.test.js.snap
+++ b/packages/video/__tests__/ios/__snapshots__/video.ios.test.js.snap
@@ -7,6 +7,7 @@ exports[`1. video 1`] = `
 >
   <View>
     <Image
+      aspectRatio={1.5}
       uri="b9a31d3949b1882a09ed2f8508d538f3"
     />
     <View>
@@ -101,6 +102,7 @@ exports[`3. sky sports video 1`] = `
       />
     </OverlayGradient>
     <Image
+      aspectRatio={1.5}
       uri="b9a31d3949b1882a09ed2f8508d538f3"
     />
     <View>
@@ -144,6 +146,7 @@ exports[`4. 360 video 1`] = `
 >
   <View>
     <Image
+      aspectRatio={1.5}
       uri="b9a31d3949b1882a09ed2f8508d538f3"
     />
     <View>

--- a/packages/video/src/video.js
+++ b/packages/video/src/video.js
@@ -33,6 +33,7 @@ const Video = ({
       {skySports && <SkySportsBanner />}
       {poster ? (
         <Image
+          aspectRatio={width / height}
           style={{
             height,
             width


### PR DESCRIPTION
Native apps are crashing due to empty aspect ratio on certain images.

- Handled empty aspect ratio on images
- Added aspect ratio to video cover images