### PR TITLE
fix: save and share breaks mobile storybook

### DIFF
--- a/packages/save-and-share-bar/__tests__/web/__snapshots__/save-and-share-bar.test.js.snap
+++ b/packages/save-and-share-bar/__tests__/web/__snapshots__/save-and-share-bar.test.js.snap
@@ -69,7 +69,7 @@ exports[`1. save and share bar renders correctly 1`] = `
       url="https://twitter.com/intent/tweet?text="
     >
       <IconTwitter
-        fillColour="#696969"
+        fillColour="currentColor"
         height={15}
         title="Share on Twitter"
       />

--- a/packages/save-and-share-bar/src/bar-item.js
+++ b/packages/save-and-share-bar/src/bar-item.js
@@ -3,12 +3,14 @@ import { LinkWithPressedStyle } from "@times-components/link";
 import styled from "styled-components";
 import styles from "./styles";
 
-const HoverIcon = styled.div`
-  color: ${props => props.color};
-  &:hover {
-    color: ${props => props.hoverColor || props.color};
-  }
-`;
+const HoverIcon =
+  styled.div &&
+  styled.div`
+    color: ${props => props.color};
+    &:hover {
+      color: ${props => props.hoverColor || props.color};
+    }
+  `;
 
 const BarItem = ({
   children,

--- a/packages/save-and-share-bar/src/save-and-share-bar.js
+++ b/packages/save-and-share-bar/src/save-and-share-bar.js
@@ -34,7 +34,7 @@ const SaveAndShareBar = ({
         url={`${SharingApiUrls.twitter}?text=${articleUrl}`}
       >
         <IconTwitter
-          fillColour={styles.svgIcon.fillColour}
+          fillColour="currentColor"
           height={styles.svgIcon.height}
           title="Share on Twitter"
         />


### PR DESCRIPTION
little fix for the share and save bar 
