### PR TITLE
fix: prevent image placeholder rendering at stale dimensions on android (wip)

### DIFF
--- a/packages/image/src/placeholder.android.js
+++ b/packages/image/src/placeholder.android.js
@@ -1,0 +1,35 @@
+import React, { Component } from "react";
+import Placeholder from "./placeholder.base";
+
+class PlaceholderAndroidWrapper extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { renderChildren: true };
+  }
+
+  /**
+   * Deal with a bug in react-native-art that leads to the placeholder being
+   * rendered with stale dimensions. This forces a re-render
+   */
+  componentDidUpdate({ dimensions: prevDimensions }) {
+    const { dimensions } = this.props;
+    const { renderChildren } = this.state;
+
+    if (renderChildren && prevDimensions && dimensions !== prevDimensions) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ renderChildren: false }, () =>
+        this.setState({ renderChildren: true })
+      );
+    }
+  }
+
+  render() {
+    const { renderChildren } = this.state;
+
+    return renderChildren ? <Placeholder {...this.props} /> : null;
+  }
+}
+
+PlaceholderAndroidWrapper.propTypes = Placeholder.propTypes;
+
+export default PlaceholderAndroidWrapper;

--- a/packages/image/src/placeholder.base.js
+++ b/packages/image/src/placeholder.base.js
@@ -1,0 +1,44 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Image, View } from "react-native";
+import styles from "./styles/index";
+
+function Placeholder({ dimensions }) {
+  if (!dimensions) {
+    return null;
+  }
+
+  const { height, width } = dimensions;
+
+  return (
+    <View
+      height={height}
+      style={[
+        styles.container,
+        styles.placeholderContainer,
+        styles.placeholderBackground
+      ]}
+      width={width}
+    >
+      <Image
+        resizeMode="contain"
+        // eslint-disable-next-line global-require
+        source={require("../assets/t.png")}
+        style={{ width: Math.floor(width / 4) }}
+      />
+    </View>
+  );
+}
+
+Placeholder.propTypes = {
+  dimensions: PropTypes.shape({
+    height: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired
+  })
+};
+
+Placeholder.defaultProps = {
+  dimensions: null
+};
+
+export default Placeholder;


### PR DESCRIPTION
Creating a pull request to keep a record of these changes, but we probably don't need this anymore as we removed all surfaces from the placeholder, which seems to be have been the cause of the issue. 

This is made not necessary by https://github.com/newsuk/times-components/pull/1845 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
