### PR TITLE
feat: Update section data on native event

### DIFF
--- a/packages/pages/__tests__/android/section-update.test.js
+++ b/packages/pages/__tests__/android/section-update.test.js
@@ -1,0 +1,3 @@
+import shared from "../section-update";
+
+shared();

--- a/packages/pages/__tests__/ios/section-update.test.js
+++ b/packages/pages/__tests__/ios/section-update.test.js
@@ -1,0 +1,3 @@
+import shared from "../section-update";
+
+shared();

--- a/packages/pages/__tests__/mocks.js
+++ b/packages/pages/__tests__/mocks.js
@@ -28,6 +28,7 @@ jest.mock("react-native", () => {
   rn.NativeModules.SectionEvents = {
     getOpenedPuzzleCount: jest.fn(),
     getSavedArticles: jest.fn().mockReturnValue(Promise.resolve([])),
+    getSectionData: jest.fn().mockReturnValue(Promise.resolve("{}")),
     onArticlePress: () => {},
     onArticleSavePress: jest.fn().mockReturnValue(Promise.resolve(true)),
     onPuzzleBarPress: () => {},

--- a/packages/pages/__tests__/section-update.js
+++ b/packages/pages/__tests__/section-update.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { DeviceEventEmitter, NativeModules } from "react-native";
+import TestRenderer from "react-test-renderer";
+import { delay } from "@times-components/test-utils";
+import "./mocks";
+import Section from "../src/section";
+
+jest.mock("@times-components/section", () => "Section");
+
+export default () => {
+  it("section data gets updated through the bridge on updateSectionData event", async () => {
+    const {
+      SectionEvents: { getSectionData }
+    } = NativeModules;
+
+    const initialSectionData = { name: "InitialSection" };
+    const updatedSectionData = { name: "UpdatedSection" };
+
+    getSectionData.mockReturnValue(Promise.resolve(JSON.stringify(updatedSectionData)));
+
+    const testInstance = TestRenderer.create(
+      <Section section={JSON.stringify(initialSectionData)} />
+    );
+
+    const sectionInstance = testInstance.root.findByType("Section");
+
+    // Initial Data
+    expect(sectionInstance.props.section).toEqual(initialSectionData);
+
+    // Updated Data
+    DeviceEventEmitter.emit("updateSectionData");
+    await delay(0);
+    expect(sectionInstance.props.section).toEqual(updatedSectionData);
+  });
+};

--- a/packages/pages/__tests__/section-update.js
+++ b/packages/pages/__tests__/section-update.js
@@ -16,7 +16,9 @@ export default () => {
     const initialSectionData = { name: "InitialSection" };
     const updatedSectionData = { name: "UpdatedSection" };
 
-    getSectionData.mockReturnValue(Promise.resolve(JSON.stringify(updatedSectionData)));
+    getSectionData.mockReturnValue(
+      Promise.resolve(JSON.stringify(updatedSectionData))
+    );
 
     const testInstance = TestRenderer.create(
       <Section section={JSON.stringify(initialSectionData)} />


### PR DESCRIPTION
This PR enables Section page data to be updated without a need to re-create the view. (https://nidigitalsolutions.jira.com/browse/REPLAT-6100)

To use this feature, native apps needs to implement `getSectionData` method in `SectionEvents` and resolve the promise with a section data (as a raw json string). 
```
fun getSectionData(sectionId: String, promise: Promise) {
  ...
}
```

Then, whenever the native app send an event named `updateSectionData`, components will use `getSectionData` bridge to ask for the updated section data and refresh its view. 


- Section prop is moved to state to enable reloads
- Subscribes and unsubscribes added to listen to `updateSectionData` events through DeviceEventEmitter
- Ask for section data when event is fired and update the state if it's successfully resolved
- Tidied up the pages/section a bit to remove inline functions