### PR TITLE
fix: remove android specific modal x margin

### DIFF
--- a/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
@@ -33,7 +33,6 @@ exports[`1. landscape default modal 1`] = `
             style={
               Object {
                 "alignItems": "flex-end",
-                "margin": 16,
               }
             }
           >
@@ -183,7 +182,6 @@ exports[`2. portrait default modal 1`] = `
             style={
               Object {
                 "alignItems": "flex-end",
-                "margin": 16,
               }
             }
           >
@@ -333,7 +331,6 @@ exports[`3. tablet landscape default modal 1`] = `
             style={
               Object {
                 "alignItems": "flex-end",
-                "margin": 16,
                 "marginHorizontal": 20,
                 "marginVertical": 20,
               }
@@ -485,7 +482,6 @@ exports[`4. tablet portrait default modal 1`] = `
             style={
               Object {
                 "alignItems": "flex-end",
-                "margin": 16,
                 "marginHorizontal": 20,
                 "marginVertical": 20,
               }

--- a/packages/image/src/styles/index.android.js
+++ b/packages/image/src/styles/index.android.js
@@ -4,8 +4,7 @@ import sharedStyles, { captionStyles, tabletCaptionStyles } from "./shared";
 const styles = StyleSheet.create({
   ...sharedStyles,
   buttonContainer: {
-    alignItems: "flex-end",
-    margin: 16
+    alignItems: "flex-end"
   }
 });
 


### PR DESCRIPTION
Very quick PR to remove the android specific margins around the x button in the modals. This should have been done in previous PRs. 

![Screen Shot 2019-04-02 at 11 47 02](https://user-images.githubusercontent.com/719814/55396958-0bbfdc80-553d-11e9-986c-a167ce85e2f9.png)


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
