### PR TITLE
Fix/daily register lead four huge breakpoint

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
@@ -40,8 +40,8 @@ exports[`1. daily universal register 1`] = `
         "borderBottomWidth": 1,
         "borderColor": "#DBDBDB",
         "borderStyle": "solid",
-        "marginBottom": 25,
         "marginHorizontal": 10,
+        "marginVertical": 25,
         "width": "100%",
       }
     }
@@ -54,8 +54,8 @@ exports[`1. daily universal register 1`] = `
         "borderBottomWidth": 1,
         "borderColor": "#DBDBDB",
         "borderStyle": "solid",
-        "marginBottom": 25,
         "marginHorizontal": 10,
+        "marginVertical": 25,
         "width": "100%",
       }
     }
@@ -76,8 +76,8 @@ exports[`1. daily universal register 1`] = `
         "borderBottomWidth": 1,
         "borderColor": "#DBDBDB",
         "borderStyle": "solid",
-        "marginBottom": 25,
         "marginHorizontal": 10,
+        "marginVertical": 25,
         "width": "100%",
       }
     }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -75,9 +75,8 @@ exports[`2. daily universal register - medium 1`] = `
     <Image
       style={
         Object {
-          "height": 73,
-          "marginVertical": 10,
-          "width": 285,
+          "height": 97,
+          "width": 380,
         }
       }
     />
@@ -101,8 +100,8 @@ exports[`2. daily universal register - medium 1`] = `
           "borderBottomWidth": 1,
           "borderColor": "#DBDBDB",
           "borderStyle": "solid",
-          "marginBottom": 25,
           "marginHorizontal": 10,
+          "marginVertical": 25,
           "width": "100%",
         }
       }
@@ -115,8 +114,8 @@ exports[`2. daily universal register - medium 1`] = `
           "borderBottomWidth": 1,
           "borderColor": "#DBDBDB",
           "borderStyle": "solid",
-          "marginBottom": 25,
           "marginHorizontal": 10,
+          "marginVertical": 25,
           "width": "100%",
         }
       }
@@ -137,8 +136,8 @@ exports[`2. daily universal register - medium 1`] = `
           "borderBottomWidth": 1,
           "borderColor": "#DBDBDB",
           "borderStyle": "solid",
-          "marginBottom": 25,
           "marginHorizontal": 10,
+          "marginVertical": 25,
           "width": "100%",
         }
       }
@@ -1220,8 +1219,8 @@ exports[`17. daily universal register - wide 1`] = `
           "borderBottomWidth": 1,
           "borderColor": "#DBDBDB",
           "borderStyle": "solid",
-          "marginBottom": 25,
           "marginHorizontal": 10,
+          "marginVertical": 25,
           "width": "100%",
         }
       }
@@ -1234,8 +1233,8 @@ exports[`17. daily universal register - wide 1`] = `
           "borderBottomWidth": 1,
           "borderColor": "#DBDBDB",
           "borderStyle": "solid",
-          "marginBottom": 25,
           "marginHorizontal": 10,
+          "marginVertical": 25,
           "width": "100%",
         }
       }
@@ -1256,8 +1255,8 @@ exports[`17. daily universal register - wide 1`] = `
           "borderBottomWidth": 1,
           "borderColor": "#DBDBDB",
           "borderStyle": "solid",
-          "marginBottom": 25,
           "marginHorizontal": 10,
+          "marginVertical": 25,
           "width": "100%",
         }
       }
@@ -2284,9 +2283,10 @@ exports[`32. daily universal register - huge 1`] = `
     style={
       Object {
         "alignItems": "center",
+        "alignSelf": "center",
         "backgroundColor": "#F0F0F0",
         "flex": 1,
-        "padding": 10,
+        "width": "86%",
       }
     }
   >
@@ -2314,63 +2314,9 @@ exports[`32. daily universal register - huge 1`] = `
     <View
       style={
         Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginBottom": 25,
-          "marginHorizontal": 10,
-          "width": "100%",
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "alignItems": "center",
           "flexDirection": "row",
-          "paddingHorizontal": "30%",
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "paddingHorizontal": "5%",
-          }
-        }
-      >
-        <TileS />
-      </View>
-      <View
-        style={
-          Object {
-            "paddingHorizontal": "5%",
-          }
-        }
-      >
-        <TileS />
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginBottom": 25,
-          "marginHorizontal": 10,
+          "paddingHorizontal": "8%",
           "width": "100%",
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "paddingHorizontal": "30%",
         }
       }
     >
@@ -2378,25 +2324,26 @@ exports[`32. daily universal register - huge 1`] = `
         style={
           Object {
             "alignItems": "center",
+            "flex": 1,
             "flexDirection": "column",
+            "paddingHorizontal": 25,
           }
         }
       >
-        <Image
-          style={
-            Object {
-              "height": 45,
-              "width": 60,
-            }
-          }
-        />
         <View
           style={
             Object {
-              "paddingHorizontal": "5%",
+              "borderBottomColor": "#DBDBDB",
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+              "marginVertical": 25,
+              "width": "100%",
             }
           }
-        >
+        />
+        <View>
           <TileS />
         </View>
       </View>
@@ -2404,10 +2351,62 @@ exports[`32. daily universal register - huge 1`] = `
         style={
           Object {
             "alignItems": "center",
+            "flex": 1,
             "flexDirection": "column",
+            "paddingHorizontal": 25,
           }
         }
       >
+        <View
+          style={
+            Object {
+              "borderBottomColor": "#DBDBDB",
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+              "marginVertical": 25,
+              "width": "100%",
+            }
+          }
+        />
+        <View>
+          <TileS />
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "paddingHorizontal": "8%",
+          "width": "100%",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "column",
+            "paddingHorizontal": 25,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderBottomColor": "#DBDBDB",
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+              "marginVertical": 25,
+              "width": "100%",
+            }
+          }
+        />
         <Image
           style={
             Object {
@@ -2416,13 +2415,42 @@ exports[`32. daily universal register - huge 1`] = `
             }
           }
         />
+        <View>
+          <TileS />
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "column",
+            "paddingHorizontal": 25,
+          }
+        }
+      >
         <View
           style={
             Object {
-              "paddingHorizontal": "5%",
+              "borderBottomColor": "#DBDBDB",
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+              "marginVertical": 25,
+              "width": "100%",
             }
           }
-        >
+        />
+        <Image
+          style={
+            Object {
+              "height": 45,
+              "width": 60,
+            }
+          }
+        />
+        <View>
           <TileS />
         </View>
       </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -918,18 +918,23 @@ exports[`32. daily universal register - huge 1`] = `
     <Text>
       Daily Universal Register
     </Text>
-    <View />
     <View>
       <View>
-        <TileS />
+        <View />
+        <View>
+          <TileS />
+        </View>
       </View>
       <View>
-        <TileS />
+        <View />
+        <View>
+          <TileS />
+        </View>
       </View>
     </View>
-    <View />
     <View>
       <View>
+        <View />
         <Image
           resizeMode="contain"
           source={
@@ -943,6 +948,7 @@ exports[`32. daily universal register - huge 1`] = `
         </View>
       </View>
       <View>
+        <View />
         <Image
           resizeMode="contain"
           source={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
@@ -40,8 +40,8 @@ exports[`1. daily universal register 1`] = `
         "borderBottomWidth": 1,
         "borderColor": "#DBDBDB",
         "borderStyle": "solid",
-        "marginBottom": 25,
         "marginHorizontal": 10,
+        "marginVertical": 25,
         "width": "100%",
       }
     }
@@ -54,8 +54,8 @@ exports[`1. daily universal register 1`] = `
         "borderBottomWidth": 1,
         "borderColor": "#DBDBDB",
         "borderStyle": "solid",
-        "marginBottom": 25,
         "marginHorizontal": 10,
+        "marginVertical": 25,
         "width": "100%",
       }
     }
@@ -76,8 +76,8 @@ exports[`1. daily universal register 1`] = `
         "borderBottomWidth": 1,
         "borderColor": "#DBDBDB",
         "borderStyle": "solid",
-        "marginBottom": 25,
         "marginHorizontal": 10,
+        "marginVertical": 25,
         "width": "100%",
       }
     }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -75,9 +75,8 @@ exports[`2. daily universal register - medium 1`] = `
     <Image
       style={
         Object {
-          "height": 73,
-          "marginVertical": 10,
-          "width": 285,
+          "height": 97,
+          "width": 380,
         }
       }
     />
@@ -101,8 +100,8 @@ exports[`2. daily universal register - medium 1`] = `
           "borderBottomWidth": 1,
           "borderColor": "#DBDBDB",
           "borderStyle": "solid",
-          "marginBottom": 25,
           "marginHorizontal": 10,
+          "marginVertical": 25,
           "width": "100%",
         }
       }
@@ -115,8 +114,8 @@ exports[`2. daily universal register - medium 1`] = `
           "borderBottomWidth": 1,
           "borderColor": "#DBDBDB",
           "borderStyle": "solid",
-          "marginBottom": 25,
           "marginHorizontal": 10,
+          "marginVertical": 25,
           "width": "100%",
         }
       }
@@ -137,8 +136,8 @@ exports[`2. daily universal register - medium 1`] = `
           "borderBottomWidth": 1,
           "borderColor": "#DBDBDB",
           "borderStyle": "solid",
-          "marginBottom": 25,
           "marginHorizontal": 10,
+          "marginVertical": 25,
           "width": "100%",
         }
       }
@@ -1220,8 +1219,8 @@ exports[`17. daily universal register - wide 1`] = `
           "borderBottomWidth": 1,
           "borderColor": "#DBDBDB",
           "borderStyle": "solid",
-          "marginBottom": 25,
           "marginHorizontal": 10,
+          "marginVertical": 25,
           "width": "100%",
         }
       }
@@ -1234,8 +1233,8 @@ exports[`17. daily universal register - wide 1`] = `
           "borderBottomWidth": 1,
           "borderColor": "#DBDBDB",
           "borderStyle": "solid",
-          "marginBottom": 25,
           "marginHorizontal": 10,
+          "marginVertical": 25,
           "width": "100%",
         }
       }
@@ -1256,8 +1255,8 @@ exports[`17. daily universal register - wide 1`] = `
           "borderBottomWidth": 1,
           "borderColor": "#DBDBDB",
           "borderStyle": "solid",
-          "marginBottom": 25,
           "marginHorizontal": 10,
+          "marginVertical": 25,
           "width": "100%",
         }
       }
@@ -2284,9 +2283,10 @@ exports[`32. daily universal register - huge 1`] = `
     style={
       Object {
         "alignItems": "center",
+        "alignSelf": "center",
         "backgroundColor": "#F0F0F0",
         "flex": 1,
-        "padding": 10,
+        "width": "86%",
       }
     }
   >
@@ -2314,63 +2314,9 @@ exports[`32. daily universal register - huge 1`] = `
     <View
       style={
         Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginBottom": 25,
-          "marginHorizontal": 10,
-          "width": "100%",
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "alignItems": "center",
           "flexDirection": "row",
-          "paddingHorizontal": "30%",
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "paddingHorizontal": "5%",
-          }
-        }
-      >
-        <TileS />
-      </View>
-      <View
-        style={
-          Object {
-            "paddingHorizontal": "5%",
-          }
-        }
-      >
-        <TileS />
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginBottom": 25,
-          "marginHorizontal": 10,
+          "paddingHorizontal": "8%",
           "width": "100%",
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "paddingHorizontal": "30%",
         }
       }
     >
@@ -2378,25 +2324,26 @@ exports[`32. daily universal register - huge 1`] = `
         style={
           Object {
             "alignItems": "center",
+            "flex": 1,
             "flexDirection": "column",
+            "paddingHorizontal": 25,
           }
         }
       >
-        <Image
-          style={
-            Object {
-              "height": 45,
-              "width": 60,
-            }
-          }
-        />
         <View
           style={
             Object {
-              "paddingHorizontal": "5%",
+              "borderBottomColor": "#DBDBDB",
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+              "marginVertical": 25,
+              "width": "100%",
             }
           }
-        >
+        />
+        <View>
           <TileS />
         </View>
       </View>
@@ -2404,10 +2351,62 @@ exports[`32. daily universal register - huge 1`] = `
         style={
           Object {
             "alignItems": "center",
+            "flex": 1,
             "flexDirection": "column",
+            "paddingHorizontal": 25,
           }
         }
       >
+        <View
+          style={
+            Object {
+              "borderBottomColor": "#DBDBDB",
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+              "marginVertical": 25,
+              "width": "100%",
+            }
+          }
+        />
+        <View>
+          <TileS />
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "paddingHorizontal": "8%",
+          "width": "100%",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "column",
+            "paddingHorizontal": 25,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderBottomColor": "#DBDBDB",
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+              "marginVertical": 25,
+              "width": "100%",
+            }
+          }
+        />
         <Image
           style={
             Object {
@@ -2416,13 +2415,42 @@ exports[`32. daily universal register - huge 1`] = `
             }
           }
         />
+        <View>
+          <TileS />
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "column",
+            "paddingHorizontal": 25,
+          }
+        }
+      >
         <View
           style={
             Object {
-              "paddingHorizontal": "5%",
+              "borderBottomColor": "#DBDBDB",
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+              "marginVertical": 25,
+              "width": "100%",
             }
           }
-        >
+        />
+        <Image
+          style={
+            Object {
+              "height": 45,
+              "width": 60,
+            }
+          }
+        />
+        <View>
           <TileS />
         </View>
       </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -918,18 +918,23 @@ exports[`32. daily universal register - huge 1`] = `
     <Text>
       Daily Universal Register
     </Text>
-    <View />
     <View>
       <View>
-        <TileS />
+        <View />
+        <View>
+          <TileS />
+        </View>
       </View>
       <View>
-        <TileS />
+        <View />
+        <View>
+          <TileS />
+        </View>
       </View>
     </View>
-    <View />
     <View>
       <View>
+        <View />
         <Image
           resizeMode="contain"
           source={
@@ -943,6 +948,7 @@ exports[`32. daily universal register - huge 1`] = `
         </View>
       </View>
       <View>
+        <View />
         <Image
           resizeMode="contain"
           source={

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -30,9 +30,10 @@ exports[`1. daily universal register 1`] = `
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
+  margin-top: 25px;
   margin-right: 10px;
-  margin-left: 10px;
   margin-bottom: 25px;
+  margin-left: 10px;
   width: 100%;
 }
 
@@ -42,9 +43,10 @@ exports[`1. daily universal register 1`] = `
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
+  margin-top: 25px;
   margin-right: 10px;
-  margin-left: 10px;
   margin-bottom: 25px;
+  margin-left: 10px;
   width: 100%;
 }
 
@@ -59,9 +61,10 @@ exports[`1. daily universal register 1`] = `
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
+  margin-top: 25px;
   margin-right: 10px;
-  margin-left: 10px;
   margin-bottom: 25px;
+  margin-left: 10px;
   width: 100%;
 }
 
@@ -106,7 +109,7 @@ exports[`1. daily universal register 1`] = `
     className="IS8 S2"
   >
     <Image
-      aspectRatio={5.74}
+      aspectRatio={1}
       className="IS1"
       uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
     />

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -4,7 +4,7 @@ exports[`1. daily universal register 1`] = `
 <div>
   <div>
     <Image
-      aspectRatio={5.74}
+      aspectRatio={1}
       uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
     />
     <div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -110,9 +110,10 @@ exports[`2. daily universal register - medium 1`] = `
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
+  margin-top: 25px;
   margin-right: 10px;
-  margin-left: 10px;
   margin-bottom: 25px;
+  margin-left: 10px;
   width: 100%;
 }
 
@@ -122,9 +123,10 @@ exports[`2. daily universal register - medium 1`] = `
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
+  margin-top: 25px;
   margin-right: 10px;
-  margin-left: 10px;
   margin-bottom: 25px;
+  margin-left: 10px;
   width: 100%;
 }
 
@@ -139,9 +141,10 @@ exports[`2. daily universal register - medium 1`] = `
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
+  margin-top: 25px;
   margin-right: 10px;
-  margin-left: 10px;
   margin-bottom: 25px;
+  margin-left: 10px;
   width: 100%;
 }
 
@@ -186,7 +189,7 @@ exports[`2. daily universal register - medium 1`] = `
     className="IS8 S2"
   >
     <Image
-      aspectRatio={5.74}
+      aspectRatio={1}
       className="IS1"
       uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
     />
@@ -1794,9 +1797,10 @@ exports[`17. daily universal register - wide 1`] = `
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
+  margin-top: 25px;
   margin-right: 10px;
-  margin-left: 10px;
   margin-bottom: 25px;
+  margin-left: 10px;
   width: 100%;
 }
 
@@ -1806,9 +1810,10 @@ exports[`17. daily universal register - wide 1`] = `
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
+  margin-top: 25px;
   margin-right: 10px;
-  margin-left: 10px;
   margin-bottom: 25px;
+  margin-left: 10px;
   width: 100%;
 }
 
@@ -1823,9 +1828,10 @@ exports[`17. daily universal register - wide 1`] = `
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
+  margin-top: 25px;
   margin-right: 10px;
-  margin-left: 10px;
   margin-bottom: 25px;
+  margin-left: 10px;
   width: 100%;
 }
 
@@ -1870,7 +1876,7 @@ exports[`17. daily universal register - wide 1`] = `
     className="IS8 S2"
   >
     <Image
-      aspectRatio={5.74}
+      aspectRatio={1}
       className="IS1"
       uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
     />
@@ -3478,9 +3484,10 @@ exports[`32. daily universal register - huge 1`] = `
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
+  margin-top: 25px;
   margin-right: 10px;
-  margin-left: 10px;
   margin-bottom: 25px;
+  margin-left: 10px;
   width: 100%;
 }
 
@@ -3490,9 +3497,10 @@ exports[`32. daily universal register - huge 1`] = `
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
+  margin-top: 25px;
   margin-right: 10px;
-  margin-left: 10px;
   margin-bottom: 25px;
+  margin-left: 10px;
   width: 100%;
 }
 
@@ -3507,9 +3515,10 @@ exports[`32. daily universal register - huge 1`] = `
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
+  margin-top: 25px;
   margin-right: 10px;
-  margin-left: 10px;
   margin-bottom: 25px;
+  margin-left: 10px;
   width: 100%;
 }
 
@@ -3554,7 +3563,7 @@ exports[`32. daily universal register - huge 1`] = `
     className="IS8 S2"
   >
     <Image
-      aspectRatio={5.74}
+      aspectRatio={1}
       className="IS1"
       uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
     />

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -22,7 +22,7 @@ exports[`2. daily universal register - medium 1`] = `
 <div>
   <div>
     <Image
-      aspectRatio={5.74}
+      aspectRatio={1}
       uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
     />
     <div>
@@ -447,7 +447,7 @@ exports[`17. daily universal register - wide 1`] = `
 <div>
   <div>
     <Image
-      aspectRatio={5.74}
+      aspectRatio={1}
       uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
     />
     <div>
@@ -872,7 +872,7 @@ exports[`32. daily universal register - huge 1`] = `
 <div>
   <div>
     <Image
-      aspectRatio={5.74}
+      aspectRatio={1}
       uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
     />
     <div>

--- a/packages/edition-slices/src/slices/dailyregisterleadfour/index.js
+++ b/packages/edition-slices/src/slices/dailyregisterleadfour/index.js
@@ -24,7 +24,7 @@ class DailyRegisterLeadFour extends Component {
       <View style={styles.container}>
         <Logo
           imageUri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-          ratio={1435 / 250}
+          ratio={1}
           style={styles.mastheadLogo}
           type="logo"
         />
@@ -62,23 +62,29 @@ class DailyRegisterLeadFour extends Component {
       <View style={styles.container}>
         <Logo
           imageUri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-          ratio={1435 / 250}
+          ratio={1}
           style={styles.mastheadLogo}
           type="logo"
         />
         <Text style={styles.title}>Daily Universal Register</Text>
-        <ItemRowSeparator style={styles.separator} />
-        <View style={styles.rowItems}>
-          <View style={styles.item}>
-            <TileS tile={briefing} />
-          </View>
-          <View style={styles.item}>
-            <TileS tile={onThisDay} />
-          </View>
-        </View>
-        <ItemRowSeparator style={styles.separator} />
+
         <View style={styles.rowItems}>
           <View style={styles.columnItems}>
+            <ItemRowSeparator style={styles.separator} />
+            <View style={styles.item}>
+              <TileS tile={briefing} />
+            </View>
+          </View>
+          <View style={styles.columnItems}>
+            <ItemRowSeparator style={styles.separator} />
+            <View style={styles.item}>
+              <TileS tile={onThisDay} />
+            </View>
+          </View>
+        </View>
+        <View style={styles.rowItems}>
+          <View style={styles.columnItems}>
+            <ItemRowSeparator style={styles.separator} />
             <Logo
               imageUri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
               ratio={1 / 1}
@@ -90,6 +96,7 @@ class DailyRegisterLeadFour extends Component {
             </View>
           </View>
           <View style={styles.columnItems}>
+            <ItemRowSeparator style={styles.separator} />
             <Logo
               imageUri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
               ratio={1 / 1}

--- a/packages/edition-slices/src/slices/dailyregisterleadfour/styles.js
+++ b/packages/edition-slices/src/slices/dailyregisterleadfour/styles.js
@@ -23,7 +23,7 @@ const main = {
   },
   separator: {
     borderBottomColor: colours.functional.keyline,
-    marginBottom: spacing(5),
+    marginVertical: spacing(5),
     width: "100%"
   },
   title: {
@@ -49,6 +49,10 @@ const mediumBreakpointStyles = {
     backgroundColor: colours.functional.border,
     flex: 1,
     paddingHorizontal: "20%"
+  },
+  mastheadLogo: {
+    height: 97,
+    width: 380
   }
 };
 
@@ -64,15 +68,21 @@ const wideBreakpointStyle = {
 const hugeBreakpointStyle = {
   columnItems: {
     alignItems: "center",
-    flexDirection: "column"
+    flex: 1,
+    flexDirection: "column",
+    paddingHorizontal: spacing(5)
   },
-  item: {
-    paddingHorizontal: "5%"
+  container: {
+    alignItems: "center",
+    alignSelf: "center",
+    backgroundColor: colours.functional.border,
+    flex: 1,
+    width: "86%"
   },
   rowItems: {
-    alignItems: "center",
     flexDirection: "row",
-    paddingHorizontal: "30%"
+    paddingHorizontal: "8%",
+    width: "100%"
   }
 };
 


### PR DESCRIPTION
before: 
![Screenshot 2019-04-12 at 10 47 36](https://user-images.githubusercontent.com/16742525/56021892-38c97780-5d13-11e9-9b82-990e107f2cff.png)

now:
![Screenshot 2019-04-12 at 10 45 15](https://user-images.githubusercontent.com/16742525/56021915-441ca300-5d13-11e9-80b7-f4b4c7621b72.png)

Also the design screen was updated for this slice (previously was not centred and having incorrect width measures) 

Note:

>   container: {
    alignItems: "center",
    ...
    **width: "86%"**
  }

To implement designs for huge screens we need a container with set max width and inner padding. Currently we are using a Gutter component 1366 wide that contains the different slices' layouts. The slices' layouts have the needed styles.
We have the following tree of components: SliceName -> ResponsiveSlice -> Gutter -> SliceLayout. When setting the inner padding for the Gutter the result has white space around the slice layout:

![Screenshot 2019-04-12 at 11 25 07](https://user-images.githubusercontent.com/16742525/56023470-90b5ad80-5d16-11e9-8032-a422bffffa74.png)




