### PR TITLE
fix: setup theme correctly in SSR

### DIFF
--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -4,8 +4,8 @@ const React = require("react");
 const { ApolloProvider } = require("react-apollo");
 const { ArticleProvider } = require("@times-components/provider/rnw");
 const Article = require("@times-components/article/rnw").default;
-const Context = require("@times-components/context/rnw").default;
-const { scales, colours } = require("@times-components/styleguide/rnw");
+const { default: Context, defaults } = require("@times-components/context/rnw");
+const { scales, themeFactory } = require("@times-components/styleguide/rnw");
 
 const scale = scales.large;
 
@@ -34,7 +34,10 @@ module.exports = (client, analyticsStream, data) => {
           {
             value: {
               makeArticleUrl,
-              theme: { scale, sectionColour: colours.section[article.section] }
+              theme: {
+                ...themeFactory(article.section, article.template),
+                scale: scale || defaults.theme.scale
+              }
             }
           },
           React.createElement(Article, {


### PR DESCRIPTION
SSR wasn't using the theme factory to pass theme information into the context. This caused the confusing issue where articles would appear correctly themed in the storybook but not in SSR. This PR fixes that issue by using the same theme factory that the storybook uses. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
