### PR TITLE
feat: save star storybook

### DIFF
--- a/android/app/src/main/java/com/storybooknative/stubs/SectionEvents.kt
+++ b/android/app/src/main/java/com/storybooknative/stubs/SectionEvents.kt
@@ -1,0 +1,38 @@
+package com.storybooknative.stubs
+
+import android.util.Log
+import com.facebook.react.bridge.BaseJavaModule
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
+
+class SectionEvents : BaseJavaModule() {
+    override fun getName() = "SectionEvents"
+
+    @ReactMethod
+    fun onPuzzlePress(url: String, title: String, id: String) {
+        Log.d(name, "onPuzzlePress $url $title $id")
+    }
+
+    @ReactMethod
+    fun onArticlePress(url: String, id: String) {
+        Log.d(name, "onArticlePress $url $id")
+    }
+
+    @ReactMethod
+    fun onSectionLoaded(sectionName: String, extras: ReadableMap) {
+        Log.d(name, "onSectionLoaded $sectionName $extras")
+    }
+
+    @ReactMethod
+    fun getSavedArticles(promise: Promise) {
+        Log.d(name, "getSavedArticles")
+        promise.resolve(WritableNativeArray())
+    }
+
+    @ReactMethod
+    fun onArticleSavePress(save: Boolean, articleId: String, promise: Promise) {
+        promise.resolve(true)
+    }
+}

--- a/android/app/src/main/java/com/storybooknative/stubs/StorybookStubPackage.kt
+++ b/android/app/src/main/java/com/storybooknative/stubs/StorybookStubPackage.kt
@@ -13,6 +13,7 @@ class StorybookStubPackage : ReactPackage {
             AuthorProfileEvents(),
             ReactAnalytics(),
             ReactConfig(),
+            SectionEvents(),
             TopicEvents()
     )
 

--- a/packages/pages/pages.showcase.native.js
+++ b/packages/pages/pages.showcase.native.js
@@ -1,11 +1,8 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import { ActivityIndicator, Text } from "react-native";
 import { sections } from "@times-components/storybook";
-import { EditionProvider } from "@times-components/provider";
 import { Article, AuthorProfile, Topic } from "./src/pages";
-import Section from "./src/section/section";
-import withNativeProvider from "./src/with-native-provider";
+import Section from "./section-showcase-helper";
 
 export default {
   children: [
@@ -36,26 +33,9 @@ export default {
           "Edition id",
           "2b6e462c-225f-11e9-b782-40e94f317da5"
         );
-        const sectionTitle = sections[select("Section", sections, "News")];
+        const sectionTitle = select("Section", sections, "News");
 
-        return withNativeProvider(
-          <EditionProvider debounceTimeMs={0} id={editionId}>
-            {({ edition, error, isLoading }) => {
-              if (isLoading) {
-                return <ActivityIndicator size="large" />;
-              }
-              if (error) {
-                return <Text>{JSON.stringify(error)}</Text>;
-              }
-              const { publicationName: pubName } = edition;
-              return edition.sections
-                .filter(({ title }) => title === sectionTitle)
-                .map(sectionData => (
-                  <Section publicationName={pubName} section={sectionData} />
-                ));
-            }}
-          </EditionProvider>
-        );
+        return <Section editionId={editionId} sectionTitle={sectionTitle} />;
       },
       name: "Section",
       type: "story"

--- a/packages/pages/section-showcase-helper.js
+++ b/packages/pages/section-showcase-helper.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { ActivityIndicator, Text } from "react-native";
+import PropTypes from "prop-types";
+import { EditionProvider } from "@times-components/provider";
+import withNativeProvider from "./src/with-native-provider";
+import Section from "./src/section/section";
+
+const SectionPage = ({ editionId, sectionTitle }) => {
+  const SectionPageView = withNativeProvider(
+    <EditionProvider debounceTimeMs={0} id={editionId}>
+      {({ edition, error, isLoading }) => {
+        if (isLoading) {
+          return <ActivityIndicator size="large" />;
+        }
+        if (error) {
+          return <Text>{JSON.stringify(error)}</Text>;
+        }
+        const { publicationName: pubName } = edition;
+        return edition.sections
+          .filter(({ title }) => title === sectionTitle)
+          .map(sectionData => (
+            <Section publicationName={pubName} section={sectionData} />
+          ));
+      }}
+    </EditionProvider>
+  );
+
+  return <SectionPageView />;
+};
+
+SectionPage.propTypes = {
+  editionId: PropTypes.string.isRequired,
+  sectionTitle: PropTypes.string.isRequired
+};
+
+export default SectionPage;

--- a/packages/pages/src/section/section.js
+++ b/packages/pages/src/section/section.js
@@ -26,6 +26,7 @@ class SectionPage extends Component {
       savedArticles: null
     };
     this.onAppStateChange = this.onAppStateChange.bind(this);
+    this.toggleArticleSaveStatus = this.toggleArticleSaveStatus.bind(this);
   }
 
   componentDidMount() {
@@ -69,6 +70,12 @@ class SectionPage extends Component {
     }
   }
 
+  toggleArticleSaveStatus(save, articleId) {
+    const { savedArticles } = this.state;
+    savedArticles[articleId] = save || undefined;
+    this.setState({ savedArticles });
+  }
+
   render() {
     const { publicationName, section } = this.props;
     const { recentlyOpenedPuzzleCount, savedArticles } = this.state;
@@ -77,11 +84,13 @@ class SectionPage extends Component {
       <SectionContext.Provider
         value={{
           onArticleSavePress: onArticleSavePress
-            ? (save, articleId) =>
-                onArticleSavePress(save, articleId).then(() => {
-                  savedArticles[articleId] = save || undefined;
-                  this.setState({ savedArticles });
-                })
+            ? (save, articleId) => {
+                this.toggleArticleSaveStatus(save, articleId);
+
+                onArticleSavePress(save, articleId).catch(() => {
+                  this.toggleArticleSaveStatus(!save, articleId);
+                });
+              }
             : null,
           publicationName,
           recentlyOpenedPuzzleCount,


### PR DESCRIPTION
This PR will simplify save star development by adding stubs to storybook

- Added SectionEvents to android storybook app
- Fixed the storybook on pages.
- Changed the way we update saved article context. Now, we update save status in a synchronous manner, and undo it if native app rejects the promise. This removed the lag on status updates caused by the async nature of NativeModules