### PR TITLE
chore: Fix storybook entry file

### DIFF
--- a/ios/storybooknative/AppDelegate.m
+++ b/ios/storybooknative/AppDelegate.m
@@ -22,7 +22,7 @@
   NSURL *jsCodeLocation;
 
   bundleJSLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
-  packagerJSLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+  packagerJSLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.storybook" fallbackResource:nil];
 
   if (bundleJSLocation) {
     jsCodeLocation = bundleJSLocation;


### PR DESCRIPTION
Fixed ios storybook entry file to `index.storybook.js`