### PR TITLE
fix: temporary fix for article showcase

### DIFF
--- a/packages/article-skeleton/__tests__/web/head.web.test.js
+++ b/packages/article-skeleton/__tests__/web/head.web.test.js
@@ -279,6 +279,27 @@ describe("Head", () => {
     ).toHaveLength(0);
   });
 
+  it("removes description tags if descriptionMarkup is empty", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={{
+          ...article,
+          descriptionMarkup: []
+        }}
+      />
+    );
+
+    expect(
+      testRenderer.root.findAllByProps({ name: "description" })
+    ).toHaveLength(0);
+    expect(
+      testRenderer.root.findAllByProps({ property: "og:description" })
+    ).toHaveLength(0);
+    expect(
+      testRenderer.root.findAllByProps({ name: "twitter:description" })
+    ).toHaveLength(0);
+  });
+
   it("shows description tags if descriptionMarkup available", () => {
     const testRenderer = TestRenderer.create(<Head article={article} />);
 

--- a/packages/article-skeleton/src/head.web.js
+++ b/packages/article-skeleton/src/head.web.js
@@ -63,7 +63,9 @@ function Head({ article }) {
   const publication = PUBLICATION_NAMES[publicationName];
   const authorName = getAuthorAsText(article);
   const desc =
-    descriptionMarkup && renderTreeAsText({ children: descriptionMarkup });
+    Array.isArray(descriptionMarkup) && descriptionMarkup.length
+      ? renderTreeAsText({ children: descriptionMarkup })
+      : null;
   const sectionname = getSectionName(article);
   const leadassetUrl = get(leadAsset, "crop169.url", null);
   const title = headline || shortHeadline;

--- a/packages/article/showcase-helper.js
+++ b/packages/article/showcase-helper.js
@@ -212,11 +212,8 @@ const renderArticle = ({
 
       const data = {
         ...article,
-        author: {
-          image:
-            "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg?crop=854,854,214,0&resize=400"
-        },
         backgroundColour: inDepthBackgroundColour,
+        descriptionMarkup: [article.content.find(m => m.name === "paragraph")],
         template,
         textColour: inDepthTextColour
       };

--- a/packages/provider-test-tools/fixtures/article.json
+++ b/packages/provider-test-tools/fixtures/article.json
@@ -42,6 +42,20 @@
   ],
   "commentCount": 65,
   "commentsEnabled": true,
+  "descriptionMarkup": [
+    {
+      "name": "paragraph",
+      "children": [
+        {
+          "name": "text",
+          "attributes": {
+            "value": "In the autumn of 1973 Vice-President Spiro Agnew was having difficulty getting President Richard Nixon on the phone. If the White House really wanted him to resign, he reasoned, Nixon should tell him"
+          },
+          "children": []
+        }
+      ]
+    }
+  ],
   "dropcapsDisabled": false,
   "paywalledContent": [
     {
@@ -1672,6 +1686,54 @@
       "red": 0
     }
   },
+  "tiles": [
+    {
+      "__typename": "Tile",
+      "slices": [
+        {
+          "__typename": "SecondaryFourSlice",
+          "sections": [
+            {
+              "__typename": "StandardSection",
+              "title": "Comment"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "__typename": "Tile",
+      "slices": [
+        {
+          "__typename": "StandardSlice",
+          "sections": []
+        }
+      ]
+    },
+    {
+      "__typename": "Tile",
+      "slices": [
+        {
+          "__typename": "StandardSlice",
+          "sections": []
+        }
+      ]
+    },
+    {
+      "__typename": "Tile",
+      "slices": [
+        {
+          "__typename": "LeadTwoNoPicAndTwoSlice",
+          "sections": [
+            {
+              "__typename": "StandardSection",
+              "title": "News"
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "topics": [
     {
       "name": "Islington",


### PR DESCRIPTION
Fixing the fixtures that render the article with template choice showcase. This is a bit of hack because I couldn't figure out how to make the mock provider understand the `descriptionMarkup` summary alias in the article web query. 