### PR TITLE
fix: article showcase & article lead assets on web

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -34,6 +34,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         <div>
           <div>
             <Image
+              aspectRatio={1.7777777777777777}
               highResSize={null}
               lowResSize={100}
               uri="https://crop169.io"
@@ -197,6 +198,7 @@ exports[`4. an article with ads 1`] = `
         <div>
           <div>
             <Image
+              aspectRatio={1.7777777777777777}
               highResSize={null}
               lowResSize={100}
               uri="https://crop169.io"

--- a/packages/article-lead-asset/__tests__/web/__snapshots__/article-lead-asset.test.js.snap
+++ b/packages/article-lead-asset/__tests__/web/__snapshots__/article-lead-asset.test.js.snap
@@ -28,6 +28,7 @@ exports[`1. renders correctly with an image lead asset 1`] = `
         className="IS1"
       >
         <Image
+          aspectRatio={1.7777777777777777}
           highResSize={600}
           lowResSize={100}
           uri="https://crop169.io/"
@@ -134,6 +135,7 @@ exports[`5. it renders correctly with a classname 1`] = `
         className="IS1"
       >
         <Image
+          aspectRatio={1.7777777777777777}
           highResSize={600}
           lowResSize={100}
           uri="https://crop169.io/"

--- a/packages/article-lead-asset/src/article-lead-asset.web.js
+++ b/packages/article-lead-asset/src/article-lead-asset.web.js
@@ -5,6 +5,7 @@ import { AspectRatioContainer } from "@times-components/utils";
 import Video from "@times-components/video";
 
 import { defaultProps, propTypes } from "./article-lead-asset-prop-types";
+import getRatio from "./get-ratio";
 
 const ArticleLeadAsset = ({
   aspectRatio,
@@ -39,7 +40,12 @@ const ArticleLeadAsset = ({
       width="100%"
     />
   ) : (
-    <Image highResSize={width} lowResSize={100} uri={displayImage.url} />
+    <Image
+      aspectRatio={getRatio(aspectRatio)}
+      highResSize={width}
+      lowResSize={100}
+      uri={displayImage.url}
+    />
   );
 
   return (

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -72,6 +72,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         <div>
           <div>
             <Image
+              aspectRatio={1.7777777777777777}
               highResSize={null}
               lowResSize={100}
               uri="https://crop169.io"
@@ -230,6 +231,7 @@ exports[`4. an article with ads 1`] = `
         <div>
           <div>
             <Image
+              aspectRatio={1.7777777777777777}
               highResSize={null}
               lowResSize={100}
               uri="https://crop169.io"
@@ -411,6 +413,7 @@ exports[`7. an article with no author 1`] = `
         <div>
           <div>
             <Image
+              aspectRatio={1.7777777777777777}
               highResSize={null}
               lowResSize={100}
               uri="https://crop169.io"

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -67,6 +67,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         <div>
           <div>
             <Image
+              aspectRatio={1.7777777777777777}
               highResSize={null}
               lowResSize={100}
               uri="https://crop169.io"
@@ -220,6 +221,7 @@ exports[`4. an article with ads 1`] = `
         <div>
           <div>
             <Image
+              aspectRatio={1.7777777777777777}
               highResSize={null}
               lowResSize={100}
               uri="https://crop169.io"

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -101,6 +101,7 @@ exports[`1. an article 1`] = `
         <div>
           <div>
             <Image
+              aspectRatio={1.7777777777777777}
               highResSize={null}
               lowResSize={100}
               uri="https://crop169.io"

--- a/packages/provider-test-tools/fixtures/article.json
+++ b/packages/provider-test-tools/fixtures/article.json
@@ -1096,6 +1096,7 @@
       {
         "bylines": [
           {
+            "__typename": "TextByline",
             "byline": [
               {
                 "name": "inline",
@@ -1333,6 +1334,7 @@
       {
         "bylines": [
           {
+            "__typename": "TextByline",
             "byline": [
               {
                 "name": "inline",
@@ -1508,6 +1510,7 @@
       {
         "bylines": [
           {
+            "__typename": "TextByline",
             "byline": [
               {
                 "name": "inline",

--- a/packages/provider-test-tools/src/fixtures/byline-with-link.json
+++ b/packages/provider-test-tools/src/fixtures/byline-with-link.json
@@ -1,29 +1,39 @@
 [
   {
-    "name": "author",
-    "attributes": {
-      "slug": "kaya-burgess"
-    },
-    "children": [
+    "__typename": "AuthorByline",
+    "byline": [
       {
-        "name": "text",
+        "name": "author",
         "attributes": {
-          "value": "Kaya Burgess"
+          "slug": "kaya-burgess"
         },
-        "children": []
+        "children": [
+          {
+            "name": "text",
+            "attributes": {
+              "value": "Kaya Burgess"
+            },
+            "children": []
+          }
+        ]
       }
     ]
   },
   {
-    "name": "inline",
-    "attributes": {},
-    "children": [
+    "__typename": "TextByline",
+    "byline": [
       {
-        "name": "text",
-        "attributes": {
-          "value": ", Religious Affairs Correspondent"
-        },
-        "children": []
+        "name": "inline",
+        "attributes": {},
+        "children": [
+          {
+            "name": "text",
+            "attributes": {
+              "value": ", Religious Affairs Correspondent"
+            },
+            "children": []
+          }
+        ]
       }
     ]
   }

--- a/packages/provider/__tests__/__snapshots__/article-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/article-provider.test.js.snap
@@ -1,3 +1,274 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleProvider returns query result 1`] = `undefined`;
+exports[`ArticleProvider returns query result 1`] = `
+Object {
+  "__typename": "Article",
+  "backgroundColour": Object {
+    "__typename": "Colour",
+    "rgba": Object {
+      "__typename": "RGBA",
+      "alpha": 1,
+      "blue": 255,
+      "green": 255,
+      "red": 255,
+    },
+  },
+  "bylines": Array [
+    Object {
+      "__typename": "TextByline",
+      "byline": Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Rick Broadbent",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "inline",
+        },
+      ],
+      "image": Object {
+        "__typename": "Image",
+        "caption": "some caption",
+        "credits": "some credits",
+        "crop": Object {
+          "__typename": "Crop",
+          "ratio": "1:1",
+          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c1333a8-1aa2-11e9-944c-54b267eb465b.jpg?crop=1037%2C1037%2C448%2C38",
+        },
+        "id": "372bc095-34c4-47e4-8b1e-d352f5641ee5",
+        "title": "some title",
+      },
+    },
+  ],
+  "content": Array [
+    Object {
+      "children": Array [
+        Object {
+          "attributes": Object {
+            "value": "test",
+          },
+          "name": "text",
+        },
+      ],
+      "name": "paragraph",
+    },
+  ],
+  "dropcapsDisabled": false,
+  "expirableFlags": Array [
+    Object {
+      "__typename": "ExpirableFlag",
+      "expiryTime": "2020-03-13T15:00:00.000Z",
+      "type": "NEW",
+    },
+    Object {
+      "__typename": "ExpirableFlag",
+      "expiryTime": "2019-03-13T13:00:00.000Z",
+      "type": "UPDATED",
+    },
+  ],
+  "hasVideo": true,
+  "headline": "Exclusive interview: the cyclist Geraint Thomas on Welsh pride, drugs cheats and winning the Tour de France",
+  "id": "113e9875-b7bf-4dd7-ac99-dee231bf6e74",
+  "keywords": Array [
+    "Supplement",
+    "In",
+    "Depth",
+    "Template",
+    "Style",
+  ],
+  "label": "Random label",
+  "leadAsset": Object {
+    "__typename": "Image",
+    "caption": "Chris Reynolds Gordon at one of his party venues in London",
+    "credits": "Gareth Philips",
+    "crop11": Object {
+      "__typename": "Crop",
+      "ratio": "16:9",
+      "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46f.jpg?crop=2848%2C2848%2C712%2C0",
+    },
+    "crop1251": Object {
+      "__typename": "Crop",
+      "ratio": "16:9",
+      "url": "https://placeimg.com/100/100/tech",
+    },
+    "crop169": Object {
+      "__typename": "Crop",
+      "ratio": "16:9",
+      "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd67cded0-ca7a-11e8-998e-a6e3c63abd14.jpg?crop=1600%2C900%2C0%2C0",
+    },
+    "crop2251": Object {
+      "__typename": "Crop",
+      "ratio": "16:9",
+      "url": "https://placeimg.com/100/100/tech",
+    },
+    "crop23": Object {
+      "__typename": "Crop",
+      "ratio": "16:9",
+      "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46f.jpg?crop=1899%2C2848%2C1187%2C0",
+    },
+    "crop32": Object {
+      "__typename": "Crop",
+      "ratio": "16:9",
+      "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46f.jpg?crop=4272%2C2848%2C0%2C0",
+    },
+    "crop45": Object {
+      "__typename": "Crop",
+      "ratio": "16:9",
+      "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F52e8ecac-c7e2-11e8-9259-db41e732e46f.jpg?crop=2278%2C2848%2C997%2C0",
+    },
+    "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+    "title": "Chris Reynolds Gordon at one of his party venues in London",
+  },
+  "publicationName": "TIMES",
+  "publishedTime": "2015-03-13T18:54:58.000Z",
+  "relatedArticleSlice": Object {
+    "__typename": "StandardSlice",
+    "items": Array [
+      Object {
+        "__typename": "Tile",
+        "article": Object {
+          "__typename": "Article",
+          "bylines": Array [
+            Object {
+              "__typename": "TextByline",
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "image": Object {
+                "__typename": "Image",
+                "caption": "Hello World",
+                "credits": "Hello World",
+                "crop": Object {
+                  "__typename": "Crop",
+                  "ratio": "16:9",
+                  "url": "https://placeimg.com/100/100/tech",
+                },
+                "id": "a-u-u-i-d",
+                "title": "Hello World",
+              },
+            },
+          ],
+          "hasVideo": true,
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "__typename": "Image",
+            "crop169": Object {
+              "__typename": "Crop",
+              "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop32": Object {
+              "__typename": "Crop",
+              "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "id": "6c1c108e-ed63-47af-df1d-46c63be16627",
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "section": "sport",
+          "shortHeadline": "TMS: Pratchett’s law of the jungle",
+          "shortIdentifier": "abc123",
+          "slug": "related-article-slug",
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        "leadAsset": Object {
+          "__typename": "Image",
+          "crop169": Object {
+            "__typename": "Crop",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop32": Object {
+            "__typename": "Crop",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "id": "6c1c108e-ed63-47af-df1d-46c63be16627",
+          "title": "TMS: Pratchett’s law of the jungle",
+        },
+      },
+    ],
+  },
+  "section": "business",
+  "shortHeadline": "Let's keep A levels but scrap outdated GCSEs",
+  "shortIdentifier": "37b27qd2s",
+  "slug": "france-defies-may-over-russia",
+  "standfirst": "After 10 years helping others to cycling glory, Geraint Thomas has finally won the Tour de France. Simon Barnes hangs out with the Welsh hero at home in Cardiff",
+  "template": "mainstandard",
+  "textColour": Object {
+    "__typename": "Colour",
+    "rgba": Object {
+      "__typename": "RGBA",
+      "alpha": 1,
+      "blue": 0,
+      "green": 0,
+      "red": 0,
+    },
+  },
+  "topics": Array [
+    Object {
+      "__typename": "Topic",
+      "name": "Islington",
+      "slug": "islington",
+    },
+    Object {
+      "__typename": "Topic",
+      "name": "Chelsea",
+      "slug": "chelsea",
+    },
+  ],
+  "url": "https://www.thetimes.co.uk/edition/news/france-defies-may-over-russia-37b27qd2s",
+}
+`;

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/test-utils": "2.2.26",
+    "@times-components/test-utils": "2.2.27",
     "eslint": "5.9.0",
     "prettier": "1.14.3",
     "rimraf": "2.6.1"

--- a/packages/tealium/package.json
+++ b/packages/tealium/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/jest-configurator": "2.4.5",
-    "@times-components/test-utils": "2.2.26",
+    "@times-components/jest-configurator": "2.4.6",
+    "@times-components/test-utils": "2.2.27",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-plugin-add-react-displayname": "0.0.5",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,9 +33,9 @@
   "devDependencies": {
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/jest-configurator": "2.4.5",
+    "@times-components/jest-configurator": "2.4.6",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/test-utils": "2.2.26",
+    "@times-components/test-utils": "2.2.27",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
@@ -51,7 +51,7 @@
     "webpack-cli": "2.1.4"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.27.8",
+    "@times-components/styleguide": "3.27.9",
     "lodash.omitby": "4.6.0",
     "prop-types": "15.6.2",
     "react-native": "0.55.4"


### PR DESCRIPTION
The article showcase is currently completely broken due to incorrect byline fixtures. The lead asset was also missing as aspectRatio was not passed through. 

This PR fixes both. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
