### PR TITLE
fix: Issues with lead asset size

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -177,7 +177,7 @@ exports[`3. lead one and one - medium 1`] = `
     <View
       style={
         Object {
-          "width": "80%",
+          "width": "83.33%",
         }
       }
     >
@@ -196,7 +196,7 @@ exports[`3. lead one and one - medium 1`] = `
     <View
       style={
         Object {
-          "width": "20%",
+          "width": "16.67%",
         }
       }
     >
@@ -1296,7 +1296,7 @@ exports[`18. lead one and one - wide 1`] = `
     <View
       style={
         Object {
-          "width": "80%",
+          "width": "83.33%",
         }
       }
     >
@@ -1315,7 +1315,7 @@ exports[`18. lead one and one - wide 1`] = `
     <View
       style={
         Object {
-          "width": "20%",
+          "width": "16.67%",
         }
       }
     >
@@ -2481,7 +2481,7 @@ exports[`33. lead one and one - huge 1`] = `
     <View
       style={
         Object {
-          "width": "80%",
+          "width": "83.33%",
         }
       }
     >
@@ -2500,7 +2500,7 @@ exports[`33. lead one and one - huge 1`] = `
     <View
       style={
         Object {
-          "width": "20%",
+          "width": "16.67%",
         }
       }
     >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -1016,8 +1016,8 @@ exports[`23. tile w 1`] = `
     </View>
     <View>
       <Image
-        aspectRatio={1.5}
-        uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+        aspectRatio={1.7777777777777777}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
       />
     </View>
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -177,7 +177,7 @@ exports[`3. lead one and one - medium 1`] = `
     <View
       style={
         Object {
-          "width": "80%",
+          "width": "83.33%",
         }
       }
     >
@@ -196,7 +196,7 @@ exports[`3. lead one and one - medium 1`] = `
     <View
       style={
         Object {
-          "width": "20%",
+          "width": "16.67%",
         }
       }
     >
@@ -1296,7 +1296,7 @@ exports[`18. lead one and one - wide 1`] = `
     <View
       style={
         Object {
-          "width": "80%",
+          "width": "83.33%",
         }
       }
     >
@@ -1315,7 +1315,7 @@ exports[`18. lead one and one - wide 1`] = `
     <View
       style={
         Object {
-          "width": "20%",
+          "width": "16.67%",
         }
       }
     >
@@ -2481,7 +2481,7 @@ exports[`33. lead one and one - huge 1`] = `
     <View
       style={
         Object {
-          "width": "80%",
+          "width": "83.33%",
         }
       }
     >
@@ -2500,7 +2500,7 @@ exports[`33. lead one and one - huge 1`] = `
     <View
       style={
         Object {
-          "width": "20%",
+          "width": "16.67%",
         }
       }
     >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -1016,8 +1016,8 @@ exports[`23. tile w 1`] = `
     </View>
     <View>
       <Image
-        aspectRatio={1.5}
-        uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+        aspectRatio={1.7777777777777777}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
       />
     </View>
   </View>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -888,7 +888,7 @@ exports[`3. lead one and one 1`] = `
 }
 
 .IS1 {
-  width: 80%;
+  width: 83.33%;
 }
 
 .IS2 {
@@ -902,7 +902,7 @@ exports[`3. lead one and one 1`] = `
 }
 
 .IS3 {
-  width: 20%;
+  width: 16.67%;
 }
 
 .IS4 {

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -232,7 +232,7 @@ exports[`3. lead one and one - medium 1`] = `
 }
 
 .IS1 {
-  width: 80%;
+  width: 83.33%;
 }
 
 .IS2 {
@@ -246,7 +246,7 @@ exports[`3. lead one and one - medium 1`] = `
 }
 
 .IS3 {
-  width: 20%;
+  width: 16.67%;
 }
 
 .IS4 {
@@ -1929,7 +1929,7 @@ exports[`18. lead one and one - wide 1`] = `
 }
 
 .IS1 {
-  width: 80%;
+  width: 83.33%;
 }
 
 .IS2 {
@@ -1943,7 +1943,7 @@ exports[`18. lead one and one - wide 1`] = `
 }
 
 .IS3 {
-  width: 20%;
+  width: 16.67%;
 }
 
 .IS4 {
@@ -3626,7 +3626,7 @@ exports[`33. lead one and one - huge 1`] = `
 }
 
 .IS1 {
-  width: 80%;
+  width: 83.33%;
 }
 
 .IS2 {
@@ -3640,7 +3640,7 @@ exports[`33. lead one and one - huge 1`] = `
 }
 
 .IS3 {
-  width: 20%;
+  width: 16.67%;
 }
 
 .IS4 {

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -3277,8 +3277,8 @@ exports[`23. tile w 1`] = `
       className="IS6 S2"
     >
       <Image
-        aspectRatio={1.5}
-        uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+        aspectRatio={1.7777777777777777}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
       />
     </div>
   </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -1016,8 +1016,8 @@ exports[`23. tile w 1`] = `
     </div>
     <div>
       <Image
-        aspectRatio={1.5}
-        uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+        aspectRatio={1.7777777777777777}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
       />
     </div>
   </div>

--- a/packages/edition-slices/src/tiles/tile-ah/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/styles/index.js
@@ -31,7 +31,7 @@ const styles = {
   imageContainer: {
     borderRadius: 9999,
     overflow: "hidden",
-    width: "30%"
+    width: "40%"
   },
   star: verticalStyles,
   strapline: {

--- a/packages/edition-slices/src/tiles/tile-w/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/index.js
@@ -22,9 +22,9 @@ const TileW = ({ onPress, tile }) => (
         tile={tile}
       />
       <TileImage
-        aspectRatio={3 / 2}
+        aspectRatio={16 / 9}
         style={styles.imageContainer}
-        uri={getTileImageUri(tile, "crop32")}
+        uri={getTileImageUri(tile, "crop169")}
       />
     </View>
   </TileLink>

--- a/packages/fixture-generator/src/types.ts
+++ b/packages/fixture-generator/src/types.ts
@@ -1,3 +1,11 @@
+export interface PaginateArgs {
+  cursor?: Cursor | null;
+
+  first?: number | null;
+
+  desc?: boolean | null;
+}
+
 export interface DateFilter {
   from: DateTime;
 
@@ -20,8 +28,6 @@ export interface ArticleInput {
   listingAsset?: MediaInput | null;
 
   authors: Slug[];
-
-  byline: Markup;
 
   bylines?: (BylineInput | null)[] | null;
 
@@ -65,8 +71,6 @@ export interface ArticleInput {
 
   standfirst?: string | null;
 
-  strapline?: string | null;
-
   updatedTime: DateTime;
 
   isLegacy: boolean;
@@ -106,18 +110,12 @@ export interface CropInput {
   width: number;
 
   height: number;
-
-  sourceWidth?: number | null;
-
-  sourceHeight?: number | null;
 }
 
 export interface VideoInput {
   id: Uuid;
 
   caption?: string | null;
-
-  title?: string | null;
 
   brightcovePolicyKey: string;
 
@@ -680,14 +678,6 @@ export interface InTheNewsSectionItemInput {
   inTheNews?: InTheNewsSliceInput | null;
 }
 
-export interface PaginateArgs {
-  cursor?: Cursor | null;
-
-  first?: number | null;
-
-  desc?: boolean | null;
-}
-
 export interface PuffMainLinkInput {
   tile?: TileInput | null;
 
@@ -721,7 +711,7 @@ export interface TopicInput {
 export interface TopicTagInput {
   id: Uuid;
 
-  scoreThreshold: number;
+  thresholdScore: number;
 }
 
 export interface TopicUpdateInput {
@@ -793,10 +783,6 @@ export enum TemplateType {
   Mainstandard = "mainstandard"
 }
 
-export enum EditionGroupOptions {
-  Date = "date"
-}
-
 export enum Display {
   Primary = "primary",
   Secondary = "secondary",
@@ -806,12 +792,6 @@ export enum Display {
 
 /** A lower kebab case string */
 export type Slug = any;
-
-/** Tiny integer (range of 0-255) */
-export type TinyInt = any;
-
-/** Unit interval type (0-1 decimal range) */
-export type UnitInterval = any;
 
 /** An AST representing cross platform UI */
 export type Markup = any;
@@ -835,6 +815,12 @@ export type Cursor = any;
 
 /** Represents a date and time of day in ISO 8601 */
 export type ShortDate = any;
+
+/** Tiny integer (range of 0-255) */
+export type TinyInt = any;
+
+/** Unit interval type (0-1 decimal range) */
+export type UnitInterval = any;
 
 /** An dictionary of string-based key-value pairs */
 export type Dictionary = any;
@@ -940,8 +926,6 @@ export interface AuthorArticles {
 export interface Article {
   /** Used for indepth templates to define the background colour to be used. */
   backgroundColour?: Colour | null;
-  /** An AST of one or more authors that may contain job titles and/or locations */
-  byline?: Markup | null;
   /** Text or structured bylines for one or more authors */
   bylines?: (ArticleByline | null)[] | null;
   /** The content for the article in the shape of an AST */
@@ -1008,8 +992,6 @@ export interface Article {
   slug?: string | null;
   /** A brief introductory summary, typically appearing immediately after theheadline and typographically distinct from the rest of the article */
   standfirst?: string | null;
-  /** A brief introductory summary, typically appearing immediately after the standfirst */
-  strapline?: string | null;
   /** A predefined truncated version of the article with a max length of the teaser,can optionally choose a shorter length. Use this to avoid ACS. */
   summary?: Markup | null;
   /** Used for indepth templates to define the text colour to be used. */
@@ -1026,10 +1008,6 @@ export interface Article {
   template?: TemplateType | null;
 
   tags?: ArticleTagConnection | null;
-
-  synonyms: ArticleSynonymConnection;
-
-  topicConnection: ArticleTopicConnection;
 }
 
 export interface Colour {
@@ -1037,13 +1015,13 @@ export interface Colour {
 }
 
 export interface Rgba {
-  red: TinyInt;
+  red: number;
 
-  green: TinyInt;
+  green: number;
 
-  blue: TinyInt;
+  blue: number;
 
-  alpha: UnitInterval;
+  alpha: number;
 }
 
 export interface TextByline extends Byline {
@@ -1071,14 +1049,6 @@ export interface Crop {
   ratio?: Ratio | null;
 
   url?: Url | null;
-
-  relativeHorizontalOffset?: UnitInterval | null;
-
-  relativeVerticalOffset?: UnitInterval | null;
-
-  relativeWidth?: UnitInterval | null;
-
-  relativeHeight?: UnitInterval | null;
 }
 
 export interface AuthorByline extends Byline {
@@ -1099,8 +1069,6 @@ export interface Video {
   id: Uuid;
 
   caption?: string | null;
-
-  title?: string | null;
 
   brightcovePolicyKey?: string | null;
 
@@ -1145,8 +1113,6 @@ export interface Topic {
 
   slug: Slug;
 
-  articleConnection: TopicArticleConnection;
-
   tagConnection: TopicTagConnection;
 
   createdAt?: DateTime | null;
@@ -1159,24 +1125,6 @@ export interface TopicArticles {
   count?: number | null;
   /** List of articles associated with that topic */
   list: Article[];
-}
-
-export interface TopicArticleConnection {
-  nodes: Article[];
-
-  pageInfo?: PageInfo | null;
-
-  totalCount?: number | null;
-}
-
-export interface PageInfo {
-  startCursor?: Cursor | null;
-
-  endCursor?: Cursor | null;
-
-  hasNextPage: boolean;
-
-  hasPreviousPage: boolean;
 }
 
 export interface TopicTagConnection {
@@ -1194,19 +1142,27 @@ export interface TopicTagEdge {
 
   cursor?: Cursor | null;
 
-  scoreThreshold?: number | null;
+  thresholdScore?: number | null;
 }
 
 export interface Tag {
   id: Uuid;
 
-  primarySynonym: Synonym;
+  primarySynonymId: Uuid;
 
   description?: string | null;
 
   synonyms: SynonymConnection;
 
   articles: TagArticleConnection;
+}
+
+export interface SynonymConnection {
+  nodes: (Synonym | null)[];
+
+  pageInfo: PageInfo;
+
+  totalCount: number;
 }
 
 export interface Synonym {
@@ -1219,12 +1175,14 @@ export interface Synonym {
   type: SynonymType;
 }
 
-export interface SynonymConnection {
-  nodes: (Synonym | null)[];
+export interface PageInfo {
+  startCursor?: Cursor | null;
 
-  pageInfo: PageInfo;
+  endCursor?: Cursor | null;
 
-  totalCount: number;
+  hasNextPage: boolean;
+
+  hasPreviousPage: boolean;
 }
 
 export interface TagArticleConnection {
@@ -1242,9 +1200,9 @@ export interface TagArticleEdge {
 
   cursor: Cursor;
 
-  combinedScore: number;
+  score: number;
 
-  scoreOverride?: number | null;
+  originalScore?: number | null;
 }
 
 export interface ArticleTagConnection {
@@ -1262,35 +1220,9 @@ export interface ArticleTagEdge {
 
   cursor: Cursor;
 
-  combinedScore: number;
-
-  scoreOverride?: number | null;
-}
-
-export interface ArticleSynonymConnection {
-  edges: (ArticleSynonymEdge | null)[];
-
-  nodes: (Synonym | null)[];
-
-  pageInfo: PageInfo;
-
-  totalCount: number;
-}
-
-export interface ArticleSynonymEdge {
-  node: Synonym;
-
-  cursor: Cursor;
-
   score: number;
-}
 
-export interface ArticleTopicConnection {
-  nodes: Topic[];
-
-  pageInfo?: PageInfo | null;
-
-  totalCount?: number | null;
+  originalScore?: number | null;
 }
 
 export interface Articles {
@@ -1409,10 +1341,6 @@ export interface Mutation {
   saveBookmarks: Bookmark[];
 
   unsaveBookmarks: Uuid[];
-}
-
-export interface ArticleTagUpsertResult {
-  id: Uuid;
 }
 
 export interface ArticleUpsertResult {
@@ -1904,6 +1832,8 @@ export interface TagQueryArgs {
 export interface TagsQueryArgs {
   ids?: Uuid[] | null;
 
+  articleId?: Uuid | null;
+
   cursor?: Cursor | null;
 
   first?: number | null;
@@ -1913,8 +1843,6 @@ export interface TagsQueryArgs {
   dateFilter?: DateFilter | null;
 
   term?: string | null;
-
-  isOverflow?: boolean | null;
 }
 export interface TopicQueryArgs {
   slug?: Slug | null;
@@ -1945,25 +1873,7 @@ export interface TopicsArticleArgs {
   maxCount?: number | null;
 }
 export interface TagsArticleArgs {
-  cursor?: Cursor | null;
-
-  first?: number | null;
-
-  desc?: boolean | null;
-}
-export interface SynonymsArticleArgs {
-  cursor?: Cursor | null;
-
-  first?: number | null;
-
-  desc?: boolean | null;
-}
-export interface TopicConnectionArticleArgs {
-  cursor?: Cursor | null;
-
-  first?: number | null;
-
-  desc?: boolean | null;
+  paginateArgs?: PaginateArgs | null;
 }
 export interface CropImageArgs {
   ratio: Ratio;
@@ -1971,19 +1881,8 @@ export interface CropImageArgs {
 export interface TeaserTileArgs {
   maxCharCount?: number | null;
 }
-export interface ArticleConnectionTopicArgs {
-  cursor?: Cursor | null;
-
-  first?: number | null;
-
-  desc?: boolean | null;
-}
 export interface TagConnectionTopicArgs {
-  cursor?: Cursor | null;
-
-  first?: number | null;
-
-  desc?: boolean | null;
+  options?: PaginateArgs | null;
 }
 export interface ListTopicArticlesArgs {
   /** The maximum number of articles you want to take, defaults to 10 */
@@ -1992,18 +1891,10 @@ export interface ListTopicArticlesArgs {
   skip?: number | null;
 }
 export interface SynonymsTagArgs {
-  cursor?: Cursor | null;
-
-  first?: number | null;
-
-  desc?: boolean | null;
+  options?: PaginateArgs | null;
 }
 export interface ArticlesTagArgs {
-  cursor?: Cursor | null;
-
-  first?: number | null;
-
-  desc?: boolean | null;
+  options?: PaginateArgs | null;
 }
 export interface ListArticlesArgs {
   /** The maximum number of articles you want to take, defaults to 10 */
@@ -2016,8 +1907,6 @@ export interface ListEditionsPagedArgs {
   first?: number | null;
   /** The number of editions to skip over, useful for paging, defaults to 0 */
   skip?: number | null;
-  /** Grouping options, useful to deduplicate results */
-  group?: EditionGroupOptions | null;
 }
 export interface SpotimCodeBUserArgs {
   codeA: string;

--- a/packages/fixture-generator/src/types.ts
+++ b/packages/fixture-generator/src/types.ts
@@ -1,11 +1,3 @@
-export interface PaginateArgs {
-  cursor?: Cursor | null;
-
-  first?: number | null;
-
-  desc?: boolean | null;
-}
-
 export interface DateFilter {
   from: DateTime;
 
@@ -28,6 +20,8 @@ export interface ArticleInput {
   listingAsset?: MediaInput | null;
 
   authors: Slug[];
+
+  byline: Markup;
 
   bylines?: (BylineInput | null)[] | null;
 
@@ -71,6 +65,8 @@ export interface ArticleInput {
 
   standfirst?: string | null;
 
+  strapline?: string | null;
+
   updatedTime: DateTime;
 
   isLegacy: boolean;
@@ -110,12 +106,18 @@ export interface CropInput {
   width: number;
 
   height: number;
+
+  sourceWidth?: number | null;
+
+  sourceHeight?: number | null;
 }
 
 export interface VideoInput {
   id: Uuid;
 
   caption?: string | null;
+
+  title?: string | null;
 
   brightcovePolicyKey: string;
 
@@ -678,6 +680,14 @@ export interface InTheNewsSectionItemInput {
   inTheNews?: InTheNewsSliceInput | null;
 }
 
+export interface PaginateArgs {
+  cursor?: Cursor | null;
+
+  first?: number | null;
+
+  desc?: boolean | null;
+}
+
 export interface PuffMainLinkInput {
   tile?: TileInput | null;
 
@@ -711,7 +721,7 @@ export interface TopicInput {
 export interface TopicTagInput {
   id: Uuid;
 
-  thresholdScore: number;
+  scoreThreshold: number;
 }
 
 export interface TopicUpdateInput {
@@ -783,6 +793,10 @@ export enum TemplateType {
   Mainstandard = "mainstandard"
 }
 
+export enum EditionGroupOptions {
+  Date = "date"
+}
+
 export enum Display {
   Primary = "primary",
   Secondary = "secondary",
@@ -792,6 +806,12 @@ export enum Display {
 
 /** A lower kebab case string */
 export type Slug = any;
+
+/** Tiny integer (range of 0-255) */
+export type TinyInt = any;
+
+/** Unit interval type (0-1 decimal range) */
+export type UnitInterval = any;
 
 /** An AST representing cross platform UI */
 export type Markup = any;
@@ -815,12 +835,6 @@ export type Cursor = any;
 
 /** Represents a date and time of day in ISO 8601 */
 export type ShortDate = any;
-
-/** Tiny integer (range of 0-255) */
-export type TinyInt = any;
-
-/** Unit interval type (0-1 decimal range) */
-export type UnitInterval = any;
 
 /** An dictionary of string-based key-value pairs */
 export type Dictionary = any;
@@ -926,6 +940,8 @@ export interface AuthorArticles {
 export interface Article {
   /** Used for indepth templates to define the background colour to be used. */
   backgroundColour?: Colour | null;
+  /** An AST of one or more authors that may contain job titles and/or locations */
+  byline?: Markup | null;
   /** Text or structured bylines for one or more authors */
   bylines?: (ArticleByline | null)[] | null;
   /** The content for the article in the shape of an AST */
@@ -992,6 +1008,8 @@ export interface Article {
   slug?: string | null;
   /** A brief introductory summary, typically appearing immediately after theheadline and typographically distinct from the rest of the article */
   standfirst?: string | null;
+  /** A brief introductory summary, typically appearing immediately after the standfirst */
+  strapline?: string | null;
   /** A predefined truncated version of the article with a max length of the teaser,can optionally choose a shorter length. Use this to avoid ACS. */
   summary?: Markup | null;
   /** Used for indepth templates to define the text colour to be used. */
@@ -1008,6 +1026,10 @@ export interface Article {
   template?: TemplateType | null;
 
   tags?: ArticleTagConnection | null;
+
+  synonyms: ArticleSynonymConnection;
+
+  topicConnection: ArticleTopicConnection;
 }
 
 export interface Colour {
@@ -1015,13 +1037,13 @@ export interface Colour {
 }
 
 export interface Rgba {
-  red: number;
+  red: TinyInt;
 
-  green: number;
+  green: TinyInt;
 
-  blue: number;
+  blue: TinyInt;
 
-  alpha: number;
+  alpha: UnitInterval;
 }
 
 export interface TextByline extends Byline {
@@ -1049,6 +1071,14 @@ export interface Crop {
   ratio?: Ratio | null;
 
   url?: Url | null;
+
+  relativeHorizontalOffset?: UnitInterval | null;
+
+  relativeVerticalOffset?: UnitInterval | null;
+
+  relativeWidth?: UnitInterval | null;
+
+  relativeHeight?: UnitInterval | null;
 }
 
 export interface AuthorByline extends Byline {
@@ -1069,6 +1099,8 @@ export interface Video {
   id: Uuid;
 
   caption?: string | null;
+
+  title?: string | null;
 
   brightcovePolicyKey?: string | null;
 
@@ -1113,6 +1145,8 @@ export interface Topic {
 
   slug: Slug;
 
+  articleConnection: TopicArticleConnection;
+
   tagConnection: TopicTagConnection;
 
   createdAt?: DateTime | null;
@@ -1125,6 +1159,24 @@ export interface TopicArticles {
   count?: number | null;
   /** List of articles associated with that topic */
   list: Article[];
+}
+
+export interface TopicArticleConnection {
+  nodes: Article[];
+
+  pageInfo?: PageInfo | null;
+
+  totalCount?: number | null;
+}
+
+export interface PageInfo {
+  startCursor?: Cursor | null;
+
+  endCursor?: Cursor | null;
+
+  hasNextPage: boolean;
+
+  hasPreviousPage: boolean;
 }
 
 export interface TopicTagConnection {
@@ -1142,27 +1194,19 @@ export interface TopicTagEdge {
 
   cursor?: Cursor | null;
 
-  thresholdScore?: number | null;
+  scoreThreshold?: number | null;
 }
 
 export interface Tag {
   id: Uuid;
 
-  primarySynonymId: Uuid;
+  primarySynonym: Synonym;
 
   description?: string | null;
 
   synonyms: SynonymConnection;
 
   articles: TagArticleConnection;
-}
-
-export interface SynonymConnection {
-  nodes: (Synonym | null)[];
-
-  pageInfo: PageInfo;
-
-  totalCount: number;
 }
 
 export interface Synonym {
@@ -1175,14 +1219,12 @@ export interface Synonym {
   type: SynonymType;
 }
 
-export interface PageInfo {
-  startCursor?: Cursor | null;
+export interface SynonymConnection {
+  nodes: (Synonym | null)[];
 
-  endCursor?: Cursor | null;
+  pageInfo: PageInfo;
 
-  hasNextPage: boolean;
-
-  hasPreviousPage: boolean;
+  totalCount: number;
 }
 
 export interface TagArticleConnection {
@@ -1200,9 +1242,9 @@ export interface TagArticleEdge {
 
   cursor: Cursor;
 
-  score: number;
+  combinedScore: number;
 
-  originalScore?: number | null;
+  scoreOverride?: number | null;
 }
 
 export interface ArticleTagConnection {
@@ -1220,9 +1262,35 @@ export interface ArticleTagEdge {
 
   cursor: Cursor;
 
-  score: number;
+  combinedScore: number;
 
-  originalScore?: number | null;
+  scoreOverride?: number | null;
+}
+
+export interface ArticleSynonymConnection {
+  edges: (ArticleSynonymEdge | null)[];
+
+  nodes: (Synonym | null)[];
+
+  pageInfo: PageInfo;
+
+  totalCount: number;
+}
+
+export interface ArticleSynonymEdge {
+  node: Synonym;
+
+  cursor: Cursor;
+
+  score: number;
+}
+
+export interface ArticleTopicConnection {
+  nodes: Topic[];
+
+  pageInfo?: PageInfo | null;
+
+  totalCount?: number | null;
 }
 
 export interface Articles {
@@ -1341,6 +1409,10 @@ export interface Mutation {
   saveBookmarks: Bookmark[];
 
   unsaveBookmarks: Uuid[];
+}
+
+export interface ArticleTagUpsertResult {
+  id: Uuid;
 }
 
 export interface ArticleUpsertResult {
@@ -1832,8 +1904,6 @@ export interface TagQueryArgs {
 export interface TagsQueryArgs {
   ids?: Uuid[] | null;
 
-  articleId?: Uuid | null;
-
   cursor?: Cursor | null;
 
   first?: number | null;
@@ -1843,6 +1913,8 @@ export interface TagsQueryArgs {
   dateFilter?: DateFilter | null;
 
   term?: string | null;
+
+  isOverflow?: boolean | null;
 }
 export interface TopicQueryArgs {
   slug?: Slug | null;
@@ -1873,7 +1945,25 @@ export interface TopicsArticleArgs {
   maxCount?: number | null;
 }
 export interface TagsArticleArgs {
-  paginateArgs?: PaginateArgs | null;
+  cursor?: Cursor | null;
+
+  first?: number | null;
+
+  desc?: boolean | null;
+}
+export interface SynonymsArticleArgs {
+  cursor?: Cursor | null;
+
+  first?: number | null;
+
+  desc?: boolean | null;
+}
+export interface TopicConnectionArticleArgs {
+  cursor?: Cursor | null;
+
+  first?: number | null;
+
+  desc?: boolean | null;
 }
 export interface CropImageArgs {
   ratio: Ratio;
@@ -1881,8 +1971,19 @@ export interface CropImageArgs {
 export interface TeaserTileArgs {
   maxCharCount?: number | null;
 }
+export interface ArticleConnectionTopicArgs {
+  cursor?: Cursor | null;
+
+  first?: number | null;
+
+  desc?: boolean | null;
+}
 export interface TagConnectionTopicArgs {
-  options?: PaginateArgs | null;
+  cursor?: Cursor | null;
+
+  first?: number | null;
+
+  desc?: boolean | null;
 }
 export interface ListTopicArticlesArgs {
   /** The maximum number of articles you want to take, defaults to 10 */
@@ -1891,10 +1992,18 @@ export interface ListTopicArticlesArgs {
   skip?: number | null;
 }
 export interface SynonymsTagArgs {
-  options?: PaginateArgs | null;
+  cursor?: Cursor | null;
+
+  first?: number | null;
+
+  desc?: boolean | null;
 }
 export interface ArticlesTagArgs {
-  options?: PaginateArgs | null;
+  cursor?: Cursor | null;
+
+  first?: number | null;
+
+  desc?: boolean | null;
 }
 export interface ListArticlesArgs {
   /** The maximum number of articles you want to take, defaults to 10 */
@@ -1907,6 +2016,8 @@ export interface ListEditionsPagedArgs {
   first?: number | null;
   /** The number of editions to skip over, useful for paging, defaults to 0 */
   skip?: number | null;
+  /** Grouping options, useful to deduplicate results */
+  group?: EditionGroupOptions | null;
 }
 export interface SpotimCodeBUserArgs {
   codeA: string;

--- a/packages/slice-layout/__tests__/android/__snapshots__/l1and1-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/l1and1-with-style.android.test.js.snap
@@ -24,7 +24,7 @@ exports[`2. lead one and one - medium 1`] = `
   <View
     style={
       Object {
-        "width": "80%",
+        "width": "83.33%",
       }
     }
   >
@@ -45,7 +45,7 @@ exports[`2. lead one and one - medium 1`] = `
   <View
     style={
       Object {
-        "width": "20%",
+        "width": "16.67%",
       }
     }
   >

--- a/packages/slice-layout/__tests__/ios/__snapshots__/l1and1-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/l1and1-with-style.ios.test.js.snap
@@ -24,7 +24,7 @@ exports[`2. lead one and one - medium 1`] = `
   <View
     style={
       Object {
-        "width": "80%",
+        "width": "83.33%",
       }
     }
   >
@@ -45,7 +45,7 @@ exports[`2. lead one and one - medium 1`] = `
   <View
     style={
       Object {
-        "width": "20%",
+        "width": "16.67%",
       }
     }
   >

--- a/packages/slice-layout/__tests__/web/__snapshots__/l1and1-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/l1and1-with-style.web.test.js.snap
@@ -66,7 +66,7 @@ exports[`2. lead one and one - medium 1`] = `
     className="S1"
     style={
       Object {
-        "width": "80%",
+        "width": "83.33%",
       }
     }
   >
@@ -94,7 +94,7 @@ exports[`2. lead one and one - medium 1`] = `
     className="S1"
     style={
       Object {
-        "width": "20%",
+        "width": "16.67%",
       }
     }
   >

--- a/packages/slice-layout/src/templates/leadoneandone/styles.js
+++ b/packages/slice-layout/src/templates/leadoneandone/styles.js
@@ -7,10 +7,10 @@ const styles = {
     marginHorizontal: spacing(2)
   },
   leadItem: {
-    width: "80%"
+    width: "83.33%"
   },
   supportItem: {
-    width: "20%"
+    width: "16.67%"
   }
 };
 


### PR DESCRIPTION
- Fixes various issue with lead asset / summary text sizes (https://nidigitalsolutions.jira.com/browse/REPLAT-6298)
- ~Updates types.ts as it was out of date~
- Other issues raised in the ticket should be solved once ios app has the latest queries updated (missing `bylines` and `strapline` field in some slices