### PR TITLE
spike: helmet proof of concept for topic title

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "aws-sdk": "2.238.1",
     "babel-preset-es2015": "6.24.1",
     "react-art": "16.5.2",
+    "react-helmet-async": "1.0.2",
     "react-native": "0.55.4",
     "react-native-showcase-loader": "1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -164,7 +164,6 @@
     "aws-sdk": "2.238.1",
     "babel-preset-es2015": "6.24.1",
     "react-art": "16.5.2",
-    "react-helmet-async": "1.0.2",
     "react-native": "0.55.4",
     "react-native-showcase-loader": "1.1.0"
   }

--- a/packages/article-image/__tests__/shared-with-style.base.js
+++ b/packages/article-image/__tests__/shared-with-style.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { setIsTablet } from "@times-components/test-utils/dimensions";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { iterator } from "@times-components/test-utils";
 import ArticleImage from "../src/article-image";
 import primaryImageFixture from "../fixtures/primary-image";
@@ -137,7 +137,7 @@ export default makeTest => {
       test: () => {
         expect(
           makeTest(
-            <Context.Provider
+            <ContextProviderWithDefaults
               value={{
                 theme: { imageCaptionAlignment: { primary: "center" } }
               }}
@@ -146,7 +146,7 @@ export default makeTest => {
                 captionOptions={primaryImage.captionOptions}
                 imageOptions={primaryImage.imageOptions}
               />
-            </Context.Provider>
+            </ContextProviderWithDefaults>
           )
         ).toMatchSnapshot();
       }
@@ -157,7 +157,7 @@ export default makeTest => {
       test: () => {
         expect(
           makeTest(
-            <Context.Provider
+            <ContextProviderWithDefaults
               value={{
                 theme: { imageCaptionAlignment: { secondary: "center" } }
               }}
@@ -166,7 +166,7 @@ export default makeTest => {
                 captionOptions={secondaryImage.captionOptions}
                 imageOptions={secondaryImage.imageOptions}
               />
-            </Context.Provider>
+            </ContextProviderWithDefaults>
           )
         ).toMatchSnapshot();
       }

--- a/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
@@ -504,7 +504,17 @@ exports[`8. primary image with caption and credits with center caption override 
   }
 }
 
-Array [
+<ContextProviderWithDefaults
+  value={
+    Object {
+      "theme": Object {
+        "imageCaptionAlignment": Object {
+          "primary": "center",
+        },
+      },
+    }
+  }
+>
   <div>
     <TimesImage
       aspectRatio={1.25}
@@ -520,7 +530,7 @@ Array [
       onImagePress={null}
       uri="https://img/someImage"
     />
-  </div>,
+  </div>
   <div>
     <InsetCenteredCaption
       credits="Some credits"
@@ -548,8 +558,8 @@ Array [
         </div>
       </responsiveweb__InsetCaptionStyle>
     </InsetCenteredCaption>
-  </div>,
-]
+  </div>
+</ContextProviderWithDefaults>
 `;
 
 exports[`9. secondary image with caption and credits with center caption override 1`] = `
@@ -563,7 +573,17 @@ exports[`9. secondary image with caption and credits with center caption overrid
   z-index: 2;
 }
 
-Array [
+<ContextProviderWithDefaults
+  value={
+    Object {
+      "theme": Object {
+        "imageCaptionAlignment": Object {
+          "secondary": "center",
+        },
+      },
+    }
+  }
+>
   <div>
     <TimesImage
       aspectRatio={1.5}
@@ -579,7 +599,7 @@ Array [
       onImagePress={null}
       uri="https://img/someImage"
     />
-  </div>,
+  </div>
   <div>
     <CentredCaption
       credits="Other credits"
@@ -596,6 +616,6 @@ Array [
         </div>
       </div>
     </CentredCaption>
-  </div>,
-]
+  </div>
+</ContextProviderWithDefaults>
 `;

--- a/packages/article-in-depth/__tests__/shared-internal-components.base.js
+++ b/packages/article-in-depth/__tests__/shared-internal-components.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { iterator } from "@times-components/test-utils";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import Label from "../src/article-label/article-label";
 import Meta from "../src/article-meta/article-meta";
 import Standfirst from "../src/article-standfirst/article-standfirst";
@@ -56,7 +56,7 @@ const snapshotTests = renderComponent => [
     name: "article meta uses default section colour",
     test() {
       const output = renderComponent(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
             theme: { sectionColour: null }
           }}
@@ -67,7 +67,7 @@ const snapshotTests = renderComponent => [
             publicationName="TIMES"
             publishedTime="2015-03-23T19:39:39.000Z"
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();

--- a/packages/article-in-depth/__tests__/shared-with-style.native.js
+++ b/packages/article-in-depth/__tests__/shared-with-style.native.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -151,9 +151,9 @@ export default () => {
 
   it("full article with style in the culture magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -161,9 +161,9 @@ export default () => {
 
   it("full article with style in the style magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -171,9 +171,11 @@ export default () => {
 
   it("full article with style in the sunday times magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -182,9 +184,9 @@ export default () => {
   it("tablet full article with style in the culture magazine", () => {
     setIsTablet(true);
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -193,9 +195,9 @@ export default () => {
   it("tablet full article with style in the style magazine", () => {
     setIsTablet(true);
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -204,9 +206,11 @@ export default () => {
   it("tablet full article with style in the sunday times magazine", () => {
     setIsTablet(true);
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-in-depth/__tests__/shared-with-style.web.js
+++ b/packages/article-in-depth/__tests__/shared-with-style.web.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { AppRegistry } from "react-native-web";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -175,9 +175,9 @@ export default () => {
 
   it("full article with style in the culture magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -185,9 +185,9 @@ export default () => {
 
   it("full article with style in the style magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -195,9 +195,11 @@ export default () => {
 
   it("full article with style in the sunday times magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-in-depth/__tests__/web/semantic.web.test.js
+++ b/packages/article-in-depth/__tests__/web/semantic.web.test.js
@@ -11,7 +11,7 @@ import {
   replacePropTransform,
   replaceTransform
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import Article from "../../src/article-in-depth";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
@@ -126,9 +126,8 @@ const tests = [
       const scale = scales.large;
       const sectionColour = "#FFFFFF";
       const testRenderer = TestRenderer.create(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl: () => "https://some-url.io",
             theme: { scale, sectionColour }
           }}
         >
@@ -145,7 +144,7 @@ const tests = [
             onVideoPress={() => {}}
             receiveChildList={() => {}}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(testRenderer).toMatchSnapshot();

--- a/packages/article-in-depth/article-in-depth.showcase.js
+++ b/packages/article-in-depth/article-in-depth.showcase.js
@@ -1,7 +1,10 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context, { defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
 import {
   article as makeParams,
@@ -12,11 +15,6 @@ import { sections } from "@times-components/storybook";
 import { scales, themeFactory } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
 import ArticleInDepth from "./src/article-in-depth";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -53,9 +51,8 @@ const renderArticle = ({
       };
 
       return (
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl,
             theme: {
               ...themeFactory(section, templateName),
               scale: scale || defaults.theme.scale
@@ -95,7 +92,7 @@ const renderArticle = ({
             )}
             refetch={refetch}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
     }}
   </ArticleProvider>

--- a/packages/article-list/.jestlint
+++ b/packages/article-list/.jestlint
@@ -1,5 +1,5 @@
 {
-  "maxAttributeStringLength": 38,
+  "maxAttributeStringLength": 70,
   "maxAttributes": 7,
   "maxFileSize": 19320,
   "maxLines": 823

--- a/packages/article-list/__tests__/shared-error.base.web.js
+++ b/packages/article-list/__tests__/shared-error.base.web.js
@@ -1,16 +1,10 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
 import { iterator } from "@times-components/test-utils";
 import ArticleListPageError from "../src/article-list-page-error";
 import ArticleList from "../src/article-list";
 import articlesFixture from "../fixtures/articles.json";
 import adConfig from "../fixtures/article-ad-config.json";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 jest.mock("@times-components/button", () => "Button");
 jest.mock("../src/article-list-item", () => ({ article }) => {
@@ -46,15 +40,13 @@ export default () => {
       name: "article list",
       test() {
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture.slice(0, 2)}
-              emptyStateMessage="Empty state"
-              pageSize={1}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture.slice(0, 2)}
+            emptyStateMessage="Empty state"
+            pageSize={1}
+            refetch={() => {}}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();

--- a/packages/article-list/__tests__/shared-pagination.web.js
+++ b/packages/article-list/__tests__/shared-pagination.web.js
@@ -9,16 +9,10 @@ import {
   minimalWebTransform,
   print
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
 import ArticleList from "../src/article-list";
 import articlesFixture from "../fixtures/articles.json";
 import adConfig from "../fixtures/article-ad-config.json";
 import { omitWeb as omitProps } from "./utils";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 export default () => {
   addSerializers(
@@ -38,18 +32,16 @@ export default () => {
       test() {
         const onNext = jest.fn();
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture}
-              count={5}
-              emptyStateMessage="Empty state"
-              onNext={onNext}
-              page={1}
-              pageSize={3}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture}
+            count={5}
+            emptyStateMessage="Empty state"
+            onNext={onNext}
+            page={1}
+            pageSize={3}
+            refetch={() => {}}
+          />
         );
 
         const [nextPage] = testInstance.root.findAll(
@@ -66,18 +58,16 @@ export default () => {
       test() {
         const onPrev = jest.fn();
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture}
-              count={5}
-              emptyStateMessage="Empty state"
-              onPrev={onPrev}
-              page={2}
-              pageSize={3}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture}
+            count={5}
+            emptyStateMessage="Empty state"
+            onPrev={onPrev}
+            page={2}
+            pageSize={3}
+            refetch={() => {}}
+          />
         );
 
         const [prevPage] = testInstance.root.findAll(
@@ -96,18 +86,16 @@ export default () => {
         const onNext = jest.fn();
         const consoleSpy = jest.spyOn(console, "error").mockImplementation();
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture}
-              count={5}
-              emptyStateMessage="Empty state"
-              onNext={onNext}
-              page={1}
-              pageSize={3}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture}
+            count={5}
+            emptyStateMessage="Empty state"
+            onNext={onNext}
+            page={1}
+            pageSize={3}
+            refetch={() => {}}
+          />
         );
 
         const [, nextPage] = testInstance.root.findAll(
@@ -174,18 +162,16 @@ export default () => {
         const onPrev = jest.fn();
         const consoleSpy = jest.spyOn(console, "error").mockImplementation();
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture}
-              count={5}
-              emptyStateMessage="Empty state"
-              onPrev={onPrev}
-              page={2}
-              pageSize={3}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture}
+            count={5}
+            emptyStateMessage="Empty state"
+            onPrev={onPrev}
+            page={2}
+            pageSize={3}
+            refetch={() => {}}
+          />
         );
 
         const [, prevPage] = testInstance.root.findAll(

--- a/packages/article-list/__tests__/shared-states.web.js
+++ b/packages/article-list/__tests__/shared-states.web.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { Text } from "react-native";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
 import { iterator } from "@times-components/test-utils";
 import {
   addSerializers,
@@ -23,11 +22,6 @@ const omitProps = new Set([
   "labelProps"
 ]);
 
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
-
 export default () => {
   addSerializers(
     expect,
@@ -46,14 +40,12 @@ export default () => {
       test() {
         const apolloError = new ApolloError("Test");
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              emptyStateMessage="Empty State"
-              error={apolloError}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            emptyStateMessage="Empty State"
+            error={apolloError}
+            refetch={() => {}}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -64,15 +56,13 @@ export default () => {
       test() {
         const apolloError = new ApolloError("Test");
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articleListHeader={<Text>Some Header</Text>}
-              emptyStateMessage="Empty State"
-              error={apolloError}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articleListHeader={<Text>Some Header</Text>}
+            emptyStateMessage="Empty State"
+            error={apolloError}
+            refetch={() => {}}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -82,14 +72,12 @@ export default () => {
       name: "an empty list",
       test() {
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={[]}
-              emptyStateMessage="Empty state"
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={[]}
+            emptyStateMessage="Empty state"
+            refetch={() => {}}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -99,15 +87,13 @@ export default () => {
       name: "loading state",
       test() {
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articlesLoading
-              emptyStateMessage="Empty state"
-              pageSize={3}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articlesLoading
+            emptyStateMessage="Empty state"
+            pageSize={3}
+            refetch={() => {}}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();

--- a/packages/article-list/__tests__/shared-tracking.web.js
+++ b/packages/article-list/__tests__/shared-tracking.web.js
@@ -1,16 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
 import { iterator } from "@times-components/test-utils";
 import ArticleList from "../src/article-list";
 import articlesFixture from "../fixtures/articles.json";
 import adConfig from "../fixtures/article-ad-config.json";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 export default () => {
   jest.useFakeTimers();
@@ -32,15 +26,13 @@ export default () => {
 
           render() {
             return (
-              <Context.Provider value={{ makeArticleUrl }}>
-                <ArticleList
-                  adConfig={adConfig}
-                  articles={articlesFixture}
-                  emptyStateMessage="Empty state"
-                  pageSize={3}
-                  refetch={() => {}}
-                />
-              </Context.Provider>
+              <ArticleList
+                adConfig={adConfig}
+                articles={articlesFixture}
+                emptyStateMessage="Empty state"
+                pageSize={3}
+                refetch={() => {}}
+              />
             );
           }
         }

--- a/packages/article-list/__tests__/shared.base.web.js
+++ b/packages/article-list/__tests__/shared.base.web.js
@@ -1,12 +1,9 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
 import { iterator } from "@times-components/test-utils";
 import ArticleList from "../src/article-list";
 import articlesFixture from "../fixtures/articles.json";
 import adConfig from "../fixtures/article-ad-config.json";
-
-const makeArticleUrl = () => "https://test.io";
 
 export default (additionalTests = []) => {
   const realIntl = Intl;
@@ -29,14 +26,12 @@ export default (additionalTests = []) => {
       name: "article list",
       test() {
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture}
-              emptyStateMessage="Empty state"
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture}
+            emptyStateMessage="Empty state"
+            refetch={() => {}}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();

--- a/packages/article-list/__tests__/shared.web.js
+++ b/packages/article-list/__tests__/shared.web.js
@@ -6,7 +6,6 @@ import {
   minimalWebTransform,
   print
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
 import TestRenderer from "react-test-renderer";
 import "./mocks";
 import { omitWeb as omitProps } from "./utils";
@@ -14,8 +13,6 @@ import articlesFixture from "../fixtures/articles.json";
 import adConfig from "../fixtures/article-ad-config.json";
 import ArticleList from "../src/article-list";
 import shared from "./shared.base.web";
-
-const makeArticleUrl = () => "https://test.io";
 
 export default () => {
   addSerializers(
@@ -34,16 +31,14 @@ export default () => {
       name: "article list with no images",
       test() {
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture.slice(0, 1)}
-              emptyStateMessage="Empty state"
-              pageSize={3}
-              refetch={() => {}}
-              showImages={false}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture.slice(0, 1)}
+            emptyStateMessage="Empty state"
+            pageSize={3}
+            refetch={() => {}}
+            showImages={false}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -62,16 +57,14 @@ export default () => {
         };
 
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={[missingImage]}
-              emptyStateMessage="Empty state"
-              pageSize={3}
-              refetch={() => {}}
-              showImages={false}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={[missingImage]}
+            emptyStateMessage="Empty state"
+            pageSize={3}
+            refetch={() => {}}
+            showImages={false}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();

--- a/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. article list 1`] = `
     >
       <div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-1-968n7tdck1"
         >
           <div>
             <Card
@@ -65,7 +65,7 @@ exports[`1. article list 1`] = `
           <div />
         </div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-2-968n7tdck2"
         >
           <div>
             <Card
@@ -132,7 +132,7 @@ exports[`1. article list 1`] = `
           <div />
         </div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-3-968n7tdck3"
         >
           <div>
             <Card
@@ -199,7 +199,7 @@ exports[`1. article list 1`] = `
           <div />
         </div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-4-968n7tdck4"
         >
           <div>
             <Card
@@ -266,7 +266,7 @@ exports[`1. article list 1`] = `
           <div />
         </div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-5-968n7tdck5"
         >
           <div>
             <Card
@@ -362,7 +362,7 @@ exports[`2. article list with no images 1`] = `
     >
       <div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-1-968n7tdck1"
         >
           <div>
             <Card
@@ -452,7 +452,7 @@ exports[`3. article list with missing image 1`] = `
     >
       <div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-1-968n7tdck1"
         >
           <div>
             <Card

--- a/packages/article-list/__tests__/web/article-list-lazy.web.test.js
+++ b/packages/article-list/__tests__/web/article-list-lazy.web.test.js
@@ -7,7 +7,7 @@ import {
   enzymeRenderedSerializer,
   minimalise
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
+import { defaults } from "@times-components/context";
 import articleListFixture from "../../fixtures/articles.json";
 import adConfig from "../../fixtures/article-ad-config.json";
 import ArticleList from "../../src/article-list";
@@ -15,11 +15,6 @@ import ArticleList from "../../src/article-list";
 const delay = ms => new Promise(res => setTimeout(res, ms));
 
 const omitProps = new Set(["class", "className", "style"]);
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 addSerializers(
   expect,
@@ -88,11 +83,7 @@ const tests = [
     async test() {
       window.IntersectionObserver = FakeIntersectionObserver;
 
-      const component = mount(
-        <Context.Provider value={{ makeArticleUrl }}>
-          <ArticleList {...articleListProps} />
-        </Context.Provider>
-      );
+      const component = mount(<ArticleList {...articleListProps} />);
       // prove the first image starts off as low quality
       expect(
         component
@@ -140,11 +131,7 @@ const tests = [
     async test() {
       window.IntersectionObserver = FakeIntersectionObserver;
 
-      const component = mount(
-        <Context.Provider value={{ makeArticleUrl }}>
-          <ArticleList {...articleListProps} />
-        </Context.Provider>
-      );
+      const component = mount(<ArticleList {...articleListProps} />);
 
       const makeEntries = nodes =>
         [...nodes].map((node, indx) => ({
@@ -185,7 +172,7 @@ const tests = [
           attachTo: mountPoint,
           childContextTypes: { makeArticleUrl: PropTypes.func },
           context: {
-            makeArticleUrl,
+            makeArticleUrl: defaults.makeArticleUrl,
             tracking: {
               analytics: reporter
             }

--- a/packages/article-list/article-list.showcase.js
+++ b/packages/article-list/article-list.showcase.js
@@ -7,7 +7,6 @@ import {
   MockedProvider,
   MockFixture
 } from "@times-components/provider-test-tools";
-import Context from "@times-components/context";
 import {
   authorArticlesNoImages as authorArticlesNoImagesQuery,
   authorArticlesWithImages as authorArticlesWithImagesQuery
@@ -20,11 +19,6 @@ import get from "lodash.get";
 import ArticleList, { ArticleListPageError } from "./src/article-list";
 import adConfig from "./fixtures/article-ad-config.json";
 import { ratioTextToFloat } from "../utils/dist";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -76,36 +70,34 @@ export default {
           })}
           render={mocks => (
             <MockedProvider mocks={mocks}>
-              <Context.Provider value={{ makeArticleUrl }}>
-                <AuthorArticlesWithImagesProvider
-                  debounceTimeMs={0}
-                  page={page}
-                  pageSize={pageSize}
-                  slug={slug}
-                >
-                  {({
-                    author: data,
-                    error: articlesError,
-                    isLoading: articlesLoading,
-                    page: articlePage,
-                    pageSize: articlePageSize,
-                    variables: { imageRatio = "3:2" }
-                  }) => (
-                    <TrackedArticleList
-                      articles={get(data, "articles.list", [])}
-                      articlesLoading={articlesLoading}
-                      count={count}
-                      emptyStateMessage={emptyStateMessage}
-                      error={articlesError}
-                      imageRatio={ratioTextToFloat(imageRatio)}
-                      page={articlePage}
-                      pageSize={articlePageSize}
-                      showImages
-                      {...getProps(decorateAction)}
-                    />
-                  )}
-                </AuthorArticlesWithImagesProvider>
-              </Context.Provider>
+              <AuthorArticlesWithImagesProvider
+                debounceTimeMs={0}
+                page={page}
+                pageSize={pageSize}
+                slug={slug}
+              >
+                {({
+                  author: data,
+                  error: articlesError,
+                  isLoading: articlesLoading,
+                  page: articlePage,
+                  pageSize: articlePageSize,
+                  variables: { imageRatio = "3:2" }
+                }) => (
+                  <TrackedArticleList
+                    articles={get(data, "articles.list", [])}
+                    articlesLoading={articlesLoading}
+                    count={count}
+                    emptyStateMessage={emptyStateMessage}
+                    error={articlesError}
+                    imageRatio={ratioTextToFloat(imageRatio)}
+                    page={articlePage}
+                    pageSize={articlePageSize}
+                    showImages
+                    {...getProps(decorateAction)}
+                  />
+                )}
+              </AuthorArticlesWithImagesProvider>
             </MockedProvider>
           )}
         />
@@ -132,34 +124,32 @@ export default {
           })}
           render={mocks => (
             <MockedProvider mocks={mocks}>
-              <Context.Provider value={{ makeArticleUrl }}>
-                <AuthorArticlesNoImagesProvider
-                  debounceTimeMs={0}
-                  page={page}
-                  pageSize={pageSize}
-                  slug={slug}
-                >
-                  {({
-                    author: data,
-                    error: articlesError,
-                    isLoading: articlesLoading,
-                    page: articlePage,
-                    pageSize: articlePageSize
-                  }) => (
-                    <TrackedArticleList
-                      articles={get(data, "articles.list", [])}
-                      articlesLoading={articlesLoading}
-                      count={count}
-                      emptyStateMessage={emptyStateMessage}
-                      error={articlesError}
-                      page={articlePage}
-                      pageSize={articlePageSize}
-                      showImages={false}
-                      {...getProps(decorateAction)}
-                    />
-                  )}
-                </AuthorArticlesNoImagesProvider>
-              </Context.Provider>
+              <AuthorArticlesNoImagesProvider
+                debounceTimeMs={0}
+                page={page}
+                pageSize={pageSize}
+                slug={slug}
+              >
+                {({
+                  author: data,
+                  error: articlesError,
+                  isLoading: articlesLoading,
+                  page: articlePage,
+                  pageSize: articlePageSize
+                }) => (
+                  <TrackedArticleList
+                    articles={get(data, "articles.list", [])}
+                    articlesLoading={articlesLoading}
+                    count={count}
+                    emptyStateMessage={emptyStateMessage}
+                    error={articlesError}
+                    page={articlePage}
+                    pageSize={articlePageSize}
+                    showImages={false}
+                    {...getProps(decorateAction)}
+                  />
+                )}
+              </AuthorArticlesNoImagesProvider>
             </MockedProvider>
           )}
         />
@@ -195,36 +185,34 @@ export default {
           })}
           render={mocks => (
             <MockedProvider mocks={mocks}>
-              <Context.Provider value={{ makeArticleUrl }}>
-                <AuthorArticlesWithImagesProvider
-                  debounceTimeMs={0}
-                  page={page}
-                  pageSize={pageSize}
-                  slug={slug}
-                >
-                  {({
-                    author: data,
-                    error: articlesError,
-                    isLoading: articlesLoading,
-                    page: articlePage,
-                    pageSize: articlePageSize,
-                    variables: { imageRatio = "3:2" }
-                  }) => (
-                    <TrackedArticleList
-                      articles={get(data, "articles.list", [])}
-                      articlesLoading={articlesLoading}
-                      count={count}
-                      emptyStateMessage={emptyStateMessage}
-                      error={articlesError}
-                      imageRatio={ratioTextToFloat(imageRatio)}
-                      page={articlePage}
-                      pageSize={articlePageSize}
-                      showImages
-                      {...getProps(decorateAction)}
-                    />
-                  )}
-                </AuthorArticlesWithImagesProvider>
-              </Context.Provider>
+              <AuthorArticlesWithImagesProvider
+                debounceTimeMs={0}
+                page={page}
+                pageSize={pageSize}
+                slug={slug}
+              >
+                {({
+                  author: data,
+                  error: articlesError,
+                  isLoading: articlesLoading,
+                  page: articlePage,
+                  pageSize: articlePageSize,
+                  variables: { imageRatio = "3:2" }
+                }) => (
+                  <TrackedArticleList
+                    articles={get(data, "articles.list", [])}
+                    articlesLoading={articlesLoading}
+                    count={count}
+                    emptyStateMessage={emptyStateMessage}
+                    error={articlesError}
+                    imageRatio={ratioTextToFloat(imageRatio)}
+                    page={articlePage}
+                    pageSize={articlePageSize}
+                    showImages
+                    {...getProps(decorateAction)}
+                  />
+                )}
+              </AuthorArticlesWithImagesProvider>
             </MockedProvider>
           )}
         />
@@ -264,37 +252,35 @@ export default {
             })}
             render={mocks => (
               <MockedProvider mocks={mocks}>
-                <Context.Provider value={{ makeArticleUrl }}>
-                  <AuthorArticlesWithImagesProvider
-                    debounceTimeMs={0}
-                    page={page}
-                    pageSize={pageSize}
-                    slug={slug}
-                  >
-                    {({
-                      author: data,
-                      error: articlesError,
-                      isLoading: articlesLoading,
-                      page: articlePage,
-                      pageSize: articlePageSize,
-                      variables: { imageRatio = "3:2" }
-                    }) => (
-                      <TrackedArticleList
-                        articleListHeader={articleListHeader}
-                        articles={get(data, "articles.list", [])}
-                        articlesLoading={articlesLoading}
-                        count={count}
-                        emptyStateMessage={emptyStateMessage}
-                        error={articlesError}
-                        imageRatio={ratioTextToFloat(imageRatio)}
-                        page={articlePage}
-                        pageSize={articlePageSize}
-                        showImages
-                        {...getProps(decorateAction)}
-                      />
-                    )}
-                  </AuthorArticlesWithImagesProvider>
-                </Context.Provider>
+                <AuthorArticlesWithImagesProvider
+                  debounceTimeMs={0}
+                  page={page}
+                  pageSize={pageSize}
+                  slug={slug}
+                >
+                  {({
+                    author: data,
+                    error: articlesError,
+                    isLoading: articlesLoading,
+                    page: articlePage,
+                    pageSize: articlePageSize,
+                    variables: { imageRatio = "3:2" }
+                  }) => (
+                    <TrackedArticleList
+                      articleListHeader={articleListHeader}
+                      articles={get(data, "articles.list", [])}
+                      articlesLoading={articlesLoading}
+                      count={count}
+                      emptyStateMessage={emptyStateMessage}
+                      error={articlesError}
+                      imageRatio={ratioTextToFloat(imageRatio)}
+                      page={articlePage}
+                      pageSize={articlePageSize}
+                      showImages
+                      {...getProps(decorateAction)}
+                    />
+                  )}
+                </AuthorArticlesWithImagesProvider>
               </MockedProvider>
             )}
           />
@@ -337,36 +323,34 @@ export default {
           })}
           render={mocks => (
             <MockedProvider mocks={mocks}>
-              <Context.Provider value={{ makeArticleUrl }}>
-                <AuthorArticlesWithImagesProvider
-                  debounceTimeMs={0}
-                  page={page}
-                  pageSize={pageSize}
-                  slug={slug}
-                >
-                  {({
-                    author: data,
-                    error: articlesError,
-                    isLoading: articlesLoading,
-                    page: articlePage,
-                    pageSize: articlePageSize,
-                    variables: { imageRatio = "3:2" }
-                  }) => (
-                    <TrackedArticleList
-                      articles={get(data, "articles.list", [])}
-                      articlesLoading={articlesLoading}
-                      count={count}
-                      emptyStateMessage={emptyStateMessage}
-                      error={articlesError}
-                      imageRatio={ratioTextToFloat(imageRatio)}
-                      page={articlePage}
-                      pageSize={articlePageSize}
-                      showImages
-                      {...getProps(decorateAction)}
-                    />
-                  )}
-                </AuthorArticlesWithImagesProvider>
-              </Context.Provider>
+              <AuthorArticlesWithImagesProvider
+                debounceTimeMs={0}
+                page={page}
+                pageSize={pageSize}
+                slug={slug}
+              >
+                {({
+                  author: data,
+                  error: articlesError,
+                  isLoading: articlesLoading,
+                  page: articlePage,
+                  pageSize: articlePageSize,
+                  variables: { imageRatio = "3:2" }
+                }) => (
+                  <TrackedArticleList
+                    articles={get(data, "articles.list", [])}
+                    articlesLoading={articlesLoading}
+                    count={count}
+                    emptyStateMessage={emptyStateMessage}
+                    error={articlesError}
+                    imageRatio={ratioTextToFloat(imageRatio)}
+                    page={articlePage}
+                    pageSize={articlePageSize}
+                    showImages
+                    {...getProps(decorateAction)}
+                  />
+                )}
+              </AuthorArticlesWithImagesProvider>
             </MockedProvider>
           )}
         />
@@ -391,36 +375,34 @@ export default {
           })}
           render={mocks => (
             <MockedProvider mocks={mocks}>
-              <Context.Provider value={{ makeArticleUrl }}>
-                <AuthorArticlesWithImagesProvider
-                  debounceTimeMs={0}
-                  page={page}
-                  pageSize={pageSize}
-                  slug={slug}
-                >
-                  {({
-                    author: data,
-                    error: articlesError,
-                    isLoading: articlesLoading,
-                    page: articlePage,
-                    pageSize: articlePageSize,
-                    variables: { imageRatio = "3:2" }
-                  }) => (
-                    <TrackedArticleList
-                      articles={get(data, "articles.list", [])}
-                      articlesLoading={articlesLoading}
-                      count={count}
-                      emptyStateMessage={emptyStateMessage}
-                      error={articlesError}
-                      imageRatio={ratioTextToFloat(imageRatio)}
-                      page={articlePage}
-                      pageSize={articlePageSize}
-                      showImages
-                      {...getProps(decorateAction)}
-                    />
-                  )}
-                </AuthorArticlesWithImagesProvider>
-              </Context.Provider>
+              <AuthorArticlesWithImagesProvider
+                debounceTimeMs={0}
+                page={page}
+                pageSize={pageSize}
+                slug={slug}
+              >
+                {({
+                  author: data,
+                  error: articlesError,
+                  isLoading: articlesLoading,
+                  page: articlePage,
+                  pageSize: articlePageSize,
+                  variables: { imageRatio = "3:2" }
+                }) => (
+                  <TrackedArticleList
+                    articles={get(data, "articles.list", [])}
+                    articlesLoading={articlesLoading}
+                    count={count}
+                    emptyStateMessage={emptyStateMessage}
+                    error={articlesError}
+                    imageRatio={ratioTextToFloat(imageRatio)}
+                    page={articlePage}
+                    pageSize={articlePageSize}
+                    showImages
+                    {...getProps(decorateAction)}
+                  />
+                )}
+              </AuthorArticlesWithImagesProvider>
             </MockedProvider>
           )}
         />

--- a/packages/article-magazine-comment/__tests__/shared-internal-components.base.js
+++ b/packages/article-magazine-comment/__tests__/shared-internal-components.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { iterator } from "@times-components/test-utils";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import Label from "../src/article-label/article-label";
 import Meta from "../src/article-meta/article-meta";
 import Standfirst from "../src/article-standfirst/article-standfirst";
@@ -30,13 +30,13 @@ const snapshotTests = renderComponent => [
     name: "article label uses default section colour",
     test() {
       const output = renderComponent(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
             theme: { sectionColour: null }
           }}
         >
           <Label label="Random Label" />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();

--- a/packages/article-magazine-comment/__tests__/shared-with-style.native.js
+++ b/packages/article-magazine-comment/__tests__/shared-with-style.native.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -154,9 +154,9 @@ export default () => {
 
   it("full article with style in the culture magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -164,9 +164,9 @@ export default () => {
 
   it("full article with style in the style magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -174,9 +174,11 @@ export default () => {
 
   it("full article with style in the sunday times magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -185,9 +187,9 @@ export default () => {
   it("tablet full article with style in the culture magazine", () => {
     setIsTablet(true);
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -196,9 +198,9 @@ export default () => {
   it("tablet full article with style in the style magazine", () => {
     setIsTablet(true);
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -207,9 +209,11 @@ export default () => {
   it("tablet full article with style in the sunday times magazine", () => {
     setIsTablet(true);
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-magazine-comment/__tests__/shared-with-style.web.js
+++ b/packages/article-magazine-comment/__tests__/shared-with-style.web.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { AppRegistry } from "react-native-web";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -176,9 +176,9 @@ export default () => {
 
   it("full article with style in the culture magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -186,9 +186,9 @@ export default () => {
 
   it("full article with style in the style magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -196,9 +196,11 @@ export default () => {
 
   it("full article with style in the sunday times magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-magazine-comment/__tests__/web/semantic.web.test.js
+++ b/packages/article-magazine-comment/__tests__/web/semantic.web.test.js
@@ -11,7 +11,7 @@ import {
   replacePropTransform,
   replaceTransform
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import Article from "../../src/article-magazine-comment";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
@@ -126,9 +126,8 @@ const tests = [
       const scale = scales.large;
       const sectionColour = "#FFFFFF";
       const testRenderer = TestRenderer.create(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl: () => "https://some-url.io",
             theme: { scale, sectionColour }
           }}
         >
@@ -146,7 +145,7 @@ const tests = [
             receiveChildList={() => {}}
             spotAccountId=""
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(testRenderer).toMatchSnapshot();

--- a/packages/article-magazine-comment/article-magazine-comment.showcase.js
+++ b/packages/article-magazine-comment/article-magazine-comment.showcase.js
@@ -1,7 +1,10 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context, { defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
 import {
   article as makeParams,
@@ -12,11 +15,6 @@ import { sections } from "@times-components/storybook";
 import { scales, themeFactory } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
 import ArticleMagazineComment from "./src/article-magazine-comment";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -45,9 +43,8 @@ const renderArticle = ({
       };
 
       return (
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl,
             theme: {
               ...themeFactory(section, templateName),
               scale: scale || defaults.theme.scale
@@ -87,7 +84,7 @@ const renderArticle = ({
             )}
             refetch={refetch}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
     }}
   </ArticleProvider>

--- a/packages/article-magazine-standard/__tests__/shared-internal-components.base.js
+++ b/packages/article-magazine-standard/__tests__/shared-internal-components.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { iterator } from "@times-components/test-utils";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import Label from "../src/article-label/article-label";
 import Meta from "../src/article-meta/article-meta";
 import Standfirst from "../src/article-standfirst/article-standfirst";
@@ -30,13 +30,13 @@ const snapshotTests = renderComponent => [
     name: "article label uses default section colour",
     test() {
       const output = renderComponent(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
             theme: { sectionColour: null }
           }}
         >
           <Label label="Random Label" />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();
@@ -62,7 +62,7 @@ const snapshotTests = renderComponent => [
     name: "article meta uses default section colour",
     test() {
       const output = renderComponent(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
             theme: { sectionColour: null }
           }}
@@ -73,7 +73,7 @@ const snapshotTests = renderComponent => [
             publicationName="TIMES"
             publishedTime="2015-03-23T19:39:39.000Z"
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();

--- a/packages/article-magazine-standard/__tests__/shared-with-style.native.js
+++ b/packages/article-magazine-standard/__tests__/shared-with-style.native.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -159,9 +159,9 @@ export default () => {
 
   it("full article with style in the culture magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleMagazineStandard {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -169,9 +169,9 @@ export default () => {
 
   it("full article with style in the style magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleMagazineStandard {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -179,9 +179,11 @@ export default () => {
 
   it("full article with style in the sunday times magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleMagazineStandard {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-magazine-standard/__tests__/shared-with-style.web.js
+++ b/packages/article-magazine-standard/__tests__/shared-with-style.web.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { AppRegistry } from "react-native-web";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -175,9 +175,9 @@ export default () => {
 
   it("full article with style in the culture magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleMagazineStandard {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -185,9 +185,9 @@ export default () => {
 
   it("full article with style in the style magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleMagazineStandard {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -195,9 +195,11 @@ export default () => {
 
   it("full article with style in the sunday times magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleMagazineStandard {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-magazine-standard/__tests__/web/semantic.web.test.js
+++ b/packages/article-magazine-standard/__tests__/web/semantic.web.test.js
@@ -11,7 +11,7 @@ import {
   replacePropTransform,
   replaceTransform
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import Article from "../../src/article-magazine-standard";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
@@ -126,9 +126,8 @@ const tests = [
       const scale = scales.large;
       const sectionColour = "#FFFFFF";
       const testRenderer = TestRenderer.create(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl: () => "https://some-url.io",
             theme: { scale, sectionColour }
           }}
         >
@@ -146,7 +145,7 @@ const tests = [
             receiveChildList={() => {}}
             spotAccountId=""
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(testRenderer).toMatchSnapshot();

--- a/packages/article-magazine-standard/article-magazine-standard.showcase.js
+++ b/packages/article-magazine-standard/article-magazine-standard.showcase.js
@@ -1,7 +1,10 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context, { defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
 import {
   article as makeParams,
@@ -12,11 +15,6 @@ import { sections } from "@times-components/storybook";
 import { scales, themeFactory } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
 import ArticleMagazineStandard from "./src/article-magazine-standard";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -44,9 +42,8 @@ const renderArticle = ({
       };
 
       return (
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl,
             theme: {
               ...themeFactory(section, templateName),
               scale: scale || defaults.theme.scale
@@ -86,7 +83,7 @@ const renderArticle = ({
             )}
             refetch={refetch}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
     }}
   </ArticleProvider>

--- a/packages/article-main-comment/__tests__/shared-internal-components.base.js
+++ b/packages/article-main-comment/__tests__/shared-internal-components.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { iterator } from "@times-components/test-utils";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import Label from "../src/article-label/article-label";
 import Meta from "../src/article-meta/article-meta";
 import Standfirst from "../src/article-standfirst/article-standfirst";
@@ -30,13 +30,13 @@ const snapshotTests = renderComponent => [
     name: "article label uses default section colour",
     test() {
       const output = renderComponent(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
             theme: { sectionColour: null }
           }}
         >
           <Label label="Random Label" />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();

--- a/packages/article-main-comment/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-comment/__tests__/web/semantic.web.test.js
@@ -11,7 +11,7 @@ import {
   replacePropTransform,
   replaceTransform
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import Article from "../../src/article-main-comment";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
@@ -126,9 +126,8 @@ const tests = [
       const scale = scales.large;
       const sectionColour = "#FFFFFF";
       const testRenderer = TestRenderer.create(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl: () => "https://some-url.io",
             theme: { scale, sectionColour }
           }}
         >
@@ -146,7 +145,7 @@ const tests = [
             receiveChildList={() => {}}
             spotAccountId=""
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(testRenderer).toMatchSnapshot();

--- a/packages/article-main-comment/article-main-comment.showcase.js
+++ b/packages/article-main-comment/article-main-comment.showcase.js
@@ -1,7 +1,10 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context, { defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
 import Responsive from "@times-components/responsive";
 import {
@@ -13,11 +16,6 @@ import { sections } from "@times-components/storybook";
 import { scales, themeFactory } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
 import ArticleMainCommment from "./src/article-main-comment";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -47,9 +45,8 @@ const renderArticle = ({
         };
 
         return (
-          <Context.Provider
+          <ContextProviderWithDefaults
             value={{
-              makeArticleUrl,
               theme: {
                 ...themeFactory(section, templateName),
                 scale: scale || defaults.theme.scale
@@ -91,7 +88,7 @@ const renderArticle = ({
               )}
               refetch={refetch}
             />
-          </Context.Provider>
+          </ContextProviderWithDefaults>
         );
       }}
     </ArticleProvider>

--- a/packages/article-main-standard/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-standard/__tests__/web/semantic.web.test.js
@@ -11,7 +11,7 @@ import {
   replacePropTransform,
   replaceTransform
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import Article from "../../src/article-main-standard";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
@@ -126,9 +126,8 @@ const tests = [
       const scale = scales.large;
       const sectionColour = "#FFFFFF";
       const testInstance = TestRenderer.create(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl: () => "https://some-url.io",
             theme: { scale, sectionColour }
           }}
         >
@@ -145,7 +144,7 @@ const tests = [
             onVideoPress={() => {}}
             spotAccountId=""
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(testInstance).toMatchSnapshot();

--- a/packages/article-main-standard/article-main-standard.showcase.js
+++ b/packages/article-main-standard/article-main-standard.showcase.js
@@ -1,7 +1,10 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context, { defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
 import {
   article as makeParams,
@@ -13,11 +16,6 @@ import { scales, themeFactory } from "@times-components/styleguide";
 import Responsive from "@times-components/responsive";
 import storybookReporter from "@times-components/tealium-utils";
 import Article from "./src/article-main-standard";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -40,9 +38,8 @@ const renderArticle = ({
   <Responsive>
     <ArticleProvider debounceTimeMs={0} id={id}>
       {({ article, isLoading, error, refetch }) => (
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl,
             theme: {
               ...themeFactory(section, templateName),
               scale: scale || defaults.theme.scale
@@ -82,7 +79,7 @@ const renderArticle = ({
             )}
             refetch={refetch}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       )}
     </ArticleProvider>
   </Responsive>

--- a/packages/article-paragraph/__tests__/renderer.js
+++ b/packages/article-paragraph/__tests__/renderer.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales, themeFactory } from "@times-components/styleguide";
 import coreRenderers from "@times-components/markup";
 import { renderTree } from "@times-components/markup-forest";
@@ -9,7 +9,7 @@ import ArticleParagraph from "../src";
 export default (ast, section = "default") => {
   const theme = themeFactory(section, "magazinestandard");
   return (
-    <Context.Provider
+    <ContextProviderWithDefaults
       value={{
         theme: {
           scale: scales.medium
@@ -33,6 +33,6 @@ export default (ast, section = "default") => {
           };
         }
       })}
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 };

--- a/packages/article-paragraph/__tests__/renderer.web.js
+++ b/packages/article-paragraph/__tests__/renderer.web.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales, themeFactory } from "@times-components/styleguide";
 import coreRenderers from "@times-components/markup";
 import { renderTree } from "@times-components/markup-forest";
@@ -9,7 +9,7 @@ import DropCapView from "../src/drop-cap";
 export default (ast, section = "default") => {
   const theme = themeFactory(section, "magazinestandard");
   return (
-    <Context.Provider
+    <ContextProviderWithDefaults
       value={{
         theme: {
           ...themeFactory(section, "mainstandard"),
@@ -38,6 +38,6 @@ export default (ast, section = "default") => {
           };
         }
       })}
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 };

--- a/packages/article-paragraph/article-paragraph.showcase.js
+++ b/packages/article-paragraph/article-paragraph.showcase.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import coreRenderers from "@times-components/markup";
 import { renderTree } from "@times-components/markup-forest";
 import { sections } from "@times-components/storybook";
@@ -16,7 +16,7 @@ const renderParagraphWithScale = (select, ast) => {
   const theme = themeFactory(section, "magazinestandard");
 
   return (
-    <Context.Provider value={{ theme: { scale } }}>
+    <ContextProviderWithDefaults value={{ theme: { scale } }}>
       {renderTree(ast, {
         ...coreRenderers,
         paragraph(key, attributes, children, indx, node) {
@@ -35,7 +35,7 @@ const renderParagraphWithScale = (select, ast) => {
           };
         }
       })}
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 };
 

--- a/packages/article-skeleton/__tests__/header-with-style.base.js
+++ b/packages/article-skeleton/__tests__/header-with-style.base.js
@@ -1,8 +1,8 @@
 /* eslint-disable react/no-multi-comp */
 import React from "react";
 import { Text, View } from "react-native";
-import { iterator, makeArticleUrl } from "@times-components/test-utils";
-import Context from "@times-components/context";
+import { iterator } from "@times-components/test-utils";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import ArticleSkeleton from "../src/article-skeleton";
 import articleFixture from "../fixtures/full-article";
@@ -20,9 +20,8 @@ const emptyArticle = {
 };
 
 const renderArticle = (data, header) => (
-  <Context.Provider
+  <ContextProviderWithDefaults
     value={{
-      makeArticleUrl,
       theme: { scale: scales.medium, sectionColour: "#FF0000" }
     }}
   >
@@ -40,7 +39,7 @@ const renderArticle = (data, header) => (
       onTwitterLinkPress={() => {}}
       onVideoPress={() => {}}
     />
-  </Context.Provider>
+  </ContextProviderWithDefaults>
 );
 
 export const snapshotTests = renderComponent => [

--- a/packages/article-skeleton/__tests__/scaling.base.js
+++ b/packages/article-skeleton/__tests__/scaling.base.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import ArticleSkeleton from "../src/article-skeleton";
 import articleFixture, { testFixture } from "../fixtures/full-article";
@@ -11,7 +11,9 @@ export default renderComponent => [
     name: "scaled medium full article",
     test: () => {
       const output = renderComponent(
-        <Context.Provider value={{ theme: { scale: scales.medium } }}>
+        <ContextProviderWithDefaults
+          value={{ theme: { scale: scales.medium } }}
+        >
           <ArticleSkeleton
             {...articleSkeletonProps}
             adConfig={adConfig}
@@ -28,7 +30,7 @@ export default renderComponent => [
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();
@@ -38,7 +40,7 @@ export default renderComponent => [
     name: "scaled large full article",
     test: () => {
       const output = renderComponent(
-        <Context.Provider value={{ theme: { scale: scales.large } }}>
+        <ContextProviderWithDefaults value={{ theme: { scale: scales.large } }}>
           <ArticleSkeleton
             {...articleSkeletonProps}
             adConfig={adConfig}
@@ -55,7 +57,7 @@ export default renderComponent => [
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();
@@ -65,7 +67,9 @@ export default renderComponent => [
     name: "scaled xlarge full article",
     test: () => {
       const output = renderComponent(
-        <Context.Provider value={{ theme: { scale: scales.xlarge } }}>
+        <ContextProviderWithDefaults
+          value={{ theme: { scale: scales.xlarge } }}
+        >
           <ArticleSkeleton
             {...articleSkeletonProps}
             adConfig={adConfig}
@@ -82,7 +86,7 @@ export default renderComponent => [
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();

--- a/packages/article-skeleton/__tests__/shared.base.js
+++ b/packages/article-skeleton/__tests__/shared.base.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-multi-comp */
 import React from "react";
-import { iterator, makeArticleUrl } from "@times-components/test-utils";
-import Context from "@times-components/context";
+import { iterator } from "@times-components/test-utils";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import ArticleSkeleton from "../src/article-skeleton";
 import contentWithNestedFirstParagraph from "../fixtures/bold-article-content";
@@ -9,9 +9,8 @@ import articleFixture, { testFixture } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";
 
 export const renderArticle = (data, header = null) => (
-  <Context.Provider
+  <ContextProviderWithDefaults
     value={{
-      makeArticleUrl,
       theme: { scale: scales.medium, sectionColour: "#FF0000" }
     }}
   >
@@ -30,7 +29,7 @@ export const renderArticle = (data, header = null) => (
       onVideoPress={() => {}}
       spotAccountId=""
     />
-  </Context.Provider>
+  </ContextProviderWithDefaults>
 );
 
 export const fixtureArgs = {

--- a/packages/article-skeleton/showcase-helper.js
+++ b/packages/article-skeleton/showcase-helper.js
@@ -3,16 +3,11 @@ import React from "react";
 import { Text, View } from "react-native";
 import invert from "lodash.invert";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { colours, scales } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
 import fullArticleFixture from "./fixtures/full-article";
 import ArticleSkeleton from "./src/article-skeleton";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const TestHeader = () => (
   <View
@@ -63,9 +58,7 @@ const renderArticleSkeleton = ({
   const showHeader = header ? () => <TestHeader /> : () => null;
 
   return (
-    <Context.Provider
-      value={{ makeArticleUrl, theme: { scale, sectionColour } }}
-    >
+    <ContextProviderWithDefaults value={{ theme: { scale, sectionColour } }}>
       <ArticleSkeleton
         adConfig={articleAdConfig}
         analyticsStream={storybookReporter}
@@ -89,7 +82,7 @@ const renderArticleSkeleton = ({
         onVideoPress={preventDefaultedAction(decorateAction)("onVideoPress")}
         onViewableItemsChanged={() => null}
       />
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 };
 

--- a/packages/article-topics/__tests__/shared-with-style.base.js
+++ b/packages/article-topics/__tests__/shared-with-style.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import { iterator } from "@times-components/test-utils";
 import ArticleTopics from "../src/article-topics";
@@ -13,9 +13,9 @@ export default () => {
       test: () => {
         const scale = scales.medium;
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ theme: { scale } }}>
+          <ContextProviderWithDefaults value={{ theme: { scale } }}>
             <ArticleTopics onPress={() => {}} topics={topicData.slice(0, 1)} />
-          </Context.Provider>
+          </ContextProviderWithDefaults>
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -26,9 +26,9 @@ export default () => {
       test: () => {
         const scale = scales.large;
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ theme: { scale } }}>
+          <ContextProviderWithDefaults value={{ theme: { scale } }}>
             <ArticleTopics onPress={() => {}} topics={topicData.slice(0, 1)} />
-          </Context.Provider>
+          </ContextProviderWithDefaults>
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -39,9 +39,9 @@ export default () => {
       test: () => {
         const scale = scales.xlarge;
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ theme: { scale } }}>
+          <ContextProviderWithDefaults value={{ theme: { scale } }}>
             <ArticleTopics onPress={() => {}} topics={topicData.slice(0, 1)} />
-          </Context.Provider>
+          </ContextProviderWithDefaults>
         );
 
         expect(testInstance).toMatchSnapshot();

--- a/packages/article-topics/article-topics.showcase.js
+++ b/packages/article-topics/article-topics.showcase.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import topicsData from "./fixtures/topics";
 import renderArticleTopics from "./showcase-helper";
@@ -11,9 +11,9 @@ export default {
       component: ({ select }, { decorateAction }) => {
         const scale = select("Scale", scales, scales.medium);
         return (
-          <Context.Provider value={{ theme: { scale } }}>
+          <ContextProviderWithDefaults value={{ theme: { scale } }}>
             {renderArticleTopics({ data: topicsData, decorateAction })}
-          </Context.Provider>
+          </ContextProviderWithDefaults>
         );
       },
       name: "Group of Topics",
@@ -24,9 +24,9 @@ export default {
       component: ({ select }, { decorateAction }) => {
         const scale = select("Scale", scales, scales.medium);
         return (
-          <Context.Provider value={{ theme: { scale } }}>
+          <ContextProviderWithDefaults value={{ theme: { scale } }}>
             {renderArticleTopics({ data: [topicsData[0]], decorateAction })}
-          </Context.Provider>
+          </ContextProviderWithDefaults>
         );
       },
       name: "Single Topic",

--- a/packages/article-topics/src/article-topic.js
+++ b/packages/article-topics/src/article-topic.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Context from "@times-components/context";
 import { Text, View } from "react-native";
 import Link from "@times-components/link";
 import { withTrackEvents } from "@times-components/tracking";
@@ -9,20 +10,27 @@ const ArticleTopic = ({ fontSize, lineHeight, name, onPress, slug }) => {
   const fontSizeStyle = fontSize ? { fontSize } : null;
   const lineHeightStyle = lineHeight ? { lineHeight } : null;
   return (
-    <View style={styles.spacer}>
-      <Link onPress={e => onPress(e, { name, slug })} url={`/topic/${slug}`}>
-        <View style={styles.container}>
-          <Text
-            accessibilityComponentType="button"
-            accessibilityRole="button"
-            accessibilityTraits="button"
-            style={[styles.text, fontSizeStyle, lineHeightStyle]}
+    <Context.Consumer>
+      {({ makeTopicUrl }) => (
+        <View style={styles.spacer}>
+          <Link
+            onPress={e => onPress(e, { name, slug })}
+            url={makeTopicUrl({ slug })}
           >
-            {name}
-          </Text>
+            <View style={styles.container}>
+              <Text
+                accessibilityComponentType="button"
+                accessibilityRole="button"
+                accessibilityTraits="button"
+                style={[styles.text, fontSizeStyle, lineHeightStyle]}
+              >
+                {name}
+              </Text>
+            </View>
+          </Link>
         </View>
-      </Link>
-    </View>
+      )}
+    </Context.Consumer>
   );
 };
 

--- a/packages/article/showcase-helper.js
+++ b/packages/article/showcase-helper.js
@@ -1,7 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies, no-bitwise, operator-assignment, react/prop-types */
 import React, { Component, Fragment } from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context, { defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
 import {
   article as makeParams,
@@ -13,11 +16,6 @@ import { sections } from "@times-components/storybook";
 import { scales, themeFactory } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
 import Article, { templates } from "./src/article";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -224,9 +222,8 @@ const renderArticle = ({
       };
 
       return (
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl,
             theme: {
               ...themeFactory(section, template),
               scale: scale || defaults.theme.scale
@@ -263,7 +260,7 @@ const renderArticle = ({
             )}
             refetch={refetch}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
     }}
   </ArticleProvider>

--- a/packages/author-profile/author-profile.showcase.js
+++ b/packages/author-profile/author-profile.showcase.js
@@ -7,7 +7,6 @@ import {
   MockFixture,
   MockedProvider
 } from "@times-components/provider-test-tools";
-import Context from "@times-components/context";
 import StorybookProvider from "@times-components/storybook/storybook-provider";
 import {
   authorArticlesWithImages as authorArticlesWithImagesQuery,
@@ -15,11 +14,6 @@ import {
 } from "@times-components/provider-queries";
 import storybookReporter from "@times-components/tealium-utils";
 import AuthorProfile from "./src/author-profile";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -51,35 +45,33 @@ const makeAuthorProfile = (decorateAction, params) => (
     params={params}
     render={mocks => (
       <MockedProvider mocks={mocks}>
-        <Context.Provider value={{ makeArticleUrl }}>
-          <AuthorProfileProvider
-            articleImageRatio={articleImageRatio}
-            debounceTimeMs={250}
-            page={1}
-            pageSize={pageSize}
-            slug={slug}
-          >
-            {({
-              author,
-              isLoading,
-              error,
-              page,
-              pageSize: authorPageSize,
-              refetch
-            }) => (
-              <AuthorProfile
-                author={author}
-                error={error}
-                isLoading={isLoading}
-                page={page}
-                pageSize={authorPageSize}
-                refetch={refetch}
-                slug={slug}
-                {...getProps(decorateAction)}
-              />
-            )}
-          </AuthorProfileProvider>
-        </Context.Provider>
+        <AuthorProfileProvider
+          articleImageRatio={articleImageRatio}
+          debounceTimeMs={250}
+          page={1}
+          pageSize={pageSize}
+          slug={slug}
+        >
+          {({
+            author,
+            isLoading,
+            error,
+            page,
+            pageSize: authorPageSize,
+            refetch
+          }) => (
+            <AuthorProfile
+              author={author}
+              error={error}
+              isLoading={isLoading}
+              page={page}
+              pageSize={authorPageSize}
+              refetch={refetch}
+              slug={slug}
+              {...getProps(decorateAction)}
+            />
+          )}
+        </AuthorProfileProvider>
       </MockedProvider>
     )}
   />

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -73,7 +73,6 @@
   },
   "dependencies": {
     "@times-components/article-list": "7.0.36",
-    "@times-components/context": "0.9.20",
     "@times-components/gradient": "3.1.16",
     "@times-components/icons": "2.10.20",
     "@times-components/image": "5.3.17",

--- a/packages/context/__tests__/android/__snapshots__/theme.test.js.snap
+++ b/packages/context/__tests__/android/__snapshots__/theme.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ContextProviderWithDefaults adds defaults to the provided context 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"}}"`;
+
 exports[`article context with default values 1`] = `"{\\"theme\\":{\\"imageCaptionAlignment\\":{},\\"scale\\":\\"medium\\"}}"`;
 
 exports[`article context with inline values 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"}}"`;

--- a/packages/context/__tests__/ios/__snapshots__/theme.test.js.snap
+++ b/packages/context/__tests__/ios/__snapshots__/theme.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ContextProviderWithDefaults adds defaults to the provided context 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"}}"`;
+
 exports[`article context with default values 1`] = `"{\\"theme\\":{\\"imageCaptionAlignment\\":{},\\"scale\\":\\"medium\\"}}"`;
 
 exports[`article context with inline values 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"}}"`;

--- a/packages/context/__tests__/shared.js
+++ b/packages/context/__tests__/shared.js
@@ -1,7 +1,10 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { scales } from "@times-components/styleguide";
-import Context, { SectionContext } from "../src/context";
+import Context, {
+  ContextProviderWithDefaults,
+  SectionContext
+} from "../src/context";
 
 export default () => {
   it("article context with default values", () => {
@@ -56,5 +59,23 @@ export default () => {
     );
 
     expect(testInstance).toMatchSnapshot();
+  });
+
+  describe("ContextProviderWithDefaults", () => {
+    it("adds defaults to the provided context", () => {
+      const scale = scales.large;
+      const sectionColour = "#FFFFFF";
+      const testInstance = TestRenderer.create(
+        <ContextProviderWithDefaults
+          value={{ theme: { scale, sectionColour } }}
+        >
+          <Context.Consumer>
+            {context => JSON.stringify(context)}
+          </Context.Consumer>
+        </ContextProviderWithDefaults>
+      );
+
+      expect(testInstance).toMatchSnapshot();
+    });
   });
 };

--- a/packages/context/__tests__/web/__snapshots__/theme.test.js.snap
+++ b/packages/context/__tests__/web/__snapshots__/theme.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ContextProviderWithDefaults adds defaults to the provided context 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"}}"`;
+
 exports[`article context with default values 1`] = `"{\\"theme\\":{\\"imageCaptionAlignment\\":{},\\"scale\\":\\"medium\\"}}"`;
 
 exports[`article context with inline values 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"}}"`;

--- a/packages/context/src/context.js
+++ b/packages/context/src/context.js
@@ -5,7 +5,7 @@ import SectionContext from "./section-context";
 const Context = createContext(defaults);
 
 function ContextProviderWithDefaults({ value, ...props }) {
-  return <Context.Provider {...props} value={{ ...defaults, value }} />;
+  return <Context.Provider {...props} value={{ ...defaults, ...value }} />;
 }
 
 export default Context;

--- a/packages/context/src/context.js
+++ b/packages/context/src/context.js
@@ -1,6 +1,12 @@
-import { createContext } from "react";
+import React, { createContext } from "react";
 import defaults from "./defaults";
 import SectionContext from "./section-context";
 
-export default createContext(defaults);
-export { defaults, SectionContext };
+const Context = createContext(defaults);
+
+function ContextProviderWithDefaults({ value, ...props }) {
+  return <Context.Provider {...props} value={{ ...defaults, value }} />;
+}
+
+export default Context;
+export { defaults, SectionContext, ContextProviderWithDefaults };

--- a/packages/context/src/defaults/index.js
+++ b/packages/context/src/defaults/index.js
@@ -1,7 +1,10 @@
 import { scales } from "@times-components/styleguide";
 
 export default {
-  makeArticleUrl: () => {},
+  makeArticleUrl: ({ slug, shortIdentifier }) =>
+    slug && shortIdentifier
+      ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
+      : "",
   theme: {
     imageCaptionAlignment: {},
     scale: scales.medium

--- a/packages/context/src/defaults/index.js
+++ b/packages/context/src/defaults/index.js
@@ -5,6 +5,7 @@ export default {
     slug && shortIdentifier
       ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
       : "",
+  makeTopicUrl: ({ slug }) => `/topic/${slug}`,
   theme: {
     imageCaptionAlignment: {},
     scale: scales.medium

--- a/packages/key-facts/__tests__/shared-key-facts-with-style.native.js
+++ b/packages/key-facts/__tests__/shared-key-facts-with-style.native.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -65,9 +65,9 @@ export default () => {
     const sectionColour = "#FFFFFF";
 
     const testInstance = TestRenderer.create(
-      <Context.Provider value={{ theme: { scale, sectionColour } }}>
+      <ContextProviderWithDefaults value={{ theme: { scale, sectionColour } }}>
         <KeyFacts ast={dataWithTitle} onLinkPress={() => {}} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testInstance).toMatchSnapshot();

--- a/packages/key-facts/__tests__/web/key-facts-with-style.web.test.js
+++ b/packages/key-facts/__tests__/web/key-facts-with-style.web.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { AppRegistry } from "react-native-web";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -59,9 +59,9 @@ it("key facts with title and context theme", () => {
   const sectionColour = "#FFFFFF";
 
   const testInstance = TestRenderer.create(
-    <Context.Provider value={{ theme: { scale, sectionColour } }}>
+    <ContextProviderWithDefaults value={{ theme: { scale, sectionColour } }}>
       <KeyFacts ast={data} onLinkPress={() => {}} />
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 
   expect(testInstance).toMatchSnapshot();

--- a/packages/key-facts/showcase-helper.js
+++ b/packages/key-facts/showcase-helper.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import invert from "lodash.invert";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import Responsive from "@times-components/responsive";
 import { colours, scales } from "@times-components/styleguide";
 import KeyFacts from "./src/key-facts";
@@ -14,11 +14,11 @@ const renderKeyFacts = ({ ast, select, hasScaling = false }) => {
   const scale = hasScaling ? selectScales(select) : null;
   const sectionColour = selectSection(select);
   return (
-    <Context.Provider value={{ theme: { scale, sectionColour } }}>
+    <ContextProviderWithDefaults value={{ theme: { scale, sectionColour } }}>
       <Responsive>
         <KeyFacts ast={ast} onLinkPress={() => {}} />
       </Responsive>
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 };
 

--- a/packages/pages/src/article/article-base.js
+++ b/packages/pages/src/article/article-base.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { NativeModules, Platform } from "react-native";
 import Article from "@times-components/article";
-import Context, { defaults } from "@times-components/context";
+import { ContextProviderWithDefaults, defaults } from "@times-components/context";
 import { themeFactory } from "@times-components/styleguide";
 import adTargetConfig from "./ad-targeting-config";
 import { propTypes, defaultProps } from "./article-prop-types";
@@ -55,7 +55,7 @@ const ArticleBase = ({
   };
 
   return (
-    <Context.Provider value={{ theme }}>
+    <ContextProviderWithDefaults value={{ theme }}>
       <Article
         adConfig={adConfig}
         analyticsStream={trackArticle}
@@ -86,7 +86,7 @@ const ArticleBase = ({
         referralUrl={referralUrl}
         refetch={refetch}
       />
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 };
 

--- a/packages/related-articles/__tests__/shared-util.base.js
+++ b/packages/related-articles/__tests__/shared-util.base.js
@@ -2,10 +2,7 @@ import React from "react";
 import mockDate from "mockdate";
 import { iterator } from "@times-components/test-utils";
 import Card from "@times-components/card";
-import Context from "@times-components/context";
 import RelatedArticles from "../src/related-articles";
-
-const makeArticleUrl = () => "https://some-url.io";
 
 export const testSummary = summary => [
   {
@@ -62,9 +59,7 @@ export const noArticlesTests = ({ fixture }) => renderComponent => {
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(output).toMatchSnapshot();
@@ -74,15 +69,13 @@ export const noArticlesTests = ({ fixture }) => renderComponent => {
       name: "no related articles when there is no given slice name",
       test() {
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles
-              analyticsStream={() => {}}
-              onPress={() => {}}
-              slice={{
-                sliceName: ""
-              }}
-            />
-          </Context.Provider>
+          <RelatedArticles
+            analyticsStream={() => {}}
+            onPress={() => {}}
+            slice={{
+              sliceName: ""
+            }}
+          />
         );
 
         expect(output).toMatchSnapshot();
@@ -94,9 +87,7 @@ export const noArticlesTests = ({ fixture }) => renderComponent => {
         const events = jest.fn();
 
         renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(events.mock.calls).toMatchSnapshot();
@@ -117,9 +108,7 @@ export const hasVideoTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(output).toMatchSnapshot();
@@ -140,9 +129,7 @@ export const noShortHeadlineTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(output).toMatchSnapshot();
@@ -154,9 +141,7 @@ export const noShortHeadlineTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(events.mock.calls).toMatchSnapshot();
@@ -180,9 +165,7 @@ export const oneArticleTests = (platform = () => []) => ({
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(output).toMatchSnapshot();
@@ -194,9 +177,7 @@ export const oneArticleTests = (platform = () => []) => ({
         const events = jest.fn();
 
         renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(events.mock.calls).toMatchSnapshot();
@@ -218,9 +199,7 @@ export const twoArticlesTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(output).toMatchSnapshot();
@@ -232,9 +211,7 @@ export const twoArticlesTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(events.mock.calls).toMatchSnapshot();
@@ -255,9 +232,7 @@ export const threeArticlesTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
         expect(output).toMatchSnapshot();
       }
@@ -268,9 +243,7 @@ export const threeArticlesTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(events.mock.calls).toMatchSnapshot();
@@ -294,9 +267,7 @@ export const threeArticlesWithLeadAssetOverrideTests = ({
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(output.root.findAllByType(Card)[0].props.imageUri).toEqual(

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one lead related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one lead and one support related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -79,7 +79,7 @@ exports[`1. one lead and one support related article 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://some-url.io"
+              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
             >
               <div>
                 <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one lead and two support related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -86,7 +86,7 @@ exports[`1. one lead and two support related articles 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://some-url.io"
+              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
             >
               <div>
                 <Card
@@ -135,7 +135,7 @@ exports[`1. one lead and two support related articles 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://some-url.io"
+              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
             >
               <div>
                 <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. no short headline 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one opinion related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one opinion and one support related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -93,7 +93,7 @@ exports[`1. one opinion and one support related article 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://some-url.io"
+              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
             >
               <div>
                 <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -86,7 +86,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://some-url.io"
+              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
             >
               <div>
                 <Card
@@ -135,7 +135,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://some-url.io"
+              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
             >
               <div>
                 <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. no short headline 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. a single related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. two related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -78,7 +78,7 @@ exports[`1. two related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. three related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -85,7 +85,7 @@ exports[`1. three related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -150,7 +150,7 @@ exports[`1. three related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. has video 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. no short headline 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/related-articles.showcase.js
+++ b/packages/related-articles/related-articles.showcase.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { ScrollView } from "react-native";
-import Context from "@times-components/context";
 import storybookReporter from "@times-components/tealium-utils";
 import RelatedArticles from "./src/related-articles";
 
@@ -19,11 +18,6 @@ import opinionAndTwo2RelatedArticlesFixture from "./fixtures/opinionandtwo/2-art
 import opinionAndTwo3RelatedArticlesFixture from "./fixtures/opinionandtwo/3-articles.js";
 import opinionAndTwo3RelatedArticlesLeadAssetOverrideFixture from "./fixtures/opinionandtwo/3-articles-lead-asset-override";
 
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
-
 const preventDefaultedAction = decorateAction =>
   decorateAction([
     ([e, ...args]) => {
@@ -41,9 +35,7 @@ const createRelatedArticles = (decorateAction, fixtureData) => {
   };
   return (
     <ScrollView>
-      <Context.Provider value={{ makeArticleUrl }}>
-        <RelatedArticles {...props} />
-      </Context.Provider>
+      <RelatedArticles {...props} />
     </ScrollView>
   );
 };

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -69,6 +69,7 @@
     "react-apollo": "2.1.4",
     "react-art": "16.5.2",
     "react-dom": "16.5.2",
+    "react-helmet-async": "1.0.2",
     "react-native": "0.55.4",
     "react-native-web": "0.9.0",
     "shrink-ray": "0.1.3",

--- a/packages/ssr/src/client/article.js
+++ b/packages/ssr/src/client/article.js
@@ -2,13 +2,19 @@ const article = require("../component/article");
 const runClient = require("../lib/run-client");
 
 if (window.nuk && window.nuk.ssr && window.nuk.article) {
-  const { rootTag, makeArticleUrl, mapArticleToAdConfig } = window.nuk.ssr;
+  const {
+    rootTag,
+    makeArticleUrl,
+    makeTopicUrl,
+    mapArticleToAdConfig
+  } = window.nuk.ssr;
   const { articleId, debounceTimeMs, spotAccountId } = window.nuk.article;
 
   const data = {
     articleId,
     debounceTimeMs,
     makeArticleUrl,
+    makeTopicUrl,
     mapArticleToAdConfig,
     spotAccountId
   };

--- a/packages/ssr/src/client/author-profile.js
+++ b/packages/ssr/src/client/author-profile.js
@@ -2,7 +2,12 @@ const authorProfile = require("../component/author-profile");
 const runClient = require("../lib/run-client");
 
 if (window.nuk && window.nuk.ssr && window.nuk.authorProfile) {
-  const { rootTag, makeArticleUrl, mapProfileToAdConfig } = window.nuk.ssr;
+  const {
+    rootTag,
+    makeArticleUrl,
+    makeTopicUrl,
+    mapProfileToAdConfig
+  } = window.nuk.ssr;
   const {
     authorSlug,
     debounceTimeMs,
@@ -14,6 +19,7 @@ if (window.nuk && window.nuk.ssr && window.nuk.authorProfile) {
     authorSlug,
     debounceTimeMs,
     makeArticleUrl,
+    makeTopicUrl,
     mapProfileToAdConfig,
     page,
     pageSize

--- a/packages/ssr/src/client/topic.js
+++ b/packages/ssr/src/client/topic.js
@@ -2,12 +2,18 @@ const topic = require("../component/topic");
 const runClient = require("../lib/run-client");
 
 if (window.nuk && window.nuk.ssr && window.nuk.topicPage) {
-  const { rootTag, makeArticleUrl, mapTopicToAdConfig } = window.nuk.ssr;
+  const {
+    rootTag,
+    makeArticleUrl,
+    makeTopicUrl,
+    mapTopicToAdConfig
+  } = window.nuk.ssr;
   const { debounceTimeMs, page, pageSize, topicSlug } = window.nuk.topicPage;
 
   const data = {
     debounceTimeMs,
     makeArticleUrl,
+    makeTopicUrl,
     mapTopicToAdConfig,
     page,
     pageSize,

--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -4,7 +4,7 @@ const React = require("react");
 const { ApolloProvider } = require("react-apollo");
 const { ArticleProvider } = require("@times-components/provider/rnw");
 const Article = require("@times-components/article/rnw").default;
-const { default: Context, defaults } = require("@times-components/context/rnw");
+const { ContextProviderWithDefaults, defaults } = require("@times-components/context/rnw");
 const { scales, themeFactory } = require("@times-components/styleguide/rnw");
 
 const scale = scales.large;
@@ -30,7 +30,7 @@ module.exports = (client, analyticsStream, data) => {
       },
       ({ article, isLoading, error, refetch }) =>
         React.createElement(
-          Context.Provider,
+          ContextProviderWithDefaults,
           {
             value: {
               makeArticleUrl,

--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -14,6 +14,7 @@ module.exports = (client, analyticsStream, data) => {
     articleId,
     debounceTimeMs,
     makeArticleUrl,
+    makeTopicUrl,
     mapArticleToAdConfig,
     spotAccountId
   } = data;
@@ -34,6 +35,7 @@ module.exports = (client, analyticsStream, data) => {
           {
             value: {
               makeArticleUrl,
+              makeTopicUrl,
               theme: {
                 ...themeFactory(article.section, article.template),
                 scale: scale || defaults.theme.scale

--- a/packages/ssr/src/component/author-profile.js
+++ b/packages/ssr/src/component/author-profile.js
@@ -3,7 +3,7 @@
 const React = require("react");
 const { ApolloProvider } = require("react-apollo");
 const { AuthorProfileProvider } = require("@times-components/provider/rnw");
-const Context = require("@times-components/context/rnw").default;
+const { ContextProviderWithDefaults } = require("@times-components/context/rnw");
 const AuthorProfile = require("@times-components/author-profile/rnw").default;
 
 module.exports = (client, analyticsStream, data) => {
@@ -29,7 +29,7 @@ module.exports = (client, analyticsStream, data) => {
       },
       ({ author, isLoading, error, refetch }) =>
         React.createElement(
-          Context.Provider,
+          ContextProviderWithDefaults,
           { value: { makeArticleUrl } },
           React.createElement(AuthorProfile, {
             adConfig: mapProfileToAdConfig(),

--- a/packages/ssr/src/component/author-profile.js
+++ b/packages/ssr/src/component/author-profile.js
@@ -11,6 +11,7 @@ module.exports = (client, analyticsStream, data) => {
     authorSlug,
     debounceTimeMs,
     makeArticleUrl,
+    makeTopicUrl,
     mapProfileToAdConfig,
     page,
     pageSize
@@ -30,7 +31,7 @@ module.exports = (client, analyticsStream, data) => {
       ({ author, isLoading, error, refetch }) =>
         React.createElement(
           ContextProviderWithDefaults,
-          { value: { makeArticleUrl } },
+          { value: { makeArticleUrl, makeTopicUrl } },
           React.createElement(AuthorProfile, {
             adConfig: mapProfileToAdConfig(),
             analyticsStream,

--- a/packages/ssr/src/component/topic.js
+++ b/packages/ssr/src/component/topic.js
@@ -4,7 +4,7 @@ const React = require("react");
 const { ApolloProvider } = require("react-apollo");
 const { HelmetProvider } = require("react-helmet-async");
 const { TopicProvider } = require("@times-components/provider/rnw");
-const Context = require("@times-components/context/rnw").default;
+const { ContextProviderWithDefaults } = require("@times-components/context/rnw");
 const { scales } = require("@times-components/styleguide/rnw");
 const Topic = require("@times-components/topic/rnw").default;
 
@@ -37,7 +37,7 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
         },
         ({ isLoading, error, refetch, topic }) =>
           React.createElement(
-            Context.Provider,
+            ContextProviderWithDefaults,
             {
               value: {
                 makeArticleUrl,

--- a/packages/ssr/src/component/topic.js
+++ b/packages/ssr/src/component/topic.js
@@ -2,6 +2,7 @@
 
 const React = require("react");
 const { ApolloProvider } = require("react-apollo");
+const { HelmetProvider } = require("react-helmet-async");
 const { TopicProvider } = require("@times-components/provider/rnw");
 const Context = require("@times-components/context/rnw").default;
 const { scales } = require("@times-components/styleguide/rnw");
@@ -10,7 +11,7 @@ const Topic = require("@times-components/topic/rnw").default;
 const scale = scales.large;
 const sectionColour = "#FFFFFF";
 
-module.exports = (client, analyticsStream, data) => {
+module.exports = (client, analyticsStream, data, helmetContext) => {
   const {
     debounceTimeMs,
     makeArticleUrl,
@@ -21,39 +22,43 @@ module.exports = (client, analyticsStream, data) => {
   } = data;
 
   return React.createElement(
-    ApolloProvider,
-    { client },
+    HelmetProvider,
+    { context: helmetContext },
     React.createElement(
-      TopicProvider,
-      {
-        debounceTimeMs,
-        page,
-        pageSize,
-        slug: topicSlug
-      },
-      ({ isLoading, error, refetch, topic }) =>
-        React.createElement(
-          Context.Provider,
-          {
-            value: {
-              makeArticleUrl,
-              theme: { scale, sectionColour }
-            }
-          },
-          React.createElement(Topic, {
-            adConfig: mapTopicToAdConfig(),
-            analyticsStream,
-            error,
-            isLoading,
-            onArticlePress: () => {},
-            onTwitterLinkPress: () => {},
-            page,
-            pageSize,
-            refetch,
-            slug: topicSlug,
-            topic
-          })
-        )
+      ApolloProvider,
+      { client },
+      React.createElement(
+        TopicProvider,
+        {
+          debounceTimeMs,
+          page,
+          pageSize,
+          slug: topicSlug
+        },
+        ({ isLoading, error, refetch, topic }) =>
+          React.createElement(
+            Context.Provider,
+            {
+              value: {
+                makeArticleUrl,
+                theme: { scale, sectionColour }
+              }
+            },
+            React.createElement(Topic, {
+              adConfig: mapTopicToAdConfig(),
+              analyticsStream,
+              error,
+              isLoading,
+              onArticlePress: () => {},
+              onTwitterLinkPress: () => {},
+              page,
+              pageSize,
+              refetch,
+              slug: topicSlug,
+              topic
+            })
+          )
+      )
     )
   );
 };

--- a/packages/ssr/src/component/topic.js
+++ b/packages/ssr/src/component/topic.js
@@ -15,6 +15,7 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
   const {
     debounceTimeMs,
     makeArticleUrl,
+    makeTopicUrl,
     mapTopicToAdConfig,
     page,
     pageSize,
@@ -41,6 +42,7 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
             {
               value: {
                 makeArticleUrl,
+                makeTopicUrl,
                 theme: { scale, sectionColour }
               }
             },

--- a/packages/ssr/src/lib/make-url.js
+++ b/packages/ssr/src/lib/make-url.js
@@ -1,1 +1,0 @@
-module.exports = ({ id }) => `http://localhost:3000/article/${id}`;

--- a/packages/ssr/src/lib/make-urls.js
+++ b/packages/ssr/src/lib/make-urls.js
@@ -1,0 +1,3 @@
+module.exports.makeArticleUrl = ({ id }) =>
+  `http://localhost:3000/article/${id}`;
+module.exports.makeTopicUrl = ({ slug }) => `/topic/${slug}`;

--- a/packages/ssr/src/lib/run-client.js
+++ b/packages/ssr/src/lib/run-client.js
@@ -55,7 +55,7 @@ module.exports = (component, clientOptions, data) => {
   };
   const analyticsStream = makeAnalyticsStream(reporterOptions);
 
-  const App = component(client, analyticsStream, data);
+  const App = component(client, analyticsStream, data, {});
 
   AppRegistry.registerComponent("App", () => () => App);
 

--- a/packages/ssr/src/server/article.js
+++ b/packages/ssr/src/server/article.js
@@ -6,7 +6,7 @@ const defaultAdConfig = require("../lib/ads/make-article-ad-config")
 module.exports = (
   articleId,
   headers,
-  { graphqlApiUrl, logger, makeArticleUrl, spotAccountId }
+  { graphqlApiUrl, logger, makeArticleUrl, makeTopicUrl, spotAccountId }
 ) => {
   if (typeof articleId !== "string") {
     throw new Error(`Article ID should be a string. Received ${articleId}`);
@@ -20,6 +20,11 @@ module.exports = (
   if (!makeArticleUrl) {
     throw new Error(
       `Make article url function is required. Received ${makeArticleUrl}`
+    );
+  }
+  if (!makeTopicUrl) {
+    throw new Error(
+      `Make topic url function is required. Received ${makeTopicUrl}`
     );
   }
   if (typeof spotAccountId !== "string") {
@@ -38,6 +43,7 @@ module.exports = (
       articleId,
       debounceTimeMs: 0,
       makeArticleUrl,
+      makeTopicUrl,
       mapArticleToAdConfig: defaultAdConfig,
       spotAccountId
     },

--- a/packages/ssr/src/server/author-profile.js
+++ b/packages/ssr/src/server/author-profile.js
@@ -5,7 +5,7 @@ const defaultAdConfig = require("../lib/ads/make-author-profile-ad-config")
 
 module.exports = (
   { authorSlug, currentPage },
-  { graphqlApiUrl, logger, makeArticleUrl }
+  { graphqlApiUrl, logger, makeArticleUrl, makeTopicUrl }
 ) => {
   if (typeof authorSlug !== "string") {
     throw new Error(`Author slug should be a string. Received ${authorSlug}`);
@@ -26,6 +26,11 @@ module.exports = (
       `Make article url function is required. Received ${makeArticleUrl}`
     );
   }
+  if (!makeTopicUrl) {
+    throw new Error(
+      `Make topic url function is required. Received ${makeTopicUrl}`
+    );
+  }
 
   const options = {
     client: {
@@ -36,6 +41,7 @@ module.exports = (
       authorSlug,
       debounceTimeMs: 0,
       makeArticleUrl,
+      makeTopicUrl,
       mapProfileToAdConfig: defaultAdConfig,
       page: currentPage,
       pageSize: 20

--- a/packages/ssr/src/server/topic.js
+++ b/packages/ssr/src/server/topic.js
@@ -5,7 +5,7 @@ const defaultAdConfig = require("../lib/ads/make-topic-ad-config")
 
 module.exports = (
   { currentPage, topicSlug },
-  { graphqlApiUrl, logger, makeArticleUrl }
+  { graphqlApiUrl, logger, makeArticleUrl, makeTopicUrl }
 ) => {
   if (typeof topicSlug !== "string") {
     throw new Error(`Topic slug should be a string. Received ${topicSlug}`);
@@ -26,6 +26,11 @@ module.exports = (
       `Make article url function is required. Received ${makeArticleUrl}`
     );
   }
+  if (!makeTopicUrl) {
+    throw new Error(
+      `Make topic url function is required. Received ${makeTopicUrl}`
+    );
+  }
 
   const options = {
     client: {
@@ -35,6 +40,7 @@ module.exports = (
     data: {
       debounceTimeMs: 0,
       makeArticleUrl,
+      makeTopicUrl,
       mapTopicToAdConfig: defaultAdConfig,
       page: currentPage,
       pageSize: 20,

--- a/packages/ssr/src/standalone-renderer/app.js
+++ b/packages/ssr/src/standalone-renderer/app.js
@@ -4,7 +4,7 @@ const express = require("express");
 const shrinkRay = require("shrink-ray");
 
 const ssr = require("../server");
-const makeArticleUrl = require("../lib/make-url");
+const makeUrls = require("../lib/make-urls");
 const logger = require("../lib/simple-logger");
 
 const port = 3000;
@@ -65,9 +65,9 @@ server.get("/article/:id", (request, response) => {
 
   ssr
     .article(articleId, headers, {
+      ...makeUrls,
       graphqlApiUrl,
       logger,
-      makeArticleUrl,
       spotAccountId
     })
     .then(({ initialProps, initialState, markup, responsiveStyles, styles }) =>
@@ -93,7 +93,7 @@ server.get("/profile/:slug", (request, response) => {
   ssr
     .authorProfile(
       { authorSlug, currentPage },
-      { graphqlApiUrl, logger, makeArticleUrl }
+      { ...makeUrls, graphqlApiUrl, logger }
     )
     .then(({ initialProps, initialState, markup, responsiveStyles, styles }) =>
       response.send(
@@ -116,10 +116,7 @@ server.get("/topic/:slug", (request, response) => {
   const graphqlApiUrl = process.env.GRAPHQL_ENDPOINT;
 
   ssr
-    .topic(
-      { currentPage, topicSlug },
-      { graphqlApiUrl, logger, makeArticleUrl }
-    )
+    .topic({ currentPage, topicSlug }, { ...makeUrls, graphqlApiUrl, logger })
     .then(
       ({
         headMarkup,

--- a/packages/ssr/src/standalone-renderer/app.js
+++ b/packages/ssr/src/standalone-renderer/app.js
@@ -16,13 +16,13 @@ server.use(express.static("dist"));
 const makeHtml = (
   initialState,
   initialProps,
-  { bundleName, markup, responsiveStyles, styles, title }
+  { bundleName, headMarkup, markup, responsiveStyles, styles }
 ) => `
         <!DOCTYPE html>
         <html>
           <head>
             <meta name="viewport" content="width=device-width, initial-scale=1">
-            <title>${title}</title>
+            ${headMarkup}
             ${styles}
             ${responsiveStyles}
           </head>
@@ -76,8 +76,7 @@ server.get("/article/:id", (request, response) => {
           bundleName: "article",
           markup,
           responsiveStyles,
-          styles,
-          title: "Article"
+          styles
         })
       )
     );
@@ -102,8 +101,7 @@ server.get("/profile/:slug", (request, response) => {
           bundleName: "author-profile",
           markup,
           responsiveStyles,
-          styles,
-          title: authorSlug
+          styles
         })
       )
     );
@@ -122,16 +120,24 @@ server.get("/topic/:slug", (request, response) => {
       { currentPage, topicSlug },
       { graphqlApiUrl, logger, makeArticleUrl }
     )
-    .then(({ initialProps, initialState, markup, responsiveStyles, styles }) =>
-      response.send(
-        makeHtml(initialState, initialProps, {
-          bundleName: "topic",
-          markup,
-          responsiveStyles,
-          styles,
-          title: topicSlug
-        })
-      )
+    .then(
+      ({
+        headMarkup,
+        initialProps,
+        initialState,
+        markup,
+        responsiveStyles,
+        styles
+      }) =>
+        response.send(
+          makeHtml(initialState, initialProps, {
+            bundleName: "topic",
+            headMarkup,
+            markup,
+            responsiveStyles,
+            styles
+          })
+        )
     );
 });
 

--- a/packages/ssr/src/standalone-renderer/page-init/article.js
+++ b/packages/ssr/src/standalone-renderer/page-init/article.js
@@ -1,13 +1,13 @@
 const defaultMapArticleToConfig = require("../../lib/ads/make-article-ad-config")
   .defaultClient;
-const makeArticleUrl = require("../../lib/make-url");
+const makeUrls = require("../../lib/make-urls");
 
 const rootTag = "main-container";
 
 window.nuk = window.nuk || {};
 window.nuk.ssr = {
   ...window.nuk.ssr,
-  makeArticleUrl,
+  ...makeUrls,
   mapArticleToAdConfig: defaultMapArticleToConfig,
   rootTag
 };

--- a/packages/ssr/src/standalone-renderer/page-init/author-profile.js
+++ b/packages/ssr/src/standalone-renderer/page-init/author-profile.js
@@ -1,13 +1,13 @@
 const defaultMapProfileToConfig = require("../../lib/ads/make-author-profile-ad-config")
   .defaultClient;
-const makeArticleUrl = require("../../lib/make-url");
+const makeUrls = require("../../lib/make-urls");
 
 const rootTag = "main-container";
 
 window.nuk = window.nuk || {};
 window.nuk.ssr = {
   ...window.nuk.ssr,
-  makeArticleUrl,
+  ...makeUrls,
   mapProfileToAdConfig: defaultMapProfileToConfig,
   rootTag
 };

--- a/packages/ssr/src/standalone-renderer/page-init/topic.js
+++ b/packages/ssr/src/standalone-renderer/page-init/topic.js
@@ -1,13 +1,13 @@
 const defaultMapTopicToConfig = require("../../lib/ads/make-topic-ad-config")
   .defaultClient;
-const makeArticleUrl = require("../../lib/make-url");
+const makeUrls = require("../../lib/make-urls");
 
 const rootTag = "main-container";
 
 window.nuk = window.nuk || {};
 window.nuk.ssr = {
   ...window.nuk.ssr,
-  makeArticleUrl,
+  ...makeUrls,
   mapTopicToAdConfig: defaultMapTopicToConfig,
   rootTag
 };

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -54,6 +54,7 @@
     "prop-types": "15.6.2",
     "react": "16.5.2",
     "react-apollo": "2.1.4",
+    "react-helmet-async": "1.0.2",
     "react-test-renderer": "16.5.2"
   },
   "peerDependencies": {

--- a/packages/storybook/src/showcase-to-storybook.js
+++ b/packages/storybook/src/showcase-to-storybook.js
@@ -1,4 +1,5 @@
 import React, { StrictMode } from "react";
+import { HelmetProvider } from "react-helmet-async";
 import PropTypes from "prop-types";
 import { Platform } from "react-native";
 
@@ -10,7 +11,9 @@ React.Fragment.displayName = "React.Fragment";
 
 // eslint-disable-next-line react/prop-types
 export const StrictWrapper = ({ children }) => (
-  <StrictMode>{children}</StrictMode>
+  <StrictMode>
+    <HelmetProvider context={{}}>{children}</HelmetProvider>
+  </StrictMode>
 );
 
 const addStories = (

--- a/packages/topic/__tests__/mocks.js
+++ b/packages/topic/__tests__/mocks.js
@@ -1,3 +1,5 @@
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
+
 jest.mock("@times-components/article-list", () =>
   // eslint-disable-next-line global-require
   require("./mock-article-list")

--- a/packages/topic/__tests__/web/__snapshots__/topic-loading.web.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-loading.web.test.js.snap
@@ -2,6 +2,14 @@
 
 exports[`1. an article list loading 1`] = `
 <topicArticlesProvider>
+  <Helmet>
+    <title>
+      
+       | Page 
+      1/undefined
+       | The Times & The Sunday Times
+    </title>
+  </Helmet>
   <ArticleList
     articleListHeader={
       <TopicHead

--- a/packages/topic/__tests__/web/__snapshots__/topic.web.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic.web.test.js.snap
@@ -4,6 +4,14 @@ exports[`1. an error page 1`] = `<ArticleListPageError />`;
 
 exports[`2. a loading state 1`] = `
 <topicArticlesProvider>
+  <Helmet>
+    <title>
+      
+       | Page 
+      1/10
+       | The Times & The Sunday Times
+    </title>
+  </Helmet>
   <ArticleList
     articleListHeader={
       <TopicHead
@@ -32,6 +40,14 @@ exports[`2. a loading state 1`] = `
 
 exports[`3. an article list 1`] = `
 <topicArticlesProvider>
+  <Helmet>
+    <title>
+      Test Name
+       | Page 
+      2/10
+       | The Times & The Sunday Times
+    </title>
+  </Helmet>
   <ArticleList
     articleListHeader={
       <TopicHead
@@ -104,6 +120,14 @@ exports[`3. an article list 1`] = `
 
 exports[`4. fetches more articles 1`] = `
 <topicArticlesProvider>
+  <Helmet>
+    <title>
+      Test Name
+       | Page 
+      2/10
+       | The Times & The Sunday Times
+    </title>
+  </Helmet>
   <ArticleList
     articleListHeader={
       <TopicHead
@@ -181,6 +205,14 @@ exports[`4. fetches more articles 1`] = `
 
 exports[`5. fetches more articles and falls back to previous data if no more 1`] = `
 <topicArticlesProvider>
+  <Helmet>
+    <title>
+      Test Name
+       | Page 
+      2/10
+       | The Times & The Sunday Times
+    </title>
+  </Helmet>
   <ArticleList
     articleListHeader={
       <TopicHead

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -81,6 +81,7 @@
     "@times-components/utils": "4.10.3",
     "lodash.get": "4.4.2",
     "prop-types": "15.6.2",
+    "react-helmet-async": "1.0.2",
     "styled-components": "3.4.0"
   },
   "peerDependencies": {

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -70,7 +70,6 @@
   },
   "dependencies": {
     "@times-components/article-list": "7.0.36",
-    "@times-components/context": "0.9.20",
     "@times-components/markup": "3.3.52",
     "@times-components/markup-forest": "1.7.3",
     "@times-components/pagination": "3.2.53",

--- a/packages/topic/src/head.js
+++ b/packages/topic/src/head.js
@@ -1,0 +1,5 @@
+function Head() {
+  return null;
+}
+
+export default Head;

--- a/packages/topic/src/head.web.js
+++ b/packages/topic/src/head.web.js
@@ -1,0 +1,21 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Helmet } from "react-helmet-async";
+
+function Head({ page, pageSize, name }) {
+  return (
+    <Helmet>
+      <title>
+        {name} | Page {`${page}/${pageSize}`} | The Times &amp; The Sunday Times
+      </title>
+    </Helmet>
+  );
+}
+
+Head.propTypes = {
+  name: PropTypes.string.isRequired,
+  page: PropTypes.number.isRequired,
+  pageSize: PropTypes.number.isRequired
+};
+
+export default Head;

--- a/packages/topic/src/topic.js
+++ b/packages/topic/src/topic.js
@@ -1,6 +1,5 @@
 import React from "react";
 import get from "lodash.get";
-import { Helmet } from "react-helmet-async";
 import ArticleList, {
   ArticleListPageError
 } from "@times-components/article-list";
@@ -11,6 +10,7 @@ import { ratioTextToFloat } from "@times-components/utils";
 import { propTypes, defaultProps } from "./topic-prop-types";
 import topicTrackingContext from "./topic-tracking-context";
 import TopicHead from "./topic-head";
+import Head from "./head";
 
 const Topic = ({
   adConfig,
@@ -88,12 +88,7 @@ const Topic = ({
 
         return (
           <Responsive>
-            <Helmet>
-              <title>
-                {name} | Page {`${page}/${pageSize}`} | The Times &amp; The
-                Sunday Times
-              </title>
-            </Helmet>
+            <Head {...{ name, page, pageSize }} />
             <ArticleList
               adConfig={adConfig}
               articleListHeader={articleListHeader}

--- a/packages/topic/src/topic.js
+++ b/packages/topic/src/topic.js
@@ -1,5 +1,6 @@
 import React from "react";
 import get from "lodash.get";
+import { Helmet } from "react-helmet-async";
 import ArticleList, {
   ArticleListPageError
 } from "@times-components/article-list";
@@ -87,6 +88,12 @@ const Topic = ({
 
         return (
           <Responsive>
+            <Helmet>
+              <title>
+                {name} | Page {`${page}/${pageSize}`} | The Times &amp; The
+                Sunday Times
+              </title>
+            </Helmet>
             <ArticleList
               adConfig={adConfig}
               articleListHeader={articleListHeader}

--- a/packages/topic/topic.showcase.js
+++ b/packages/topic/topic.showcase.js
@@ -6,7 +6,6 @@ import {
   MockFixture,
   topic as makeParams
 } from "@times-components/provider-test-tools";
-import Context from "@times-components/context";
 import storybookReporter from "@times-components/tealium-utils";
 import Topic from "./src/topic";
 import TopicProvider from "../provider/src/topic";
@@ -31,25 +30,19 @@ const name = "Chelsea";
 const pageSize = 20;
 const topicSlug = "chelsea";
 
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
-
 const makeTopic = (decorateAction, params) => (
   <MockFixture
     params={params}
     render={mocks => (
       <MockedProvider mocks={mocks}>
-        <Context.Provider value={{ makeArticleUrl }}>
-          <TopicProvider
-            articleImageRatio={articleImageRatio}
-            debounceTimeMs={250}
-            page={1}
-            pageSize={pageSize}
-            slug={topicSlug}
-          >
-            {({
+        <TopicProvider
+          articleImageRatio={articleImageRatio}
+          debounceTimeMs={250}
+          page={1}
+          pageSize={pageSize}
+          slug={topicSlug}
+        >
+          {({
               error,
               isLoading,
               page,
@@ -57,19 +50,18 @@ const makeTopic = (decorateAction, params) => (
               refetch,
               topic
             }) => (
-              <Topic
-                error={error}
-                isLoading={isLoading}
-                page={page}
-                pageSize={authorPageSize}
-                refetch={refetch}
-                slug={topicSlug}
-                topic={topic}
-                {...getProps(decorateAction)}
-              />
-            )}
-          </TopicProvider>
-        </Context.Provider>
+            <Topic
+              error={error}
+              isLoading={isLoading}
+              page={page}
+              pageSize={authorPageSize}
+              refetch={refetch}
+              slug={topicSlug}
+              topic={topic}
+              {...getProps(decorateAction)}
+            />
+          )}
+        </TopicProvider>
       </MockedProvider>
     )}
   />

--- a/packages/topic/topic.showcase.js
+++ b/packages/topic/topic.showcase.js
@@ -43,13 +43,13 @@ const makeTopic = (decorateAction, params) => (
           slug={topicSlug}
         >
           {({
-              error,
-              isLoading,
-              page,
-              pageSize: authorPageSize,
-              refetch,
-              topic
-            }) => (
+            error,
+            isLoading,
+            page,
+            pageSize: authorPageSize,
+            refetch,
+            topic
+          }) => (
             <Topic
               error={error}
               isLoading={isLoading}

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,6 +765,13 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
+  integrity sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2":
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.5.tgz#4170907641cf1f61508f563ece3725150cc6fe39"
@@ -10764,7 +10771,7 @@ intrinsic-scale@3.0.3:
   resolved "https://registry.yarnpkg.com/intrinsic-scale/-/intrinsic-scale-3.0.3.tgz#a940efda97e81f783f73c450618c46c1c1fbd008"
   integrity sha1-qUDv2pfoH3g/c8RQYYxGwcH70Ag=
 
-invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -15683,6 +15690,15 @@ prop-types@15.6.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, 
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 propagate@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
@@ -16217,6 +16233,11 @@ react-error-overlay@^4.0.1:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.1.tgz#417addb0814a90f3a7082eacba7cee588d00da89"
   integrity sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw==
 
+react-fast-compare@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
 react-fuzzy@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/react-fuzzy/-/react-fuzzy-0.5.2.tgz#fc13bf6f0b785e5fefe908724efebec4935eaefe"
@@ -16226,6 +16247,17 @@ react-fuzzy@^0.5.2:
     classnames "^2.2.5"
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
+
+react-helmet-async@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.0.2.tgz#bb55dd8268f7b15aac69c6b22e2f950abda8cc44"
+  integrity sha512-qzzchrM/ibHuPS/60ief8jaibPunuRdeta4iBDQV+ri2SFKwOV+X2NlEpvevZOauhmHrH/I6dI4E90EPVfJBBg==
+  dependencies:
+    "@babel/runtime" "7.3.4"
+    invariant "2.2.4"
+    prop-types "15.7.2"
+    react-fast-compare "2.0.4"
+    shallowequal "1.1.0"
 
 react-hot-loader@3.0.0-beta.7:
   version "3.0.0-beta.7"
@@ -16275,6 +16307,11 @@ react-is@^16.5.2:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
+
+react-is@^16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-lifecycles-compat@^3, react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -17784,17 +17821,17 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+shallowequal@1.1.0, shallowequal@^1.0.2, shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shallowequal@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
   integrity sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=
   dependencies:
     lodash.keys "^3.1.2"
-
-shallowequal@^1.0.2, shallowequal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
-  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
This is a proof of concept on how we can use Helmet to manage head tags from times-components, using the title tag as an example. It has server side rendering support and can be updated dynamically on the client side.

This proof of concept is showing you the integration necessary using SSR's standalone server, but I will shortly link an example of this proof of concept being integrated with render. 

In this proof of concept, we have a dynamically updating title tag on a topic page such as http://localhost:3000/topic/religion?page=2 (you'll need to be running SSR on this branch first) 

We're using `react-helmet-async`, as the original implementation of `react-helmet` is not thread safe, meaning you cannot have any async processes as part of your rendering pipeline (such as Apollo, which we use). Read more about this here https://open.nytimes.com/the-future-of-meta-tag-management-for-modern-react-development-ec26a7dc9183

Helmet has far more features than what we need, so this proof of concept only has support for meta, title, and link tags. It'll be relatively easy to add support for more features. 

As you can see, there's a bit of work necessary in SSR to add server side rendering support, but for the most part the usage of helmet is extremely simple as you can see in the topic package.