### PR TITLE
DRAFT: feat: adding star to tiles

### DIFF
--- a/packages/edition-slices/src/tiles/shared/styles/index.js
+++ b/packages/edition-slices/src/tiles/shared/styles/index.js
@@ -1,0 +1,15 @@
+const styles = {
+    container: {
+        flexDirection: "row"
+    },
+    flagStyle: {
+        alignItems: "flex-start",
+        flex: 1
+    },
+    starButton: {
+        alignItems: "flex-end",
+        flex: 1
+    }
+};
+
+export default styles;

--- a/packages/edition-slices/src/tiles/shared/styles/index.js
+++ b/packages/edition-slices/src/tiles/shared/styles/index.js
@@ -1,4 +1,4 @@
-const styles = {
+const horizontalStyles = {
     container: {
         flexDirection: "row"
     },
@@ -12,4 +12,17 @@ const styles = {
     }
 };
 
-export default styles;
+const verticalStyles = {
+    container: {
+        flexDirection: "column"
+      },
+      flagStyle: {
+
+      },
+      starButton: {
+        textAlign: "center",
+        marginTop: 10
+      }
+};
+
+export {horizontalStyles, verticalStyles};

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -1,12 +1,16 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
+import { View } from "react-native";
 import PropTypes from "prop-types";
 import ArticleSummary, {
   ArticleSummaryContent,
   ArticleSummaryHeadline,
   ArticleSummaryStrapline
 } from "@times-components/article-summary";
+import { SectionContext } from "@times-components/context";
 import { ArticleFlags } from "@times-components/article-flag";
 import { colours } from "@times-components/styleguide";
+import TileStar from "./tile-star";
+import styles from "./styles";
 
 class TileSummary extends Component {
   constructor(props) {
@@ -26,12 +30,34 @@ class TileSummary extends Component {
   renderFlags() {
     const {
       tile: {
-        article: { expirableFlags }
+        article: { expirableFlags,  articleId}
       },
-      flagColour
+      flagColour,
+      starStyle
     } = this.props;
 
-    return <ArticleFlags {...flagColour} flags={expirableFlags} />;
+    const onArticleSavePress = () => {};
+    const savedArticles = [{1: true}];
+
+    const tileStyle = starStyle ? starStyle : styles;
+
+    return (
+    <View style={tileStyle.container}>
+      <View style={tileStyle.flagStyle}>
+        <ArticleFlags {...flagColour} flags={expirableFlags} />
+      </View>
+      <SectionContext.Provider
+        value={{
+          onArticleSavePress,
+          savedArticles
+        }}
+      >
+        <View style={tileStyle.starButton}>
+          <TileStar articleId="1" />
+        </View>
+      </SectionContext.Provider>
+    </View>
+    );
   }
 
   renderHeadline() {
@@ -67,6 +93,7 @@ class TileSummary extends Component {
       byline,
       bylineStyle,
       strapline,
+      starStyle,
       style,
       summary,
       labelColour

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -10,7 +10,7 @@ import { SectionContext } from "@times-components/context";
 import { ArticleFlags } from "@times-components/article-flag";
 import { colours } from "@times-components/styleguide";
 import TileStar from "./tile-star";
-import styles from "./styles";
+import { horizontalStyles } from "./styles";
 
 class TileSummary extends Component {
   constructor(props) {
@@ -39,7 +39,7 @@ class TileSummary extends Component {
     const onArticleSavePress = () => {};
     const savedArticles = [{1: true}];
 
-    const tileStyle = starStyle ? starStyle : styles;
+    const tileStyle = starStyle ? starStyle : horizontalStyles;
 
     return (
     <View style={tileStyle.container}>

--- a/packages/edition-slices/src/tiles/tile-ac/index.js
+++ b/packages/edition-slices/src/tiles/tile-ac/index.js
@@ -24,6 +24,7 @@ const TileAC = ({ onPress, tile }) => {
       />
       <TileSummary
         headlineStyle={headline}
+        starStyle={styles.star}
         style={summaryContainer}
         tile={tile}
       />

--- a/packages/edition-slices/src/tiles/tile-ac/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ac/styles/index.js
@@ -1,4 +1,5 @@
 import { colours, fonts, spacing } from "@times-components/styleguide";
+import { verticalStyles } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -13,6 +14,9 @@ const styles = {
   },
   imageContainer: {
     width: "100%"
+  },
+  star: {
+    ...verticalStyles
   },
   summaryContainer: {
     alignItems: "center",

--- a/packages/edition-slices/src/tiles/tile-ag/index.js
+++ b/packages/edition-slices/src/tiles/tile-ag/index.js
@@ -16,6 +16,7 @@ const TileAG = ({ onPress, tile }) => {
       <View style={styles.container}>
         <TileSummary
           headlineStyle={styles.headline}
+          starStyle={styles.star}
           strapline={strapline}
           straplineStyle={styles.strapline}
           tile={tileWithoutLabelAndFlags}

--- a/packages/edition-slices/src/tiles/tile-ag/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ag/styles/index.js
@@ -1,4 +1,5 @@
 import { fonts, spacing } from "@times-components/styleguide";
+import { verticalStyles } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -12,6 +13,9 @@ const styles = {
     marginBottom: spacing(1),
     marginTop: spacing(4),
     textAlign: "center"
+  },
+  star: {
+    ...verticalStyles
   },
   strapline: {
     fontFamily: fonts.bodyRegular,

--- a/packages/edition-slices/src/tiles/tile-ah/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/index.js
@@ -25,6 +25,7 @@ const TileAH = ({ onPress, tile }) => (
         byline={tile.article.byline}
         bylineStyle={styles.bylineOpinion}
         headlineStyle={styles.headline}
+        starStyle={styles.star}
         strapline={tile.strapline || tile.article.strapline}
         straplineStyle={styles.strapline}
         style={styles.summaryContainer}

--- a/packages/edition-slices/src/tiles/tile-ah/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/styles/index.js
@@ -4,6 +4,7 @@ import {
   fontSizes,
   spacing
 } from "@times-components/styleguide";
+import { verticalStyles } from "../../shared/styles";
 
 const styles = {
   bylineOpinion: {
@@ -31,6 +32,9 @@ const styles = {
     borderRadius: 9999,
     overflow: "hidden",
     width: "30%"
+  },
+  star: {
+    ...verticalStyles
   },
   strapline: {
     color: colours.functional.secondary,

--- a/packages/edition-slices/src/tiles/tile-al/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/index.js
@@ -23,6 +23,7 @@ const TileAL = ({ onPress, tile }) => (
       />
       <TileSummary
         headlineStyle={styles.headline}
+        starStyle={styles.star}
         summary={tile.teaser125 || tile.article.summary125}
         summaryStyle={styles.summaryContainer}
         tile={tile}

--- a/packages/edition-slices/src/tiles/tile-al/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/styles/index.js
@@ -1,4 +1,5 @@
 import { fontFactory, spacing } from "@times-components/styleguide";
+import { verticalStyles } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -15,6 +16,9 @@ const styles = {
   imageContainer: {
     paddingVertical: spacing(2),
     width: "100%"
+  },
+  star: {
+    ...verticalStyles
   },
   summaryContainer: {
     lineHeight: 1.43,

--- a/packages/edition-slices/src/tiles/tile-i/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/index.js
@@ -21,6 +21,7 @@ const TileI = ({ onPress, tile }) => (
     />
     <TileSummary
       headlineStyle={styles.headline}
+      starStyle={styles.star}
       style={styles.summaryContainer}
       tile={tile}
     />

--- a/packages/edition-slices/src/tiles/tile-i/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/styles/index.js
@@ -11,6 +11,18 @@ const styles = {
   imageContainer: {
     width: "100%"
   },
+  star: {
+    container: {
+      flexDirection: "column"
+    },
+    flagStyle: {
+
+    },
+    starButton: {
+      textAlign: "center",
+      marginTop: 10
+    }
+  },
   summaryContainer: {
     alignItems: "center",
     backgroundColor: colours.functional.border,

--- a/packages/edition-slices/src/tiles/tile-i/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/styles/index.js
@@ -1,4 +1,5 @@
 import { colours, fonts, spacing } from "@times-components/styleguide";
+import { verticalStyles } from "../../shared/styles";
 
 const styles = {
   headline: {
@@ -12,16 +13,7 @@ const styles = {
     width: "100%"
   },
   star: {
-    container: {
-      flexDirection: "column"
-    },
-    flagStyle: {
-
-    },
-    starButton: {
-      textAlign: "center",
-      marginTop: 10
-    }
+    ...verticalStyles
   },
   summaryContainer: {
     alignItems: "center",

--- a/packages/edition-slices/src/tiles/tile-m/index.js
+++ b/packages/edition-slices/src/tiles/tile-m/index.js
@@ -16,6 +16,7 @@ const TileM = ({ onPress, tile }) => {
       <View style={styles.container}>
         <TileSummary
           headlineStyle={styles.headline}
+          starStyle={styles.star}
           strapline={strapline}
           straplineStyle={styles.strapline}
           tile={tileWithoutLabelAndFlags}

--- a/packages/edition-slices/src/tiles/tile-m/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-m/styles/index.js
@@ -1,4 +1,5 @@
 import { colours, fonts, spacing } from "@times-components/styleguide";
+import { verticalStyles } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -11,6 +12,9 @@ const styles = {
     marginBottom: spacing(1),
     marginTop: spacing(4),
     textAlign: "center"
+  },
+  star: {
+    ...verticalStyles
   },
   strapline: {
     color: colours.functional.secondary,

--- a/packages/edition-slices/src/tiles/tile-p/index.js
+++ b/packages/edition-slices/src/tiles/tile-p/index.js
@@ -25,6 +25,7 @@ const TileP = ({ onPress, tile }) => (
         byline={tile.article.byline}
         bylineStyle={styles.bylineOpinion}
         headlineStyle={styles.headline}
+        starStyle={styles.star}
         strapline={tile.strapline || tile.article.strapline}
         straplineStyle={styles.strapline}
         style={styles.summaryContainer}

--- a/packages/edition-slices/src/tiles/tile-p/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-p/styles/index.js
@@ -4,6 +4,7 @@ import {
   fontSizes,
   spacing
 } from "@times-components/styleguide";
+import { verticalStyles } from "../../shared/styles";
 
 const styles = {
   bylineOpinion: {
@@ -30,6 +31,9 @@ const styles = {
     borderRadius: 9999,
     overflow: "hidden",
     width: "30%"
+  },
+  star: {
+    ...verticalStyles
   },
   strapline: {
     color: colours.functional.secondary,

--- a/packages/edition-slices/src/tiles/tile-q/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-q/styles/index.js
@@ -1,4 +1,5 @@
 import { spacing } from "@times-components/styleguide";
+import { verticalStyles } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -8,6 +9,9 @@ const styles = {
   imageContainer: {
     marginBottom: spacing(2),
     width: "100%"
+  },
+  star: {
+    ...verticalStyles
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-s/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-s/styles/index.js
@@ -5,6 +5,7 @@ import {
   fontSizes,
   colours
 } from "@times-components/styleguide";
+import { verticalStyles } from "../../shared/styles";
 
 const styles = {
   bold: {
@@ -26,6 +27,9 @@ const styles = {
       font: "body",
       fontSize: "teaser"
     })
+  },
+  star: {
+    ...verticalStyles
   },
   title: {
     color: colours.functional.brandColour,

--- a/packages/link/src/link.android.js
+++ b/packages/link/src/link.android.js
@@ -9,7 +9,7 @@ const Link = ({ children, linkStyle, onPress, disabled }) => (
     onPress={onPress}
     useForeground={TouchableNativeFeedback.canUseNativeForeground()}
   >
-    <View pointerEvents="box-only" style={linkStyle}>
+    <View style={linkStyle}>
       {children}
     </View>
   </TouchableNativeFeedback>


### PR DESCRIPTION
This is the first draft
- This takes care of Tiles which have Star at the same level as Flag
- `Tile I` which has center align star.

Todo
- [ ] Tiles which are variant from above
- [ ] Moving Provider outside of Tile
- [ ] Test cases


![Screen Shot 2019-04-02 at 19 17 39](https://user-images.githubusercontent.com/9569135/55426181-0df55b80-557c-11e9-8414-6cc1e56b57f5.png)
![Screen Shot 2019-04-02 at 19 17 49](https://user-images.githubusercontent.com/9569135/55426184-1057b580-557c-11e9-93de-9bd5a19e91ce.png)
