### PR TITLE
Feat/modal slide

### DIFF
--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -3,6 +3,7 @@
 exports[`1. modal image 1`] = `
 <View>
   <Modal
+    animationType="slide"
     hardwareAccelerated={false}
     presentationStyle="fullScreen"
     supportedOrientations={
@@ -124,6 +125,7 @@ exports[`1. modal image 1`] = `
 exports[`2. modal image with no caption 1`] = `
 <View>
   <Modal
+    animationType="slide"
     hardwareAccelerated={false}
     presentationStyle="fullScreen"
     supportedOrientations={
@@ -198,6 +200,7 @@ exports[`2. modal image with no caption 1`] = `
 exports[`3. modal image with custom highressize 1`] = `
 <View>
   <Modal
+    animationType="slide"
     hardwareAccelerated={false}
     presentationStyle="fullScreen"
     supportedOrientations={
@@ -319,6 +322,7 @@ exports[`3. modal image with custom highressize 1`] = `
 exports[`8. hides elements when tapping on the image 1`] = `
 <View>
   <Modal
+    animationType="slide"
     hardwareAccelerated={false}
     presentationStyle="fullScreen"
     supportedOrientations={
@@ -377,6 +381,7 @@ exports[`8. hides elements when tapping on the image 1`] = `
 exports[`9. re-shows elements when tapping on the image a second time 1`] = `
 <View>
   <Modal
+    animationType="slide"
     hardwareAccelerated={false}
     presentationStyle="fullScreen"
     supportedOrientations={

--- a/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
@@ -3,6 +3,7 @@
 exports[`1. modal image 1`] = `
 <View>
   <Modal
+    animationType="slide"
     hardwareAccelerated={false}
     presentationStyle="fullScreen"
     supportedOrientations={
@@ -134,6 +135,7 @@ exports[`1. modal image 1`] = `
 exports[`2. modal image with no caption 1`] = `
 <View>
   <Modal
+    animationType="slide"
     hardwareAccelerated={false}
     presentationStyle="fullScreen"
     supportedOrientations={
@@ -218,6 +220,7 @@ exports[`2. modal image with no caption 1`] = `
 exports[`3. modal image with custom highressize 1`] = `
 <View>
   <Modal
+    animationType="slide"
     hardwareAccelerated={false}
     presentationStyle="fullScreen"
     supportedOrientations={
@@ -349,6 +352,7 @@ exports[`3. modal image with custom highressize 1`] = `
 exports[`8. hides elements when tapping on the image 1`] = `
 <View>
   <Modal
+    animationType="slide"
     hardwareAccelerated={false}
     presentationStyle="fullScreen"
     supportedOrientations={
@@ -405,6 +409,7 @@ exports[`8. hides elements when tapping on the image 1`] = `
 exports[`9. re-shows elements when tapping on the image a second time 1`] = `
 <View>
   <Modal
+    animationType="slide"
     hardwareAccelerated={false}
     presentationStyle="fullScreen"
     supportedOrientations={

--- a/packages/image/src/modal-image.js
+++ b/packages/image/src/modal-image.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import { Modal, View } from "react-native";
 import Gestures from "@times-components/gestures";
 import { ResponsiveContext } from "@times-components/responsive";
@@ -64,59 +64,65 @@ class ModalImage extends Component {
     return (
       <View>
         <Modal
+          animationType="slide"
           onRequestClose={this.hideModal}
           presentationStyle="fullScreen"
           supportedOrientations={["portrait", "landscape"]}
           visible={showModal}
         >
-          <ResponsiveContext.Consumer>
-            {({ isTablet }) => (
-              <View style={styles.modal}>
-                <SafeAreaView
-                  forceInset={{
-                    bottom: "never",
-                    horizontal: "always",
-                    top: "always"
-                  }}
-                  style={styles.topSafeView}
-                />
-                <View
-                  style={[
-                    styles.buttonContainer,
-                    isTablet && styles.buttonContainerTablet
-                  ]}
-                >
+          <View style={styles.modal}>
+            <ResponsiveContext.Consumer>
+              {({ isTablet }) => (
+                <Fragment>
+                  <SafeAreaView
+                    forceInset={{
+                      bottom: "never",
+                      horizontal: "always",
+                      top: "always"
+                    }}
+                    style={styles.topSafeView}
+                  />
+                  <View
+                    style={[
+                      styles.buttonContainer,
+                      isTablet && styles.buttonContainerTablet
+                    ]}
+                  >
+                    {elementsVisible ? (
+                      <CloseButton
+                        isTablet={isTablet}
+                        onPress={this.hideModal}
+                      />
+                    ) : null}
+                  </View>
+                  <SafeAreaView
+                    forceInset={{ horizontal: "always", vertical: "always" }}
+                    style={styles.middleSafeView}
+                  >
+                    <Gestures
+                      onPress={this.toggleElements}
+                      onSwipeDown={this.hideModal}
+                      style={styles.gestureContainer}
+                    >
+                      <Image
+                        {...this.props}
+                        lowResSize={lowResSize}
+                        style={styles.modalImageContainer}
+                      />
+                    </Gestures>
+                  </SafeAreaView>
                   {elementsVisible ? (
-                    <CloseButton isTablet={isTablet} onPress={this.hideModal} />
+                    <ModalCaptionContainer
+                      pointerEvents="none"
+                      style={styles.bottomSafeView}
+                    >
+                      {this.renderCaption({ isTablet })}
+                    </ModalCaptionContainer>
                   ) : null}
-                </View>
-                <SafeAreaView
-                  forceInset={{ horizontal: "always", vertical: "always" }}
-                  style={styles.middleSafeView}
-                >
-                  <Gestures
-                    onPress={this.toggleElements}
-                    onSwipeDown={this.hideModal}
-                    style={styles.gestureContainer}
-                  >
-                    <Image
-                      {...this.props}
-                      lowResSize={lowResSize}
-                      style={styles.modalImageContainer}
-                    />
-                  </Gestures>
-                </SafeAreaView>
-                {elementsVisible ? (
-                  <ModalCaptionContainer
-                    pointerEvents="none"
-                    style={styles.bottomSafeView}
-                  >
-                    {this.renderCaption({ isTablet })}
-                  </ModalCaptionContainer>
-                ) : null}
-              </View>
-            )}
-          </ResponsiveContext.Consumer>
+                </Fragment>
+              )}
+            </ResponsiveContext.Consumer>
+          </View>
         </Modal>
         <Button onPress={this.showModal}>
           <Image {...this.props} onImageLayout={this.onLowResLayout} />

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -80,7 +80,6 @@ const styles = {
   placeholder: {
     alignItems: "center",
     backgroundColor: colours.functional.backgroundSecondary,
-    flex: 1,
     justifyContent: "center"
   },
   topSafeView: {

--- a/packages/provider-test-tools/package.json
+++ b/packages/provider-test-tools/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/test-utils": "2.2.18",
+    "@times-components/test-utils": "2.2.19",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/test-utils": "2.2.18",
+    "@times-components/test-utils": "2.2.19",
     "eslint": "5.9.0",
     "prettier": "1.14.3",
     "rimraf": "2.6.1"

--- a/packages/slice-layout/package.json
+++ b/packages/slice-layout/package.json
@@ -41,7 +41,7 @@
     "@times-components/jest-configurator": "2.4.2",
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/storybook": "3.4.10",
-    "@times-components/styleguide": "3.27.0",
+    "@times-components/styleguide": "3.27.1",
     "@times-components/test-utils": "2.2.19",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/tealium/package.json
+++ b/packages/tealium/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/jest-configurator": "2.4.1",
-    "@times-components/test-utils": "2.2.18",
+    "@times-components/jest-configurator": "2.4.2",
+    "@times-components/test-utils": "2.2.19",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-plugin-add-react-displayname": "0.0.5",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,9 +33,9 @@
   "devDependencies": {
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/jest-configurator": "2.4.1",
+    "@times-components/jest-configurator": "2.4.2",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/test-utils": "2.2.18",
+    "@times-components/test-utils": "2.2.19",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
@@ -51,7 +51,7 @@
     "webpack-cli": "2.1.4"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.27.0",
+    "@times-components/styleguide": "3.27.1",
     "lodash.omitby": "4.6.0",
     "prop-types": "15.6.2",
     "react-native": "0.55.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1861,51 +1861,6 @@
     webpack-dev-server "3.1.7"
     webpack-merge "^4.1.1"
 
-"@times-components/schema@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@times-components/schema/-/schema-0.3.4.tgz#8e70eb0cdbc4f4bfecae7224d7576ab726d876a8"
-  integrity sha512-vsLnwEpZzd4iDsrw/JqeLIKoRkWmrmH1/0KtfS4FZnsa9rfj/ky2kKy1c0FQKUgJ5Qu7qZgo5izwy9e438XkoA==
-  dependencies:
-    apollo-cache-inmemory "1.3.11"
-    chalk "2.4.1"
-    graphql "0.13.2"
-    mkdirp "0.5.1"
-    node-fetch "2.2.0"
-
-"@times-components/storybook@3.4.6":
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/@times-components/storybook/-/storybook-3.4.6.tgz#f4eceead6d42a52a335d60f03817c69c58b9c118"
-  integrity sha512-FyUHxb3QALNpH97jps4JbzPqrmbLnSz70gUB9fKWvoLvVL1iuaH5fWAhAPVGBgqQGJuMI0nKhFLuUShbW4/9nA==
-  dependencies:
-    "@storybook/addon-actions" "3.4.10"
-    "@storybook/addon-knobs" "3.4.10"
-    "@storybook/react-native" "3.4.10"
-    "@times-components/schema" "0.3.4"
-    apollo-cache-inmemory "1.3.11"
-    apollo-client "2.4.7"
-    apollo-link-http "1.5.7"
-    babel-core "6.26.0"
-    babel-runtime "6.26.0"
-    prop-types "15.6.2"
-    react "16.5.2"
-    react-apollo "2.1.4"
-    react-test-renderer "16.5.2"
-
-"@times-components/styleguide@3.26.4":
-  version "3.26.4"
-  resolved "https://registry.yarnpkg.com/@times-components/styleguide/-/styleguide-3.26.4.tgz#860166f56fe87173a89be908cd766844b4201795"
-  integrity sha512-UE3pRac6IA2j1ATwXXVDbAnflvd926knHehhu7bVEPZdL+XRb+TQNStNHnj6jGjNzgsAirsTLMyPMaHNOWX4zA==
-  dependencies:
-    prop-types "15.6.2"
-    styled-components "3.4.0"
-
-"@times-components/test-utils@2.2.15":
-  version "2.2.15"
-  resolved "https://registry.yarnpkg.com/@times-components/test-utils/-/test-utils-2.2.15.tgz#20802a8f9dd36154ef0e1adf67d8cefe93f14759"
-  integrity sha512-nZ5W2w1aJzrVeteKq90TDP7Tkcbnz/jEQN3qPJ8B5woE39H/tij9CfO2R6/QmsWVRCcwtwZmpWPF1/3oNDTpQw==
-  dependencies:
-    "@times-components/styleguide" "3.26.4"
-
 "@types/accepts@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"


### PR DESCRIPTION
The modal will now slide on entry/exit. This makes it feel more fluid when you swipe down to exit the image, and makes it less jarring when the modal appears. 

It also reduces flashes caused by the placeholder appearing initially at the wrong size. 

**Note**: This will need to be reviewed by design post-merge. 

![ezgif-2-ae8b834568f4](https://user-images.githubusercontent.com/719814/55735355-12f15980-5a19-11e9-9992-e7f985c6836b.gif)


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
