### PR TITLE
feat: fix image display on phone layout

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
@@ -256,7 +256,7 @@ exports[`1. article with header 1`] = `
               }
               imageOptions={
                 Object {
-                  "display": "primary",
+                  "display": "secondary",
                   "ratio": "3:2",
                   "uri": "https://image.io",
                 }

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-images.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-images.android.test.js.snap
@@ -37,7 +37,7 @@ exports[`1. a secondary image 1`] = `
               }
               imageOptions={
                 Object {
-                  "display": "primary",
+                  "display": "secondary",
                   "ratio": "3:2",
                   "uri": "https://image-2.io",
                 }
@@ -102,7 +102,7 @@ exports[`2. an inline image 1`] = `
               }
               imageOptions={
                 Object {
-                  "display": "primary",
+                  "display": "secondary",
                   "ratio": "9:4",
                   "uri": "https://image-inline.io",
                 }

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -92,7 +92,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               }
               imageOptions={
                 Object {
-                  "display": "primary",
+                  "display": "secondary",
                   "ratio": "1500:1000",
                   "uri": "https://image.io/secondary",
                 }
@@ -113,7 +113,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               }
               imageOptions={
                 Object {
-                  "display": "primary",
+                  "display": "secondary",
                   "ratio": "1500:1000",
                   "uri": "https://image.io/inline",
                 }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-header-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-header-with-style.ios.test.js.snap
@@ -256,7 +256,7 @@ exports[`1. article with header 1`] = `
               }
               imageOptions={
                 Object {
-                  "display": "primary",
+                  "display": "secondary",
                   "ratio": "3:2",
                   "uri": "https://image.io",
                 }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-images.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-images.ios.test.js.snap
@@ -37,7 +37,7 @@ exports[`1. a secondary image 1`] = `
               }
               imageOptions={
                 Object {
-                  "display": "primary",
+                  "display": "secondary",
                   "ratio": "3:2",
                   "uri": "https://image-2.io",
                 }
@@ -102,7 +102,7 @@ exports[`2. an inline image 1`] = `
               }
               imageOptions={
                 Object {
-                  "display": "primary",
+                  "display": "secondary",
                   "ratio": "9:4",
                   "uri": "https://image-inline.io",
                 }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -92,7 +92,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               }
               imageOptions={
                 Object {
-                  "display": "primary",
+                  "display": "secondary",
                   "ratio": "1500:1000",
                   "uri": "https://image.io/secondary",
                 }
@@ -113,7 +113,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               }
               imageOptions={
                 Object {
-                  "display": "primary",
+                  "display": "secondary",
                   "ratio": "1500:1000",
                   "uri": "https://image.io/inline",
                 }

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -117,7 +117,7 @@ export default ({
                       credits
                     }}
                     imageOptions={{
-                      display: "primary",
+                      display: display === "inline" ? "secondary" : display,
                       ratio,
                       uri: url
                     }}


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Fixes image display on phone, they were all showing as primary before.

![image](https://user-images.githubusercontent.com/615608/57634326-01ade680-759d-11e9-8150-bd2c56ad0742.png)

