### PR TITLE
feat: Topic list feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ This has been made possible using [Fructose](https://github.com/newsuk/fructose)
 
 ## Getting Started
 
-1. Run `yarn install`
+1. Install [fontforge](http://fontforge.github.io/en-US/): `brew install fontforge` (See [Fonts section](#fonts))
 
-2. Install [fontforge](http://fontforge.github.io/en-US/): `brew install fontforge` (See [Fonts section](#fonts))
+2. Run `yarn install`
+
 3. Components can be seen running in a storybook:
 
 - web storybook

--- a/packages/ssr/src/client/topic.js
+++ b/packages/ssr/src/client/topic.js
@@ -8,7 +8,13 @@ if (window.nuk && window.nuk.ssr && window.nuk.topicPage) {
     makeTopicUrl,
     mapTopicToAdConfig
   } = window.nuk.ssr;
-  const { debounceTimeMs, page, pageSize, topicSlug } = window.nuk.topicPage;
+  const {
+    debounceTimeMs,
+    page,
+    pageSize,
+    topicSlug,
+    useNewTopicDataSource
+  } = window.nuk.topicPage;
 
   const data = {
     debounceTimeMs,
@@ -22,7 +28,12 @@ if (window.nuk && window.nuk.ssr && window.nuk.topicPage) {
 
   const clientOptions = {
     rootTag,
-    useGET: true
+    useGET: true,
+    headers: useNewTopicDataSource
+      ? {
+          "x-new-topic-data-source": true
+        }
+      : {}
   };
 
   runClient(topic, clientOptions, data);

--- a/packages/ssr/src/lib/run-client.js
+++ b/packages/ssr/src/lib/run-client.js
@@ -17,7 +17,11 @@ const makeClient = options => {
     throw new Error("API endpoint is empty");
   }
 
-  const networkInterfaceOptions = { fetch, headers: {}, uri: options.uri };
+  const networkInterfaceOptions = {
+    fetch,
+    headers: options.headers,
+    uri: options.uri
+  };
 
   if (options.useGET) {
     networkInterfaceOptions.headers["content-type"] =
@@ -47,7 +51,8 @@ module.exports = (component, clientOptions, data) => {
   const client = makeClient({
     initialState: window.__APOLLO_STATE__,
     uri: window.nuk.graphqlapi.url,
-    useGET: clientOptions.useGET
+    useGET: clientOptions.useGET,
+    headers: clientOptions.headers
   });
 
   const reporterOptions = {

--- a/packages/ssr/src/lib/run-client.js
+++ b/packages/ssr/src/lib/run-client.js
@@ -19,7 +19,7 @@ const makeClient = options => {
 
   const networkInterfaceOptions = {
     fetch,
-    headers: options.headers,
+    headers: options.headers || {},
     uri: options.uri
   };
 

--- a/packages/ssr/src/server/topic.js
+++ b/packages/ssr/src/server/topic.js
@@ -4,7 +4,7 @@ const defaultAdConfig = require("../lib/ads/make-topic-ad-config")
   .defaultServer;
 
 module.exports = (
-  { currentPage, topicSlug },
+  { currentPage, topicSlug, useNewTopicDataSource = false },
   { graphqlApiUrl, logger, makeArticleUrl, makeTopicUrl }
 ) => {
   if (typeof topicSlug !== "string") {
@@ -35,7 +35,12 @@ module.exports = (
   const options = {
     client: {
       logger,
-      uri: graphqlApiUrl
+      uri: graphqlApiUrl,
+      headers: useNewTopicDataSource
+        ? {
+            "x-new-topic-data-source": true
+          }
+        : {}
     },
     data: {
       debounceTimeMs: 0,
@@ -44,7 +49,8 @@ module.exports = (
       mapTopicToAdConfig: defaultAdConfig,
       page: currentPage,
       pageSize: 20,
-      topicSlug
+      topicSlug,
+      useNewTopicDataSource
     },
     name: "topicPage"
   };


### PR DESCRIPTION
This PR adds support for passing a header to TPA when querying topics on SSR + client side. This header toggles the data source in TPA from Elastisearch to RDS, and is triggered by the presence of a URL query parameter `?useNewTopicDataSource=true` beiong provided on render.

The associated render PR is here: https://github.com/newsuk/cps-content-render/pull/2714