### PR TITLE
fix: Video labels and Article label bugs

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -349,11 +349,11 @@ exports[`full article with style 1`] = `
 
 .S2 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S3 {
@@ -1091,11 +1091,11 @@ exports[`full article with style in the culture magazine 1`] = `
 
 .S2 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S3 {
@@ -1834,11 +1834,11 @@ exports[`full article with style in the style magazine 1`] = `
 
 .S2 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S3 {
@@ -2577,11 +2577,11 @@ exports[`full article with style in the sunday times magazine 1`] = `
 
 .S2 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S3 {

--- a/packages/article-label/__tests__/android/__snapshots__/article-label.android.test.js.snap
+++ b/packages/article-label/__tests__/android/__snapshots__/article-label.android.test.js.snap
@@ -12,8 +12,10 @@ exports[`Article Label test on android renders ArticleLabel 1`] = `
       "fontSize": 12,
       "fontWeight": "400",
       "letterSpacing": 0.6,
-      "lineHeight": 14,
+      "lineHeight": 12,
       "marginBottom": 0,
+      "marginTop": -1,
+      "paddingTop": 0,
     }
   }
 >
@@ -33,8 +35,10 @@ exports[`Article Label test on android renders ArticleLabel with GraphQL Colour 
       "fontSize": 12,
       "fontWeight": "400",
       "letterSpacing": 0.6,
-      "lineHeight": 14,
+      "lineHeight": 12,
       "marginBottom": 0,
+      "marginTop": -1,
+      "paddingTop": 0,
     }
   }
 >

--- a/packages/article-label/__tests__/ios/__snapshots__/article-label.ios.test.js.snap
+++ b/packages/article-label/__tests__/ios/__snapshots__/article-label.ios.test.js.snap
@@ -12,8 +12,10 @@ exports[`Article Label test on ios renders ArticleLabel 1`] = `
       "fontSize": 12,
       "fontWeight": "400",
       "letterSpacing": 0.6,
-      "lineHeight": 14,
+      "lineHeight": 11,
       "marginBottom": 0,
+      "marginTop": -1,
+      "paddingTop": 1,
     }
   }
 >
@@ -33,8 +35,10 @@ exports[`Article Label test on ios renders ArticleLabel with GraphQL Colour type
       "fontSize": 12,
       "fontWeight": "400",
       "letterSpacing": 0.6,
-      "lineHeight": 14,
+      "lineHeight": 11,
       "marginBottom": 0,
+      "marginTop": -1,
+      "paddingTop": 1,
     }
   }
 >

--- a/packages/article-label/src/style/index.android.js
+++ b/packages/article-label/src/style/index.android.js
@@ -2,7 +2,12 @@ import { StyleSheet } from "react-native";
 import sharedStyles from "./shared";
 
 const styles = StyleSheet.create({
-  ...sharedStyles
+  ...sharedStyles,
+  title: {
+    ...sharedStyles.title,
+    lineHeight: 12,
+    paddingTop: 0
+  }
 });
 
 export default styles;

--- a/packages/article-label/src/style/index.web.js
+++ b/packages/article-label/src/style/index.web.js
@@ -2,7 +2,11 @@ import { StyleSheet } from "react-native";
 import sharedStyles from "./shared";
 
 const styles = StyleSheet.create({
-  ...sharedStyles
+  ...sharedStyles,
+  title: {
+    ...sharedStyles.title,
+    lineHeight: 12
+  }
 });
 
 export default styles;

--- a/packages/article-label/src/style/shared.js
+++ b/packages/article-label/src/style/shared.js
@@ -1,0 +1,19 @@
+import styleguide from "@times-components/styleguide";
+
+const { fontFactory } = styleguide();
+const styles = {
+  title: {
+    ...fontFactory({
+      font: "supporting",
+      fontSize: "cardMetaMobile"
+    }),
+    fontWeight: "400",
+    letterSpacing: 0.6,
+    lineHeight: 11,
+    marginBottom: 0,
+    marginTop: -1,
+    paddingTop: 1
+  }
+};
+
+export default styles;

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -377,11 +377,11 @@ exports[`full article with style 1`] = `
 
 .S3 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S4 {
@@ -1098,11 +1098,11 @@ exports[`full article with style in the culture magazine 1`] = `
 
 .S3 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S4 {
@@ -1827,11 +1827,11 @@ exports[`full article with style in the style magazine 1`] = `
 
 .S3 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S4 {
@@ -2556,11 +2556,11 @@ exports[`full article with style in the sunday times magazine 1`] = `
 
 .S3 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S4 {

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -349,11 +349,11 @@ exports[`full article with style 1`] = `
 
 .S2 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S3 {
@@ -996,11 +996,11 @@ exports[`full article with style in the culture magazine 1`] = `
 
 .S2 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S3 {
@@ -1651,11 +1651,11 @@ exports[`full article with style in the style magazine 1`] = `
 
 .S2 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S3 {
@@ -2306,11 +2306,11 @@ exports[`full article with style in the sunday times magazine 1`] = `
 
 .S2 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S3 {

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -360,11 +360,11 @@ exports[`full article with style 1`] = `
 
 .S3 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S4 {

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -359,11 +359,11 @@ exports[`full article with style 1`] = `
 
 .S2 {
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
-  padding-top: 0px;
+  margin-top: -1px;
   padding-bottom: 0px;
+  padding-top: 1px;
 }
 
 .S3 {

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -25,8 +25,10 @@ exports[`1. tile a 1`] = `
             "fontSize": 12,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 14,
+            "lineHeight": 12,
             "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 0,
           }
         }
       >
@@ -95,8 +97,10 @@ exports[`2. tile b 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -177,8 +181,10 @@ exports[`3. tile c 1`] = `
             "fontSize": 12,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 14,
+            "lineHeight": 12,
             "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 0,
           }
         }
       >
@@ -256,8 +262,10 @@ exports[`4. tile d 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -335,8 +343,10 @@ exports[`5. tile e 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -397,8 +407,10 @@ exports[`6. tile f 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -510,8 +522,10 @@ exports[`7. tile g 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -581,8 +595,10 @@ exports[`8. tile h 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -714,8 +730,10 @@ exports[`9. tile i 1`] = `
             "fontSize": 12,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 14,
+            "lineHeight": 12,
             "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 0,
           }
         }
       >
@@ -792,8 +810,10 @@ exports[`10. tile j 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -870,8 +890,10 @@ exports[`11. tile k 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -932,8 +954,10 @@ exports[`12. tile l 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -1065,8 +1089,10 @@ exports[`14. tile n 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -1141,8 +1167,10 @@ exports[`15. tile o 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -1222,8 +1250,10 @@ exports[`16. tile p 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -1357,8 +1387,10 @@ exports[`18. tile r 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -1548,8 +1580,10 @@ exports[`20. tile t 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -1618,8 +1652,10 @@ exports[`21. tile u 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -1700,8 +1736,10 @@ exports[`22. tile v 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -1772,8 +1810,10 @@ exports[`23. tile w 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -1861,8 +1901,10 @@ exports[`24. tile x 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -1946,8 +1988,10 @@ exports[`25. tile y 1`] = `
             "fontSize": 12,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 14,
+            "lineHeight": 12,
             "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 0,
           }
         }
       >
@@ -2024,8 +2068,10 @@ exports[`26. tile z 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -2103,8 +2149,10 @@ exports[`27. tile aa 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -2173,8 +2221,10 @@ exports[`28. tile ab 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -2295,8 +2345,10 @@ exports[`29. tile ae 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -2538,8 +2590,10 @@ exports[`33. tile al 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -2629,8 +2683,10 @@ exports[`34. tile am 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -2727,8 +2783,10 @@ exports[`35. tile an 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >
@@ -2824,8 +2882,10 @@ exports[`36. tile ap 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 12,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 0,
             }
           }
         >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -25,8 +25,10 @@ exports[`1. tile a 1`] = `
             "fontSize": 12,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 14,
+            "lineHeight": 11,
             "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 1,
           }
         }
       >
@@ -95,8 +97,10 @@ exports[`2. tile b 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -177,8 +181,10 @@ exports[`3. tile c 1`] = `
             "fontSize": 12,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 14,
+            "lineHeight": 11,
             "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 1,
           }
         }
       >
@@ -256,8 +262,10 @@ exports[`4. tile d 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -335,8 +343,10 @@ exports[`5. tile e 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -397,8 +407,10 @@ exports[`6. tile f 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -510,8 +522,10 @@ exports[`7. tile g 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -581,8 +595,10 @@ exports[`8. tile h 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -714,8 +730,10 @@ exports[`9. tile i 1`] = `
             "fontSize": 12,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 14,
+            "lineHeight": 11,
             "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 1,
           }
         }
       >
@@ -792,8 +810,10 @@ exports[`10. tile j 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -870,8 +890,10 @@ exports[`11. tile k 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -932,8 +954,10 @@ exports[`12. tile l 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -1065,8 +1089,10 @@ exports[`14. tile n 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -1141,8 +1167,10 @@ exports[`15. tile o 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -1222,8 +1250,10 @@ exports[`16. tile p 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -1357,8 +1387,10 @@ exports[`18. tile r 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -1548,8 +1580,10 @@ exports[`20. tile t 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -1618,8 +1652,10 @@ exports[`21. tile u 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -1700,8 +1736,10 @@ exports[`22. tile v 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -1772,8 +1810,10 @@ exports[`23. tile w 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -1861,8 +1901,10 @@ exports[`24. tile x 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -1946,8 +1988,10 @@ exports[`25. tile y 1`] = `
             "fontSize": 12,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 14,
+            "lineHeight": 11,
             "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 1,
           }
         }
       >
@@ -2024,8 +2068,10 @@ exports[`26. tile z 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -2103,8 +2149,10 @@ exports[`27. tile aa 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -2173,8 +2221,10 @@ exports[`28. tile ab 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -2295,8 +2345,10 @@ exports[`29. tile ae 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -2538,8 +2590,10 @@ exports[`33. tile al 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -2629,8 +2683,10 @@ exports[`34. tile am 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -2727,8 +2783,10 @@ exports[`35. tile an 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >
@@ -2824,8 +2882,10 @@ exports[`36. tile ap 1`] = `
               "fontSize": 12,
               "fontWeight": "400",
               "letterSpacing": 0.6,
-              "lineHeight": 14,
+              "lineHeight": 11,
               "marginBottom": 0,
+              "marginTop": -1,
+              "paddingTop": 1,
             }
           }
         >

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -6,7 +6,7 @@ exports[`1. tile a 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -99,7 +99,7 @@ exports[`2. tile b 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -221,7 +221,7 @@ exports[`3. tile c 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -316,7 +316,7 @@ exports[`4. tile d 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -426,7 +426,7 @@ exports[`5. tile e 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -532,7 +532,7 @@ exports[`6. tile f 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -670,7 +670,7 @@ exports[`7. tile g 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -786,7 +786,7 @@ exports[`8. tile h 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -971,7 +971,7 @@ exports[`9. tile i 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -1071,7 +1071,7 @@ exports[`10. tile j 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -1174,7 +1174,7 @@ exports[`11. tile k 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -1272,7 +1272,7 @@ exports[`12. tile l 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -1432,7 +1432,7 @@ exports[`14. tile n 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -1549,7 +1549,7 @@ exports[`15. tile o 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -1641,7 +1641,7 @@ exports[`16. tile p 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -1668,6 +1668,7 @@ exports[`16. tile p 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: inherit;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -1712,12 +1713,10 @@ exports[`16. tile p 1`] = `
 
 .IS5 {
   color: rgba(133,0,41,1.00);
-  line-height: 12px;
 }
 
 .IS6 {
   color: rgba(133,0,41,1.00);
-  line-height: 12px;
 }
 
 .IS7 {
@@ -1858,7 +1857,7 @@ exports[`18. tile r 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -2065,7 +2064,7 @@ exports[`20. tile t 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -2166,7 +2165,7 @@ exports[`21. tile u 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -2284,7 +2283,7 @@ exports[`22. tile v 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -2378,7 +2377,7 @@ exports[`23. tile w 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -2514,7 +2513,7 @@ exports[`24. tile x 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -2652,7 +2651,7 @@ exports[`25. tile y 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -2767,7 +2766,7 @@ exports[`26. tile z 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -2864,7 +2863,7 @@ exports[`27. tile aa 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -2961,7 +2960,7 @@ exports[`28. tile ab 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -3137,7 +3136,7 @@ exports[`29. tile ae 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -3497,7 +3496,7 @@ exports[`33. tile al 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -3627,7 +3626,7 @@ exports[`34. tile am 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -3758,7 +3757,7 @@ exports[`35. tile an 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 
@@ -3903,7 +3902,7 @@ exports[`36. tile ap 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 12px;
   margin-bottom: 0px;
 }
 

--- a/packages/fixture-generator/src/mock-slice.ts
+++ b/packages/fixture-generator/src/mock-slice.ts
@@ -234,10 +234,27 @@ function mockSecondaryTwoNoPicAndTwoSlice(): SecondaryTwoNoPicAndTwoSliceWithNam
 
 function mockSecondaryTwoAndTwoSlice(): SecondaryTwoAndTwoSliceWithName {
   const tiles = getTiles(4);
+  const secondaryOneTile = {
+    ...tiles[0],
+    article: {
+      ...tiles[0].article,
+      hasVideo: true,
+      label: "long label | video icon too"
+    }
+  };
+
+  const secondaryTwoTile = {
+    ...tiles[1],
+    article: {
+      ...tiles[1].article,
+      label: "long label | by some author"
+    }
+  };
+
   return <SecondaryTwoAndTwoSliceWithName>{
     name: "SecondaryTwoAndTwoSlice",
-    secondary1: tiles[0],
-    secondary2: tiles[1],
+    secondary1: secondaryOneTile,
+    secondary2: secondaryTwoTile,
     support1: tiles[2],
     support2: tiles[3],
     items: tiles

--- a/packages/jest-configurator/package.json
+++ b/packages/jest-configurator/package.json
@@ -55,7 +55,7 @@
     ]
   },
   "dependencies": {
-    "@times-components/test-utils": "2.2.19",
+    "@times-components/test-utils": "2.2.20",
     "babel-core": "6.26.0",
     "babel-jest": "23.4.2",
     "babel-plugin-istanbul": "4.1.6",

--- a/packages/markup-forest/package.json
+++ b/packages/markup-forest/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.4.2",
-    "@times-components/test-utils": "2.2.19",
+    "@times-components/test-utils": "2.2.20",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "eslint": "5.9.0",

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
@@ -65,8 +65,10 @@ exports[`default styles 1`] = `
                         "fontSize": 12,
                         "fontWeight": "400",
                         "letterSpacing": 0.6,
-                        "lineHeight": 14,
+                        "lineHeight": 12,
                         "marginBottom": 0,
+                        "marginTop": -1,
+                        "paddingTop": 0,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
@@ -66,8 +66,10 @@ exports[`default styles 1`] = `
                         "fontSize": 12,
                         "fontWeight": "400",
                         "letterSpacing": 0.6,
-                        "lineHeight": 14,
+                        "lineHeight": 12,
                         "marginBottom": 0,
+                        "marginTop": -1,
+                        "paddingTop": 0,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
@@ -65,8 +65,10 @@ exports[`default styles 1`] = `
                         "fontSize": 12,
                         "fontWeight": "400",
                         "letterSpacing": 0.6,
-                        "lineHeight": 14,
+                        "lineHeight": 12,
                         "marginBottom": 0,
+                        "marginTop": -1,
+                        "paddingTop": 0,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
@@ -65,8 +65,10 @@ exports[`default styles 1`] = `
                         "fontSize": 12,
                         "fontWeight": "400",
                         "letterSpacing": 0.6,
-                        "lineHeight": 14,
+                        "lineHeight": 11,
                         "marginBottom": 0,
+                        "marginTop": -1,
+                        "paddingTop": 1,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
@@ -66,8 +66,10 @@ exports[`default styles 1`] = `
                         "fontSize": 12,
                         "fontWeight": "400",
                         "letterSpacing": 0.6,
-                        "lineHeight": 14,
+                        "lineHeight": 11,
                         "marginBottom": 0,
+                        "marginTop": -1,
+                        "paddingTop": 1,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
@@ -65,8 +65,10 @@ exports[`default styles 1`] = `
                         "fontSize": 12,
                         "fontWeight": "400",
                         "letterSpacing": 0.6,
-                        "lineHeight": 14,
+                        "lineHeight": 11,
                         "marginBottom": 0,
+                        "marginTop": -1,
+                        "paddingTop": 1,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -199,9 +199,9 @@ exports[`default styles 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
+  margin-top: -1px;
 }
 
 .S4 {

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -228,9 +228,9 @@ exports[`default styles 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
+  margin-top: -1px;
 }
 
 .S4 {

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -172,9 +172,9 @@ exports[`default styles 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
   font-weight: 400;
-  line-height: 14px;
-  margin-top: 0px;
+  line-height: 12px;
   margin-bottom: 0px;
+  margin-top: -1px;
 }
 
 .S4 {

--- a/packages/slice-layout/package.json
+++ b/packages/slice-layout/package.json
@@ -41,7 +41,7 @@
     "@times-components/jest-configurator": "2.4.2",
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/storybook": "3.4.11",
-    "@times-components/styleguide": "3.27.1",
+    "@times-components/styleguide": "3.27.2",
     "@times-components/test-utils": "2.2.20",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/svgs/package.json
+++ b/packages/svgs/package.json
@@ -53,7 +53,7 @@
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.4.2",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/test-utils": "2.2.19",
+    "@times-components/test-utils": "2.2.20",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",

--- a/packages/video-label/__tests__/android/__snapshots__/video-label-with-style.android.test.js.snap
+++ b/packages/video-label/__tests__/android/__snapshots__/video-label-with-style.android.test.js.snap
@@ -4,14 +4,16 @@ exports[`1. video label with a title 1`] = `
 <View
   style={
     Object {
-      "alignItems": "center",
+      "alignItems": "flex-start",
       "flexDirection": "row",
+      "marginTop": -1,
     }
   }
 >
   <View
     style={
       Object {
+        "marginBottom": 3,
         "paddingBottom": 0,
       }
     }
@@ -25,15 +27,14 @@ exports[`1. video label with a title 1`] = `
     style={
       Object {
         "color": "#008347",
+        "flex": 1,
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 12,
         "fontWeight": "400",
         "letterSpacing": 1.2,
-        "lineHeight": 14,
+        "lineHeight": 12,
         "marginLeft": 5,
-        "padding": 0,
-        "position": "relative",
-        "top": 1,
+        "paddingTop": 0,
       }
     }
   >
@@ -46,14 +47,16 @@ exports[`2. video label without a title shows video 1`] = `
 <View
   style={
     Object {
-      "alignItems": "center",
+      "alignItems": "flex-start",
       "flexDirection": "row",
+      "marginTop": -1,
     }
   }
 >
   <View
     style={
       Object {
+        "marginBottom": 3,
         "paddingBottom": 0,
       }
     }
@@ -67,15 +70,14 @@ exports[`2. video label without a title shows video 1`] = `
     style={
       Object {
         "color": "#008347",
+        "flex": 1,
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 12,
         "fontWeight": "400",
         "letterSpacing": 1.2,
-        "lineHeight": 14,
+        "lineHeight": 12,
         "marginLeft": 5,
-        "padding": 0,
-        "position": "relative",
-        "top": 1,
+        "paddingTop": 0,
       }
     }
   >
@@ -88,14 +90,16 @@ exports[`3. video label with the black default colour 1`] = `
 <View
   style={
     Object {
-      "alignItems": "center",
+      "alignItems": "flex-start",
       "flexDirection": "row",
+      "marginTop": -1,
     }
   }
 >
   <View
     style={
       Object {
+        "marginBottom": 3,
         "paddingBottom": 0,
       }
     }
@@ -109,15 +113,14 @@ exports[`3. video label with the black default colour 1`] = `
     style={
       Object {
         "color": "black",
+        "flex": 1,
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 12,
         "fontWeight": "400",
         "letterSpacing": 1.2,
-        "lineHeight": 14,
+        "lineHeight": 12,
         "marginLeft": 5,
-        "padding": 0,
-        "position": "relative",
-        "top": 1,
+        "paddingTop": 0,
       }
     }
   >

--- a/packages/video-label/__tests__/ios/__snapshots__/video-label-with-style.ios.test.js.snap
+++ b/packages/video-label/__tests__/ios/__snapshots__/video-label-with-style.ios.test.js.snap
@@ -4,8 +4,9 @@ exports[`1. video label with a title 1`] = `
 <View
   style={
     Object {
-      "alignItems": "center",
+      "alignItems": "flex-start",
       "flexDirection": "row",
+      "marginTop": -1,
     }
   }
 >
@@ -25,15 +26,14 @@ exports[`1. video label with a title 1`] = `
     style={
       Object {
         "color": "#008347",
+        "flex": 1,
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 12,
         "fontWeight": "400",
         "letterSpacing": 1.2,
-        "lineHeight": 14,
+        "lineHeight": 11,
         "marginLeft": 5,
-        "padding": 0,
-        "position": "relative",
-        "top": 1,
+        "paddingTop": 1,
       }
     }
   >
@@ -46,8 +46,9 @@ exports[`2. video label without a title shows video 1`] = `
 <View
   style={
     Object {
-      "alignItems": "center",
+      "alignItems": "flex-start",
       "flexDirection": "row",
+      "marginTop": -1,
     }
   }
 >
@@ -67,15 +68,14 @@ exports[`2. video label without a title shows video 1`] = `
     style={
       Object {
         "color": "#008347",
+        "flex": 1,
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 12,
         "fontWeight": "400",
         "letterSpacing": 1.2,
-        "lineHeight": 14,
+        "lineHeight": 11,
         "marginLeft": 5,
-        "padding": 0,
-        "position": "relative",
-        "top": 1,
+        "paddingTop": 1,
       }
     }
   >
@@ -88,8 +88,9 @@ exports[`3. video label with the black default colour 1`] = `
 <View
   style={
     Object {
-      "alignItems": "center",
+      "alignItems": "flex-start",
       "flexDirection": "row",
+      "marginTop": -1,
     }
   }
 >
@@ -109,15 +110,14 @@ exports[`3. video label with the black default colour 1`] = `
     style={
       Object {
         "color": "black",
+        "flex": 1,
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 12,
         "fontWeight": "400",
         "letterSpacing": 1.2,
-        "lineHeight": 14,
+        "lineHeight": 11,
         "marginLeft": 5,
-        "padding": 0,
-        "position": "relative",
-        "top": 1,
+        "paddingTop": 1,
       }
     }
   >

--- a/packages/video-label/__tests__/web/__snapshots__/video-label-with-style.web.test.js.snap
+++ b/packages/video-label/__tests__/web/__snapshots__/video-label-with-style.web.test.js.snap
@@ -23,26 +23,24 @@ exports[`1. video label with a title 1`] = `
   font-size: 12px;
   font-weight: 400;
   letter-spacing: 1.2px;
-  line-height: 11px;
+  line-height: 12px;
   margin-bottom: 0px;
   margin-left: 5px;
   padding-bottom: 0px;
-  position: relative;
-  top: 1px;
 }
 
 .S3 {
-  -ms-flex-align: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  align-items: center;
+  -ms-flex-align: start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: start;
+  align-items: flex-start;
   -ms-flex-direction: row;
   -webkit-box-direction: normal;
   -webkit-box-orient: horizontal;
   -webkit-flex-direction: row;
   flex-direction: row;
   margin-left: 0px;
-  margin-bottom: 3px;
+  margin-bottom: 1px;
   padding-bottom: 0px;
   position: relative;
 }
@@ -58,20 +56,20 @@ exports[`1. video label with a title 1`] = `
 .IS3 {
   font-family: GillSansMTStd-Medium;
   font-size: 12;
-  line-height: 11;
+  line-height: 12;
+  flex: 1;
   font-weight: 400;
   letter-spacing: 1.2;
-  margin-left: 5;
-  padding: 0;
-  position: relative;
-  top: 1;
+  margin-left: 5px;
+  padding-top: 1;
   color: #008347;
 }
 
 .IS4 {
-  align-items: center;
+  align-items: flex-start;
   flex-direction: row;
-  margin-bottom: 3;
+  margin-top: -1;
+  margin-bottom: 1;
 }
 </style>
 
@@ -122,26 +120,24 @@ exports[`2. video label without a title shows video 1`] = `
   font-size: 12px;
   font-weight: 400;
   letter-spacing: 1.2px;
-  line-height: 11px;
+  line-height: 12px;
   margin-bottom: 0px;
   margin-left: 5px;
   padding-bottom: 0px;
-  position: relative;
-  top: 1px;
 }
 
 .S3 {
-  -ms-flex-align: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  align-items: center;
+  -ms-flex-align: start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: start;
+  align-items: flex-start;
   -ms-flex-direction: row;
   -webkit-box-direction: normal;
   -webkit-box-orient: horizontal;
   -webkit-flex-direction: row;
   flex-direction: row;
   margin-left: 0px;
-  margin-bottom: 3px;
+  margin-bottom: 1px;
   padding-bottom: 0px;
   position: relative;
 }
@@ -157,20 +153,20 @@ exports[`2. video label without a title shows video 1`] = `
 .IS3 {
   font-family: GillSansMTStd-Medium;
   font-size: 12;
-  line-height: 11;
+  line-height: 12;
+  flex: 1;
   font-weight: 400;
   letter-spacing: 1.2;
-  margin-left: 5;
-  padding: 0;
-  position: relative;
-  top: 1;
+  margin-left: 5px;
+  padding-top: 1;
   color: #008347;
 }
 
 .IS4 {
-  align-items: center;
+  align-items: flex-start;
   flex-direction: row;
-  margin-bottom: 3;
+  margin-top: -1;
+  margin-bottom: 1;
 }
 </style>
 
@@ -221,26 +217,24 @@ exports[`3. video label with the black default colour 1`] = `
   font-size: 12px;
   font-weight: 400;
   letter-spacing: 1.2px;
-  line-height: 11px;
+  line-height: 12px;
   margin-bottom: 0px;
   margin-left: 5px;
   padding-bottom: 0px;
-  position: relative;
-  top: 1px;
 }
 
 .S3 {
-  -ms-flex-align: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  align-items: center;
+  -ms-flex-align: start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: start;
+  align-items: flex-start;
   -ms-flex-direction: row;
   -webkit-box-direction: normal;
   -webkit-box-orient: horizontal;
   -webkit-flex-direction: row;
   flex-direction: row;
   margin-left: 0px;
-  margin-bottom: 3px;
+  margin-bottom: 1px;
   padding-bottom: 0px;
   position: relative;
 }
@@ -256,20 +250,20 @@ exports[`3. video label with the black default colour 1`] = `
 .IS3 {
   font-family: GillSansMTStd-Medium;
   font-size: 12;
-  line-height: 11;
+  line-height: 12;
+  flex: 1;
   font-weight: 400;
   letter-spacing: 1.2;
-  margin-left: 5;
-  padding: 0;
-  position: relative;
-  top: 1;
+  margin-left: 5px;
+  padding-top: 1;
   color: black;
 }
 
 .IS4 {
-  align-items: center;
+  align-items: flex-start;
   flex-direction: row;
-  margin-bottom: 3;
+  margin-top: -1;
+  margin-bottom: 1;
 }
 </style>
 

--- a/packages/video-label/src/style/index.android.js
+++ b/packages/video-label/src/style/index.android.js
@@ -5,11 +5,13 @@ const styles = StyleSheet.create({
   ...sharedStyles,
   iconContainer: {
     ...sharedStyles.iconContainer,
+    marginBottom: 3,
     paddingBottom: 0
   },
   title: {
     ...sharedStyles.title,
-    top: 1
+    lineHeight: 12,
+    paddingTop: 0
   }
 });
 

--- a/packages/video-label/src/style/index.js
+++ b/packages/video-label/src/style/index.js
@@ -2,7 +2,10 @@ import { StyleSheet } from "react-native";
 import sharedStyles from "./shared";
 
 const styles = StyleSheet.create({
-  ...sharedStyles
+  ...sharedStyles,
+  container: {
+    ...sharedStyles.container
+  }
 });
 
 export default styles;

--- a/packages/video-label/src/style/index.web.js
+++ b/packages/video-label/src/style/index.web.js
@@ -5,7 +5,7 @@ const styles = StyleSheet.create({
   ...sharedStyles,
   container: {
     ...sharedStyles.container,
-    marginBottom: 3
+    marginBottom: 1
   },
   iconContainer: {
     ...sharedStyles.iconContainer,
@@ -13,7 +13,7 @@ const styles = StyleSheet.create({
   },
   title: {
     ...sharedStyles.title,
-    lineHeight: 11
+    lineHeight: 12
   }
 });
 

--- a/packages/video-label/src/style/shared.js
+++ b/packages/video-label/src/style/shared.js
@@ -4,8 +4,9 @@ const { fontFactory } = styleguideFactory();
 
 const styles = {
   container: {
-    alignItems: "center",
-    flexDirection: "row"
+    alignItems: "flex-start",
+    flexDirection: "row",
+    marginTop: -1
   },
   iconContainer: {
     paddingBottom: spacing(1)
@@ -15,12 +16,12 @@ const styles = {
       font: "supporting",
       fontSize: "cardMetaMobile"
     }),
+    flex: 1,
     fontWeight: "400",
     letterSpacing: 1.2,
-    marginLeft: 5,
-    padding: 0,
-    position: "relative",
-    top: 1
+    lineHeight: 11,
+    marginLeft: spacing(1),
+    paddingTop: 1
   }
 };
 

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -40,8 +40,8 @@
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.4.2",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/storybook": "3.4.10",
-    "@times-components/test-utils": "2.2.19",
+    "@times-components/storybook": "3.4.11",
+    "@times-components/test-utils": "2.2.20",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-plugin-add-react-displayname": "0.0.5",
@@ -59,7 +59,7 @@
     "webpack-cli": "2.1.4"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.27.1",
+    "@times-components/styleguide": "3.27.2",
     "@times-components/svgs": "2.6.2",
     "prop-types": "15.6.2"
   },


### PR DESCRIPTION
- https://nidigitalsolutions.jira.com/browse/REPLAT-6059

- Video labels broke when wrapping onto more than 1 line and line-height was incorrect
- Article label line-height also needed adjusting to match
- updated fixtures to showcase multiple line article labels and video labels in secondary two and two slice.

### iOS edition slice
<img width="440" alt="Screenshot 2019-04-05 at 17 24 55" src="https://user-images.githubusercontent.com/1736782/55644377-a9313f80-57cd-11e9-9cf1-8d20d8421141.png">

### Android edition slice
<img width="365" alt="Screenshot 2019-04-05 at 17 25 00" src="https://user-images.githubusercontent.com/1736782/55644380-ac2c3000-57cd-11e9-8bc8-761441696bce.png">

### Web Article Summary
![Screenshot 2019-04-05 at 17 25 20](https://user-images.githubusercontent.com/1736782/55644573-3d030b80-57ce-11e9-9c5a-8d661f9d02c7.png)

### iOS Article Summary
<img width="423" alt="Screenshot 2019-04-05 at 17 25 50" src="https://user-images.githubusercontent.com/1736782/55644504-088f4f80-57ce-11e9-804e-6b09bcf2606c.png">

### Android Article Summary
<img width="352" alt="Screenshot 2019-04-05 at 17 25 53" src="https://user-images.githubusercontent.com/1736782/55644581-42f8ec80-57ce-11e9-9e09-cd041f3ae3f2.png">

