### PR TITLE
BREAKING CHANGE feat: manage meta tags in times-components 

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "aws-sdk": "2.238.1",
     "babel-preset-es2015": "6.24.1",
     "react-art": "16.5.2",
+    "react-helmet-async": "1.0.2",
     "react-native": "0.55.4",
     "react-native-showcase-loader": "1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -164,7 +164,6 @@
     "aws-sdk": "2.238.1",
     "babel-preset-es2015": "6.24.1",
     "react-art": "16.5.2",
-    "react-helmet-async": "1.0.2",
     "react-native": "0.55.4",
     "react-native-showcase-loader": "1.1.0"
   }

--- a/packages/article-image/__tests__/shared-with-style.base.js
+++ b/packages/article-image/__tests__/shared-with-style.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { setIsTablet } from "@times-components/mocks/dimensions";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { iterator } from "@times-components/test-utils";
 import ArticleImage from "../src/article-image";
 import primaryImageFixture from "../fixtures/primary-image";
@@ -137,7 +137,7 @@ export default makeTest => {
       test: () => {
         expect(
           makeTest(
-            <Context.Provider
+            <ContextProviderWithDefaults
               value={{
                 theme: { imageCaptionAlignment: { primary: "center" } }
               }}
@@ -146,7 +146,7 @@ export default makeTest => {
                 captionOptions={primaryImage.captionOptions}
                 imageOptions={primaryImage.imageOptions}
               />
-            </Context.Provider>
+            </ContextProviderWithDefaults>
           )
         ).toMatchSnapshot();
       }
@@ -157,7 +157,7 @@ export default makeTest => {
       test: () => {
         expect(
           makeTest(
-            <Context.Provider
+            <ContextProviderWithDefaults
               value={{
                 theme: { imageCaptionAlignment: { secondary: "center" } }
               }}
@@ -166,7 +166,7 @@ export default makeTest => {
                 captionOptions={secondaryImage.captionOptions}
                 imageOptions={secondaryImage.imageOptions}
               />
-            </Context.Provider>
+            </ContextProviderWithDefaults>
           )
         ).toMatchSnapshot();
       }

--- a/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
@@ -504,7 +504,17 @@ exports[`8. primary image with caption and credits with center caption override 
   }
 }
 
-Array [
+<ContextProviderWithDefaults
+  value={
+    Object {
+      "theme": Object {
+        "imageCaptionAlignment": Object {
+          "primary": "center",
+        },
+      },
+    }
+  }
+>
   <div>
     <TimesImage
       aspectRatio={1.25}
@@ -520,7 +530,7 @@ Array [
       onImagePress={null}
       uri="https://img/someImage"
     />
-  </div>,
+  </div>
   <div>
     <InsetCenteredCaption
       credits="Some credits"
@@ -548,8 +558,8 @@ Array [
         </div>
       </responsiveweb__InsetCaptionStyle>
     </InsetCenteredCaption>
-  </div>,
-]
+  </div>
+</ContextProviderWithDefaults>
 `;
 
 exports[`9. secondary image with caption and credits with center caption override 1`] = `
@@ -563,7 +573,17 @@ exports[`9. secondary image with caption and credits with center caption overrid
   z-index: 2;
 }
 
-Array [
+<ContextProviderWithDefaults
+  value={
+    Object {
+      "theme": Object {
+        "imageCaptionAlignment": Object {
+          "secondary": "center",
+        },
+      },
+    }
+  }
+>
   <div>
     <TimesImage
       aspectRatio={1.5}
@@ -579,7 +599,7 @@ Array [
       onImagePress={null}
       uri="https://img/someImage"
     />
-  </div>,
+  </div>
   <div>
     <CentredCaption
       credits="Other credits"
@@ -596,6 +616,6 @@ Array [
         </div>
       </div>
     </CentredCaption>
-  </div>,
-]
+  </div>
+</ContextProviderWithDefaults>
 `;

--- a/packages/article-in-depth/__tests__/mocks.web.js
+++ b/packages/article-in-depth/__tests__/mocks.web.js
@@ -1,3 +1,4 @@
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
 // eslint-disable-next-line global-require
 jest.mock("@times-components/ad", () => require("./ad-mock"));
 jest.mock("@times-components/article-byline", () => ({

--- a/packages/article-in-depth/__tests__/shared-internal-components.base.js
+++ b/packages/article-in-depth/__tests__/shared-internal-components.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { iterator } from "@times-components/test-utils";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import Label from "../src/article-label/article-label";
 import Meta from "../src/article-meta/article-meta";
 import Standfirst from "../src/article-standfirst/article-standfirst";
@@ -56,7 +56,7 @@ const snapshotTests = renderComponent => [
     name: "article meta uses default section colour",
     test() {
       const output = renderComponent(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
             theme: { sectionColour: null }
           }}
@@ -67,7 +67,7 @@ const snapshotTests = renderComponent => [
             publicationName="TIMES"
             publishedTime="2015-03-23T19:39:39.000Z"
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();

--- a/packages/article-in-depth/__tests__/shared-with-style.native.js
+++ b/packages/article-in-depth/__tests__/shared-with-style.native.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -151,9 +151,9 @@ export default () => {
 
   it("full article with style in the culture magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -161,9 +161,9 @@ export default () => {
 
   it("full article with style in the style magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -171,9 +171,11 @@ export default () => {
 
   it("full article with style in the sunday times magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -182,9 +184,9 @@ export default () => {
   it("tablet full article with style in the culture magazine", () => {
     setIsTablet(true);
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -193,9 +195,9 @@ export default () => {
   it("tablet full article with style in the style magazine", () => {
     setIsTablet(true);
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -204,9 +206,11 @@ export default () => {
   it("tablet full article with style in the sunday times magazine", () => {
     setIsTablet(true);
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-in-depth/__tests__/shared-with-style.web.js
+++ b/packages/article-in-depth/__tests__/shared-with-style.web.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { AppRegistry } from "react-native-web";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -175,9 +175,9 @@ export default () => {
 
   it("full article with style in the culture magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -185,9 +185,9 @@ export default () => {
 
   it("full article with style in the style magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -195,9 +195,11 @@ export default () => {
 
   it("full article with style in the sunday times magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleInDepth {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -543,6 +543,25 @@ exports[`full article with style 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >
@@ -1255,6 +1274,25 @@ exports[`full article with style in the culture magazine 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >
@@ -1967,6 +2005,25 @@ exports[`full article with style in the style magazine 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >
@@ -2679,6 +2736,25 @@ exports[`full article with style in the sunday times magazine 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >

--- a/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -8,13 +8,13 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 <article>
   <Helmet>
     <title>
-      
+      Some Short Headline
        | 
       
       The Times
     </title>
     <meta
-      content=""
+      content="Some Short Headline"
       name="article:title"
     />
     <meta
@@ -23,7 +23,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
     />
     
     <meta
-      content=""
+      content="Some Short Headline"
       property="og:title"
     />
     <meta
@@ -39,7 +39,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       property="og:image"
     />
     <meta
-      content=""
+      content="Some Short Headline"
       name="twitter:title"
     />
     <meta

--- a/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -6,6 +6,55 @@ exports[`2. loading 1`] = `null`;
 
 exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 <article>
+  <Helmet>
+    <title>
+      
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content=""
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    
+    <meta
+      content=""
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content=""
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <div>
     <Ad
       contextUrl="https://url.io"
@@ -157,6 +206,55 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 
 exports[`4. an article with ads 1`] = `
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content="Some Headline"
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    
+    <meta
+      content="Some Headline"
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content="Some Headline"
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <div>
     <Ad
       contextUrl="https://url.io"

--- a/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -2,6 +2,55 @@
 
 exports[`1. a full article 1`] = `
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content="Some Headline"
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    
+    <meta
+      content="Some Headline"
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content="Some Headline"
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <svg
     height={250}
     viewBox="-630 120 1200 50"

--- a/packages/article-in-depth/__tests__/web/semantic.web.test.js
+++ b/packages/article-in-depth/__tests__/web/semantic.web.test.js
@@ -17,6 +17,8 @@ import Article from "../../src/article-in-depth";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
 import { adConfig } from "../ad-mock";
 
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
+
 const omitProps = new Set([
   "className",
   "fill",

--- a/packages/article-in-depth/__tests__/web/semantic.web.test.js
+++ b/packages/article-in-depth/__tests__/web/semantic.web.test.js
@@ -11,7 +11,7 @@ import {
   replacePropTransform,
   replaceTransform
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import Article from "../../src/article-in-depth";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
@@ -126,9 +126,8 @@ const tests = [
       const scale = scales.large;
       const sectionColour = "#FFFFFF";
       const testRenderer = TestRenderer.create(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl: () => "https://some-url.io",
             theme: { scale, sectionColour }
           }}
         >
@@ -145,7 +144,7 @@ const tests = [
             onVideoPress={() => {}}
             receiveChildList={() => {}}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(testRenderer).toMatchSnapshot();

--- a/packages/article-in-depth/article-in-depth.showcase.js
+++ b/packages/article-in-depth/article-in-depth.showcase.js
@@ -1,7 +1,10 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context, { defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
 import {
   article as makeParams,
@@ -12,11 +15,6 @@ import { sections } from "@times-components/storybook";
 import { scales, themeFactory } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
 import ArticleInDepth from "./src/article-in-depth";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -53,9 +51,8 @@ const renderArticle = ({
       };
 
       return (
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl,
             theme: {
               ...themeFactory(section, templateName),
               scale: scale || defaults.theme.scale
@@ -95,7 +92,7 @@ const renderArticle = ({
             )}
             refetch={refetch}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
     }}
   </ArticleProvider>

--- a/packages/article-list/.jestlint
+++ b/packages/article-list/.jestlint
@@ -1,5 +1,5 @@
 {
-  "maxAttributeStringLength": 38,
+  "maxAttributeStringLength": 70,
   "maxAttributes": 7,
   "maxFileSize": 19320,
   "maxLines": 823

--- a/packages/article-list/__tests__/shared-error.base.web.js
+++ b/packages/article-list/__tests__/shared-error.base.web.js
@@ -1,16 +1,10 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
 import { iterator } from "@times-components/test-utils";
 import ArticleListPageError from "../src/article-list-page-error";
 import ArticleList from "../src/article-list";
 import articlesFixture from "../fixtures/articles.json";
 import adConfig from "../fixtures/article-ad-config.json";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 jest.mock("@times-components/button", () => "Button");
 jest.mock("../src/article-list-item", () => ({ article }) => {
@@ -46,15 +40,13 @@ export default () => {
       name: "article list",
       test() {
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture.slice(0, 2)}
-              emptyStateMessage="Empty state"
-              pageSize={1}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture.slice(0, 2)}
+            emptyStateMessage="Empty state"
+            pageSize={1}
+            refetch={() => {}}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();

--- a/packages/article-list/__tests__/shared-pagination.web.js
+++ b/packages/article-list/__tests__/shared-pagination.web.js
@@ -9,16 +9,10 @@ import {
   minimalWebTransform,
   print
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
 import ArticleList from "../src/article-list";
 import articlesFixture from "../fixtures/articles.json";
 import adConfig from "../fixtures/article-ad-config.json";
 import { omitWeb as omitProps } from "./utils";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 export default () => {
   addSerializers(
@@ -38,18 +32,16 @@ export default () => {
       test() {
         const onNext = jest.fn();
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture}
-              count={5}
-              emptyStateMessage="Empty state"
-              onNext={onNext}
-              page={1}
-              pageSize={3}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture}
+            count={5}
+            emptyStateMessage="Empty state"
+            onNext={onNext}
+            page={1}
+            pageSize={3}
+            refetch={() => {}}
+          />
         );
 
         const [nextPage] = testInstance.root.findAll(
@@ -66,18 +58,16 @@ export default () => {
       test() {
         const onPrev = jest.fn();
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture}
-              count={5}
-              emptyStateMessage="Empty state"
-              onPrev={onPrev}
-              page={2}
-              pageSize={3}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture}
+            count={5}
+            emptyStateMessage="Empty state"
+            onPrev={onPrev}
+            page={2}
+            pageSize={3}
+            refetch={() => {}}
+          />
         );
 
         const [prevPage] = testInstance.root.findAll(
@@ -96,18 +86,16 @@ export default () => {
         const onNext = jest.fn();
         const consoleSpy = jest.spyOn(console, "error").mockImplementation();
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture}
-              count={5}
-              emptyStateMessage="Empty state"
-              onNext={onNext}
-              page={1}
-              pageSize={3}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture}
+            count={5}
+            emptyStateMessage="Empty state"
+            onNext={onNext}
+            page={1}
+            pageSize={3}
+            refetch={() => {}}
+          />
         );
 
         const [, nextPage] = testInstance.root.findAll(
@@ -174,18 +162,16 @@ export default () => {
         const onPrev = jest.fn();
         const consoleSpy = jest.spyOn(console, "error").mockImplementation();
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture}
-              count={5}
-              emptyStateMessage="Empty state"
-              onPrev={onPrev}
-              page={2}
-              pageSize={3}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture}
+            count={5}
+            emptyStateMessage="Empty state"
+            onPrev={onPrev}
+            page={2}
+            pageSize={3}
+            refetch={() => {}}
+          />
         );
 
         const [, prevPage] = testInstance.root.findAll(

--- a/packages/article-list/__tests__/shared-states.web.js
+++ b/packages/article-list/__tests__/shared-states.web.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { Text } from "react-native";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
 import { iterator } from "@times-components/test-utils";
 import {
   addSerializers,
@@ -23,11 +22,6 @@ const omitProps = new Set([
   "labelProps"
 ]);
 
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
-
 export default () => {
   addSerializers(
     expect,
@@ -46,14 +40,12 @@ export default () => {
       test() {
         const apolloError = new ApolloError("Test");
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              emptyStateMessage="Empty State"
-              error={apolloError}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            emptyStateMessage="Empty State"
+            error={apolloError}
+            refetch={() => {}}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -64,15 +56,13 @@ export default () => {
       test() {
         const apolloError = new ApolloError("Test");
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articleListHeader={<Text>Some Header</Text>}
-              emptyStateMessage="Empty State"
-              error={apolloError}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articleListHeader={<Text>Some Header</Text>}
+            emptyStateMessage="Empty State"
+            error={apolloError}
+            refetch={() => {}}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -82,14 +72,12 @@ export default () => {
       name: "an empty list",
       test() {
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={[]}
-              emptyStateMessage="Empty state"
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={[]}
+            emptyStateMessage="Empty state"
+            refetch={() => {}}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -99,15 +87,13 @@ export default () => {
       name: "loading state",
       test() {
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articlesLoading
-              emptyStateMessage="Empty state"
-              pageSize={3}
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articlesLoading
+            emptyStateMessage="Empty state"
+            pageSize={3}
+            refetch={() => {}}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();

--- a/packages/article-list/__tests__/shared-tracking.web.js
+++ b/packages/article-list/__tests__/shared-tracking.web.js
@@ -1,16 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
 import { iterator } from "@times-components/test-utils";
 import ArticleList from "../src/article-list";
 import articlesFixture from "../fixtures/articles.json";
 import adConfig from "../fixtures/article-ad-config.json";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 export default () => {
   jest.useFakeTimers();
@@ -32,15 +26,13 @@ export default () => {
 
           render() {
             return (
-              <Context.Provider value={{ makeArticleUrl }}>
-                <ArticleList
-                  adConfig={adConfig}
-                  articles={articlesFixture}
-                  emptyStateMessage="Empty state"
-                  pageSize={3}
-                  refetch={() => {}}
-                />
-              </Context.Provider>
+              <ArticleList
+                adConfig={adConfig}
+                articles={articlesFixture}
+                emptyStateMessage="Empty state"
+                pageSize={3}
+                refetch={() => {}}
+              />
             );
           }
         }

--- a/packages/article-list/__tests__/shared.base.web.js
+++ b/packages/article-list/__tests__/shared.base.web.js
@@ -1,12 +1,9 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
 import { iterator } from "@times-components/test-utils";
 import ArticleList from "../src/article-list";
 import articlesFixture from "../fixtures/articles.json";
 import adConfig from "../fixtures/article-ad-config.json";
-
-const makeArticleUrl = () => "https://test.io";
 
 export default (additionalTests = []) => {
   const realIntl = Intl;
@@ -29,14 +26,12 @@ export default (additionalTests = []) => {
       name: "article list",
       test() {
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture}
-              emptyStateMessage="Empty state"
-              refetch={() => {}}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture}
+            emptyStateMessage="Empty state"
+            refetch={() => {}}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();

--- a/packages/article-list/__tests__/shared.web.js
+++ b/packages/article-list/__tests__/shared.web.js
@@ -6,7 +6,6 @@ import {
   minimalWebTransform,
   print
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
 import TestRenderer from "react-test-renderer";
 import "./mocks";
 import { omitWeb as omitProps } from "./utils";
@@ -14,8 +13,6 @@ import articlesFixture from "../fixtures/articles.json";
 import adConfig from "../fixtures/article-ad-config.json";
 import ArticleList from "../src/article-list";
 import shared from "./shared.base.web";
-
-const makeArticleUrl = () => "https://test.io";
 
 export default () => {
   addSerializers(
@@ -34,16 +31,14 @@ export default () => {
       name: "article list with no images",
       test() {
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={articlesFixture.slice(0, 1)}
-              emptyStateMessage="Empty state"
-              pageSize={3}
-              refetch={() => {}}
-              showImages={false}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={articlesFixture.slice(0, 1)}
+            emptyStateMessage="Empty state"
+            pageSize={3}
+            refetch={() => {}}
+            showImages={false}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -62,16 +57,14 @@ export default () => {
         };
 
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <ArticleList
-              adConfig={adConfig}
-              articles={[missingImage]}
-              emptyStateMessage="Empty state"
-              pageSize={3}
-              refetch={() => {}}
-              showImages={false}
-            />
-          </Context.Provider>
+          <ArticleList
+            adConfig={adConfig}
+            articles={[missingImage]}
+            emptyStateMessage="Empty state"
+            pageSize={3}
+            refetch={() => {}}
+            showImages={false}
+          />
         );
 
         expect(testInstance).toMatchSnapshot();

--- a/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. article list 1`] = `
     >
       <div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-1-968n7tdck1"
         >
           <div>
             <Card
@@ -65,7 +65,7 @@ exports[`1. article list 1`] = `
           <div />
         </div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-2-968n7tdck2"
         >
           <div>
             <Card
@@ -132,7 +132,7 @@ exports[`1. article list 1`] = `
           <div />
         </div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-3-968n7tdck3"
         >
           <div>
             <Card
@@ -199,7 +199,7 @@ exports[`1. article list 1`] = `
           <div />
         </div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-4-968n7tdck4"
         >
           <div>
             <Card
@@ -266,7 +266,7 @@ exports[`1. article list 1`] = `
           <div />
         </div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-5-968n7tdck5"
         >
           <div>
             <Card
@@ -362,7 +362,7 @@ exports[`2. article list with no images 1`] = `
     >
       <div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-1-968n7tdck1"
         >
           <div>
             <Card
@@ -452,7 +452,7 @@ exports[`3. article list with missing image 1`] = `
     >
       <div>
         <Link
-          url="https://test.io"
+          url="https://www.thetimes.co.uk/article/this-is-slug-1-968n7tdck1"
         >
           <div>
             <Card

--- a/packages/article-list/__tests__/web/article-list-lazy.web.test.js
+++ b/packages/article-list/__tests__/web/article-list-lazy.web.test.js
@@ -7,7 +7,7 @@ import {
   enzymeRenderedSerializer,
   minimalise
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
+import { defaults } from "@times-components/context";
 import articleListFixture from "../../fixtures/articles.json";
 import adConfig from "../../fixtures/article-ad-config.json";
 import ArticleList from "../../src/article-list";
@@ -15,11 +15,6 @@ import ArticleList from "../../src/article-list";
 const delay = ms => new Promise(res => setTimeout(res, ms));
 
 const omitProps = new Set(["class", "className", "style"]);
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 addSerializers(
   expect,
@@ -88,11 +83,7 @@ const tests = [
     async test() {
       window.IntersectionObserver = FakeIntersectionObserver;
 
-      const component = mount(
-        <Context.Provider value={{ makeArticleUrl }}>
-          <ArticleList {...articleListProps} />
-        </Context.Provider>
-      );
+      const component = mount(<ArticleList {...articleListProps} />);
       // prove the first image starts off as low quality
       expect(
         component
@@ -140,11 +131,7 @@ const tests = [
     async test() {
       window.IntersectionObserver = FakeIntersectionObserver;
 
-      const component = mount(
-        <Context.Provider value={{ makeArticleUrl }}>
-          <ArticleList {...articleListProps} />
-        </Context.Provider>
-      );
+      const component = mount(<ArticleList {...articleListProps} />);
 
       const makeEntries = nodes =>
         [...nodes].map((node, indx) => ({
@@ -185,7 +172,7 @@ const tests = [
           attachTo: mountPoint,
           childContextTypes: { makeArticleUrl: PropTypes.func },
           context: {
-            makeArticleUrl,
+            makeArticleUrl: defaults.makeArticleUrl,
             tracking: {
               analytics: reporter
             }

--- a/packages/article-list/article-list.showcase.js
+++ b/packages/article-list/article-list.showcase.js
@@ -7,7 +7,6 @@ import {
   MockedProvider,
   MockFixture
 } from "@times-components/provider-test-tools";
-import Context from "@times-components/context";
 import {
   authorArticlesNoImages as authorArticlesNoImagesQuery,
   authorArticlesWithImages as authorArticlesWithImagesQuery
@@ -20,11 +19,6 @@ import get from "lodash.get";
 import ArticleList, { ArticleListPageError } from "./src/article-list";
 import adConfig from "./fixtures/article-ad-config.json";
 import { ratioTextToFloat } from "../utils/dist";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -76,36 +70,34 @@ export default {
           })}
           render={mocks => (
             <MockedProvider mocks={mocks}>
-              <Context.Provider value={{ makeArticleUrl }}>
-                <AuthorArticlesWithImagesProvider
-                  debounceTimeMs={0}
-                  page={page}
-                  pageSize={pageSize}
-                  slug={slug}
-                >
-                  {({
-                    author: data,
-                    error: articlesError,
-                    isLoading: articlesLoading,
-                    page: articlePage,
-                    pageSize: articlePageSize,
-                    variables: { imageRatio = "3:2" }
-                  }) => (
-                    <TrackedArticleList
-                      articles={get(data, "articles.list", [])}
-                      articlesLoading={articlesLoading}
-                      count={count}
-                      emptyStateMessage={emptyStateMessage}
-                      error={articlesError}
-                      imageRatio={ratioTextToFloat(imageRatio)}
-                      page={articlePage}
-                      pageSize={articlePageSize}
-                      showImages
-                      {...getProps(decorateAction)}
-                    />
-                  )}
-                </AuthorArticlesWithImagesProvider>
-              </Context.Provider>
+              <AuthorArticlesWithImagesProvider
+                debounceTimeMs={0}
+                page={page}
+                pageSize={pageSize}
+                slug={slug}
+              >
+                {({
+                  author: data,
+                  error: articlesError,
+                  isLoading: articlesLoading,
+                  page: articlePage,
+                  pageSize: articlePageSize,
+                  variables: { imageRatio = "3:2" }
+                }) => (
+                  <TrackedArticleList
+                    articles={get(data, "articles.list", [])}
+                    articlesLoading={articlesLoading}
+                    count={count}
+                    emptyStateMessage={emptyStateMessage}
+                    error={articlesError}
+                    imageRatio={ratioTextToFloat(imageRatio)}
+                    page={articlePage}
+                    pageSize={articlePageSize}
+                    showImages
+                    {...getProps(decorateAction)}
+                  />
+                )}
+              </AuthorArticlesWithImagesProvider>
             </MockedProvider>
           )}
         />
@@ -132,34 +124,32 @@ export default {
           })}
           render={mocks => (
             <MockedProvider mocks={mocks}>
-              <Context.Provider value={{ makeArticleUrl }}>
-                <AuthorArticlesNoImagesProvider
-                  debounceTimeMs={0}
-                  page={page}
-                  pageSize={pageSize}
-                  slug={slug}
-                >
-                  {({
-                    author: data,
-                    error: articlesError,
-                    isLoading: articlesLoading,
-                    page: articlePage,
-                    pageSize: articlePageSize
-                  }) => (
-                    <TrackedArticleList
-                      articles={get(data, "articles.list", [])}
-                      articlesLoading={articlesLoading}
-                      count={count}
-                      emptyStateMessage={emptyStateMessage}
-                      error={articlesError}
-                      page={articlePage}
-                      pageSize={articlePageSize}
-                      showImages={false}
-                      {...getProps(decorateAction)}
-                    />
-                  )}
-                </AuthorArticlesNoImagesProvider>
-              </Context.Provider>
+              <AuthorArticlesNoImagesProvider
+                debounceTimeMs={0}
+                page={page}
+                pageSize={pageSize}
+                slug={slug}
+              >
+                {({
+                  author: data,
+                  error: articlesError,
+                  isLoading: articlesLoading,
+                  page: articlePage,
+                  pageSize: articlePageSize
+                }) => (
+                  <TrackedArticleList
+                    articles={get(data, "articles.list", [])}
+                    articlesLoading={articlesLoading}
+                    count={count}
+                    emptyStateMessage={emptyStateMessage}
+                    error={articlesError}
+                    page={articlePage}
+                    pageSize={articlePageSize}
+                    showImages={false}
+                    {...getProps(decorateAction)}
+                  />
+                )}
+              </AuthorArticlesNoImagesProvider>
             </MockedProvider>
           )}
         />
@@ -195,36 +185,34 @@ export default {
           })}
           render={mocks => (
             <MockedProvider mocks={mocks}>
-              <Context.Provider value={{ makeArticleUrl }}>
-                <AuthorArticlesWithImagesProvider
-                  debounceTimeMs={0}
-                  page={page}
-                  pageSize={pageSize}
-                  slug={slug}
-                >
-                  {({
-                    author: data,
-                    error: articlesError,
-                    isLoading: articlesLoading,
-                    page: articlePage,
-                    pageSize: articlePageSize,
-                    variables: { imageRatio = "3:2" }
-                  }) => (
-                    <TrackedArticleList
-                      articles={get(data, "articles.list", [])}
-                      articlesLoading={articlesLoading}
-                      count={count}
-                      emptyStateMessage={emptyStateMessage}
-                      error={articlesError}
-                      imageRatio={ratioTextToFloat(imageRatio)}
-                      page={articlePage}
-                      pageSize={articlePageSize}
-                      showImages
-                      {...getProps(decorateAction)}
-                    />
-                  )}
-                </AuthorArticlesWithImagesProvider>
-              </Context.Provider>
+              <AuthorArticlesWithImagesProvider
+                debounceTimeMs={0}
+                page={page}
+                pageSize={pageSize}
+                slug={slug}
+              >
+                {({
+                  author: data,
+                  error: articlesError,
+                  isLoading: articlesLoading,
+                  page: articlePage,
+                  pageSize: articlePageSize,
+                  variables: { imageRatio = "3:2" }
+                }) => (
+                  <TrackedArticleList
+                    articles={get(data, "articles.list", [])}
+                    articlesLoading={articlesLoading}
+                    count={count}
+                    emptyStateMessage={emptyStateMessage}
+                    error={articlesError}
+                    imageRatio={ratioTextToFloat(imageRatio)}
+                    page={articlePage}
+                    pageSize={articlePageSize}
+                    showImages
+                    {...getProps(decorateAction)}
+                  />
+                )}
+              </AuthorArticlesWithImagesProvider>
             </MockedProvider>
           )}
         />
@@ -264,37 +252,35 @@ export default {
             })}
             render={mocks => (
               <MockedProvider mocks={mocks}>
-                <Context.Provider value={{ makeArticleUrl }}>
-                  <AuthorArticlesWithImagesProvider
-                    debounceTimeMs={0}
-                    page={page}
-                    pageSize={pageSize}
-                    slug={slug}
-                  >
-                    {({
-                      author: data,
-                      error: articlesError,
-                      isLoading: articlesLoading,
-                      page: articlePage,
-                      pageSize: articlePageSize,
-                      variables: { imageRatio = "3:2" }
-                    }) => (
-                      <TrackedArticleList
-                        articleListHeader={articleListHeader}
-                        articles={get(data, "articles.list", [])}
-                        articlesLoading={articlesLoading}
-                        count={count}
-                        emptyStateMessage={emptyStateMessage}
-                        error={articlesError}
-                        imageRatio={ratioTextToFloat(imageRatio)}
-                        page={articlePage}
-                        pageSize={articlePageSize}
-                        showImages
-                        {...getProps(decorateAction)}
-                      />
-                    )}
-                  </AuthorArticlesWithImagesProvider>
-                </Context.Provider>
+                <AuthorArticlesWithImagesProvider
+                  debounceTimeMs={0}
+                  page={page}
+                  pageSize={pageSize}
+                  slug={slug}
+                >
+                  {({
+                    author: data,
+                    error: articlesError,
+                    isLoading: articlesLoading,
+                    page: articlePage,
+                    pageSize: articlePageSize,
+                    variables: { imageRatio = "3:2" }
+                  }) => (
+                    <TrackedArticleList
+                      articleListHeader={articleListHeader}
+                      articles={get(data, "articles.list", [])}
+                      articlesLoading={articlesLoading}
+                      count={count}
+                      emptyStateMessage={emptyStateMessage}
+                      error={articlesError}
+                      imageRatio={ratioTextToFloat(imageRatio)}
+                      page={articlePage}
+                      pageSize={articlePageSize}
+                      showImages
+                      {...getProps(decorateAction)}
+                    />
+                  )}
+                </AuthorArticlesWithImagesProvider>
               </MockedProvider>
             )}
           />
@@ -337,36 +323,34 @@ export default {
           })}
           render={mocks => (
             <MockedProvider mocks={mocks}>
-              <Context.Provider value={{ makeArticleUrl }}>
-                <AuthorArticlesWithImagesProvider
-                  debounceTimeMs={0}
-                  page={page}
-                  pageSize={pageSize}
-                  slug={slug}
-                >
-                  {({
-                    author: data,
-                    error: articlesError,
-                    isLoading: articlesLoading,
-                    page: articlePage,
-                    pageSize: articlePageSize,
-                    variables: { imageRatio = "3:2" }
-                  }) => (
-                    <TrackedArticleList
-                      articles={get(data, "articles.list", [])}
-                      articlesLoading={articlesLoading}
-                      count={count}
-                      emptyStateMessage={emptyStateMessage}
-                      error={articlesError}
-                      imageRatio={ratioTextToFloat(imageRatio)}
-                      page={articlePage}
-                      pageSize={articlePageSize}
-                      showImages
-                      {...getProps(decorateAction)}
-                    />
-                  )}
-                </AuthorArticlesWithImagesProvider>
-              </Context.Provider>
+              <AuthorArticlesWithImagesProvider
+                debounceTimeMs={0}
+                page={page}
+                pageSize={pageSize}
+                slug={slug}
+              >
+                {({
+                  author: data,
+                  error: articlesError,
+                  isLoading: articlesLoading,
+                  page: articlePage,
+                  pageSize: articlePageSize,
+                  variables: { imageRatio = "3:2" }
+                }) => (
+                  <TrackedArticleList
+                    articles={get(data, "articles.list", [])}
+                    articlesLoading={articlesLoading}
+                    count={count}
+                    emptyStateMessage={emptyStateMessage}
+                    error={articlesError}
+                    imageRatio={ratioTextToFloat(imageRatio)}
+                    page={articlePage}
+                    pageSize={articlePageSize}
+                    showImages
+                    {...getProps(decorateAction)}
+                  />
+                )}
+              </AuthorArticlesWithImagesProvider>
             </MockedProvider>
           )}
         />
@@ -391,36 +375,34 @@ export default {
           })}
           render={mocks => (
             <MockedProvider mocks={mocks}>
-              <Context.Provider value={{ makeArticleUrl }}>
-                <AuthorArticlesWithImagesProvider
-                  debounceTimeMs={0}
-                  page={page}
-                  pageSize={pageSize}
-                  slug={slug}
-                >
-                  {({
-                    author: data,
-                    error: articlesError,
-                    isLoading: articlesLoading,
-                    page: articlePage,
-                    pageSize: articlePageSize,
-                    variables: { imageRatio = "3:2" }
-                  }) => (
-                    <TrackedArticleList
-                      articles={get(data, "articles.list", [])}
-                      articlesLoading={articlesLoading}
-                      count={count}
-                      emptyStateMessage={emptyStateMessage}
-                      error={articlesError}
-                      imageRatio={ratioTextToFloat(imageRatio)}
-                      page={articlePage}
-                      pageSize={articlePageSize}
-                      showImages
-                      {...getProps(decorateAction)}
-                    />
-                  )}
-                </AuthorArticlesWithImagesProvider>
-              </Context.Provider>
+              <AuthorArticlesWithImagesProvider
+                debounceTimeMs={0}
+                page={page}
+                pageSize={pageSize}
+                slug={slug}
+              >
+                {({
+                  author: data,
+                  error: articlesError,
+                  isLoading: articlesLoading,
+                  page: articlePage,
+                  pageSize: articlePageSize,
+                  variables: { imageRatio = "3:2" }
+                }) => (
+                  <TrackedArticleList
+                    articles={get(data, "articles.list", [])}
+                    articlesLoading={articlesLoading}
+                    count={count}
+                    emptyStateMessage={emptyStateMessage}
+                    error={articlesError}
+                    imageRatio={ratioTextToFloat(imageRatio)}
+                    page={articlePage}
+                    pageSize={articlePageSize}
+                    showImages
+                    {...getProps(decorateAction)}
+                  />
+                )}
+              </AuthorArticlesWithImagesProvider>
             </MockedProvider>
           )}
         />

--- a/packages/article-magazine-comment/__tests__/mocks.web.js
+++ b/packages/article-magazine-comment/__tests__/mocks.web.js
@@ -1,3 +1,4 @@
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
 // eslint-disable-next-line global-require
 jest.mock("@times-components/ad", () => require("./ad-mock"));
 jest.mock("@times-components/article-byline", () => ({

--- a/packages/article-magazine-comment/__tests__/shared-internal-components.base.js
+++ b/packages/article-magazine-comment/__tests__/shared-internal-components.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { iterator } from "@times-components/test-utils";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import Label from "../src/article-label/article-label";
 import Meta from "../src/article-meta/article-meta";
 import Standfirst from "../src/article-standfirst/article-standfirst";
@@ -30,13 +30,13 @@ const snapshotTests = renderComponent => [
     name: "article label uses default section colour",
     test() {
       const output = renderComponent(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
             theme: { sectionColour: null }
           }}
         >
           <Label label="Random Label" />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();

--- a/packages/article-magazine-comment/__tests__/shared-with-style.native.js
+++ b/packages/article-magazine-comment/__tests__/shared-with-style.native.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -154,9 +154,9 @@ export default () => {
 
   it("full article with style in the culture magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -164,9 +164,9 @@ export default () => {
 
   it("full article with style in the style magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -174,9 +174,11 @@ export default () => {
 
   it("full article with style in the sunday times magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -185,9 +187,9 @@ export default () => {
   it("tablet full article with style in the culture magazine", () => {
     setIsTablet(true);
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -196,9 +198,9 @@ export default () => {
   it("tablet full article with style in the style magazine", () => {
     setIsTablet(true);
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -207,9 +209,11 @@ export default () => {
   it("tablet full article with style in the sunday times magazine", () => {
     setIsTablet(true);
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-magazine-comment/__tests__/shared-with-style.web.js
+++ b/packages/article-magazine-comment/__tests__/shared-with-style.web.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { AppRegistry } from "react-native-web";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -176,9 +176,9 @@ export default () => {
 
   it("full article with style in the culture magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -186,9 +186,9 @@ export default () => {
 
   it("full article with style in the style magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -196,9 +196,11 @@ export default () => {
 
   it("full article with style in the sunday times magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleMagazineComment {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -520,6 +520,25 @@ exports[`full article with style 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >
@@ -1218,6 +1237,25 @@ exports[`full article with style in the culture magazine 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >
@@ -1916,6 +1954,25 @@ exports[`full article with style in the style magazine 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >
@@ -2614,6 +2671,25 @@ exports[`full article with style in the sunday times magazine 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -6,6 +6,58 @@ exports[`2. loading 1`] = `null`;
 
 exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 <article>
+  <Helmet>
+    <title>
+      
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content=""
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Some byline"
+      name="author"
+    />
+    <meta
+      content=""
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content=""
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <div>
     <Ad
       contextUrl="https://url.io"
@@ -152,6 +204,58 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 
 exports[`4. an article with ads 1`] = `
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content="Some Headline"
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Some byline"
+      name="author"
+    />
+    <meta
+      content="Some Headline"
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content="Some Headline"
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <div>
     <Ad
       contextUrl="https://url.io"
@@ -300,6 +404,58 @@ exports[`4. an article with ads 1`] = `
 
 exports[`7. an article with no author 1`] = `
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content="Some Headline"
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Rick Broadbent"
+      name="author"
+    />
+    <meta
+      content="Some Headline"
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content="Some Headline"
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <div>
     <Ad
       contextUrl="https://url.io"

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -8,13 +8,13 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 <article>
   <Helmet>
     <title>
-      
+      Some Short Headline
        | 
       
       The Times
     </title>
     <meta
-      content=""
+      content="Some Short Headline"
       name="article:title"
     />
     <meta
@@ -26,7 +26,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       name="author"
     />
     <meta
-      content=""
+      content="Some Short Headline"
       property="og:title"
     />
     <meta
@@ -42,7 +42,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       property="og:image"
     />
     <meta
-      content=""
+      content="Some Short Headline"
       name="twitter:title"
     />
     <meta

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -2,6 +2,58 @@
 
 exports[`1. a full article 1`] = `
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content="Some Headline"
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Some byline"
+      name="author"
+    />
+    <meta
+      content="Some Headline"
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content="Some Headline"
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <svg
     height={250}
     viewBox="-630 120 1200 50"

--- a/packages/article-magazine-comment/__tests__/web/semantic.web.test.js
+++ b/packages/article-magazine-comment/__tests__/web/semantic.web.test.js
@@ -11,7 +11,7 @@ import {
   replacePropTransform,
   replaceTransform
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import Article from "../../src/article-magazine-comment";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
@@ -126,9 +126,8 @@ const tests = [
       const scale = scales.large;
       const sectionColour = "#FFFFFF";
       const testRenderer = TestRenderer.create(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl: () => "https://some-url.io",
             theme: { scale, sectionColour }
           }}
         >
@@ -146,7 +145,7 @@ const tests = [
             receiveChildList={() => {}}
             spotAccountId=""
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(testRenderer).toMatchSnapshot();

--- a/packages/article-magazine-comment/__tests__/web/semantic.web.test.js
+++ b/packages/article-magazine-comment/__tests__/web/semantic.web.test.js
@@ -17,6 +17,8 @@ import Article from "../../src/article-magazine-comment";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
 import { adConfig } from "../ad-mock";
 
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
+
 const omitProps = new Set([
   "className",
   "fill",

--- a/packages/article-magazine-comment/article-magazine-comment.showcase.js
+++ b/packages/article-magazine-comment/article-magazine-comment.showcase.js
@@ -1,7 +1,10 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context, { defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
 import {
   article as makeParams,
@@ -12,11 +15,6 @@ import { sections } from "@times-components/storybook";
 import { scales, themeFactory } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
 import ArticleMagazineComment from "./src/article-magazine-comment";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -45,9 +43,8 @@ const renderArticle = ({
       };
 
       return (
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl,
             theme: {
               ...themeFactory(section, templateName),
               scale: scale || defaults.theme.scale
@@ -87,7 +84,7 @@ const renderArticle = ({
             )}
             refetch={refetch}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
     }}
   </ArticleProvider>

--- a/packages/article-magazine-standard/__tests__/mocks.web.js
+++ b/packages/article-magazine-standard/__tests__/mocks.web.js
@@ -1,3 +1,4 @@
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
 // eslint-disable-next-line global-require
 jest.mock("@times-components/ad", () => require("./ad-mock"));
 jest.mock("@times-components/article-byline", () => ({

--- a/packages/article-magazine-standard/__tests__/shared-internal-components.base.js
+++ b/packages/article-magazine-standard/__tests__/shared-internal-components.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { iterator } from "@times-components/test-utils";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import Label from "../src/article-label/article-label";
 import Meta from "../src/article-meta/article-meta";
 import Standfirst from "../src/article-standfirst/article-standfirst";
@@ -30,13 +30,13 @@ const snapshotTests = renderComponent => [
     name: "article label uses default section colour",
     test() {
       const output = renderComponent(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
             theme: { sectionColour: null }
           }}
         >
           <Label label="Random Label" />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();
@@ -62,7 +62,7 @@ const snapshotTests = renderComponent => [
     name: "article meta uses default section colour",
     test() {
       const output = renderComponent(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
             theme: { sectionColour: null }
           }}
@@ -73,7 +73,7 @@ const snapshotTests = renderComponent => [
             publicationName="TIMES"
             publishedTime="2015-03-23T19:39:39.000Z"
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();

--- a/packages/article-magazine-standard/__tests__/shared-with-style.native.js
+++ b/packages/article-magazine-standard/__tests__/shared-with-style.native.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -159,9 +159,9 @@ export default () => {
 
   it("full article with style in the culture magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleMagazineStandard {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -169,9 +169,9 @@ export default () => {
 
   it("full article with style in the style magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleMagazineStandard {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -179,9 +179,11 @@ export default () => {
 
   it("full article with style in the sunday times magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleMagazineStandard {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-magazine-standard/__tests__/shared-with-style.web.js
+++ b/packages/article-magazine-standard/__tests__/shared-with-style.web.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { AppRegistry } from "react-native-web";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -175,9 +175,9 @@ export default () => {
 
   it("full article with style in the culture magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("culture")}>
+      <ContextProviderWithDefaults value={themeForSection("culture")}>
         <ArticleMagazineStandard {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -185,9 +185,9 @@ export default () => {
 
   it("full article with style in the style magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("style")}>
+      <ContextProviderWithDefaults value={themeForSection("style")}>
         <ArticleMagazineStandard {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();
@@ -195,9 +195,11 @@ export default () => {
 
   it("full article with style in the sunday times magazine", () => {
     const testRenderer = TestRenderer.create(
-      <Context.Provider value={themeForSection("thesundaytimesmagazine")}>
+      <ContextProviderWithDefaults
+        value={themeForSection("thesundaytimesmagazine")}
+      >
         <ArticleMagazineStandard {...sharedProps} article={article} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -468,6 +468,25 @@ exports[`full article with style 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >
@@ -1092,6 +1111,25 @@ exports[`full article with style in the culture magazine 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >
@@ -1716,6 +1754,25 @@ exports[`full article with style in the style magazine 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >
@@ -2340,6 +2397,25 @@ exports[`full article with style in the sunday times magazine 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -6,6 +6,58 @@ exports[`2. loading 1`] = `null`;
 
 exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 <article>
+  <Helmet>
+    <title>
+      
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content=""
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Some byline"
+      name="author"
+    />
+    <meta
+      content=""
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content=""
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <div>
     <Ad
       contextUrl="https://url.io"
@@ -147,6 +199,58 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 
 exports[`4. an article with ads 1`] = `
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content="Some Headline"
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Some byline"
+      name="author"
+    />
+    <meta
+      content="Some Headline"
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content="Some Headline"
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <div>
     <Ad
       contextUrl="https://url.io"

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -8,13 +8,13 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 <article>
   <Helmet>
     <title>
-      
+      Some Short Headline
        | 
       
       The Times
     </title>
     <meta
-      content=""
+      content="Some Short Headline"
       name="article:title"
     />
     <meta
@@ -26,7 +26,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       name="author"
     />
     <meta
-      content=""
+      content="Some Short Headline"
       property="og:title"
     />
     <meta
@@ -42,7 +42,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       property="og:image"
     />
     <meta
-      content=""
+      content="Some Short Headline"
       name="twitter:title"
     />
     <meta

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -2,6 +2,58 @@
 
 exports[`1. a full article 1`] = `
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content="Some Headline"
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Some byline"
+      name="author"
+    />
+    <meta
+      content="Some Headline"
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content="Some Headline"
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <svg
     height={250}
     viewBox="-630 120 1200 50"

--- a/packages/article-magazine-standard/__tests__/web/semantic.web.test.js
+++ b/packages/article-magazine-standard/__tests__/web/semantic.web.test.js
@@ -11,7 +11,7 @@ import {
   replacePropTransform,
   replaceTransform
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import Article from "../../src/article-magazine-standard";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
@@ -126,9 +126,8 @@ const tests = [
       const scale = scales.large;
       const sectionColour = "#FFFFFF";
       const testRenderer = TestRenderer.create(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl: () => "https://some-url.io",
             theme: { scale, sectionColour }
           }}
         >
@@ -146,7 +145,7 @@ const tests = [
             receiveChildList={() => {}}
             spotAccountId=""
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(testRenderer).toMatchSnapshot();

--- a/packages/article-magazine-standard/__tests__/web/semantic.web.test.js
+++ b/packages/article-magazine-standard/__tests__/web/semantic.web.test.js
@@ -17,6 +17,8 @@ import Article from "../../src/article-magazine-standard";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
 import { adConfig } from "../ad-mock";
 
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
+
 const omitProps = new Set([
   "className",
   "fill",

--- a/packages/article-magazine-standard/article-magazine-standard.showcase.js
+++ b/packages/article-magazine-standard/article-magazine-standard.showcase.js
@@ -1,7 +1,10 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context, { defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
 import {
   article as makeParams,
@@ -12,11 +15,6 @@ import { sections } from "@times-components/storybook";
 import { scales, themeFactory } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
 import ArticleMagazineStandard from "./src/article-magazine-standard";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -44,9 +42,8 @@ const renderArticle = ({
       };
 
       return (
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl,
             theme: {
               ...themeFactory(section, templateName),
               scale: scale || defaults.theme.scale
@@ -86,7 +83,7 @@ const renderArticle = ({
             )}
             refetch={refetch}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
     }}
   </ArticleProvider>

--- a/packages/article-main-comment/__tests__/mocks.web.js
+++ b/packages/article-main-comment/__tests__/mocks.web.js
@@ -1,3 +1,4 @@
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
 // eslint-disable-next-line global-require
 jest.mock("@times-components/ad", () => require("./ad-mock"));
 jest.mock("@times-components/article-byline", () => ({

--- a/packages/article-main-comment/__tests__/shared-internal-components.base.js
+++ b/packages/article-main-comment/__tests__/shared-internal-components.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { iterator } from "@times-components/test-utils";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import Label from "../src/article-label/article-label";
 import Meta from "../src/article-meta/article-meta";
 import Standfirst from "../src/article-standfirst/article-standfirst";
@@ -30,13 +30,13 @@ const snapshotTests = renderComponent => [
     name: "article label uses default section colour",
     test() {
       const output = renderComponent(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
             theme: { sectionColour: null }
           }}
         >
           <Label label="Random Label" />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -475,6 +475,25 @@ exports[`full article with style 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -6,6 +6,58 @@ exports[`2. loading 1`] = `null`;
 
 exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 <article>
+  <Helmet>
+    <title>
+      
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content=""
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Some byline"
+      name="author"
+    />
+    <meta
+      content=""
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content=""
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <div>
     <Ad
       contextUrl="https://url.io"
@@ -139,6 +191,58 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 
 exports[`4. an article with ads 1`] = `
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content="Some Headline"
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Some byline"
+      name="author"
+    />
+    <meta
+      content="Some Headline"
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content="Some Headline"
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <div>
     <Ad
       contextUrl="https://url.io"

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -8,13 +8,13 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 <article>
   <Helmet>
     <title>
-      
+      Some Short Headline
        | 
       
       The Times
     </title>
     <meta
-      content=""
+      content="Some Short Headline"
       name="article:title"
     />
     <meta
@@ -26,7 +26,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       name="author"
     />
     <meta
-      content=""
+      content="Some Short Headline"
       property="og:title"
     />
     <meta
@@ -42,7 +42,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       property="og:image"
     />
     <meta
-      content=""
+      content="Some Short Headline"
       name="twitter:title"
     />
     <meta

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -2,6 +2,58 @@
 
 exports[`1. a full article 1`] = `
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content="Some Headline"
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Some byline"
+      name="author"
+    />
+    <meta
+      content="Some Headline"
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content="Some Headline"
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <svg
     height={250}
     viewBox="-630 120 1200 50"

--- a/packages/article-main-comment/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-comment/__tests__/web/semantic.web.test.js
@@ -17,6 +17,8 @@ import Article from "../../src/article-main-comment";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
 import { adConfig } from "../ad-mock";
 
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
+
 const omitProps = new Set([
   "className",
   "fill",

--- a/packages/article-main-comment/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-comment/__tests__/web/semantic.web.test.js
@@ -11,7 +11,7 @@ import {
   replacePropTransform,
   replaceTransform
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import Article from "../../src/article-main-comment";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
@@ -126,9 +126,8 @@ const tests = [
       const scale = scales.large;
       const sectionColour = "#FFFFFF";
       const testRenderer = TestRenderer.create(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl: () => "https://some-url.io",
             theme: { scale, sectionColour }
           }}
         >
@@ -146,7 +145,7 @@ const tests = [
             receiveChildList={() => {}}
             spotAccountId=""
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(testRenderer).toMatchSnapshot();

--- a/packages/article-main-comment/article-main-comment.showcase.js
+++ b/packages/article-main-comment/article-main-comment.showcase.js
@@ -1,7 +1,10 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context, { defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
 import Responsive from "@times-components/responsive";
 import {
@@ -13,11 +16,6 @@ import { sections } from "@times-components/storybook";
 import { scales, themeFactory } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
 import ArticleMainCommment from "./src/article-main-comment";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -47,9 +45,8 @@ const renderArticle = ({
         };
 
         return (
-          <Context.Provider
+          <ContextProviderWithDefaults
             value={{
-              makeArticleUrl,
               theme: {
                 ...themeFactory(section, templateName),
                 scale: scale || defaults.theme.scale
@@ -91,7 +88,7 @@ const renderArticle = ({
               )}
               refetch={refetch}
             />
-          </Context.Provider>
+          </ContextProviderWithDefaults>
         );
       }}
     </ArticleProvider>

--- a/packages/article-main-standard/__tests__/mocks.web.js
+++ b/packages/article-main-standard/__tests__/mocks.web.js
@@ -1,3 +1,4 @@
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
 // eslint-disable-next-line global-require
 jest.mock("@times-components/ad", () => require("./ad-mock"));
 jest.mock("@times-components/article-byline", () => ({

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -524,6 +524,25 @@ exports[`full article with style 1`] = `
 </style>
 
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+    <meta />
+  </Helmet>
   <div
     className="c0 S1"
   >

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -2,6 +2,58 @@
 
 exports[`1. an article 1`] = `
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content="Some Headline"
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Some byline"
+      name="author"
+    />
+    <meta
+      content="Some Headline"
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content="Some Headline"
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <div>
     <Ad
       contextUrl="https://url.io"
@@ -193,6 +245,46 @@ exports[`3. an error 1`] = `null`;
 
 exports[`4. an article with no headline falls back to use shortheadline 1`] = `
 <article>
+  <Helmet>
+    <title>
+      
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content=""
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content=""
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content=""
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+  </Helmet>
   <div>
     <Ad
       contextUrl="https://url.io"
@@ -242,6 +334,46 @@ exports[`4. an article with no headline falls back to use shortheadline 1`] = `
 
 exports[`5. an article with ads 1`] = `
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content="Some Headline"
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Some Headline"
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="Some Headline"
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+  </Helmet>
   <div>
     <Ad
       contextUrl="https://url.io"

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -247,13 +247,13 @@ exports[`4. an article with no headline falls back to use shortheadline 1`] = `
 <article>
   <Helmet>
     <title>
-      
+      Some Short Headline
        | 
       
       The Times
     </title>
     <meta
-      content=""
+      content="Some Short Headline"
       name="article:title"
     />
     <meta
@@ -261,7 +261,7 @@ exports[`4. an article with no headline falls back to use shortheadline 1`] = `
       name="article:publication"
     />
     <meta
-      content=""
+      content="Some Short Headline"
       property="og:title"
     />
     <meta
@@ -273,7 +273,7 @@ exports[`4. an article with no headline falls back to use shortheadline 1`] = `
       property="og:url"
     />
     <meta
-      content=""
+      content="Some Short Headline"
       name="twitter:title"
     />
     <meta

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -2,6 +2,58 @@
 
 exports[`1. a full article with an image as the lead asset 1`] = `
 <article>
+  <Helmet>
+    <title>
+      Some Headline
+       | 
+      
+      The Times
+    </title>
+    <meta
+      content="Some Headline"
+      name="article:title"
+    />
+    <meta
+      content="The Times"
+      name="article:publication"
+    />
+    <meta
+      content="Some byline"
+      name="author"
+    />
+    <meta
+      content="Some Headline"
+      property="og:title"
+    />
+    <meta
+      content="article"
+      property="og:type"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      property="og:url"
+    />
+    <meta
+      content="https://crop169.io"
+      property="og:image"
+    />
+    <meta
+      content="Some Headline"
+      name="twitter:title"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      name="twitter:url"
+    />
+    <meta
+      content="https://crop169.io"
+      name="twitter:image"
+    />
+  </Helmet>
   <svg
     height={250}
     viewBox="-630 120 1200 50"

--- a/packages/article-main-standard/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-standard/__tests__/web/semantic.web.test.js
@@ -11,7 +11,7 @@ import {
   replacePropTransform,
   replaceTransform
 } from "@times-components/jest-serializer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import Article from "../../src/article-main-standard";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
@@ -126,9 +126,8 @@ const tests = [
       const scale = scales.large;
       const sectionColour = "#FFFFFF";
       const testInstance = TestRenderer.create(
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl: () => "https://some-url.io",
             theme: { scale, sectionColour }
           }}
         >
@@ -145,7 +144,7 @@ const tests = [
             onVideoPress={() => {}}
             spotAccountId=""
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(testInstance).toMatchSnapshot();

--- a/packages/article-main-standard/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-standard/__tests__/web/semantic.web.test.js
@@ -17,6 +17,8 @@ import Article from "../../src/article-main-standard";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
 import { adConfig } from "../ad-mock";
 
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
+
 const omitProps = new Set([
   "className",
   "fill",

--- a/packages/article-main-standard/article-main-standard.showcase.js
+++ b/packages/article-main-standard/article-main-standard.showcase.js
@@ -1,7 +1,10 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context, { defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
 import {
   article as makeParams,
@@ -13,11 +16,6 @@ import { scales, themeFactory } from "@times-components/styleguide";
 import Responsive from "@times-components/responsive";
 import storybookReporter from "@times-components/tealium-utils";
 import Article from "./src/article-main-standard";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -40,9 +38,8 @@ const renderArticle = ({
   <Responsive>
     <ArticleProvider debounceTimeMs={0} id={id}>
       {({ article, isLoading, error, refetch }) => (
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl,
             theme: {
               ...themeFactory(section, templateName),
               scale: scale || defaults.theme.scale
@@ -82,7 +79,7 @@ const renderArticle = ({
             )}
             refetch={refetch}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       )}
     </ArticleProvider>
   </Responsive>

--- a/packages/article-paragraph/__tests__/renderer.js
+++ b/packages/article-paragraph/__tests__/renderer.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales, themeFactory } from "@times-components/styleguide";
 import coreRenderers from "@times-components/markup";
 import { renderTree } from "@times-components/markup-forest";
@@ -9,7 +9,7 @@ import ArticleParagraph from "../src";
 export default (ast, section = "default") => {
   const theme = themeFactory(section, "magazinestandard");
   return (
-    <Context.Provider
+    <ContextProviderWithDefaults
       value={{
         theme: {
           scale: scales.medium
@@ -33,6 +33,6 @@ export default (ast, section = "default") => {
           };
         }
       })}
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 };

--- a/packages/article-paragraph/__tests__/renderer.web.js
+++ b/packages/article-paragraph/__tests__/renderer.web.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales, themeFactory } from "@times-components/styleguide";
 import coreRenderers from "@times-components/markup";
 import { renderTree } from "@times-components/markup-forest";
@@ -9,7 +9,7 @@ import DropCapView from "../src/drop-cap";
 export default (ast, section = "default") => {
   const theme = themeFactory(section, "magazinestandard");
   return (
-    <Context.Provider
+    <ContextProviderWithDefaults
       value={{
         theme: {
           ...themeFactory(section, "mainstandard"),
@@ -38,6 +38,6 @@ export default (ast, section = "default") => {
           };
         }
       })}
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 };

--- a/packages/article-paragraph/article-paragraph.showcase.js
+++ b/packages/article-paragraph/article-paragraph.showcase.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import coreRenderers from "@times-components/markup";
 import { renderTree } from "@times-components/markup-forest";
 import { sections } from "@times-components/storybook";
@@ -16,7 +16,7 @@ const renderParagraphWithScale = (select, ast) => {
   const theme = themeFactory(section, "magazinestandard");
 
   return (
-    <Context.Provider value={{ theme: { scale } }}>
+    <ContextProviderWithDefaults value={{ theme: { scale } }}>
       {renderTree(ast, {
         ...coreRenderers,
         paragraph(key, attributes, children, indx, node) {
@@ -35,7 +35,7 @@ const renderParagraphWithScale = (select, ast) => {
           };
         }
       })}
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 };
 

--- a/packages/article-skeleton/.jestlint
+++ b/packages/article-skeleton/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 11,
-  "maxAttributeStringLength": 36,
+  "maxAttributeStringLength": 200,
   "maxFileSize": 23725,
   "maxLines": 780
 }

--- a/packages/article-skeleton/__tests__/header-with-style.base.js
+++ b/packages/article-skeleton/__tests__/header-with-style.base.js
@@ -1,8 +1,8 @@
 /* eslint-disable react/no-multi-comp */
 import React from "react";
 import { Text, View } from "react-native";
-import { iterator, makeArticleUrl } from "@times-components/test-utils";
-import Context from "@times-components/context";
+import { iterator } from "@times-components/test-utils";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import ArticleSkeleton from "../src/article-skeleton";
 import articleFixture from "../fixtures/full-article";
@@ -20,9 +20,8 @@ const emptyArticle = {
 };
 
 const renderArticle = (data, header) => (
-  <Context.Provider
+  <ContextProviderWithDefaults
     value={{
-      makeArticleUrl,
       theme: { scale: scales.medium, sectionColour: "#FF0000" }
     }}
   >
@@ -40,7 +39,7 @@ const renderArticle = (data, header) => (
       onTwitterLinkPress={() => {}}
       onVideoPress={() => {}}
     />
-  </Context.Provider>
+  </ContextProviderWithDefaults>
 );
 
 export const snapshotTests = renderComponent => [

--- a/packages/article-skeleton/__tests__/images.web.js
+++ b/packages/article-skeleton/__tests__/images.web.js
@@ -10,6 +10,7 @@ import "./mocks.web";
 import shared from "./images.base";
 
 const omitProps = new Set([
+  "article",
   "className",
   "data-testid",
   "responsiveLinkStyles",

--- a/packages/article-skeleton/__tests__/mocks.web.js
+++ b/packages/article-skeleton/__tests__/mocks.web.js
@@ -1,3 +1,5 @@
+jest.mock("../src/head.web", () => "Head");
+
 // eslint-disable-next-line global-require
 jest.mock("@times-components/ad", () => require("./ad-mock"));
 jest.mock("@times-components/article-byline", () => ({

--- a/packages/article-skeleton/__tests__/scaling.base.js
+++ b/packages/article-skeleton/__tests__/scaling.base.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import ArticleSkeleton from "../src/article-skeleton";
 import articleFixture, { testFixture } from "../fixtures/full-article";
@@ -11,7 +11,9 @@ export default renderComponent => [
     name: "scaled medium full article",
     test: () => {
       const output = renderComponent(
-        <Context.Provider value={{ theme: { scale: scales.medium } }}>
+        <ContextProviderWithDefaults
+          value={{ theme: { scale: scales.medium } }}
+        >
           <ArticleSkeleton
             {...articleSkeletonProps}
             adConfig={adConfig}
@@ -28,7 +30,7 @@ export default renderComponent => [
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();
@@ -38,7 +40,7 @@ export default renderComponent => [
     name: "scaled large full article",
     test: () => {
       const output = renderComponent(
-        <Context.Provider value={{ theme: { scale: scales.large } }}>
+        <ContextProviderWithDefaults value={{ theme: { scale: scales.large } }}>
           <ArticleSkeleton
             {...articleSkeletonProps}
             adConfig={adConfig}
@@ -55,7 +57,7 @@ export default renderComponent => [
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();
@@ -65,7 +67,9 @@ export default renderComponent => [
     name: "scaled xlarge full article",
     test: () => {
       const output = renderComponent(
-        <Context.Provider value={{ theme: { scale: scales.xlarge } }}>
+        <ContextProviderWithDefaults
+          value={{ theme: { scale: scales.xlarge } }}
+        >
           <ArticleSkeleton
             {...articleSkeletonProps}
             adConfig={adConfig}
@@ -82,7 +86,7 @@ export default renderComponent => [
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
 
       expect(output).toMatchSnapshot();

--- a/packages/article-skeleton/__tests__/shared.base.js
+++ b/packages/article-skeleton/__tests__/shared.base.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-multi-comp */
 import React from "react";
-import { iterator, makeArticleUrl } from "@times-components/test-utils";
-import Context from "@times-components/context";
+import { iterator } from "@times-components/test-utils";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import ArticleSkeleton from "../src/article-skeleton";
 import contentWithNestedFirstParagraph from "../fixtures/bold-article-content";
@@ -9,9 +9,8 @@ import articleFixture, { testFixture } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";
 
 export const renderArticle = (data, header = null) => (
-  <Context.Provider
+  <ContextProviderWithDefaults
     value={{
-      makeArticleUrl,
       theme: { scale: scales.medium, sectionColour: "#FF0000" }
     }}
   >
@@ -30,7 +29,7 @@ export const renderArticle = (data, header = null) => (
       onVideoPress={() => {}}
       spotAccountId=""
     />
-  </Context.Provider>
+  </ContextProviderWithDefaults>
 );
 
 export const fixtureArgs = {

--- a/packages/article-skeleton/__tests__/shared.web.js
+++ b/packages/article-skeleton/__tests__/shared.web.js
@@ -11,6 +11,7 @@ import "./mocks.web";
 import shared from "./shared.base";
 
 const omitProps = new Set([
+  "article",
   "className",
   "data-testid",
   "responsiveLinkStyles",

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
@@ -83,6 +83,7 @@ exports[`1. a secondary image 1`] = `
 </style>
 
 <article>
+  <Head />
   <div
     className="c0 S1"
   >
@@ -193,6 +194,7 @@ exports[`2. an inline image 1`] = `
 </style>
 
 <article>
+  <Head />
   <div
     className="c0 S1"
   >

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`1. a secondary image 1`] = `
 <article>
+  <Head />
   <div>
     <Ad
       contextUrl="https://url.io"
@@ -47,6 +48,7 @@ exports[`1. a secondary image 1`] = `
 
 exports[`2. an inline image 1`] = `
 <article>
+  <Head />
   <div>
     <Ad
       contextUrl="https://url.io"

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -302,6 +302,7 @@ exports[`full article with style 1`] = `
 </style>
 
 <article>
+  <Head />
   <div
     className="c0 S1"
   >

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`1. a full article with all content items with dropcap template 1`] = `
 <article>
+  <Head />
   <div>
     <Ad
       contextUrl="https://url.io"
@@ -324,6 +325,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
 
 exports[`2. an article with no content 1`] = `
 <article>
+  <Head />
   <div>
     <Ad
       contextUrl="https://url.io"
@@ -395,6 +397,7 @@ exports[`2. an article with no content 1`] = `
 
 exports[`3. an article with a nested markup in first paragraph displays no drop cap 1`] = `
 <article>
+  <Head />
   <div>
     <Ad
       contextUrl="https://url.io"

--- a/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
@@ -121,6 +121,15 @@ Array [
 ]
 `;
 
+exports[`Head uses short headline if headline not available 1`] = `
+Array [
+  "short headline",
+  " | ",
+  "Comment | ",
+  "The Times",
+]
+`;
+
 exports[`Head uses the first non-news section in title 1`] = `
 Array [
   "Some Headline",

--- a/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
@@ -1,0 +1,131 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Head outputs correct metadata 1`] = `
+<Helmet>
+  <title>
+    Some Headline
+     | 
+    Comment | 
+    The Times
+  </title>
+  <meta
+    content="Some Headline"
+    name="article:title"
+  />
+  <meta
+    content="The Times"
+    name="article:publication"
+  />
+  <meta
+    content="Boris Johnson’s sister an ex-BBC broadcaster and John Major’s health secretary will stand for Change UK in next month’s European elections.The pro-Remain party announced its MEP hopefuls from almost 4"
+    name="description"
+  />
+  <meta
+    content="Some byline"
+    name="author"
+  />
+  <meta
+    content="Some Headline"
+    property="og:title"
+  />
+  <meta
+    content="article"
+    property="og:type"
+  />
+  <meta
+    content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+    property="og:url"
+  />
+  <meta
+    content="Boris Johnson’s sister an ex-BBC broadcaster and John Major’s health secretary will stand for Change UK in next month’s European elections.The pro-Remain party announced its MEP hopefuls from almost 4"
+    property="og:description"
+  />
+  <meta
+    content="https://crop169.io"
+    property="og:image"
+  />
+  <meta
+    content="Some Headline"
+    name="twitter:title"
+  />
+  <meta
+    content="summary_large_image"
+    name="twitter:card"
+  />
+  <meta
+    content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+    name="twitter:url"
+  />
+  <meta
+    content="Boris Johnson’s sister an ex-BBC broadcaster and John Major’s health secretary will stand for Change UK in next month’s European elections.The pro-Remain party announced its MEP hopefuls from almost 4"
+    name="twitter:description"
+  />
+  <meta
+    content="https://crop169.io"
+    name="twitter:image"
+  />
+</Helmet>
+`;
+
+exports[`Head removes section from title if there are no tiles 1`] = `
+Array [
+  "Some Headline",
+  " | ",
+  "",
+  "The Times",
+]
+`;
+
+exports[`Head removes section from title if there are no tiles with sections 1`] = `
+Array [
+  "Some Headline",
+  " | ",
+  "",
+  "The Times",
+]
+`;
+
+exports[`Head shows Sunday Times in title if publication is SUNDAYTIMES 1`] = `
+Array [
+  "Some Headline",
+  " | ",
+  "Comment | ",
+  "The Sunday Times",
+]
+`;
+
+exports[`Head shows Times in title if publication is TIMES 1`] = `
+Array [
+  "Some Headline",
+  " | ",
+  "Comment | ",
+  "The Times",
+]
+`;
+
+exports[`Head uses news in title if news is the only available section 1`] = `
+Array [
+  "Some Headline",
+  " | ",
+  "News | ",
+  "The Times",
+]
+`;
+
+exports[`Head uses news in title if news is the only available section 2`] = `
+Array [
+  "Some Headline",
+  " | ",
+  "News | ",
+  "The Times",
+]
+`;
+
+exports[`Head uses the first non-news section in title 1`] = `
+Array [
+  "Some Headline",
+  " | ",
+  "Comment | ",
+  "The Times",
+]
+`;

--- a/packages/article-skeleton/__tests__/web/head.web.test.js
+++ b/packages/article-skeleton/__tests__/web/head.web.test.js
@@ -1,0 +1,308 @@
+import React from "react";
+import TestRenderer from "react-test-renderer";
+
+import {
+  addSerializers,
+  compose,
+  enzymeRenderedSerializer,
+  minimaliseTransform,
+  minimalWebTransform,
+  print
+} from "@times-components/jest-serializer";
+
+import Head from "../../src/head.web";
+import articleFixture, { testFixture } from "../../fixtures/full-article";
+
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
+
+const omitProps = new Set([
+  "className",
+  "data-testid",
+  "responsiveLinkStyles",
+  "style"
+]);
+
+addSerializers(
+  expect,
+  enzymeRenderedSerializer(),
+  compose(
+    print,
+    minimalWebTransform,
+    minimaliseTransform((value, key) => omitProps.has(key))
+  )
+);
+
+const article = articleFixture({ ...testFixture });
+
+describe("Head", () => {
+  it("outputs correct metadata", () => {
+    const testRenderer = TestRenderer.create(<Head article={article} />);
+
+    expect(testRenderer).toMatchSnapshot();
+  });
+
+  it("uses the first non-news section in title", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={{
+          ...article,
+          tiles: [
+            {
+              slices: [
+                {
+                  sections: [
+                    {
+                      title: "News"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              slices: [
+                {
+                  sections: [
+                    {
+                      title: "Comment"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              slices: [
+                {
+                  sections: [
+                    {
+                      title: "Foreign"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }}
+      />
+    );
+
+    const title = testRenderer.root.findByType("title");
+
+    expect(title.children).toMatchSnapshot();
+  });
+
+  it("uses news in title if news is the only available section", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={{
+          ...article,
+          tiles: [
+            {
+              slices: [
+                {
+                  sections: [
+                    {
+                      title: "News"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }}
+      />
+    );
+
+    const title = testRenderer.root.findByType("title");
+
+    expect(title.children).toMatchSnapshot();
+  });
+
+  it("uses news in title if news is the only available section", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={{
+          ...article,
+          tiles: [
+            {
+              slices: [
+                {
+                  sections: [
+                    {
+                      title: "News"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }}
+      />
+    );
+
+    const title = testRenderer.root.findByType("title");
+
+    expect(title.children).toMatchSnapshot();
+  });
+
+  it("removes section from title if there are no tiles", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={{
+          ...article,
+          tiles: null
+        }}
+      />
+    );
+
+    const title = testRenderer.root.findByType("title");
+
+    expect(title.children).toMatchSnapshot();
+  });
+
+  it("removes section from title if there are no tiles with sections", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={{
+          ...article,
+          tiles: [
+            {
+              slices: [
+                {
+                  sections: []
+                }
+              ]
+            },
+            {
+              slices: [
+                {
+                  sections: []
+                }
+              ]
+            }
+          ]
+        }}
+      />
+    );
+
+    const title = testRenderer.root.findByType("title");
+
+    expect(title.children).toMatchSnapshot();
+  });
+
+  it("shows Sunday Times in title if publication is SUNDAYTIMES", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={{
+          ...article,
+          publicationName: "SUNDAYTIMES"
+        }}
+      />
+    );
+
+    const title = testRenderer.root.findByType("title");
+
+    expect(title.children).toMatchSnapshot();
+  });
+
+  it("shows Times in title if publication is TIMES", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={{
+          ...article,
+          publicationName: "TIMES"
+        }}
+      />
+    );
+
+    const title = testRenderer.root.findByType("title");
+
+    expect(title.children).toMatchSnapshot();
+  });
+
+  it("removes author tags if bylines not available", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={{
+          ...article,
+          bylines: null
+        }}
+      />
+    );
+
+    expect(testRenderer.root.findAllByProps({ name: "author" })).toHaveLength(
+      0
+    );
+  });
+
+  it("shows author tags if bylines available", () => {
+    const testRenderer = TestRenderer.create(<Head article={article} />);
+
+    expect(testRenderer.root.findAllByProps({ name: "author" })).toHaveLength(
+      1
+    );
+  });
+
+  it("removes description tags if descriptionMarkup not available", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={{
+          ...article,
+          descriptionMarkup: null
+        }}
+      />
+    );
+
+    expect(
+      testRenderer.root.findAllByProps({ name: "description" })
+    ).toHaveLength(0);
+    expect(
+      testRenderer.root.findAllByProps({ property: "og:description" })
+    ).toHaveLength(0);
+    expect(
+      testRenderer.root.findAllByProps({ name: "twitter:description" })
+    ).toHaveLength(0);
+  });
+
+  it("shows description tags if descriptionMarkup available", () => {
+    const testRenderer = TestRenderer.create(<Head article={article} />);
+
+    expect(
+      testRenderer.root.findAllByProps({ name: "description" })
+    ).toHaveLength(1);
+    expect(
+      testRenderer.root.findAllByProps({ property: "og:description" })
+    ).toHaveLength(1);
+    expect(
+      testRenderer.root.findAllByProps({ name: "twitter:description" })
+    ).toHaveLength(1);
+  });
+
+  it("removes image tags if leadAsset not available", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={{
+          ...article,
+          leadAsset: null
+        }}
+      />
+    );
+
+    expect(
+      testRenderer.root.findAllByProps({ property: "og:image" })
+    ).toHaveLength(0);
+    expect(
+      testRenderer.root.findAllByProps({ name: "twitter:image" })
+    ).toHaveLength(0);
+  });
+
+  it("shows image tags if leadAsset available", () => {
+    const testRenderer = TestRenderer.create(<Head article={article} />);
+
+    expect(
+      testRenderer.root.findAllByProps({ property: "og:image" })
+    ).toHaveLength(1);
+    expect(
+      testRenderer.root.findAllByProps({ name: "twitter:image" })
+    ).toHaveLength(1);
+  });
+});

--- a/packages/article-skeleton/__tests__/web/head.web.test.js
+++ b/packages/article-skeleton/__tests__/web/head.web.test.js
@@ -41,6 +41,22 @@ describe("Head", () => {
     expect(testRenderer).toMatchSnapshot();
   });
 
+  it("uses short headline if headline not available", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={{
+          ...article,
+          headline: null,
+          shortHeadline: "short headline"
+        }}
+      />
+    );
+
+    const title = testRenderer.root.findByType("title");
+
+    expect(title.children).toMatchSnapshot();
+  });
+
   it("uses the first non-news section in title", () => {
     const testRenderer = TestRenderer.create(
       <Head

--- a/packages/article-skeleton/fixtures/full-article.js
+++ b/packages/article-skeleton/fixtures/full-article.js
@@ -821,6 +821,75 @@ const defaultBylines = [
 ];
 const defaultCommentCount = 65;
 const defaultCommentsEnabled = true;
+const defaultDescriptionMarkup = [
+  {
+    children: [
+      {
+        attributes: {
+          href: "https://www.thetimes.co.uk/topic/boris-johnson",
+          type: "topic"
+        },
+        children: [
+          {
+            attributes: {
+              value: "Boris Johnson"
+            },
+            children: [],
+            name: "text"
+          }
+        ],
+        name: "link"
+      },
+      {
+        attributes: {
+          value:
+            "’s sister an ex-BBC broadcaster and John Major’s health secretary will stand for "
+        },
+        children: [],
+        name: "text"
+      },
+      {
+        attributes: {
+          canonicalId:
+            "independent-group-change-uk-gets-approval-but-makes-a-hash-of-logo-hwm0bxsxn",
+          href:
+            "https://www.thetimes.co.uk/article/independent-group-change-uk-gets-approval-but-makes-a-hash-of-logo-hwm0bxsxn",
+          type: "article"
+        },
+        children: [
+          {
+            attributes: {
+              value: "Change UK"
+            },
+            children: [],
+            name: "text"
+          }
+        ],
+        name: "link"
+      },
+      {
+        attributes: {
+          value: " in next month’s European elections."
+        },
+        children: [],
+        name: "text"
+      }
+    ],
+    name: "paragraph"
+  },
+  {
+    children: [
+      {
+        attributes: {
+          value: "The pro-Remain party announced its MEP hopefuls from almost 4"
+        },
+        children: [],
+        name: "text"
+      }
+    ],
+    name: "paragraph"
+  }
+];
 const defaultFlags = ["NEW", "EXCLUSIVE"];
 const defaultHasVideo = false;
 const defaultHeadline =
@@ -1505,6 +1574,44 @@ const defaultTopics = [
 ];
 const defaultUrl = "https://www.thetimes.co.uk/";
 const defaultTemplate = "mainstandard";
+const defaultTiles = [
+  {
+    slices: [
+      {
+        sections: []
+      }
+    ]
+  },
+  {
+    slices: [
+      {
+        sections: [
+          {
+            title: "Comment"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    slices: [
+      {
+        sections: []
+      }
+    ]
+  },
+  {
+    slices: [
+      {
+        sections: [
+          {
+            title: "News"
+          }
+        ]
+      }
+    ]
+  }
+];
 const addProp = (obj, key, value) => {
   if (value != null) {
     return {
@@ -1521,6 +1628,7 @@ const makeDefaultConfig = ({
   commentsEnabled = defaultCommentsEnabled,
   commentCount = defaultCommentCount,
   content = defaultContent,
+  descriptionMarkup = defaultDescriptionMarkup,
   dropcapsDisabled,
   flags = defaultFlags,
   hasVideo = defaultHasVideo,
@@ -1536,12 +1644,14 @@ const makeDefaultConfig = ({
   standfirst = defaultStandfirst,
   topics = defaultTopics,
   template = defaultTemplate,
+  tiles = defaultTiles,
   url = defaultUrl
 } = {}) => ({
   bylines,
   commentCount,
   commentsEnabled,
   content,
+  descriptionMarkup,
   dropcapsDisabled,
   flags,
   hasVideo,
@@ -1556,6 +1666,7 @@ const makeDefaultConfig = ({
   slug,
   standfirst,
   template,
+  tiles,
   topics,
   url
 });
@@ -1582,7 +1693,6 @@ export default ({ withAds = true, ...config } = {}) => {
     core
   );
 };
-
 export const testFixture = {
   __typename: "Article",
   bylines: [
@@ -1621,6 +1731,7 @@ export const testFixture = {
       name: "paragraph"
     }
   ],
+  descriptionMarkup: defaultDescriptionMarkup,
   flags: ["NEW"],
   hasVideo: false,
   headline: "Some Headline",
@@ -1706,6 +1817,7 @@ export const testFixture = {
   shortIdentifier: "2k629tpvh",
   slug: "this-is-slug",
   standfirst: "Some Standfirst",
+  tiles: defaultTiles,
   topics: [
     {
       name: "Topic",

--- a/packages/article-skeleton/package.json
+++ b/packages/article-skeleton/package.json
@@ -97,6 +97,7 @@
     "lodash.invert": "4.3.0",
     "mockdate": "2.0.2",
     "prop-types": "15.6.2",
+    "react-helmet-async": "1.0.2",
     "styled-components": "3.4.0"
   },
   "peerDependencies": {

--- a/packages/article-skeleton/showcase-helper.js
+++ b/packages/article-skeleton/showcase-helper.js
@@ -3,16 +3,11 @@ import React from "react";
 import { Text, View } from "react-native";
 import invert from "lodash.invert";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { colours, scales } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
 import fullArticleFixture from "./fixtures/full-article";
 import ArticleSkeleton from "./src/article-skeleton";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const TestHeader = () => (
   <View
@@ -63,9 +58,7 @@ const renderArticleSkeleton = ({
   const showHeader = header ? () => <TestHeader /> : () => null;
 
   return (
-    <Context.Provider
-      value={{ makeArticleUrl, theme: { scale, sectionColour } }}
-    >
+    <ContextProviderWithDefaults value={{ theme: { scale, sectionColour } }}>
       <ArticleSkeleton
         adConfig={articleAdConfig}
         analyticsStream={storybookReporter}
@@ -89,7 +82,7 @@ const renderArticleSkeleton = ({
         onVideoPress={preventDefaultedAction(decorateAction)("onVideoPress")}
         onViewableItemsChanged={() => null}
       />
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 };
 

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -16,6 +16,7 @@ import {
   HeaderAdContainer,
   MainContainer
 } from "./styles/responsive";
+import Head from "./head";
 
 const adStyle = {
   marginBottom: 0
@@ -41,21 +42,24 @@ class ArticleSkeleton extends Component {
     const {
       adConfig,
       analyticsStream,
-      data: {
-        commentsEnabled,
-        content,
-        dropcapsDisabled,
-        id: articleId,
-        section,
-        url,
-        topics,
-        relatedArticleSlice,
-        template
-      },
+      data: article,
       Header,
       receiveChildList,
       spotAccountId
     } = this.props;
+
+    const {
+      commentsEnabled,
+      content,
+      dropcapsDisabled,
+      id: articleId,
+      section,
+      url,
+      topics,
+      relatedArticleSlice,
+      template
+    } = article;
+
     const { articleWidth } = this.state;
     const newContent = [...content];
     if (newContent && newContent.length > 0) {
@@ -79,6 +83,7 @@ class ArticleSkeleton extends Component {
           this.node = node;
         }}
       >
+        <Head article={article} />
         <AdComposer adConfig={adConfig}>
           <LazyLoad rootMargin={spacing(10)} threshold={0.5}>
             {({ observed, registerNode }) => (

--- a/packages/article-skeleton/src/head.web.js
+++ b/packages/article-skeleton/src/head.web.js
@@ -1,0 +1,107 @@
+import React from "react";
+import get from "lodash.get";
+import { Helmet } from "react-helmet-async";
+import PropTypes from "prop-types";
+import Context from "@times-components/context";
+import { renderTreeAsText } from "@times-components/markup-forest";
+
+// Get the section for an article, preferring it not to be News
+function getSectionName(article) {
+  const { tiles } = article;
+
+  if (!tiles) {
+    return null;
+  }
+
+  const slices = tiles.reduce((acc, tile) => {
+    acc.push(...tile.slices);
+    return acc;
+  }, []);
+  const sections = slices.reduce((acc, slice) => {
+    acc.push(...slice.sections);
+    return acc;
+  }, []);
+  const titles = sections.map(section => section.title);
+
+  if (titles.length === 0) {
+    return null;
+  }
+
+  const nonNews = titles.filter(title => title !== "News");
+
+  return nonNews.length ? nonNews[0] : "News";
+}
+
+function getAuthorAsText(article) {
+  const { bylines } = article;
+
+  if (!bylines) {
+    return null;
+  }
+
+  const children = bylines.reduce((acc, byline) => {
+    acc.push(...byline.byline);
+    return acc;
+  }, []);
+
+  return renderTreeAsText({ children });
+}
+
+const PUBLICATION_NAMES = {
+  SUNDAYTIMES: "The Sunday Times",
+  TIMES: "The Times"
+};
+
+function Head({ article }) {
+  const { descriptionMarkup, headline, leadAsset, publicationName } = article;
+  const publication = PUBLICATION_NAMES[publicationName];
+  const authorName = getAuthorAsText(article);
+  const desc =
+    descriptionMarkup && renderTreeAsText({ children: descriptionMarkup });
+  const sectionname = getSectionName(article);
+  const leadassetUrl = get(leadAsset, "crop169.url", null);
+
+  return (
+    <Context.Consumer>
+      {({ makeArticleUrl }) => (
+        <Helmet>
+          <title>
+            {headline} | {sectionname ? `${sectionname} | ` : ""}
+            {publication}
+          </title>
+          <meta content={headline} name="article:title" />
+          <meta content={publication} name="article:publication" />
+          {desc && <meta content={desc} name="description" />}
+          {authorName && <meta content={authorName} name="author" />}
+
+          <meta content={headline} property="og:title" />
+          <meta content="article" property="og:type" />
+          <meta content={makeArticleUrl(article)} property="og:url" />
+          {desc && <meta content={desc} property="og:description" />}
+          {leadassetUrl && <meta content={leadassetUrl} property="og:image" />}
+
+          <meta content={headline} name="twitter:title" />
+          <meta content="summary_large_image" name="twitter:card" />
+          <meta content={makeArticleUrl(article)} name="twitter:url" />
+          {desc && <meta content={desc} name="twitter:description" />}
+          {leadassetUrl && <meta content={leadassetUrl} name="twitter:image" />}
+        </Helmet>
+      )}
+    </Context.Consumer>
+  );
+}
+
+Head.propTypes = {
+  article: PropTypes.shape({
+    bylines: PropTypes.array,
+    descriptionMarkup: PropTypes.array,
+    headline: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    leadAsset: PropTypes.object,
+    publicationName: PropTypes.string.isRequired,
+    shortIdentifier: PropTypes.string.isRequired,
+    tiles: PropTypes.array
+  }).isRequired
+};
+
+export default Head;

--- a/packages/article-skeleton/src/head.web.js
+++ b/packages/article-skeleton/src/head.web.js
@@ -53,34 +53,41 @@ const PUBLICATION_NAMES = {
 };
 
 function Head({ article }) {
-  const { descriptionMarkup, headline, leadAsset, publicationName } = article;
+  const {
+    descriptionMarkup,
+    headline,
+    leadAsset,
+    publicationName,
+    shortHeadline
+  } = article;
   const publication = PUBLICATION_NAMES[publicationName];
   const authorName = getAuthorAsText(article);
   const desc =
     descriptionMarkup && renderTreeAsText({ children: descriptionMarkup });
   const sectionname = getSectionName(article);
   const leadassetUrl = get(leadAsset, "crop169.url", null);
+  const title = headline || shortHeadline;
 
   return (
     <Context.Consumer>
       {({ makeArticleUrl }) => (
         <Helmet>
           <title>
-            {headline} | {sectionname ? `${sectionname} | ` : ""}
+            {title} | {sectionname ? `${sectionname} | ` : ""}
             {publication}
           </title>
-          <meta content={headline} name="article:title" />
+          <meta content={title} name="article:title" />
           <meta content={publication} name="article:publication" />
           {desc && <meta content={desc} name="description" />}
           {authorName && <meta content={authorName} name="author" />}
 
-          <meta content={headline} property="og:title" />
+          <meta content={title} property="og:title" />
           <meta content="article" property="og:type" />
           <meta content={makeArticleUrl(article)} property="og:url" />
           {desc && <meta content={desc} property="og:description" />}
           {leadassetUrl && <meta content={leadassetUrl} property="og:image" />}
 
-          <meta content={headline} name="twitter:title" />
+          <meta content={title} name="twitter:title" />
           <meta content="summary_large_image" name="twitter:card" />
           <meta content={makeArticleUrl(article)} name="twitter:url" />
           {desc && <meta content={desc} name="twitter:description" />}
@@ -95,10 +102,11 @@ Head.propTypes = {
   article: PropTypes.shape({
     bylines: PropTypes.array,
     descriptionMarkup: PropTypes.array,
-    headline: PropTypes.string.isRequired,
+    headline: PropTypes.string,
     id: PropTypes.string.isRequired,
     leadAsset: PropTypes.object,
     publicationName: PropTypes.string.isRequired,
+    shortHeadline: PropTypes.string,
     shortIdentifier: PropTypes.string.isRequired,
     tiles: PropTypes.array
   }).isRequired

--- a/packages/article-topics/__tests__/shared-with-style.base.js
+++ b/packages/article-topics/__tests__/shared-with-style.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import { iterator } from "@times-components/test-utils";
 import ArticleTopics from "../src/article-topics";
@@ -13,9 +13,9 @@ export default () => {
       test: () => {
         const scale = scales.medium;
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ theme: { scale } }}>
+          <ContextProviderWithDefaults value={{ theme: { scale } }}>
             <ArticleTopics onPress={() => {}} topics={topicData.slice(0, 1)} />
-          </Context.Provider>
+          </ContextProviderWithDefaults>
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -26,9 +26,9 @@ export default () => {
       test: () => {
         const scale = scales.large;
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ theme: { scale } }}>
+          <ContextProviderWithDefaults value={{ theme: { scale } }}>
             <ArticleTopics onPress={() => {}} topics={topicData.slice(0, 1)} />
-          </Context.Provider>
+          </ContextProviderWithDefaults>
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -39,9 +39,9 @@ export default () => {
       test: () => {
         const scale = scales.xlarge;
         const testInstance = TestRenderer.create(
-          <Context.Provider value={{ theme: { scale } }}>
+          <ContextProviderWithDefaults value={{ theme: { scale } }}>
             <ArticleTopics onPress={() => {}} topics={topicData.slice(0, 1)} />
-          </Context.Provider>
+          </ContextProviderWithDefaults>
         );
 
         expect(testInstance).toMatchSnapshot();

--- a/packages/article-topics/article-topics.showcase.js
+++ b/packages/article-topics/article-topics.showcase.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import { scales } from "@times-components/styleguide";
 import topicsData from "./fixtures/topics";
 import renderArticleTopics from "./showcase-helper";
@@ -11,9 +11,9 @@ export default {
       component: ({ select }, { decorateAction }) => {
         const scale = select("Scale", scales, scales.medium);
         return (
-          <Context.Provider value={{ theme: { scale } }}>
+          <ContextProviderWithDefaults value={{ theme: { scale } }}>
             {renderArticleTopics({ data: topicsData, decorateAction })}
-          </Context.Provider>
+          </ContextProviderWithDefaults>
         );
       },
       name: "Group of Topics",
@@ -24,9 +24,9 @@ export default {
       component: ({ select }, { decorateAction }) => {
         const scale = select("Scale", scales, scales.medium);
         return (
-          <Context.Provider value={{ theme: { scale } }}>
+          <ContextProviderWithDefaults value={{ theme: { scale } }}>
             {renderArticleTopics({ data: [topicsData[0]], decorateAction })}
-          </Context.Provider>
+          </ContextProviderWithDefaults>
         );
       },
       name: "Single Topic",

--- a/packages/article-topics/src/article-topic.js
+++ b/packages/article-topics/src/article-topic.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Context from "@times-components/context";
 import { Text, View } from "react-native";
 import Link from "@times-components/link";
 import { withTrackEvents } from "@times-components/tracking";
@@ -9,20 +10,27 @@ const ArticleTopic = ({ fontSize, lineHeight, name, onPress, slug }) => {
   const fontSizeStyle = fontSize ? { fontSize } : null;
   const lineHeightStyle = lineHeight ? { lineHeight } : null;
   return (
-    <View style={styles.spacer}>
-      <Link onPress={e => onPress(e, { name, slug })} url={`/topic/${slug}`}>
-        <View style={styles.container}>
-          <Text
-            accessibilityComponentType="button"
-            accessibilityRole="button"
-            accessibilityTraits="button"
-            style={[styles.text, fontSizeStyle, lineHeightStyle]}
+    <Context.Consumer>
+      {({ makeTopicUrl }) => (
+        <View style={styles.spacer}>
+          <Link
+            onPress={e => onPress(e, { name, slug })}
+            url={makeTopicUrl({ slug })}
           >
-            {name}
-          </Text>
+            <View style={styles.container}>
+              <Text
+                accessibilityComponentType="button"
+                accessibilityRole="button"
+                accessibilityTraits="button"
+                style={[styles.text, fontSizeStyle, lineHeightStyle]}
+              >
+                {name}
+              </Text>
+            </View>
+          </Link>
         </View>
-      </Link>
-    </View>
+      )}
+    </Context.Consumer>
   );
 };
 

--- a/packages/article/showcase-helper.js
+++ b/packages/article/showcase-helper.js
@@ -1,7 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies, no-bitwise, operator-assignment, react/prop-types */
 import React, { Component, Fragment } from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
-import Context, { defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
 import {
   article as makeParams,
@@ -13,11 +16,6 @@ import { sections } from "@times-components/storybook";
 import { scales, themeFactory } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
 import Article, { templates } from "./src/article";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -224,9 +222,8 @@ const renderArticle = ({
       };
 
       return (
-        <Context.Provider
+        <ContextProviderWithDefaults
           value={{
-            makeArticleUrl,
             theme: {
               ...themeFactory(section, template),
               scale: scale || defaults.theme.scale
@@ -263,7 +260,7 @@ const renderArticle = ({
             )}
             refetch={refetch}
           />
-        </Context.Provider>
+        </ContextProviderWithDefaults>
       );
     }}
   </ArticleProvider>

--- a/packages/author-profile/.jestlint
+++ b/packages/author-profile/.jestlint
@@ -1,3 +1,4 @@
 {
-  "maxAttributes": 9
+  "maxAttributes": 9,
+  "maxAttributeStringLength": 90
 }

--- a/packages/author-profile/__tests__/mocks.js
+++ b/packages/author-profile/__tests__/mocks.js
@@ -1,3 +1,5 @@
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
+
 jest.mock("@times-components/article-list", () =>
   // eslint-disable-next-line global-require
   require("./mock-article-list")

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile-loading.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile-loading.web.test.js.snap
@@ -2,6 +2,16 @@
 
 exports[`1. an article list loading with images 1`] = `
 <authorArticlesWithImagesProvider>
+  <Helmet>
+    <title>
+      
+       | The Times & The Sunday Times
+    </title>
+    <meta
+      content="Get up to date information and read all the latest articles from ."
+      name="description"
+    />
+  </Helmet>
   <ArticleList
     articleListHeader={
       <AuthorProfileHead
@@ -24,6 +34,16 @@ exports[`1. an article list loading with images 1`] = `
 
 exports[`2. an article list loading without images 1`] = `
 <authorArticlesWithImagesProvider>
+  <Helmet>
+    <title>
+      
+       | The Times & The Sunday Times
+    </title>
+    <meta
+      content="Get up to date information and read all the latest articles from ."
+      name="description"
+    />
+  </Helmet>
   <ArticleList
     articleListHeader={
       <AuthorProfileHead

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
@@ -4,6 +4,16 @@ exports[`1. an error page 1`] = `<ArticleListPageError />`;
 
 exports[`2. a loading state 1`] = `
 <authorArticlesWithImagesProvider>
+  <Helmet>
+    <title>
+      
+       | The Times & The Sunday Times
+    </title>
+    <meta
+      content="Get up to date information and read all the latest articles from ."
+      name="description"
+    />
+  </Helmet>
   <ArticleList
     articleListHeader={
       <AuthorProfileHead
@@ -35,6 +45,16 @@ exports[`2. a loading state 1`] = `
 
 exports[`3. an article list with images 1`] = `
 <authorArticlesWithImagesProvider>
+  <Helmet>
+    <title>
+      Name
+       | The Times & The Sunday Times
+    </title>
+    <meta
+      content="Get up to date information and read all the latest articles from Name."
+      name="description"
+    />
+  </Helmet>
   <ArticleList
     articleListHeader={
       <AuthorProfileHead
@@ -77,6 +97,16 @@ exports[`3. an article list with images 1`] = `
 
 exports[`4. an article list without images 1`] = `
 <authorArticlesNoImagesProvider>
+  <Helmet>
+    <title>
+      Name
+       | The Times & The Sunday Times
+    </title>
+    <meta
+      content="Get up to date information and read all the latest articles from Name."
+      name="description"
+    />
+  </Helmet>
   <ArticleList
     articleListHeader={
       <AuthorProfileHead
@@ -119,6 +149,16 @@ exports[`4. an article list without images 1`] = `
 
 exports[`5. fetches more articles 1`] = `
 <authorArticlesWithImagesProvider>
+  <Helmet>
+    <title>
+      Name
+       | The Times & The Sunday Times
+    </title>
+    <meta
+      content="Get up to date information and read all the latest articles from Name."
+      name="description"
+    />
+  </Helmet>
   <ArticleList
     articleListHeader={
       <AuthorProfileHead
@@ -166,6 +206,16 @@ exports[`5. fetches more articles 1`] = `
 
 exports[`6. fetches more articles and falls back to previous data if no more 1`] = `
 <authorArticlesNoImagesProvider>
+  <Helmet>
+    <title>
+      Name
+       | The Times & The Sunday Times
+    </title>
+    <meta
+      content="Get up to date information and read all the latest articles from Name."
+      name="description"
+    />
+  </Helmet>
   <ArticleList
     articleListHeader={
       <AuthorProfileHead

--- a/packages/author-profile/author-profile.showcase.js
+++ b/packages/author-profile/author-profile.showcase.js
@@ -7,7 +7,6 @@ import {
   MockFixture,
   MockedProvider
 } from "@times-components/provider-test-tools";
-import Context from "@times-components/context";
 import StorybookProvider from "@times-components/storybook/storybook-provider";
 import {
   authorArticlesWithImages as authorArticlesWithImagesQuery,
@@ -15,11 +14,6 @@ import {
 } from "@times-components/provider-queries";
 import storybookReporter from "@times-components/tealium-utils";
 import AuthorProfile from "./src/author-profile";
-
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -51,35 +45,33 @@ const makeAuthorProfile = (decorateAction, params) => (
     params={params}
     render={mocks => (
       <MockedProvider mocks={mocks}>
-        <Context.Provider value={{ makeArticleUrl }}>
-          <AuthorProfileProvider
-            articleImageRatio={articleImageRatio}
-            debounceTimeMs={250}
-            page={1}
-            pageSize={pageSize}
-            slug={slug}
-          >
-            {({
-              author,
-              isLoading,
-              error,
-              page,
-              pageSize: authorPageSize,
-              refetch
-            }) => (
-              <AuthorProfile
-                author={author}
-                error={error}
-                isLoading={isLoading}
-                page={page}
-                pageSize={authorPageSize}
-                refetch={refetch}
-                slug={slug}
-                {...getProps(decorateAction)}
-              />
-            )}
-          </AuthorProfileProvider>
-        </Context.Provider>
+        <AuthorProfileProvider
+          articleImageRatio={articleImageRatio}
+          debounceTimeMs={250}
+          page={1}
+          pageSize={pageSize}
+          slug={slug}
+        >
+          {({
+            author,
+            isLoading,
+            error,
+            page,
+            pageSize: authorPageSize,
+            refetch
+          }) => (
+            <AuthorProfile
+              author={author}
+              error={error}
+              isLoading={isLoading}
+              page={page}
+              pageSize={authorPageSize}
+              refetch={refetch}
+              slug={slug}
+              {...getProps(decorateAction)}
+            />
+          )}
+        </AuthorProfileProvider>
       </MockedProvider>
     )}
   />

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -88,7 +88,8 @@
     "@times-components/utils": "4.10.4",
     "lodash.get": "4.4.2",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "3.4.0",
+    "react-helmet-async": "1.0.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -74,7 +74,6 @@
   },
   "dependencies": {
     "@times-components/article-list": "7.0.39",
-    "@times-components/context": "0.9.22",
     "@times-components/gradient": "3.1.18",
     "@times-components/icons": "2.10.22",
     "@times-components/image": "5.3.20",

--- a/packages/author-profile/src/author-profile.js
+++ b/packages/author-profile/src/author-profile.js
@@ -13,6 +13,7 @@ import { ratioTextToFloat } from "@times-components/utils";
 import AuthorProfileHead from "./author-profile-head";
 import { propTypes, defaultProps } from "./author-profile-prop-types";
 import authorProfileTrackingContext from "./author-profile-tracking-context";
+import Head from "./head";
 
 const AuthorProfile = ({
   adConfig,
@@ -110,6 +111,7 @@ const AuthorProfile = ({
 
         return (
           <Responsive>
+            <Head name={name} />
             <ArticleList
               adConfig={adConfig}
               articleListHeader={articleListHeader}

--- a/packages/author-profile/src/head.js
+++ b/packages/author-profile/src/head.js
@@ -1,0 +1,5 @@
+function Head() {
+  return null;
+}
+
+export default Head;

--- a/packages/author-profile/src/head.web.js
+++ b/packages/author-profile/src/head.web.js
@@ -1,0 +1,21 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Helmet } from "react-helmet-async";
+
+function Head({ name }) {
+  return (
+    <Helmet>
+      <title>{name} | The Times &amp; The Sunday Times</title>
+      <meta
+        content={`Get up to date information and read all the latest articles from ${name}.`}
+        name="description"
+      />
+    </Helmet>
+  );
+}
+
+Head.propTypes = {
+  name: PropTypes.string.isRequired
+};
+
+export default Head;

--- a/packages/context/__tests__/android/__snapshots__/theme.test.js.snap
+++ b/packages/context/__tests__/android/__snapshots__/theme.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ContextProviderWithDefaults adds defaults to the provided context 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"}}"`;
+
 exports[`article context with default values 1`] = `"{\\"theme\\":{\\"imageCaptionAlignment\\":{},\\"scale\\":\\"medium\\"}}"`;
 
 exports[`article context with inline values 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"}}"`;

--- a/packages/context/__tests__/ios/__snapshots__/theme.test.js.snap
+++ b/packages/context/__tests__/ios/__snapshots__/theme.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ContextProviderWithDefaults adds defaults to the provided context 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"}}"`;
+
 exports[`article context with default values 1`] = `"{\\"theme\\":{\\"imageCaptionAlignment\\":{},\\"scale\\":\\"medium\\"}}"`;
 
 exports[`article context with inline values 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"}}"`;

--- a/packages/context/__tests__/shared.js
+++ b/packages/context/__tests__/shared.js
@@ -1,7 +1,10 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { scales } from "@times-components/styleguide";
-import Context, { SectionContext } from "../src/context";
+import Context, {
+  ContextProviderWithDefaults,
+  SectionContext
+} from "../src/context";
 
 export default () => {
   it("article context with default values", () => {
@@ -56,5 +59,23 @@ export default () => {
     );
 
     expect(testInstance).toMatchSnapshot();
+  });
+
+  describe("ContextProviderWithDefaults", () => {
+    it("adds defaults to the provided context", () => {
+      const scale = scales.large;
+      const sectionColour = "#FFFFFF";
+      const testInstance = TestRenderer.create(
+        <ContextProviderWithDefaults
+          value={{ theme: { scale, sectionColour } }}
+        >
+          <Context.Consumer>
+            {context => JSON.stringify(context)}
+          </Context.Consumer>
+        </ContextProviderWithDefaults>
+      );
+
+      expect(testInstance).toMatchSnapshot();
+    });
   });
 };

--- a/packages/context/__tests__/web/__snapshots__/theme.test.js.snap
+++ b/packages/context/__tests__/web/__snapshots__/theme.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ContextProviderWithDefaults adds defaults to the provided context 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"}}"`;
+
 exports[`article context with default values 1`] = `"{\\"theme\\":{\\"imageCaptionAlignment\\":{},\\"scale\\":\\"medium\\"}}"`;
 
 exports[`article context with inline values 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"}}"`;

--- a/packages/context/src/context.js
+++ b/packages/context/src/context.js
@@ -5,7 +5,7 @@ import SectionContext from "./section-context";
 const Context = createContext(defaults);
 
 function ContextProviderWithDefaults({ value, ...props }) {
-  return <Context.Provider {...props} value={{ ...defaults, value }} />;
+  return <Context.Provider {...props} value={{ ...defaults, ...value }} />;
 }
 
 export default Context;

--- a/packages/context/src/context.js
+++ b/packages/context/src/context.js
@@ -1,6 +1,12 @@
-import { createContext } from "react";
+import React, { createContext } from "react";
 import defaults from "./defaults";
 import SectionContext from "./section-context";
 
-export default createContext(defaults);
-export { defaults, SectionContext };
+const Context = createContext(defaults);
+
+function ContextProviderWithDefaults({ value, ...props }) {
+  return <Context.Provider {...props} value={{ ...defaults, value }} />;
+}
+
+export default Context;
+export { defaults, SectionContext, ContextProviderWithDefaults };

--- a/packages/context/src/defaults/index.js
+++ b/packages/context/src/defaults/index.js
@@ -1,7 +1,10 @@
 import { scales } from "@times-components/styleguide";
 
 export default {
-  makeArticleUrl: () => {},
+  makeArticleUrl: ({ slug, shortIdentifier }) =>
+    slug && shortIdentifier
+      ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
+      : "",
   theme: {
     imageCaptionAlignment: {},
     scale: scales.medium

--- a/packages/context/src/defaults/index.js
+++ b/packages/context/src/defaults/index.js
@@ -5,6 +5,7 @@ export default {
     slug && shortIdentifier
       ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
       : "",
+  makeTopicUrl: ({ slug }) => `/topic/${slug}`,
   theme: {
     imageCaptionAlignment: {},
     scale: scales.medium

--- a/packages/key-facts/__tests__/shared-key-facts-with-style.native.js
+++ b/packages/key-facts/__tests__/shared-key-facts-with-style.native.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -65,9 +65,9 @@ export default () => {
     const sectionColour = "#FFFFFF";
 
     const testInstance = TestRenderer.create(
-      <Context.Provider value={{ theme: { scale, sectionColour } }}>
+      <ContextProviderWithDefaults value={{ theme: { scale, sectionColour } }}>
         <KeyFacts ast={dataWithTitle} onLinkPress={() => {}} />
-      </Context.Provider>
+      </ContextProviderWithDefaults>
     );
 
     expect(testInstance).toMatchSnapshot();

--- a/packages/key-facts/__tests__/web/key-facts-with-style.web.test.js
+++ b/packages/key-facts/__tests__/web/key-facts-with-style.web.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { AppRegistry } from "react-native-web";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import {
   addSerializers,
   compose,
@@ -59,9 +59,9 @@ it("key facts with title and context theme", () => {
   const sectionColour = "#FFFFFF";
 
   const testInstance = TestRenderer.create(
-    <Context.Provider value={{ theme: { scale, sectionColour } }}>
+    <ContextProviderWithDefaults value={{ theme: { scale, sectionColour } }}>
       <KeyFacts ast={data} onLinkPress={() => {}} />
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 
   expect(testInstance).toMatchSnapshot();

--- a/packages/key-facts/showcase-helper.js
+++ b/packages/key-facts/showcase-helper.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import invert from "lodash.invert";
-import Context from "@times-components/context";
+import { ContextProviderWithDefaults } from "@times-components/context";
 import Responsive from "@times-components/responsive";
 import { colours, scales } from "@times-components/styleguide";
 import KeyFacts from "./src/key-facts";
@@ -14,11 +14,11 @@ const renderKeyFacts = ({ ast, select, hasScaling = false }) => {
   const scale = hasScaling ? selectScales(select) : null;
   const sectionColour = selectSection(select);
   return (
-    <Context.Provider value={{ theme: { scale, sectionColour } }}>
+    <ContextProviderWithDefaults value={{ theme: { scale, sectionColour } }}>
       <Responsive>
         <KeyFacts ast={ast} onLinkPress={() => {}} />
       </Responsive>
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 };
 

--- a/packages/pages/src/article/article-base.js
+++ b/packages/pages/src/article/article-base.js
@@ -1,7 +1,10 @@
 import React from "react";
 import { NativeModules, Platform } from "react-native";
 import Article from "@times-components/article";
-import { ContextProviderWithDefaults, defaults } from "@times-components/context";
+import {
+  ContextProviderWithDefaults,
+  defaults
+} from "@times-components/context";
 import { themeFactory } from "@times-components/styleguide";
 import adTargetConfig from "./ad-targeting-config";
 import { propTypes, defaultProps } from "./article-prop-types";

--- a/packages/pages/src/article/article-base.js
+++ b/packages/pages/src/article/article-base.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { NativeModules, Platform } from "react-native";
 import Article from "@times-components/article";
-import Context, { defaults } from "@times-components/context";
+import { ContextProviderWithDefaults, defaults } from "@times-components/context";
 import { themeFactory } from "@times-components/styleguide";
 import adTargetConfig from "./ad-targeting-config";
 import { propTypes, defaultProps } from "./article-prop-types";
@@ -55,7 +55,7 @@ const ArticleBase = ({
   };
 
   return (
-    <Context.Provider value={{ theme }}>
+    <ContextProviderWithDefaults value={{ theme }}>
       <Article
         adConfig={adConfig}
         analyticsStream={trackArticle}
@@ -86,7 +86,7 @@ const ArticleBase = ({
         referralUrl={referralUrl}
         refetch={refetch}
       />
-    </Context.Provider>
+    </ContextProviderWithDefaults>
   );
 };
 

--- a/packages/provider-queries/src/article.web.js
+++ b/packages/provider-queries/src/article.web.js
@@ -14,6 +14,7 @@ export default addTypenameToDocument(gql`
       }
       commentsEnabled
       content: paywalledContent
+      descriptionMarkup: summary(maxCharCount: 200)
       dropcapsDisabled
       expirableFlags {
         type
@@ -65,6 +66,13 @@ export default addTypenameToDocument(gql`
         }
       }
       standfirst
+      tiles {
+        slices {
+          sections {
+            title
+          }
+        }
+      }
       template
       textColour {
         rgba {

--- a/packages/related-articles/.jestlint
+++ b/packages/related-articles/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 7,
-  "maxAttributeStringLength": 44,
+  "maxAttributeStringLength": 54,
   "maxDepth": 11,
   "maxLines": 431
 }

--- a/packages/related-articles/__tests__/shared-util.base.js
+++ b/packages/related-articles/__tests__/shared-util.base.js
@@ -2,10 +2,7 @@ import React from "react";
 import mockDate from "mockdate";
 import { iterator } from "@times-components/test-utils";
 import Card from "@times-components/card";
-import Context from "@times-components/context";
 import RelatedArticles from "../src/related-articles";
-
-const makeArticleUrl = () => "https://some-url.io";
 
 export const testSummary = summary => [
   {
@@ -62,9 +59,7 @@ export const noArticlesTests = ({ fixture }) => renderComponent => {
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(output).toMatchSnapshot();
@@ -74,15 +69,13 @@ export const noArticlesTests = ({ fixture }) => renderComponent => {
       name: "no related articles when there is no given slice name",
       test() {
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles
-              analyticsStream={() => {}}
-              onPress={() => {}}
-              slice={{
-                sliceName: ""
-              }}
-            />
-          </Context.Provider>
+          <RelatedArticles
+            analyticsStream={() => {}}
+            onPress={() => {}}
+            slice={{
+              sliceName: ""
+            }}
+          />
         );
 
         expect(output).toMatchSnapshot();
@@ -94,9 +87,7 @@ export const noArticlesTests = ({ fixture }) => renderComponent => {
         const events = jest.fn();
 
         renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(events.mock.calls).toMatchSnapshot();
@@ -117,9 +108,7 @@ export const hasVideoTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(output).toMatchSnapshot();
@@ -140,9 +129,7 @@ export const noShortHeadlineTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(output).toMatchSnapshot();
@@ -154,9 +141,7 @@ export const noShortHeadlineTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(events.mock.calls).toMatchSnapshot();
@@ -180,9 +165,7 @@ export const oneArticleTests = (platform = () => []) => ({
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(output).toMatchSnapshot();
@@ -194,9 +177,7 @@ export const oneArticleTests = (platform = () => []) => ({
         const events = jest.fn();
 
         renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(events.mock.calls).toMatchSnapshot();
@@ -218,9 +199,7 @@ export const twoArticlesTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(output).toMatchSnapshot();
@@ -232,9 +211,7 @@ export const twoArticlesTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(events.mock.calls).toMatchSnapshot();
@@ -255,9 +232,7 @@ export const threeArticlesTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
         expect(output).toMatchSnapshot();
       }
@@ -268,9 +243,7 @@ export const threeArticlesTests = ({ fixture, name }) => renderComponent => {
         const events = jest.fn();
 
         renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(events.mock.calls).toMatchSnapshot();
@@ -294,9 +267,7 @@ export const threeArticlesWithLeadAssetOverrideTests = ({
         const events = jest.fn();
 
         const output = renderComponent(
-          <Context.Provider value={{ makeArticleUrl }}>
-            <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
-          </Context.Provider>
+          <RelatedArticles {...createRelatedArticlesProps(fixture, events)} />
         );
 
         expect(output.root.findAllByType(Card)[0].props.imageUri).toEqual(

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one lead related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one lead and one support related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -79,7 +79,7 @@ exports[`1. one lead and one support related article 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://some-url.io"
+              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
             >
               <div>
                 <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one lead and two support related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -86,7 +86,7 @@ exports[`1. one lead and two support related articles 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://some-url.io"
+              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
             >
               <div>
                 <Card
@@ -135,7 +135,7 @@ exports[`1. one lead and two support related articles 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://some-url.io"
+              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
             >
               <div>
                 <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. no short headline 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one opinion related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one opinion and one support related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -93,7 +93,7 @@ exports[`1. one opinion and one support related article 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://some-url.io"
+              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
             >
               <div>
                 <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -86,7 +86,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://some-url.io"
+              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
             >
               <div>
                 <Card
@@ -135,7 +135,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://some-url.io"
+              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
             >
               <div>
                 <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. no short headline 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. a single related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. two related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -78,7 +78,7 @@ exports[`1. two related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. three related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -85,7 +85,7 @@ exports[`1. three related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card
@@ -150,7 +150,7 @@ exports[`1. three related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. has video 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. no short headline 1`] = `
                 "padding": 10,
               }
             }
-            url="https://some-url.io"
+            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
           >
             <div>
               <Card

--- a/packages/related-articles/related-articles.showcase.js
+++ b/packages/related-articles/related-articles.showcase.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { ScrollView } from "react-native";
-import Context from "@times-components/context";
 import storybookReporter from "@times-components/tealium-utils";
 import RelatedArticles from "./src/related-articles";
 
@@ -19,11 +18,6 @@ import opinionAndTwo2RelatedArticlesFixture from "./fixtures/opinionandtwo/2-art
 import opinionAndTwo3RelatedArticlesFixture from "./fixtures/opinionandtwo/3-articles.js";
 import opinionAndTwo3RelatedArticlesLeadAssetOverrideFixture from "./fixtures/opinionandtwo/3-articles-lead-asset-override";
 
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
-
 const preventDefaultedAction = decorateAction =>
   decorateAction([
     ([e, ...args]) => {
@@ -41,9 +35,7 @@ const createRelatedArticles = (decorateAction, fixtureData) => {
   };
   return (
     <ScrollView>
-      <Context.Provider value={{ makeArticleUrl }}>
-        <RelatedArticles {...props} />
-      </Context.Provider>
+      <RelatedArticles {...props} />
     </ScrollView>
   );
 };

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -69,6 +69,7 @@
     "react-apollo": "2.1.4",
     "react-art": "16.5.2",
     "react-dom": "16.5.2",
+    "react-helmet-async": "1.0.2",
     "react-native": "0.55.4",
     "react-native-web": "0.9.0",
     "shrink-ray": "0.1.3",

--- a/packages/ssr/src/client/article.js
+++ b/packages/ssr/src/client/article.js
@@ -2,13 +2,19 @@ const article = require("../component/article");
 const runClient = require("../lib/run-client");
 
 if (window.nuk && window.nuk.ssr && window.nuk.article) {
-  const { rootTag, makeArticleUrl, mapArticleToAdConfig } = window.nuk.ssr;
+  const {
+    rootTag,
+    makeArticleUrl,
+    makeTopicUrl,
+    mapArticleToAdConfig
+  } = window.nuk.ssr;
   const { articleId, debounceTimeMs, spotAccountId } = window.nuk.article;
 
   const data = {
     articleId,
     debounceTimeMs,
     makeArticleUrl,
+    makeTopicUrl,
     mapArticleToAdConfig,
     spotAccountId
   };

--- a/packages/ssr/src/client/author-profile.js
+++ b/packages/ssr/src/client/author-profile.js
@@ -2,7 +2,12 @@ const authorProfile = require("../component/author-profile");
 const runClient = require("../lib/run-client");
 
 if (window.nuk && window.nuk.ssr && window.nuk.authorProfile) {
-  const { rootTag, makeArticleUrl, mapProfileToAdConfig } = window.nuk.ssr;
+  const {
+    rootTag,
+    makeArticleUrl,
+    makeTopicUrl,
+    mapProfileToAdConfig
+  } = window.nuk.ssr;
   const {
     authorSlug,
     debounceTimeMs,
@@ -14,6 +19,7 @@ if (window.nuk && window.nuk.ssr && window.nuk.authorProfile) {
     authorSlug,
     debounceTimeMs,
     makeArticleUrl,
+    makeTopicUrl,
     mapProfileToAdConfig,
     page,
     pageSize

--- a/packages/ssr/src/client/topic.js
+++ b/packages/ssr/src/client/topic.js
@@ -2,12 +2,18 @@ const topic = require("../component/topic");
 const runClient = require("../lib/run-client");
 
 if (window.nuk && window.nuk.ssr && window.nuk.topicPage) {
-  const { rootTag, makeArticleUrl, mapTopicToAdConfig } = window.nuk.ssr;
+  const {
+    rootTag,
+    makeArticleUrl,
+    makeTopicUrl,
+    mapTopicToAdConfig
+  } = window.nuk.ssr;
   const { debounceTimeMs, page, pageSize, topicSlug } = window.nuk.topicPage;
 
   const data = {
     debounceTimeMs,
     makeArticleUrl,
+    makeTopicUrl,
     mapTopicToAdConfig,
     page,
     pageSize,

--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -4,7 +4,7 @@ const React = require("react");
 const { ApolloProvider } = require("react-apollo");
 const { ArticleProvider } = require("@times-components/provider/rnw");
 const Article = require("@times-components/article/rnw").default;
-const { default: Context, defaults } = require("@times-components/context/rnw");
+const { ContextProviderWithDefaults, defaults } = require("@times-components/context/rnw");
 const { scales, themeFactory } = require("@times-components/styleguide/rnw");
 
 const scale = scales.large;
@@ -30,7 +30,7 @@ module.exports = (client, analyticsStream, data) => {
       },
       ({ article, isLoading, error, refetch }) =>
         React.createElement(
-          Context.Provider,
+          ContextProviderWithDefaults,
           {
             value: {
               makeArticleUrl,

--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -4,7 +4,10 @@ const React = require("react");
 const { ApolloProvider } = require("react-apollo");
 const { ArticleProvider } = require("@times-components/provider/rnw");
 const Article = require("@times-components/article/rnw").default;
-const { ContextProviderWithDefaults, defaults } = require("@times-components/context/rnw");
+const {
+  ContextProviderWithDefaults,
+  defaults
+} = require("@times-components/context/rnw");
 const { scales, themeFactory } = require("@times-components/styleguide/rnw");
 
 const scale = scales.large;

--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -2,6 +2,7 @@
 
 const React = require("react");
 const { ApolloProvider } = require("react-apollo");
+const { HelmetProvider } = require("react-helmet-async");
 const { ArticleProvider } = require("@times-components/provider/rnw");
 const Article = require("@times-components/article/rnw").default;
 const {
@@ -12,7 +13,7 @@ const { scales, themeFactory } = require("@times-components/styleguide/rnw");
 
 const scale = scales.large;
 
-module.exports = (client, analyticsStream, data) => {
+module.exports = (client, analyticsStream, data, helmetContext) => {
   const {
     articleId,
     debounceTimeMs,
@@ -23,41 +24,45 @@ module.exports = (client, analyticsStream, data) => {
   } = data;
 
   return React.createElement(
-    ApolloProvider,
-    { client },
+    HelmetProvider,
+    { context: helmetContext },
     React.createElement(
-      ArticleProvider,
-      {
-        analyticsStream,
-        debounceTimeMs,
-        id: articleId
-      },
-      ({ article, isLoading, error, refetch }) =>
-        React.createElement(
-          ContextProviderWithDefaults,
-          {
-            value: {
-              makeArticleUrl,
-              makeTopicUrl,
-              theme: {
-                ...themeFactory(article.section, article.template),
-                scale: scale || defaults.theme.scale
+      ApolloProvider,
+      { client },
+      React.createElement(
+        ArticleProvider,
+        {
+          analyticsStream,
+          debounceTimeMs,
+          id: articleId
+        },
+        ({ article, isLoading, error, refetch }) =>
+          React.createElement(
+            ContextProviderWithDefaults,
+            {
+              value: {
+                makeArticleUrl,
+                makeTopicUrl,
+                theme: {
+                  ...themeFactory(article.section, article.template),
+                  scale: scale || defaults.theme.scale
+                }
               }
-            }
-          },
-          React.createElement(Article, {
-            adConfig: mapArticleToAdConfig(article),
-            analyticsStream,
-            article,
-            error,
-            isLoading,
-            onAuthorPress: () => {},
-            onRelatedArticlePress: () => {},
-            onTopicPress: () => {},
-            refetch,
-            spotAccountId
-          })
-        )
+            },
+            React.createElement(Article, {
+              adConfig: mapArticleToAdConfig(article),
+              analyticsStream,
+              article,
+              error,
+              isLoading,
+              onAuthorPress: () => {},
+              onRelatedArticlePress: () => {},
+              onTopicPress: () => {},
+              refetch,
+              spotAccountId
+            })
+          )
+      )
     )
   );
 };

--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -14,6 +14,7 @@ module.exports = (client, analyticsStream, data) => {
     articleId,
     debounceTimeMs,
     makeArticleUrl,
+    makeTopicUrl,
     mapArticleToAdConfig,
     spotAccountId
   } = data;
@@ -34,6 +35,7 @@ module.exports = (client, analyticsStream, data) => {
           {
             value: {
               makeArticleUrl,
+              makeTopicUrl,
               theme: {
                 ...themeFactory(article.section, article.template),
                 scale: scale || defaults.theme.scale

--- a/packages/ssr/src/component/author-profile.js
+++ b/packages/ssr/src/component/author-profile.js
@@ -3,7 +3,7 @@
 const React = require("react");
 const { ApolloProvider } = require("react-apollo");
 const { AuthorProfileProvider } = require("@times-components/provider/rnw");
-const Context = require("@times-components/context/rnw").default;
+const { ContextProviderWithDefaults } = require("@times-components/context/rnw");
 const AuthorProfile = require("@times-components/author-profile/rnw").default;
 
 module.exports = (client, analyticsStream, data) => {
@@ -29,7 +29,7 @@ module.exports = (client, analyticsStream, data) => {
       },
       ({ author, isLoading, error, refetch }) =>
         React.createElement(
-          Context.Provider,
+          ContextProviderWithDefaults,
           { value: { makeArticleUrl } },
           React.createElement(AuthorProfile, {
             adConfig: mapProfileToAdConfig(),

--- a/packages/ssr/src/component/author-profile.js
+++ b/packages/ssr/src/component/author-profile.js
@@ -2,11 +2,14 @@
 
 const React = require("react");
 const { ApolloProvider } = require("react-apollo");
+const { HelmetProvider } = require("react-helmet-async");
 const { AuthorProfileProvider } = require("@times-components/provider/rnw");
-const { ContextProviderWithDefaults } = require("@times-components/context/rnw");
+const {
+  ContextProviderWithDefaults
+} = require("@times-components/context/rnw");
 const AuthorProfile = require("@times-components/author-profile/rnw").default;
 
-module.exports = (client, analyticsStream, data) => {
+module.exports = (client, analyticsStream, data, helmetContext) => {
   const {
     authorSlug,
     debounceTimeMs,
@@ -18,34 +21,38 @@ module.exports = (client, analyticsStream, data) => {
   } = data;
 
   return React.createElement(
-    ApolloProvider,
-    { client },
+    HelmetProvider,
+    { context: helmetContext },
     React.createElement(
-      AuthorProfileProvider,
-      {
-        debounceTimeMs,
-        page,
-        pageSize,
-        slug: authorSlug
-      },
-      ({ author, isLoading, error, refetch }) =>
-        React.createElement(
-          ContextProviderWithDefaults,
-          { value: { makeArticleUrl, makeTopicUrl } },
-          React.createElement(AuthorProfile, {
-            adConfig: mapProfileToAdConfig(),
-            analyticsStream,
-            author,
-            error,
-            isLoading,
-            onArticlePress: () => {},
-            onTwitterLinkPress: () => {},
-            page,
-            pageSize,
-            refetch,
-            slug: authorSlug
-          })
-        )
+      ApolloProvider,
+      { client },
+      React.createElement(
+        AuthorProfileProvider,
+        {
+          debounceTimeMs,
+          page,
+          pageSize,
+          slug: authorSlug
+        },
+        ({ author, isLoading, error, refetch }) =>
+          React.createElement(
+            ContextProviderWithDefaults,
+            { value: { makeArticleUrl, makeTopicUrl } },
+            React.createElement(AuthorProfile, {
+              adConfig: mapProfileToAdConfig(),
+              analyticsStream,
+              author,
+              error,
+              isLoading,
+              onArticlePress: () => {},
+              onTwitterLinkPress: () => {},
+              page,
+              pageSize,
+              refetch,
+              slug: authorSlug
+            })
+          )
+      )
     )
   );
 };

--- a/packages/ssr/src/component/author-profile.js
+++ b/packages/ssr/src/component/author-profile.js
@@ -11,6 +11,7 @@ module.exports = (client, analyticsStream, data) => {
     authorSlug,
     debounceTimeMs,
     makeArticleUrl,
+    makeTopicUrl,
     mapProfileToAdConfig,
     page,
     pageSize
@@ -30,7 +31,7 @@ module.exports = (client, analyticsStream, data) => {
       ({ author, isLoading, error, refetch }) =>
         React.createElement(
           ContextProviderWithDefaults,
-          { value: { makeArticleUrl } },
+          { value: { makeArticleUrl, makeTopicUrl } },
           React.createElement(AuthorProfile, {
             adConfig: mapProfileToAdConfig(),
             analyticsStream,

--- a/packages/ssr/src/component/topic.js
+++ b/packages/ssr/src/component/topic.js
@@ -4,7 +4,9 @@ const React = require("react");
 const { ApolloProvider } = require("react-apollo");
 const { HelmetProvider } = require("react-helmet-async");
 const { TopicProvider } = require("@times-components/provider/rnw");
-const { ContextProviderWithDefaults } = require("@times-components/context/rnw");
+const {
+  ContextProviderWithDefaults
+} = require("@times-components/context/rnw");
 const { scales } = require("@times-components/styleguide/rnw");
 const Topic = require("@times-components/topic/rnw").default;
 

--- a/packages/ssr/src/component/topic.js
+++ b/packages/ssr/src/component/topic.js
@@ -4,7 +4,7 @@ const React = require("react");
 const { ApolloProvider } = require("react-apollo");
 const { HelmetProvider } = require("react-helmet-async");
 const { TopicProvider } = require("@times-components/provider/rnw");
-const Context = require("@times-components/context/rnw").default;
+const { ContextProviderWithDefaults } = require("@times-components/context/rnw");
 const { scales } = require("@times-components/styleguide/rnw");
 const Topic = require("@times-components/topic/rnw").default;
 
@@ -37,7 +37,7 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
         },
         ({ isLoading, error, refetch, topic }) =>
           React.createElement(
-            Context.Provider,
+            ContextProviderWithDefaults,
             {
               value: {
                 makeArticleUrl,

--- a/packages/ssr/src/component/topic.js
+++ b/packages/ssr/src/component/topic.js
@@ -2,6 +2,7 @@
 
 const React = require("react");
 const { ApolloProvider } = require("react-apollo");
+const { HelmetProvider } = require("react-helmet-async");
 const { TopicProvider } = require("@times-components/provider/rnw");
 const Context = require("@times-components/context/rnw").default;
 const { scales } = require("@times-components/styleguide/rnw");
@@ -10,7 +11,7 @@ const Topic = require("@times-components/topic/rnw").default;
 const scale = scales.large;
 const sectionColour = "#FFFFFF";
 
-module.exports = (client, analyticsStream, data) => {
+module.exports = (client, analyticsStream, data, helmetContext) => {
   const {
     debounceTimeMs,
     makeArticleUrl,
@@ -21,39 +22,43 @@ module.exports = (client, analyticsStream, data) => {
   } = data;
 
   return React.createElement(
-    ApolloProvider,
-    { client },
+    HelmetProvider,
+    { context: helmetContext },
     React.createElement(
-      TopicProvider,
-      {
-        debounceTimeMs,
-        page,
-        pageSize,
-        slug: topicSlug
-      },
-      ({ isLoading, error, refetch, topic }) =>
-        React.createElement(
-          Context.Provider,
-          {
-            value: {
-              makeArticleUrl,
-              theme: { scale, sectionColour }
-            }
-          },
-          React.createElement(Topic, {
-            adConfig: mapTopicToAdConfig(),
-            analyticsStream,
-            error,
-            isLoading,
-            onArticlePress: () => {},
-            onTwitterLinkPress: () => {},
-            page,
-            pageSize,
-            refetch,
-            slug: topicSlug,
-            topic
-          })
-        )
+      ApolloProvider,
+      { client },
+      React.createElement(
+        TopicProvider,
+        {
+          debounceTimeMs,
+          page,
+          pageSize,
+          slug: topicSlug
+        },
+        ({ isLoading, error, refetch, topic }) =>
+          React.createElement(
+            Context.Provider,
+            {
+              value: {
+                makeArticleUrl,
+                theme: { scale, sectionColour }
+              }
+            },
+            React.createElement(Topic, {
+              adConfig: mapTopicToAdConfig(),
+              analyticsStream,
+              error,
+              isLoading,
+              onArticlePress: () => {},
+              onTwitterLinkPress: () => {},
+              page,
+              pageSize,
+              refetch,
+              slug: topicSlug,
+              topic
+            })
+          )
+      )
     )
   );
 };

--- a/packages/ssr/src/component/topic.js
+++ b/packages/ssr/src/component/topic.js
@@ -15,6 +15,7 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
   const {
     debounceTimeMs,
     makeArticleUrl,
+    makeTopicUrl,
     mapTopicToAdConfig,
     page,
     pageSize,
@@ -41,6 +42,7 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
             {
               value: {
                 makeArticleUrl,
+                makeTopicUrl,
                 theme: { scale, sectionColour }
               }
             },

--- a/packages/ssr/src/lib/make-url.js
+++ b/packages/ssr/src/lib/make-url.js
@@ -1,1 +1,0 @@
-module.exports = ({ id }) => `http://localhost:3000/article/${id}`;

--- a/packages/ssr/src/lib/make-urls.js
+++ b/packages/ssr/src/lib/make-urls.js
@@ -1,0 +1,3 @@
+module.exports.makeArticleUrl = ({ id }) =>
+  `http://localhost:3000/article/${id}`;
+module.exports.makeTopicUrl = ({ slug }) => `/topic/${slug}`;

--- a/packages/ssr/src/lib/make-urls.js
+++ b/packages/ssr/src/lib/make-urls.js
@@ -1,3 +1,2 @@
-module.exports.makeArticleUrl = ({ id }) =>
-  `http://localhost:3000/article/${id}`;
+module.exports.makeArticleUrl = ({ id }) => `/article/${id}`;
 module.exports.makeTopicUrl = ({ slug }) => `/topic/${slug}`;

--- a/packages/ssr/src/lib/run-client.js
+++ b/packages/ssr/src/lib/run-client.js
@@ -55,7 +55,7 @@ module.exports = (component, clientOptions, data) => {
   };
   const analyticsStream = makeAnalyticsStream(reporterOptions);
 
-  const App = component(client, analyticsStream, data);
+  const App = component(client, analyticsStream, data, {});
 
   AppRegistry.registerComponent("App", () => () => App);
 

--- a/packages/ssr/src/server/article.js
+++ b/packages/ssr/src/server/article.js
@@ -6,7 +6,7 @@ const defaultAdConfig = require("../lib/ads/make-article-ad-config")
 module.exports = (
   articleId,
   headers,
-  { graphqlApiUrl, logger, makeArticleUrl, spotAccountId }
+  { graphqlApiUrl, logger, makeArticleUrl, makeTopicUrl, spotAccountId }
 ) => {
   if (typeof articleId !== "string") {
     throw new Error(`Article ID should be a string. Received ${articleId}`);
@@ -20,6 +20,11 @@ module.exports = (
   if (!makeArticleUrl) {
     throw new Error(
       `Make article url function is required. Received ${makeArticleUrl}`
+    );
+  }
+  if (!makeTopicUrl) {
+    throw new Error(
+      `Make topic url function is required. Received ${makeTopicUrl}`
     );
   }
   if (typeof spotAccountId !== "string") {
@@ -38,6 +43,7 @@ module.exports = (
       articleId,
       debounceTimeMs: 0,
       makeArticleUrl,
+      makeTopicUrl,
       mapArticleToAdConfig: defaultAdConfig,
       spotAccountId
     },

--- a/packages/ssr/src/server/author-profile.js
+++ b/packages/ssr/src/server/author-profile.js
@@ -5,7 +5,7 @@ const defaultAdConfig = require("../lib/ads/make-author-profile-ad-config")
 
 module.exports = (
   { authorSlug, currentPage },
-  { graphqlApiUrl, logger, makeArticleUrl }
+  { graphqlApiUrl, logger, makeArticleUrl, makeTopicUrl }
 ) => {
   if (typeof authorSlug !== "string") {
     throw new Error(`Author slug should be a string. Received ${authorSlug}`);
@@ -26,6 +26,11 @@ module.exports = (
       `Make article url function is required. Received ${makeArticleUrl}`
     );
   }
+  if (!makeTopicUrl) {
+    throw new Error(
+      `Make topic url function is required. Received ${makeTopicUrl}`
+    );
+  }
 
   const options = {
     client: {
@@ -36,6 +41,7 @@ module.exports = (
       authorSlug,
       debounceTimeMs: 0,
       makeArticleUrl,
+      makeTopicUrl,
       mapProfileToAdConfig: defaultAdConfig,
       page: currentPage,
       pageSize: 20

--- a/packages/ssr/src/server/topic.js
+++ b/packages/ssr/src/server/topic.js
@@ -5,7 +5,7 @@ const defaultAdConfig = require("../lib/ads/make-topic-ad-config")
 
 module.exports = (
   { currentPage, topicSlug },
-  { graphqlApiUrl, logger, makeArticleUrl }
+  { graphqlApiUrl, logger, makeArticleUrl, makeTopicUrl }
 ) => {
   if (typeof topicSlug !== "string") {
     throw new Error(`Topic slug should be a string. Received ${topicSlug}`);
@@ -26,6 +26,11 @@ module.exports = (
       `Make article url function is required. Received ${makeArticleUrl}`
     );
   }
+  if (!makeTopicUrl) {
+    throw new Error(
+      `Make topic url function is required. Received ${makeTopicUrl}`
+    );
+  }
 
   const options = {
     client: {
@@ -35,6 +40,7 @@ module.exports = (
     data: {
       debounceTimeMs: 0,
       makeArticleUrl,
+      makeTopicUrl,
       mapTopicToAdConfig: defaultAdConfig,
       page: currentPage,
       pageSize: 20,

--- a/packages/ssr/src/standalone-renderer/app.js
+++ b/packages/ssr/src/standalone-renderer/app.js
@@ -95,15 +95,24 @@ server.get("/profile/:slug", (request, response) => {
       { authorSlug, currentPage },
       { ...makeUrls, graphqlApiUrl, logger }
     )
-    .then(({ initialProps, initialState, markup, responsiveStyles, styles }) =>
-      response.send(
-        makeHtml(initialState, initialProps, {
-          bundleName: "author-profile",
-          markup,
-          responsiveStyles,
-          styles
-        })
-      )
+    .then(
+      ({
+        initialProps,
+        initialState,
+        headMarkup,
+        markup,
+        responsiveStyles,
+        styles
+      }) =>
+        response.send(
+          makeHtml(initialState, initialProps, {
+            bundleName: "author-profile",
+            headMarkup,
+            markup,
+            responsiveStyles,
+            styles
+          })
+        )
     );
 });
 

--- a/packages/ssr/src/standalone-renderer/app.js
+++ b/packages/ssr/src/standalone-renderer/app.js
@@ -70,15 +70,24 @@ server.get("/article/:id", (request, response) => {
       logger,
       spotAccountId
     })
-    .then(({ initialProps, initialState, markup, responsiveStyles, styles }) =>
-      response.send(
-        makeHtml(initialState, initialProps, {
-          bundleName: "article",
-          markup,
-          responsiveStyles,
-          styles
-        })
-      )
+    .then(
+      ({
+        initialProps,
+        initialState,
+        headMarkup,
+        markup,
+        responsiveStyles,
+        styles
+      }) =>
+        response.send(
+          makeHtml(initialState, initialProps, {
+            bundleName: "article",
+            headMarkup,
+            markup,
+            responsiveStyles,
+            styles
+          })
+        )
     );
 });
 

--- a/packages/ssr/src/standalone-renderer/app.js
+++ b/packages/ssr/src/standalone-renderer/app.js
@@ -4,7 +4,7 @@ const express = require("express");
 const shrinkRay = require("shrink-ray");
 
 const ssr = require("../server");
-const makeArticleUrl = require("../lib/make-url");
+const makeUrls = require("../lib/make-urls");
 const logger = require("../lib/simple-logger");
 
 const port = 3000;
@@ -65,9 +65,9 @@ server.get("/article/:id", (request, response) => {
 
   ssr
     .article(articleId, headers, {
+      ...makeUrls,
       graphqlApiUrl,
       logger,
-      makeArticleUrl,
       spotAccountId
     })
     .then(({ initialProps, initialState, markup, responsiveStyles, styles }) =>
@@ -93,7 +93,7 @@ server.get("/profile/:slug", (request, response) => {
   ssr
     .authorProfile(
       { authorSlug, currentPage },
-      { graphqlApiUrl, logger, makeArticleUrl }
+      { ...makeUrls, graphqlApiUrl, logger }
     )
     .then(({ initialProps, initialState, markup, responsiveStyles, styles }) =>
       response.send(
@@ -116,10 +116,7 @@ server.get("/topic/:slug", (request, response) => {
   const graphqlApiUrl = process.env.GRAPHQL_ENDPOINT;
 
   ssr
-    .topic(
-      { currentPage, topicSlug },
-      { graphqlApiUrl, logger, makeArticleUrl }
-    )
+    .topic({ currentPage, topicSlug }, { ...makeUrls, graphqlApiUrl, logger })
     .then(
       ({
         headMarkup,

--- a/packages/ssr/src/standalone-renderer/app.js
+++ b/packages/ssr/src/standalone-renderer/app.js
@@ -16,13 +16,13 @@ server.use(express.static("dist"));
 const makeHtml = (
   initialState,
   initialProps,
-  { bundleName, markup, responsiveStyles, styles, title }
+  { bundleName, headMarkup, markup, responsiveStyles, styles }
 ) => `
         <!DOCTYPE html>
         <html>
           <head>
             <meta name="viewport" content="width=device-width, initial-scale=1">
-            <title>${title}</title>
+            ${headMarkup}
             ${styles}
             ${responsiveStyles}
           </head>
@@ -76,8 +76,7 @@ server.get("/article/:id", (request, response) => {
           bundleName: "article",
           markup,
           responsiveStyles,
-          styles,
-          title: "Article"
+          styles
         })
       )
     );
@@ -102,8 +101,7 @@ server.get("/profile/:slug", (request, response) => {
           bundleName: "author-profile",
           markup,
           responsiveStyles,
-          styles,
-          title: authorSlug
+          styles
         })
       )
     );
@@ -122,16 +120,24 @@ server.get("/topic/:slug", (request, response) => {
       { currentPage, topicSlug },
       { graphqlApiUrl, logger, makeArticleUrl }
     )
-    .then(({ initialProps, initialState, markup, responsiveStyles, styles }) =>
-      response.send(
-        makeHtml(initialState, initialProps, {
-          bundleName: "topic",
-          markup,
-          responsiveStyles,
-          styles,
-          title: topicSlug
-        })
-      )
+    .then(
+      ({
+        headMarkup,
+        initialProps,
+        initialState,
+        markup,
+        responsiveStyles,
+        styles
+      }) =>
+        response.send(
+          makeHtml(initialState, initialProps, {
+            bundleName: "topic",
+            headMarkup,
+            markup,
+            responsiveStyles,
+            styles
+          })
+        )
     );
 });
 

--- a/packages/ssr/src/standalone-renderer/page-init/article.js
+++ b/packages/ssr/src/standalone-renderer/page-init/article.js
@@ -1,13 +1,13 @@
 const defaultMapArticleToConfig = require("../../lib/ads/make-article-ad-config")
   .defaultClient;
-const makeArticleUrl = require("../../lib/make-url");
+const makeUrls = require("../../lib/make-urls");
 
 const rootTag = "main-container";
 
 window.nuk = window.nuk || {};
 window.nuk.ssr = {
   ...window.nuk.ssr,
-  makeArticleUrl,
+  ...makeUrls,
   mapArticleToAdConfig: defaultMapArticleToConfig,
   rootTag
 };

--- a/packages/ssr/src/standalone-renderer/page-init/author-profile.js
+++ b/packages/ssr/src/standalone-renderer/page-init/author-profile.js
@@ -1,13 +1,13 @@
 const defaultMapProfileToConfig = require("../../lib/ads/make-author-profile-ad-config")
   .defaultClient;
-const makeArticleUrl = require("../../lib/make-url");
+const makeUrls = require("../../lib/make-urls");
 
 const rootTag = "main-container";
 
 window.nuk = window.nuk || {};
 window.nuk.ssr = {
   ...window.nuk.ssr,
-  makeArticleUrl,
+  ...makeUrls,
   mapProfileToAdConfig: defaultMapProfileToConfig,
   rootTag
 };

--- a/packages/ssr/src/standalone-renderer/page-init/topic.js
+++ b/packages/ssr/src/standalone-renderer/page-init/topic.js
@@ -1,13 +1,13 @@
 const defaultMapTopicToConfig = require("../../lib/ads/make-topic-ad-config")
   .defaultClient;
-const makeArticleUrl = require("../../lib/make-url");
+const makeUrls = require("../../lib/make-urls");
 
 const rootTag = "main-container";
 
 window.nuk = window.nuk || {};
 window.nuk.ssr = {
   ...window.nuk.ssr,
-  makeArticleUrl,
+  ...makeUrls,
   mapTopicToAdConfig: defaultMapTopicToConfig,
   rootTag
 };

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -54,6 +54,7 @@
     "prop-types": "15.6.2",
     "react": "16.5.2",
     "react-apollo": "2.1.4",
+    "react-helmet-async": "1.0.2",
     "react-test-renderer": "16.5.2"
   },
   "peerDependencies": {

--- a/packages/storybook/src/showcase-to-storybook.js
+++ b/packages/storybook/src/showcase-to-storybook.js
@@ -1,4 +1,5 @@
 import React, { StrictMode } from "react";
+import { HelmetProvider } from "react-helmet-async";
 import PropTypes from "prop-types";
 import { Platform } from "react-native";
 
@@ -10,7 +11,9 @@ React.Fragment.displayName = "React.Fragment";
 
 // eslint-disable-next-line react/prop-types
 export const StrictWrapper = ({ children }) => (
-  <StrictMode>{children}</StrictMode>
+  <StrictMode>
+    <HelmetProvider context={{}}>{children}</HelmetProvider>
+  </StrictMode>
 );
 
 const addStories = (

--- a/packages/topic/.jestlint
+++ b/packages/topic/.jestlint
@@ -1,3 +1,4 @@
 {
   "maxAttributes": 9
+  "maxAttributeStringLength": 90
 }

--- a/packages/topic/.jestlint
+++ b/packages/topic/.jestlint
@@ -1,4 +1,4 @@
 {
-  "maxAttributes": 9
+  "maxAttributes": 9,
   "maxAttributeStringLength": 90
 }

--- a/packages/topic/__tests__/mocks.js
+++ b/packages/topic/__tests__/mocks.js
@@ -1,3 +1,5 @@
+jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
+
 jest.mock("@times-components/article-list", () =>
   // eslint-disable-next-line global-require
   require("./mock-article-list")

--- a/packages/topic/__tests__/web/__snapshots__/topic-loading.web.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-loading.web.test.js.snap
@@ -5,10 +5,16 @@ exports[`1. an article list loading 1`] = `
   <Helmet>
     <title>
       
-       | Page 
-      1/undefined
        | The Times & The Sunday Times
     </title>
+    <meta
+      content="Discover expert  articles from The Times and The Sunday Times."
+      name="description"
+    />
+    <link
+      href="/topic/some-slug"
+      rel="canonical"
+    />
   </Helmet>
   <ArticleList
     articleListHeader={

--- a/packages/topic/__tests__/web/__snapshots__/topic-loading.web.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-loading.web.test.js.snap
@@ -2,6 +2,14 @@
 
 exports[`1. an article list loading 1`] = `
 <topicArticlesProvider>
+  <Helmet>
+    <title>
+      
+       | Page 
+      1/undefined
+       | The Times & The Sunday Times
+    </title>
+  </Helmet>
   <ArticleList
     articleListHeader={
       <TopicHead

--- a/packages/topic/__tests__/web/__snapshots__/topic.web.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic.web.test.js.snap
@@ -4,6 +4,14 @@ exports[`1. an error page 1`] = `<ArticleListPageError />`;
 
 exports[`2. a loading state 1`] = `
 <topicArticlesProvider>
+  <Helmet>
+    <title>
+      
+       | Page 
+      1/10
+       | The Times & The Sunday Times
+    </title>
+  </Helmet>
   <ArticleList
     articleListHeader={
       <TopicHead
@@ -32,6 +40,14 @@ exports[`2. a loading state 1`] = `
 
 exports[`3. an article list 1`] = `
 <topicArticlesProvider>
+  <Helmet>
+    <title>
+      Test Name
+       | Page 
+      2/10
+       | The Times & The Sunday Times
+    </title>
+  </Helmet>
   <ArticleList
     articleListHeader={
       <TopicHead
@@ -104,6 +120,14 @@ exports[`3. an article list 1`] = `
 
 exports[`4. fetches more articles 1`] = `
 <topicArticlesProvider>
+  <Helmet>
+    <title>
+      Test Name
+       | Page 
+      2/10
+       | The Times & The Sunday Times
+    </title>
+  </Helmet>
   <ArticleList
     articleListHeader={
       <TopicHead
@@ -181,6 +205,14 @@ exports[`4. fetches more articles 1`] = `
 
 exports[`5. fetches more articles and falls back to previous data if no more 1`] = `
 <topicArticlesProvider>
+  <Helmet>
+    <title>
+      Test Name
+       | Page 
+      2/10
+       | The Times & The Sunday Times
+    </title>
+  </Helmet>
   <ArticleList
     articleListHeader={
       <TopicHead

--- a/packages/topic/__tests__/web/__snapshots__/topic.web.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic.web.test.js.snap
@@ -7,10 +7,16 @@ exports[`2. a loading state 1`] = `
   <Helmet>
     <title>
       
-       | Page 
-      1/10
        | The Times & The Sunday Times
     </title>
+    <meta
+      content="Discover expert  articles from The Times and The Sunday Times."
+      name="description"
+    />
+    <link
+      href="/topic/some-slug"
+      rel="canonical"
+    />
   </Helmet>
   <ArticleList
     articleListHeader={
@@ -43,10 +49,16 @@ exports[`3. an article list 1`] = `
   <Helmet>
     <title>
       Test Name
-       | Page 
-      2/10
        | The Times & The Sunday Times
     </title>
+    <meta
+      content="Discover expert Test Name articles from The Times and The Sunday Times."
+      name="description"
+    />
+    <link
+      href="/topic/some-slug"
+      rel="canonical"
+    />
   </Helmet>
   <ArticleList
     articleListHeader={
@@ -123,10 +135,16 @@ exports[`4. fetches more articles 1`] = `
   <Helmet>
     <title>
       Test Name
-       | Page 
-      2/10
        | The Times & The Sunday Times
     </title>
+    <meta
+      content="Discover expert Test Name articles from The Times and The Sunday Times."
+      name="description"
+    />
+    <link
+      href="/topic/some-slug"
+      rel="canonical"
+    />
   </Helmet>
   <ArticleList
     articleListHeader={
@@ -208,10 +226,16 @@ exports[`5. fetches more articles and falls back to previous data if no more 1`]
   <Helmet>
     <title>
       Test Name
-       | Page 
-      2/10
        | The Times & The Sunday Times
     </title>
+    <meta
+      content="Discover expert Test Name articles from The Times and The Sunday Times."
+      name="description"
+    />
+    <link
+      href="/topic/some-slug"
+      rel="canonical"
+    />
   </Helmet>
   <ArticleList
     articleListHeader={

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -82,6 +82,7 @@
     "@times-components/utils": "4.10.4",
     "lodash.get": "4.4.2",
     "prop-types": "15.6.2",
+    "react-helmet-async": "1.0.2",
     "styled-components": "3.4.0"
   },
   "peerDependencies": {

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -71,6 +71,7 @@
   },
   "dependencies": {
     "@times-components/article-list": "7.0.39",
+    "@times-components/context": "0.9.20",
     "@times-components/markup": "3.3.54",
     "@times-components/markup-forest": "1.7.4",
     "@times-components/pagination": "3.2.56",

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -71,7 +71,6 @@
   },
   "dependencies": {
     "@times-components/article-list": "7.0.39",
-    "@times-components/context": "0.9.22",
     "@times-components/markup": "3.3.54",
     "@times-components/markup-forest": "1.7.4",
     "@times-components/pagination": "3.2.56",

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@times-components/article-list": "7.0.39",
-    "@times-components/context": "0.9.20",
+    "@times-components/context": "0.9.22",
     "@times-components/markup": "3.3.54",
     "@times-components/markup-forest": "1.7.4",
     "@times-components/pagination": "3.2.56",

--- a/packages/topic/src/head.js
+++ b/packages/topic/src/head.js
@@ -1,0 +1,5 @@
+function Head() {
+  return null;
+}
+
+export default Head;

--- a/packages/topic/src/head.web.js
+++ b/packages/topic/src/head.web.js
@@ -1,0 +1,21 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Helmet } from "react-helmet-async";
+
+function Head({ page, pageSize, name }) {
+  return (
+    <Helmet>
+      <title>
+        {name} | Page {`${page}/${pageSize}`} | The Times &amp; The Sunday Times
+      </title>
+    </Helmet>
+  );
+}
+
+Head.propTypes = {
+  name: PropTypes.string.isRequired,
+  page: PropTypes.number.isRequired,
+  pageSize: PropTypes.number.isRequired
+};
+
+export default Head;

--- a/packages/topic/src/head.web.js
+++ b/packages/topic/src/head.web.js
@@ -1,21 +1,28 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Helmet } from "react-helmet-async";
+import Context from "@times-components/context";
 
-function Head({ page, pageSize, name }) {
+function Head({ name, slug }) {
   return (
-    <Helmet>
-      <title>
-        {name} | Page {`${page}/${pageSize}`} | The Times &amp; The Sunday Times
-      </title>
-    </Helmet>
+    <Context.Consumer>
+      {({ makeTopicUrl }) => (
+        <Helmet>
+          <title>{name} | The Times &amp; The Sunday Times</title>
+          <meta
+            content={`Discover expert ${name} articles from The Times and The Sunday Times.`}
+            name="description"
+          />
+          <link href={makeTopicUrl({ slug })} rel="canonical" />
+        </Helmet>
+      )}
+    </Context.Consumer>
   );
 }
 
 Head.propTypes = {
   name: PropTypes.string.isRequired,
-  page: PropTypes.number.isRequired,
-  pageSize: PropTypes.number.isRequired
+  slug: PropTypes.string.isRequired
 };
 
 export default Head;

--- a/packages/topic/src/topic.js
+++ b/packages/topic/src/topic.js
@@ -1,6 +1,5 @@
 import React from "react";
 import get from "lodash.get";
-import { Helmet } from "react-helmet-async";
 import ArticleList, {
   ArticleListPageError
 } from "@times-components/article-list";
@@ -11,6 +10,7 @@ import { ratioTextToFloat } from "@times-components/utils";
 import { propTypes, defaultProps } from "./topic-prop-types";
 import topicTrackingContext from "./topic-tracking-context";
 import TopicHead from "./topic-head";
+import Head from "./head";
 
 const Topic = ({
   adConfig,
@@ -88,12 +88,7 @@ const Topic = ({
 
         return (
           <Responsive>
-            <Helmet>
-              <title>
-                {name} | Page {`${page}/${pageSize}`} | The Times &amp; The
-                Sunday Times
-              </title>
-            </Helmet>
+            <Head {...{ name, page, pageSize }} />
             <ArticleList
               adConfig={adConfig}
               articleListHeader={articleListHeader}

--- a/packages/topic/src/topic.js
+++ b/packages/topic/src/topic.js
@@ -1,5 +1,6 @@
 import React from "react";
 import get from "lodash.get";
+import { Helmet } from "react-helmet-async";
 import ArticleList, {
   ArticleListPageError
 } from "@times-components/article-list";
@@ -87,6 +88,12 @@ const Topic = ({
 
         return (
           <Responsive>
+            <Helmet>
+              <title>
+                {name} | Page {`${page}/${pageSize}`} | The Times &amp; The
+                Sunday Times
+              </title>
+            </Helmet>
             <ArticleList
               adConfig={adConfig}
               articleListHeader={articleListHeader}

--- a/packages/topic/src/topic.js
+++ b/packages/topic/src/topic.js
@@ -88,7 +88,7 @@ const Topic = ({
 
         return (
           <Responsive>
-            <Head {...{ name, page, pageSize }} />
+            <Head {...{ name, slug }} />
             <ArticleList
               adConfig={adConfig}
               articleListHeader={articleListHeader}

--- a/packages/topic/topic.showcase.js
+++ b/packages/topic/topic.showcase.js
@@ -6,7 +6,6 @@ import {
   MockFixture,
   topic as makeParams
 } from "@times-components/provider-test-tools";
-import Context from "@times-components/context";
 import storybookReporter from "@times-components/tealium-utils";
 import Topic from "./src/topic";
 import TopicProvider from "../provider/src/topic";
@@ -31,25 +30,19 @@ const name = "Chelsea";
 const pageSize = 20;
 const topicSlug = "chelsea";
 
-const makeArticleUrl = ({ slug, shortIdentifier }) =>
-  slug && shortIdentifier
-    ? `https://www.thetimes.co.uk/article/${slug}-${shortIdentifier}`
-    : "";
-
 const makeTopic = (decorateAction, params) => (
   <MockFixture
     params={params}
     render={mocks => (
       <MockedProvider mocks={mocks}>
-        <Context.Provider value={{ makeArticleUrl }}>
-          <TopicProvider
-            articleImageRatio={articleImageRatio}
-            debounceTimeMs={250}
-            page={1}
-            pageSize={pageSize}
-            slug={topicSlug}
-          >
-            {({
+        <TopicProvider
+          articleImageRatio={articleImageRatio}
+          debounceTimeMs={250}
+          page={1}
+          pageSize={pageSize}
+          slug={topicSlug}
+        >
+          {({
               error,
               isLoading,
               page,
@@ -57,19 +50,18 @@ const makeTopic = (decorateAction, params) => (
               refetch,
               topic
             }) => (
-              <Topic
-                error={error}
-                isLoading={isLoading}
-                page={page}
-                pageSize={authorPageSize}
-                refetch={refetch}
-                slug={topicSlug}
-                topic={topic}
-                {...getProps(decorateAction)}
-              />
-            )}
-          </TopicProvider>
-        </Context.Provider>
+            <Topic
+              error={error}
+              isLoading={isLoading}
+              page={page}
+              pageSize={authorPageSize}
+              refetch={refetch}
+              slug={topicSlug}
+              topic={topic}
+              {...getProps(decorateAction)}
+            />
+          )}
+        </TopicProvider>
       </MockedProvider>
     )}
   />

--- a/packages/topic/topic.showcase.js
+++ b/packages/topic/topic.showcase.js
@@ -43,13 +43,13 @@ const makeTopic = (decorateAction, params) => (
           slug={topicSlug}
         >
           {({
-              error,
-              isLoading,
-              page,
-              pageSize: authorPageSize,
-              refetch,
-              topic
-            }) => (
+            error,
+            isLoading,
+            page,
+            pageSize: authorPageSize,
+            refetch,
+            topic
+          }) => (
             <Topic
               error={error}
               isLoading={isLoading}

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,6 +765,13 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
+  integrity sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2":
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.5.tgz#4170907641cf1f61508f563ece3725150cc6fe39"
@@ -10764,7 +10771,7 @@ intrinsic-scale@3.0.3:
   resolved "https://registry.yarnpkg.com/intrinsic-scale/-/intrinsic-scale-3.0.3.tgz#a940efda97e81f783f73c450618c46c1c1fbd008"
   integrity sha1-qUDv2pfoH3g/c8RQYYxGwcH70Ag=
 
-invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -15683,6 +15690,15 @@ prop-types@15.6.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, 
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 propagate@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
@@ -16217,6 +16233,11 @@ react-error-overlay@^4.0.1:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.1.tgz#417addb0814a90f3a7082eacba7cee588d00da89"
   integrity sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw==
 
+react-fast-compare@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
 react-fuzzy@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/react-fuzzy/-/react-fuzzy-0.5.2.tgz#fc13bf6f0b785e5fefe908724efebec4935eaefe"
@@ -16226,6 +16247,17 @@ react-fuzzy@^0.5.2:
     classnames "^2.2.5"
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
+
+react-helmet-async@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.0.2.tgz#bb55dd8268f7b15aac69c6b22e2f950abda8cc44"
+  integrity sha512-qzzchrM/ibHuPS/60ief8jaibPunuRdeta4iBDQV+ri2SFKwOV+X2NlEpvevZOauhmHrH/I6dI4E90EPVfJBBg==
+  dependencies:
+    "@babel/runtime" "7.3.4"
+    invariant "2.2.4"
+    prop-types "15.7.2"
+    react-fast-compare "2.0.4"
+    shallowequal "1.1.0"
 
 react-hot-loader@3.0.0-beta.7:
   version "3.0.0-beta.7"
@@ -16275,6 +16307,11 @@ react-is@^16.5.2:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
+
+react-is@^16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-lifecycles-compat@^3, react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -17784,17 +17821,17 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+shallowequal@1.1.0, shallowequal@^1.0.2, shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shallowequal@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
   integrity sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=
   dependencies:
     lodash.keys "^3.1.2"
-
-shallowequal@^1.0.2, shallowequal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
-  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,13 +1842,6 @@
     fs-extra "6.0.0"
     glob "7.1.2"
 
-"@times-components/context@0.9.20":
-  version "0.9.20"
-  resolved "https://registry.yarnpkg.com/@times-components/context/-/context-0.9.20.tgz#acd0e1e029916da5cb4eafc8e787e43cef69e597"
-  integrity sha512-6jbJ8V3XYqqLRGrqWaInPa8ehjq7mfrkADsbvlDlqZQS/jss+fbhIyuqkySNpeoWlRlqq3DA4B2XSPdOfolzwQ==
-  dependencies:
-    "@times-components/styleguide" "3.28.5"
-
 "@times-components/fructose@3.11.4":
   version "3.11.4"
   resolved "https://registry.yarnpkg.com/@times-components/fructose/-/fructose-3.11.4.tgz#c653664a2aa7722550e949c10880737f2b6704b9"
@@ -1874,14 +1867,6 @@
     webpack "4.6.0"
     webpack-dev-server "3.1.7"
     webpack-merge "^4.1.1"
-
-"@times-components/styleguide@3.28.5":
-  version "3.28.5"
-  resolved "https://registry.yarnpkg.com/@times-components/styleguide/-/styleguide-3.28.5.tgz#c07f29d1c99710f3dfa5eb409a8615b273938275"
-  integrity sha512-N9LBioeqMSjOl2pgOR6aVyXVjP7+sw+82h8Y30aJQgoEC1gjLk72iU7g29JpWJmX3f+66ayv2uCG3LvlRO6CRQ==
-  dependencies:
-    prop-types "15.6.2"
-    styled-components "3.4.0"
 
 "@types/accepts@^1.3.5":
   version "1.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,6 +1842,13 @@
     fs-extra "6.0.0"
     glob "7.1.2"
 
+"@times-components/context@0.9.20":
+  version "0.9.20"
+  resolved "https://registry.yarnpkg.com/@times-components/context/-/context-0.9.20.tgz#acd0e1e029916da5cb4eafc8e787e43cef69e597"
+  integrity sha512-6jbJ8V3XYqqLRGrqWaInPa8ehjq7mfrkADsbvlDlqZQS/jss+fbhIyuqkySNpeoWlRlqq3DA4B2XSPdOfolzwQ==
+  dependencies:
+    "@times-components/styleguide" "3.28.5"
+
 "@times-components/fructose@3.11.4":
   version "3.11.4"
   resolved "https://registry.yarnpkg.com/@times-components/fructose/-/fructose-3.11.4.tgz#c653664a2aa7722550e949c10880737f2b6704b9"
@@ -1867,6 +1874,14 @@
     webpack "4.6.0"
     webpack-dev-server "3.1.7"
     webpack-merge "^4.1.1"
+
+"@times-components/styleguide@3.28.5":
+  version "3.28.5"
+  resolved "https://registry.yarnpkg.com/@times-components/styleguide/-/styleguide-3.28.5.tgz#c07f29d1c99710f3dfa5eb409a8615b273938275"
+  integrity sha512-N9LBioeqMSjOl2pgOR6aVyXVjP7+sw+82h8Y30aJQgoEC1gjLk72iU7g29JpWJmX3f+66ayv2uCG3LvlRO6CRQ==
+  dependencies:
+    prop-types "15.6.2"
+    styled-components "3.4.0"
 
 "@types/accepts@^1.3.5":
   version "1.3.5"


### PR DESCRIPTION
This PR allows pages within times-components to manage title, meta, and link tags on web using `react-helmet-async` with server slide and client side dynamic support.

SSR spits out these tags as the string `headMarkup` and it is up to the consumer to place this on the page for server side rendering. 

I've also copied across all of the meta tags for author & topic pages, and *most* of them for article. There's the default lead asset meta tags that haven't yet been copied, as this is blocked on us having the ability to bundle binary assets for web. 

I've also replaced almost all instances of `Context.Provider` with a new `ContextProviderWithDefaults`, which merges the provided value with the defaults specified (so that tests don't need to declare `makeArticleUrl` and the new `makeTopicUrl`).

This is a breaking change as consumers of SSR must now pass `makeTopicUrl` (similarly to `makeArticleUrl`)

This will require a later PR for integrating with render.

As the data for these meta tags is now coming from TPA instead of from content-api, there'll be some differences in the data. It is possible that the section displayed in the title will be different on articles that are within multiple sections. The description meta will also be 200 characters now instead of the ~170 it was previously. This should not be an issue. 

In addition, as the data used for the canonical URL on articles does not yet appear to be available in TPA, this has not yet been moved across and will be done at a later date instead. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
