### PR TITLE
fix: use post requests for graphql queries

### DIFF
--- a/packages/jest-configurator/package.json
+++ b/packages/jest-configurator/package.json
@@ -55,7 +55,7 @@
     ]
   },
   "dependencies": {
-    "@times-components/test-utils": "2.2.23",
+    "@times-components/test-utils": "2.2.24",
     "babel-core": "6.26.0",
     "babel-jest": "23.4.2",
     "babel-plugin-istanbul": "4.1.6",

--- a/packages/markup-forest/package.json
+++ b/packages/markup-forest/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.4.4",
-    "@times-components/test-utils": "2.2.23",
+    "@times-components/test-utils": "2.2.24",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "eslint": "5.9.0",

--- a/packages/slice-layout/package.json
+++ b/packages/slice-layout/package.json
@@ -41,7 +41,7 @@
     "@times-components/jest-configurator": "2.4.4",
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/storybook": "3.4.15",
-    "@times-components/styleguide": "3.27.5",
+    "@times-components/styleguide": "3.27.6",
     "@times-components/test-utils": "2.2.24",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/ssr/src/lib/run-server.js
+++ b/packages/ssr/src/lib/run-server.js
@@ -21,7 +21,7 @@ const makeClient = options => {
 
   const networkInterfaceOptions = {
     fetch,
-    headers: { "content-type": "application/x-www-form-urlencoded" },
+    headers: { "content-type": "application/json" },
     uri: options.uri
   };
 

--- a/packages/ssr/src/lib/run-server.js
+++ b/packages/ssr/src/lib/run-server.js
@@ -22,8 +22,7 @@ const makeClient = options => {
   const networkInterfaceOptions = {
     fetch,
     headers: { "content-type": "application/x-www-form-urlencoded" },
-    uri: options.uri,
-    useGETForQueries: true
+    uri: options.uri
   };
 
   if (options.headers) {

--- a/packages/svgs/package.json
+++ b/packages/svgs/package.json
@@ -53,7 +53,7 @@
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.4.4",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/test-utils": "2.2.23",
+    "@times-components/test-utils": "2.2.24",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -40,8 +40,8 @@
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.4.4",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/storybook": "3.4.14",
-    "@times-components/test-utils": "2.2.23",
+    "@times-components/storybook": "3.4.15",
+    "@times-components/test-utils": "2.2.24",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-plugin-add-react-displayname": "0.0.5",
@@ -59,7 +59,7 @@
     "webpack-cli": "2.1.4"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.27.5",
+    "@times-components/styleguide": "3.27.6",
     "@times-components/svgs": "2.6.4",
     "prop-types": "15.6.2"
   },


### PR DESCRIPTION
SSR is broken because article queries are now too large to work over GET requests. There's no real benefit to using GET requests so lets remove that and use POST requests, which is the default for apollo. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
