### PR TITLE
fix: Add TinyUnit and UnitInterval to mock types

### DIFF
--- a/packages/mock-tpa-server/src/default-mock-types.js
+++ b/packages/mock-tpa-server/src/default-mock-types.js
@@ -14,7 +14,9 @@ const defaultMockTypes = {
   Media: { __typename: "Image" },
   Ratio: "16:9",
   Slug: "a-slug",
+  TinyInt: 123,
   Topic: { __typename: "Topic" },
+  UnitInterval: 0.5,
   URL: "url",
   UUID: "uuid"
 };


### PR DESCRIPTION
TPA added TinyUnit and UnitInterval as new types to their schema. Fixing our mocks so CI tests can pass again