### PR TITLE
fix: Image resize not being sent

### DIFF
--- a/android-app/index.android.js
+++ b/android-app/index.android.js
@@ -1,15 +1,10 @@
 import { AppRegistry } from "react-native";
-import { URL, URLSearchParams } from "url-polyfill";
 import {
   Article,
   AuthorProfile,
   Section,
   Topic
 } from "@times-components/pages";
-
-// see https://github.com/facebook/react-native/issues/16434
-global.URL = URL;
-global.URLSearchParams = URLSearchParams;
 
 AppRegistry.registerComponent("Article", () => Article);
 AppRegistry.registerComponent("AuthorProfile", () => AuthorProfile);

--- a/ios-app/index.ios.js
+++ b/ios-app/index.ios.js
@@ -1,15 +1,10 @@
 import { AppRegistry } from "react-native";
-import { URL, URLSearchParams } from "url-polyfill";
 import {
   Article,
   AuthorProfile,
   Section,
   Topic
 } from "@times-components/pages";
-
-// see https://github.com/facebook/react-native/issues/16434
-global.URL = URL;
-global.URLSearchParams = URLSearchParams;
 
 AppRegistry.registerComponent("ArticlePage", () => Article);
 AppRegistry.registerComponent("AuthorProfilePage", () => AuthorProfile);

--- a/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
@@ -138,7 +138,7 @@ exports[`4. an invalid uri 1`] = `
   <div>
     <img
       alt=""
-      src="not-valid"
+      src="not-valid?resize=1400"
     />
     <div>
       <Svg

--- a/packages/image/src/utils/appendToURL.js
+++ b/packages/image/src/utils/appendToURL.js
@@ -1,5 +1,10 @@
 /* eslint-env browser */
 
+const appendUriString = (uriString, key, value) => {
+  const separator = uriString.includes("?") ? "&" : "?";
+  return `${uriString}${separator}${key}=${value}`;
+};
+
 export default (uriString, key, value) => {
   if (!uriString || !key || !value) {
     return uriString;
@@ -10,8 +15,7 @@ export default (uriString, key, value) => {
   }
 
   if (typeof URL === "undefined") {
-    const separator = uriString.includes("?") ? "&" : "?";
-    return `${uriString}${separator}${key}=${value}`;
+    return appendUriString(uriString, key, value);
   }
 
   let url;
@@ -19,7 +23,7 @@ export default (uriString, key, value) => {
   try {
     url = new URL(uriString);
   } catch (e) {
-    return uriString;
+    return appendUriString(uriString, key, value);
   }
 
   if (url.search) {


### PR DESCRIPTION
We had a `hack` to fix react-native's URL, which seems to be broken after the babel 7 bump.

Removed the usage of URL on native until this issue is properly fixed on react-native: https://github.com/facebook/react-native/issues/16434