### PR TITLE
chore: Update README to install fontforge before yarn installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ This has been made possible using [Fructose](https://github.com/newsuk/fructose)
 
 ## Getting Started
 
-1. Run `yarn install`
+1. Install [fontforge](http://fontforge.github.io/en-US/): `brew install fontforge` (See [Fonts section](#fonts))
 
-2. Install [fontforge](http://fontforge.github.io/en-US/): `brew install fontforge` (See [Fonts section](#fonts))
+2. Run `yarn install`
+
 3. Components can be seen running in a storybook:
 
 - web storybook


### PR DESCRIPTION
There is a `yarn` postinstall script that gets the requried fonts using `fontforge`, this means you need to have `fontforge` installed before running `yarn`.

I have updated the `README` to reflect this.