### PR TITLE
chore: Fix android publish script

### DIFF
--- a/android-app/package.json
+++ b/android-app/package.json
@@ -5,9 +5,7 @@
   "scripts": {
     "build:android": "./gradlew clean && ./gradlew generateReactArchives && ./gradlew assemble && ./gradlew publish",
     "build:js": "mkdir -p xnative/src/main/assets/ && mkdir -p xnative/src/main/res/ && react-native bundle --platform android --dev false --entry-file index.android.js --bundle-output xnative/src/main/assets/index.android.bundle --assets-dest xnative/src/main/res/",
-    "build:move-map": "mkdir -p build && mv xnative/src/main/assets/index.android.bundle.map build/",
-    "build:all": "yarn build && yarn build:android",
-    "build": "yarn build:js && yarn build:move-map",
+    "build:all": "yarn build:js && yarn build:android",
     "start": "react-native start",
     "fmt": "prettier --write '**/*.*'",
     "prettier:diff": "prettier --list-different '**/*.*'",


### PR DESCRIPTION
Babel 7 broke the android publish script, as it no longer generates a source map. Updated to scripts to fix this issue