### PR TITLE
fix: ripple effect is not full width any more

### DIFF
--- a/packages/edition-slices/__tests__/shared-components.base.js
+++ b/packages/edition-slices/__tests__/shared-components.base.js
@@ -266,7 +266,7 @@ export default () => {
       }
     },
     {
-      name: "Tile Star is rendered as already saved",
+      name: "Tile Star is rendered as already saved in default light theme",
       test: () => {
         const onArticleSavePress = jest.fn();
         const savedArticles = { "1": true };
@@ -283,10 +283,31 @@ export default () => {
         );
 
         expect(output.root.findByType(StarButton).props.selected).toEqual(true);
+        expect(output.root.findByType(StarButton).props.isDark).toEqual(false);
       }
     },
     {
-      name: "Tile Star is rendered as not yet saved",
+      name: "Tile Star is rendered as already saved in dark theme",
+      test: () => {
+        const onArticleSavePress = jest.fn();
+        const savedArticles = { "1": true };
+
+        const output = TestRenderer.create(
+          <SectionContext.Provider
+            value={{
+              onArticleSavePress,
+              savedArticles
+            }}
+          >
+            <TileStar articleId="1" isDark />
+          </SectionContext.Provider>
+        );
+
+        expect(output.root.findByType(StarButton).props.isDark).toEqual(true);
+      }
+    },
+    {
+      name: "Tile Star is rendered as not yet saved in default light theme",
       test: () => {
         const onArticleSavePress = jest.fn();
         const savedArticles = { "1": true };
@@ -305,10 +326,31 @@ export default () => {
         expect(output.root.findByType(StarButton).props.selected).toEqual(
           false
         );
+        expect(output.root.findByType(StarButton).props.isDark).toEqual(false);
       }
     },
     {
-      name: "Tile Star is disabled",
+      name: "Tile Star is rendered as not yet saved in dark theme",
+      test: () => {
+        const onArticleSavePress = jest.fn();
+        const savedArticles = { "1": true };
+
+        const output = TestRenderer.create(
+          <SectionContext.Provider
+            value={{
+              onArticleSavePress,
+              savedArticles
+            }}
+          >
+            <TileStar articleId="I am not saved yet" isDark />
+          </SectionContext.Provider>
+        );
+
+        expect(output.root.findByType(StarButton).props.isDark).toEqual(true);
+      }
+    },
+    {
+      name: "Tile Star is disabled in default light theme",
       test: () => {
         const onArticleSavePress = jest.fn();
         const savedArticles = null;
@@ -325,6 +367,27 @@ export default () => {
         );
 
         expect(output.root.findByType(StarButton).props.disabled).toEqual(true);
+        expect(output.root.findByType(StarButton).props.isDark).toEqual(false);
+      }
+    },
+    {
+      name: "Tile Star is disabled in dark theme",
+      test: () => {
+        const onArticleSavePress = jest.fn();
+        const savedArticles = null;
+
+        const output = TestRenderer.create(
+          <SectionContext.Provider
+            value={{
+              onArticleSavePress,
+              savedArticles
+            }}
+          >
+            <TileStar articleId="1" isDark />
+          </SectionContext.Provider>
+        );
+
+        expect(output.root.findByType(StarButton).props.isDark).toEqual(true);
       }
     }
   ];

--- a/packages/edition-slices/src/tiles/shared/tile-star.js
+++ b/packages/edition-slices/src/tiles/shared/tile-star.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import StarButton from "@times-components/star-button";
 import { SectionContext } from "@times-components/context";
 
-const renderStar = (articleId, onArticleSavePress, savedArticles) => {
+const renderStar = (articleId, onArticleSavePress, savedArticles, isDark) => {
   const disabled = !savedArticles;
   const isSaved = savedArticles && savedArticles[articleId];
 
@@ -12,22 +12,32 @@ const renderStar = (articleId, onArticleSavePress, savedArticles) => {
   };
 
   return (
-    <StarButton disabled={disabled} onPress={onStarPress} selected={isSaved} />
+    <StarButton
+      disabled={disabled}
+      isDark={isDark}
+      onPress={onStarPress}
+      selected={isSaved}
+    />
   );
 };
 
-const TileStar = ({ articleId }) => (
+const TileStar = ({ articleId, isDark }) => (
   <SectionContext.Consumer>
     {({ onArticleSavePress, savedArticles }) =>
       onArticleSavePress
-        ? renderStar(articleId, onArticleSavePress, savedArticles)
+        ? renderStar(articleId, onArticleSavePress, savedArticles, isDark)
         : null
     }
   </SectionContext.Consumer>
 );
 
 TileStar.propTypes = {
-  articleId: PropTypes.string.isRequired
+  articleId: PropTypes.string.isRequired,
+  isDark: PropTypes.bool
+};
+
+TileStar.defaultProps = {
+  isDark: false
 };
 
 export default TileStar;

--- a/packages/star-button/__tests__/android/__snapshots__/star-button.android.test.js.snap
+++ b/packages/star-button/__tests__/android/__snapshots__/star-button.android.test.js.snap
@@ -5,8 +5,9 @@ exports[`1. renders default 1`] = `
   disabled={false}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": 5,
+      "width": 28,
     }
   }
 >
@@ -24,8 +25,9 @@ exports[`2. renders selected 1`] = `
   disabled={false}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": 5,
+      "width": 28,
     }
   }
 >
@@ -43,8 +45,9 @@ exports[`3. renders disabled 1`] = `
   disabled={true}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": 5,
+      "width": 28,
     }
   }
 >
@@ -62,8 +65,9 @@ exports[`4. renders default in dark theme 1`] = `
   disabled={false}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": 5,
+      "width": 28,
     }
   }
 >
@@ -81,8 +85,9 @@ exports[`5. renders selected in dark theme 1`] = `
   disabled={false}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": 5,
+      "width": 28,
     }
   }
 >
@@ -100,8 +105,9 @@ exports[`6. renders disabled in dark theme 1`] = `
   disabled={true}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": 5,
+      "width": 28,
     }
   }
 >

--- a/packages/star-button/__tests__/android/__snapshots__/star-button.android.test.js.snap
+++ b/packages/star-button/__tests__/android/__snapshots__/star-button.android.test.js.snap
@@ -6,6 +6,7 @@ exports[`1. renders default 1`] = `
   linkStyle={
     Object {
       "alignSelf": "flex-start",
+      "padding": 5,
     }
   }
 >
@@ -24,6 +25,7 @@ exports[`2. renders selected 1`] = `
   linkStyle={
     Object {
       "alignSelf": "flex-start",
+      "padding": 5,
     }
   }
 >
@@ -42,6 +44,7 @@ exports[`3. renders disabled 1`] = `
   linkStyle={
     Object {
       "alignSelf": "flex-start",
+      "padding": 5,
     }
   }
 >
@@ -50,6 +53,63 @@ exports[`3. renders disabled 1`] = `
     height={18}
     opacity="0.4"
     strokeColour="#696969"
+  />
+</Link>
+`;
+
+exports[`4. renders default in dark theme 1`] = `
+<Link
+  disabled={false}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+      "padding": 5,
+    }
+  }
+>
+  <IconStar
+    fillColour="none"
+    height={18}
+    opacity="1"
+    strokeColour="#CCC"
+  />
+</Link>
+`;
+
+exports[`5. renders selected in dark theme 1`] = `
+<Link
+  disabled={false}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+      "padding": 5,
+    }
+  }
+>
+  <IconStar
+    fillColour="#3C81BE"
+    height={18}
+    opacity="1"
+    strokeColour="none"
+  />
+</Link>
+`;
+
+exports[`6. renders disabled in dark theme 1`] = `
+<Link
+  disabled={true}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+      "padding": 5,
+    }
+  }
+>
+  <IconStar
+    fillColour="none"
+    height={18}
+    opacity="0.4"
+    strokeColour="#CCC"
   />
 </Link>
 `;

--- a/packages/star-button/__tests__/android/__snapshots__/star-button.android.test.js.snap
+++ b/packages/star-button/__tests__/android/__snapshots__/star-button.android.test.js.snap
@@ -3,6 +3,11 @@
 exports[`1. renders default 1`] = `
 <Link
   disabled={false}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+    }
+  }
 >
   <IconStar
     fillColour="none"
@@ -16,6 +21,11 @@ exports[`1. renders default 1`] = `
 exports[`2. renders selected 1`] = `
 <Link
   disabled={false}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+    }
+  }
 >
   <IconStar
     fillColour="#006699"
@@ -29,6 +39,11 @@ exports[`2. renders selected 1`] = `
 exports[`3. renders disabled 1`] = `
 <Link
   disabled={true}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+    }
+  }
 >
   <IconStar
     fillColour="none"

--- a/packages/star-button/__tests__/ios/__snapshots__/star-button.ios.test.js.snap
+++ b/packages/star-button/__tests__/ios/__snapshots__/star-button.ios.test.js.snap
@@ -5,8 +5,9 @@ exports[`1. renders default 1`] = `
   disabled={false}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": 5,
+      "width": 28,
     }
   }
 >
@@ -24,8 +25,9 @@ exports[`2. renders selected 1`] = `
   disabled={false}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": 5,
+      "width": 28,
     }
   }
 >
@@ -43,8 +45,9 @@ exports[`3. renders disabled 1`] = `
   disabled={true}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": 5,
+      "width": 28,
     }
   }
 >
@@ -62,8 +65,9 @@ exports[`4. renders default in dark theme 1`] = `
   disabled={false}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": 5,
+      "width": 28,
     }
   }
 >
@@ -81,8 +85,9 @@ exports[`5. renders selected in dark theme 1`] = `
   disabled={false}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": 5,
+      "width": 28,
     }
   }
 >
@@ -100,8 +105,9 @@ exports[`6. renders disabled in dark theme 1`] = `
   disabled={true}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": 5,
+      "width": 28,
     }
   }
 >

--- a/packages/star-button/__tests__/ios/__snapshots__/star-button.ios.test.js.snap
+++ b/packages/star-button/__tests__/ios/__snapshots__/star-button.ios.test.js.snap
@@ -6,6 +6,7 @@ exports[`1. renders default 1`] = `
   linkStyle={
     Object {
       "alignSelf": "flex-start",
+      "padding": 5,
     }
   }
 >
@@ -24,6 +25,7 @@ exports[`2. renders selected 1`] = `
   linkStyle={
     Object {
       "alignSelf": "flex-start",
+      "padding": 5,
     }
   }
 >
@@ -42,6 +44,7 @@ exports[`3. renders disabled 1`] = `
   linkStyle={
     Object {
       "alignSelf": "flex-start",
+      "padding": 5,
     }
   }
 >
@@ -50,6 +53,63 @@ exports[`3. renders disabled 1`] = `
     height={18}
     opacity="0.4"
     strokeColour="#696969"
+  />
+</Link>
+`;
+
+exports[`4. renders default in dark theme 1`] = `
+<Link
+  disabled={false}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+      "padding": 5,
+    }
+  }
+>
+  <IconStar
+    fillColour="none"
+    height={18}
+    opacity="1"
+    strokeColour="#CCC"
+  />
+</Link>
+`;
+
+exports[`5. renders selected in dark theme 1`] = `
+<Link
+  disabled={false}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+      "padding": 5,
+    }
+  }
+>
+  <IconStar
+    fillColour="#3C81BE"
+    height={18}
+    opacity="1"
+    strokeColour="none"
+  />
+</Link>
+`;
+
+exports[`6. renders disabled in dark theme 1`] = `
+<Link
+  disabled={true}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+      "padding": 5,
+    }
+  }
+>
+  <IconStar
+    fillColour="none"
+    height={18}
+    opacity="0.4"
+    strokeColour="#CCC"
   />
 </Link>
 `;

--- a/packages/star-button/__tests__/ios/__snapshots__/star-button.ios.test.js.snap
+++ b/packages/star-button/__tests__/ios/__snapshots__/star-button.ios.test.js.snap
@@ -3,6 +3,11 @@
 exports[`1. renders default 1`] = `
 <Link
   disabled={false}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+    }
+  }
 >
   <IconStar
     fillColour="none"
@@ -16,6 +21,11 @@ exports[`1. renders default 1`] = `
 exports[`2. renders selected 1`] = `
 <Link
   disabled={false}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+    }
+  }
 >
   <IconStar
     fillColour="#006699"
@@ -29,6 +39,11 @@ exports[`2. renders selected 1`] = `
 exports[`3. renders disabled 1`] = `
 <Link
   disabled={true}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+    }
+  }
 >
   <IconStar
     fillColour="none"

--- a/packages/star-button/__tests__/shared.base.js
+++ b/packages/star-button/__tests__/shared.base.js
@@ -40,6 +40,36 @@ export default () => {
 
         expect(testInstance.toJSON()).toMatchSnapshot();
       }
+    },
+    {
+      name: "renders default in dark theme",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <StarButton isDark onPress={() => {}} />
+        );
+
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "renders selected in dark theme",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <StarButton isDark onPress={() => {}} selected />
+        );
+
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "renders disabled in dark theme",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <StarButton disabled isDark onPress={() => {}} />
+        );
+
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
     }
   ];
 

--- a/packages/star-button/__tests__/web/__snapshots__/star-button.web.test.js.snap
+++ b/packages/star-button/__tests__/web/__snapshots__/star-button.web.test.js.snap
@@ -6,6 +6,7 @@ exports[`1. renders default 1`] = `
   linkStyle={
     Object {
       "alignSelf": "flex-start",
+      "padding": "5px",
     }
   }
 >
@@ -24,6 +25,7 @@ exports[`2. renders selected 1`] = `
   linkStyle={
     Object {
       "alignSelf": "flex-start",
+      "padding": "5px",
     }
   }
 >
@@ -42,6 +44,7 @@ exports[`3. renders disabled 1`] = `
   linkStyle={
     Object {
       "alignSelf": "flex-start",
+      "padding": "5px",
     }
   }
 >
@@ -50,6 +53,63 @@ exports[`3. renders disabled 1`] = `
     height={18}
     opacity="0.4"
     strokeColour="#696969"
+  />
+</Link>
+`;
+
+exports[`4. renders default in dark theme 1`] = `
+<Link
+  disabled={false}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+      "padding": "5px",
+    }
+  }
+>
+  <IconStar
+    fillColour="none"
+    height={18}
+    opacity="1"
+    strokeColour="#CCC"
+  />
+</Link>
+`;
+
+exports[`5. renders selected in dark theme 1`] = `
+<Link
+  disabled={false}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+      "padding": "5px",
+    }
+  }
+>
+  <IconStar
+    fillColour="#3C81BE"
+    height={18}
+    opacity="1"
+    strokeColour="none"
+  />
+</Link>
+`;
+
+exports[`6. renders disabled in dark theme 1`] = `
+<Link
+  disabled={true}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+      "padding": "5px",
+    }
+  }
+>
+  <IconStar
+    fillColour="none"
+    height={18}
+    opacity="0.4"
+    strokeColour="#CCC"
   />
 </Link>
 `;

--- a/packages/star-button/__tests__/web/__snapshots__/star-button.web.test.js.snap
+++ b/packages/star-button/__tests__/web/__snapshots__/star-button.web.test.js.snap
@@ -5,8 +5,9 @@ exports[`1. renders default 1`] = `
   disabled={false}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": "5px",
+      "width": 28,
     }
   }
 >
@@ -24,8 +25,9 @@ exports[`2. renders selected 1`] = `
   disabled={false}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": "5px",
+      "width": 28,
     }
   }
 >
@@ -43,8 +45,9 @@ exports[`3. renders disabled 1`] = `
   disabled={true}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": "5px",
+      "width": 28,
     }
   }
 >
@@ -62,8 +65,9 @@ exports[`4. renders default in dark theme 1`] = `
   disabled={false}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": "5px",
+      "width": 28,
     }
   }
 >
@@ -81,8 +85,9 @@ exports[`5. renders selected in dark theme 1`] = `
   disabled={false}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": "5px",
+      "width": 28,
     }
   }
 >
@@ -100,8 +105,9 @@ exports[`6. renders disabled in dark theme 1`] = `
   disabled={true}
   linkStyle={
     Object {
-      "alignSelf": "flex-start",
+      "height": 28,
       "padding": "5px",
+      "width": 28,
     }
   }
 >

--- a/packages/star-button/__tests__/web/__snapshots__/star-button.web.test.js.snap
+++ b/packages/star-button/__tests__/web/__snapshots__/star-button.web.test.js.snap
@@ -3,6 +3,11 @@
 exports[`1. renders default 1`] = `
 <Link
   disabled={false}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+    }
+  }
 >
   <IconStar
     fillColour="none"
@@ -16,6 +21,11 @@ exports[`1. renders default 1`] = `
 exports[`2. renders selected 1`] = `
 <Link
   disabled={false}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+    }
+  }
 >
   <IconStar
     fillColour="#006699"
@@ -29,6 +39,11 @@ exports[`2. renders selected 1`] = `
 exports[`3. renders disabled 1`] = `
 <Link
   disabled={true}
+  linkStyle={
+    Object {
+      "alignSelf": "flex-start",
+    }
+  }
 >
   <IconStar
     fillColour="none"

--- a/packages/star-button/src/star-button.js
+++ b/packages/star-button/src/star-button.js
@@ -2,9 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import Link from "@times-components/link";
 import { IconStar } from "@times-components/icons";
-import styles, { stars } from "./styles";
+import styles, { getTheme } from "./styles";
 
-const StarButton = ({ disabled, height, onPress, selected }) => {
+const StarButton = ({ isDark, disabled, height, onPress, selected }) => {
+  const stars = getTheme({ isDark })
   const starState =
     (disabled && "disabled") || (selected && "selected") || "initial";
   const { fillColour, opacity, strokeColour } = stars[starState];
@@ -23,6 +24,7 @@ const StarButton = ({ disabled, height, onPress, selected }) => {
 };
 
 StarButton.propTypes = {
+  isDark: PropTypes.bool,
   disabled: PropTypes.bool,
   height: PropTypes.number,
   onPress: PropTypes.func.isRequired,
@@ -30,6 +32,7 @@ StarButton.propTypes = {
 };
 
 StarButton.defaultProps = {
+  isDark: false,
   disabled: false,
   height: 18,
   selected: false

--- a/packages/star-button/src/star-button.js
+++ b/packages/star-button/src/star-button.js
@@ -4,8 +4,8 @@ import Link from "@times-components/link";
 import { IconStar } from "@times-components/icons";
 import styles, { getTheme } from "./styles";
 
-const StarButton = ({ isDark, disabled, height, onPress, selected }) => {
-  const stars = getTheme({ isDark })
+const StarButton = ({ disabled, height, isDark, onPress, selected }) => {
+  const stars = getTheme({ isDark });
   const starState =
     (disabled && "disabled") || (selected && "selected") || "initial";
   const { fillColour, opacity, strokeColour } = stars[starState];
@@ -24,17 +24,17 @@ const StarButton = ({ isDark, disabled, height, onPress, selected }) => {
 };
 
 StarButton.propTypes = {
-  isDark: PropTypes.bool,
   disabled: PropTypes.bool,
   height: PropTypes.number,
+  isDark: PropTypes.bool,
   onPress: PropTypes.func.isRequired,
   selected: PropTypes.bool
 };
 
 StarButton.defaultProps = {
-  isDark: false,
   disabled: false,
   height: 18,
+  isDark: false,
   selected: false
 };
 

--- a/packages/star-button/src/star-button.js
+++ b/packages/star-button/src/star-button.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Link from "@times-components/link";
 import { IconStar } from "@times-components/icons";
-import stars from "./styles";
+import styles, { stars } from "./styles";
 
 const StarButton = ({ disabled, height, onPress, selected }) => {
   const starState =
@@ -11,7 +11,7 @@ const StarButton = ({ disabled, height, onPress, selected }) => {
 
   return (
     // eslint-disable-next-line jsx-a11y/anchor-is-valid
-    <Link disabled={disabled} onPress={onPress}>
+    <Link disabled={disabled} linkStyle={styles.container} onPress={onPress}>
       <IconStar
         fillColour={fillColour}
         height={height}

--- a/packages/star-button/src/styles/index.js
+++ b/packages/star-button/src/styles/index.js
@@ -1,12 +1,13 @@
-import { colours } from "@times-components/styleguide";
+import { colours, spacing } from "@times-components/styleguide";
 
 const styles = {
   container: {
-    alignSelf: "flex-start"
+    alignSelf: "flex-start",
+    padding: spacing(1)
   }
 };
 
-const stars = {
+const lightStar = {
   disabled: {
     fillColour: "none",
     opacity: "0.4",
@@ -24,5 +25,13 @@ const stars = {
   }
 };
 
-export { stars };
+const darkStar = {
+  disabled: { ...lightStar.disabled, strokeColour: colours.functional.greyLabel },
+  initial: { ...lightStar.initial, strokeColour: colours.functional.greyLabel },
+  selected: { ...lightStar.selected, fillColour: colours.functional.articleFlagUpdated },
+}
+
+const getTheme = ({ isDark }) => isDark ? darkStar : lightStar;
+
+export { getTheme };
 export default styles;

--- a/packages/star-button/src/styles/index.js
+++ b/packages/star-button/src/styles/index.js
@@ -26,12 +26,21 @@ const lightStar = {
 };
 
 const darkStar = {
-  disabled: { ...lightStar.disabled, strokeColour: colours.functional.greyLabel },
-  initial: { ...lightStar.initial, strokeColour: colours.functional.greyLabel },
-  selected: { ...lightStar.selected, fillColour: colours.functional.articleFlagUpdated },
-}
+  disabled: {
+    ...lightStar.disabled,
+    strokeColour: colours.functional.greyLabel
+  },
+  initial: {
+    ...lightStar.initial,
+    strokeColour: colours.functional.greyLabel
+  },
+  selected: {
+    ...lightStar.selected,
+    fillColour: colours.functional.articleFlagUpdated
+  }
+};
 
-const getTheme = ({ isDark }) => isDark ? darkStar : lightStar;
+const getTheme = ({ isDark }) => (isDark ? darkStar : lightStar);
 
 export { getTheme };
 export default styles;

--- a/packages/star-button/src/styles/index.js
+++ b/packages/star-button/src/styles/index.js
@@ -1,5 +1,11 @@
 import { colours } from "@times-components/styleguide";
 
+const styles = {
+  container: {
+    alignSelf: "flex-start"
+  }
+};
+
 const stars = {
   disabled: {
     fillColour: "none",
@@ -18,4 +24,5 @@ const stars = {
   }
 };
 
-export default stars;
+export { stars };
+export default styles;

--- a/packages/star-button/src/styles/index.js
+++ b/packages/star-button/src/styles/index.js
@@ -2,8 +2,9 @@ import { colours, spacing } from "@times-components/styleguide";
 
 const styles = {
   container: {
-    alignSelf: "flex-start",
-    padding: spacing(1)
+    height: 28,
+    padding: spacing(1),
+    width: 28
   }
 };
 
@@ -11,15 +12,15 @@ const lightStar = {
   disabled: {
     fillColour: "none",
     opacity: "0.4",
-    strokeColour: colours.functional.secondary
+    strokeColour: colours.star.light.default
   },
   initial: {
     fillColour: "none",
     opacity: "1",
-    strokeColour: colours.functional.secondary
+    strokeColour: colours.star.light.default
   },
   selected: {
-    fillColour: colours.functional.action,
+    fillColour: colours.star.light.selected,
     opacity: "1",
     strokeColour: "none"
   }
@@ -28,15 +29,15 @@ const lightStar = {
 const darkStar = {
   disabled: {
     ...lightStar.disabled,
-    strokeColour: colours.functional.greyLabel
+    strokeColour: colours.star.dark.default
   },
   initial: {
     ...lightStar.initial,
-    strokeColour: colours.functional.greyLabel
+    strokeColour: colours.star.dark.default
   },
   selected: {
     ...lightStar.selected,
-    fillColour: colours.functional.articleFlagUpdated
+    fillColour: colours.star.dark.selected
   }
 };
 

--- a/packages/styleguide/src/colours/star.js
+++ b/packages/styleguide/src/colours/star.js
@@ -1,0 +1,12 @@
+const starColours = {
+  dark: {
+    default: "#CCC",
+    selected: "#3C81BE"
+  },
+  light: {
+    default: "#696969",
+    selected: "#006699"
+  }
+};
+
+export default starColours;

--- a/packages/styleguide/src/styleguide.js
+++ b/packages/styleguide/src/styleguide.js
@@ -1,5 +1,6 @@
 import sectionColours, { secondarySectionColours } from "./colours/section";
 import functionalColours from "./colours/functional";
+import starColours from "./colours/star";
 
 import FadeIn from "./animations";
 
@@ -21,7 +22,8 @@ import spacing from "./spacing";
 const colours = {
   functional: functionalColours,
   secondarySectionColours,
-  section: sectionColours
+  section: sectionColours,
+  star: starColours
 };
 
 const Animations = {


### PR DESCRIPTION
Small PR for fixing full with ripple effect of the star button on android:

![save-star](https://user-images.githubusercontent.com/5912453/55617313-7884e200-579c-11e9-83cc-0ddf61f9a6c0.gif)
