### PR TITLE
fix: hide placeholders for puzzle slices

### DIFF
--- a/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
@@ -51,6 +51,7 @@ exports[`1. mobile primary image with caption and credits 1`] = `
             text="Some caption"
           />
         }
+        disablePlaceholder={false}
         fadeImageIn={false}
         highResSize={null}
         lowResSize={null}
@@ -142,6 +143,7 @@ exports[`2. tablet primary image with caption and credits 1`] = `
             text="Some caption"
           />
         }
+        disablePlaceholder={false}
         fadeImageIn={false}
         highResSize={null}
         lowResSize={null}
@@ -223,6 +225,7 @@ exports[`3. mobile fullwidth image with caption and credits 1`] = `
             text="Some caption"
           />
         }
+        disablePlaceholder={false}
         fadeImageIn={false}
         highResSize={null}
         lowResSize={null}
@@ -303,6 +306,7 @@ exports[`4. tablet fullwidth image with caption and credits 1`] = `
             text="Some caption"
           />
         }
+        disablePlaceholder={false}
         fadeImageIn={false}
         highResSize={null}
         lowResSize={null}
@@ -383,6 +387,7 @@ exports[`5. secondary image with caption and credits 1`] = `
             text="Another caption"
           />
         }
+        disablePlaceholder={false}
         fadeImageIn={false}
         highResSize={null}
         lowResSize={null}
@@ -479,6 +484,7 @@ exports[`6. primary image with caption and credits with center caption override 
               text="Some caption"
             />
           }
+          disablePlaceholder={false}
           fadeImageIn={false}
           highResSize={null}
           lowResSize={null}
@@ -582,6 +588,7 @@ exports[`7. secondary image with caption and credits with center caption overrid
               text="Another caption"
             />
           }
+          disablePlaceholder={false}
           fadeImageIn={false}
           highResSize={null}
           lowResSize={null}

--- a/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
@@ -188,6 +188,7 @@ exports[`1. card loading state 1`] = `
       >
         <TimesImage
           aspectRatio={0.6666666666666666}
+          disablePlaceholder={false}
           fadeImageIn={false}
           highResSize={800}
           lowResSize={60}
@@ -449,6 +450,7 @@ exports[`2. card with reversed loading state 1`] = `
       >
         <TimesImage
           aspectRatio={0.6666666666666666}
+          disablePlaceholder={false}
           fadeImageIn={false}
           highResSize={800}
           lowResSize={60}

--- a/packages/card/__tests__/web/__snapshots__/card-render-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-render-style.test.js.snap
@@ -102,6 +102,7 @@ exports[`card with default layout 1`] = `
   >
     <TimesImage
       aspectRatio={0.6666666666666666}
+      disablePlaceholder={false}
       fadeImageIn={false}
       highResSize={100}
       lowResSize={50}

--- a/packages/card/__tests__/web/__snapshots__/card-reverse-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-reverse-style.test.js.snap
@@ -112,6 +112,7 @@ exports[`card with reversed layout 1`] = `
   >
     <TimesImage
       aspectRatio={0.6666666666666666}
+      disablePlaceholder={false}
       fadeImageIn={false}
       highResSize={600}
       lowResSize={30}

--- a/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
@@ -5,6 +5,7 @@ exports[`1. card default state 1`] = `
   <div>
     <TimesImage
       aspectRatio={0.6666666666666666}
+      disablePlaceholder={false}
       fadeImageIn={false}
       highResSize={360}
       lowResSize={50}
@@ -25,6 +26,7 @@ exports[`2. pass an empty state to the image component 1`] = `
   <div>
     <TimesImage
       aspectRatio={0.6666666666666666}
+      disablePlaceholder={false}
       fadeImageIn={false}
       highResSize={360}
       lowResSize={50}
@@ -55,6 +57,7 @@ exports[`4. pass an empty state to the image component when the uri is null 1`] 
   <div>
     <TimesImage
       aspectRatio={0.6666666666666666}
+      disablePlaceholder={false}
       fadeImageIn={false}
       highResSize={360}
       lowResSize={50}
@@ -80,6 +83,7 @@ exports[`5. card with reversed layout 1`] = `
   <div>
     <TimesImage
       aspectRatio={0.6666666666666666}
+      disablePlaceholder={false}
       fadeImageIn={false}
       highResSize={360}
       lowResSize={50}
@@ -107,6 +111,7 @@ exports[`7. card with a loading state 1`] = `
       <div>
         <TimesImage
           aspectRatio={0.6666666666666666}
+          disablePlaceholder={false}
           fadeImageIn={false}
           highResSize={360}
           lowResSize={50}
@@ -207,6 +212,7 @@ exports[`9. card with reversed loading state 1`] = `
       <div>
         <TimesImage
           aspectRatio={0.6666666666666666}
+          disablePlaceholder={false}
           fadeImageIn={false}
           highResSize={360}
           lowResSize={50}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -1361,6 +1361,7 @@ exports[`31. tile aj 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
+    disablePlaceholder={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>
@@ -1389,6 +1390,7 @@ exports[`32. tile ak 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
+    disablePlaceholder={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -1249,6 +1249,7 @@ exports[`31. tile aj 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
+    disablePlaceholder={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>
@@ -1277,6 +1278,7 @@ exports[`32. tile ak 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
+    disablePlaceholder={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -3463,6 +3463,7 @@ exports[`31. tile aj 1`] = `
   <Image
     aspectRatio={1.5}
     className="IS3"
+    disablePlaceholder={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>
@@ -3522,6 +3523,7 @@ exports[`32. tile ak 1`] = `
   <Image
     aspectRatio={1.5}
     className="IS3"
+    disablePlaceholder={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -1361,6 +1361,7 @@ exports[`31. tile aj 1`] = `
   </div>
   <Image
     aspectRatio={1.5}
+    disablePlaceholder={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>
@@ -1389,6 +1390,7 @@ exports[`32. tile ak 1`] = `
   </div>
   <Image
     aspectRatio={1.5}
+    disablePlaceholder={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>

--- a/packages/edition-slices/src/tiles/tile-aj/index.js
+++ b/packages/edition-slices/src/tiles/tile-aj/index.js
@@ -19,7 +19,12 @@ const TileAJ = ({ id, image, onPress, title, url }) => (
     <View style={header}>
       <ArticleSummaryHeadline headline={title} style={headline} />
     </View>
-    <Image aspectRatio={3 / 2} style={imageContainer} uri={image.crop32.url} />
+    <Image
+      aspectRatio={3 / 2}
+      disablePlaceholder
+      style={imageContainer}
+      uri={image.crop32.url}
+    />
   </Link>
 );
 

--- a/packages/edition-slices/src/tiles/tile-ak/index.js
+++ b/packages/edition-slices/src/tiles/tile-ak/index.js
@@ -19,7 +19,12 @@ const TileAK = ({ id, image, onPress, title, url }) => (
     <View style={header}>
       <ArticleSummaryHeadline headline={title} style={headline} />
     </View>
-    <Image aspectRatio={3 / 2} style={imageContainer} uri={image.crop32.url} />
+    <Image
+      aspectRatio={3 / 2}
+      disablePlaceholder
+      style={imageContainer}
+      uri={image.crop32.url}
+    />
   </Link>
 );
 

--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -216,7 +216,43 @@ exports[`6. handle onload event 2`] = `
 </View>
 `;
 
-exports[`7. componentwillunmount cancels animation timer 1`] = `
+exports[`7. handle onload event with disabled placeholder 1`] = `
+<View
+  aspectRatio={2}
+>
+  <View>
+    <Image
+      fadeDuration={0}
+      fadeImageIn={false}
+      source={
+        Object {
+          "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`7. handle onload event with disabled placeholder 2`] = `
+<View
+  aspectRatio={2}
+>
+  <View>
+    <Image
+      fadeDuration={0}
+      fadeImageIn={false}
+      source={
+        Object {
+          "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`8. componentwillunmount cancels animation timer 1`] = `
 <View
   aspectRatio={2}
 >
@@ -250,7 +286,7 @@ exports[`7. componentwillunmount cancels animation timer 1`] = `
 </View>
 `;
 
-exports[`9. uses highressize if it exists 1`] = `
+exports[`10. uses highressize if it exists 1`] = `
 <View
   aspectRatio={2}
 >
@@ -284,7 +320,7 @@ exports[`9. uses highressize if it exists 1`] = `
 </View>
 `;
 
-exports[`11. uses lowressize image as placeholder if passed 1`] = `
+exports[`12. uses lowressize image as placeholder if passed 1`] = `
 <View
   aspectRatio={2}
 >
@@ -315,7 +351,7 @@ exports[`11. uses lowressize image as placeholder if passed 1`] = `
 </View>
 `;
 
-exports[`12. handle layout change 1`] = `
+exports[`13. handle layout change 1`] = `
 <View
   aspectRatio={2}
 >

--- a/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
@@ -216,7 +216,43 @@ exports[`6. handle onload event 2`] = `
 </View>
 `;
 
-exports[`7. componentwillunmount cancels animation timer 1`] = `
+exports[`7. handle onload event with disabled placeholder 1`] = `
+<View
+  aspectRatio={2}
+>
+  <View>
+    <Image
+      fadeDuration={0}
+      fadeImageIn={false}
+      source={
+        Object {
+          "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`7. handle onload event with disabled placeholder 2`] = `
+<View
+  aspectRatio={2}
+>
+  <View>
+    <Image
+      fadeDuration={0}
+      fadeImageIn={false}
+      source={
+        Object {
+          "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`8. componentwillunmount cancels animation timer 1`] = `
 <View
   aspectRatio={2}
 >
@@ -250,7 +286,7 @@ exports[`7. componentwillunmount cancels animation timer 1`] = `
 </View>
 `;
 
-exports[`9. uses highressize if it exists 1`] = `
+exports[`10. uses highressize if it exists 1`] = `
 <View
   aspectRatio={2}
 >
@@ -284,7 +320,7 @@ exports[`9. uses highressize if it exists 1`] = `
 </View>
 `;
 
-exports[`11. uses lowressize image as placeholder if passed 1`] = `
+exports[`12. uses lowressize image as placeholder if passed 1`] = `
 <View
   aspectRatio={2}
 >
@@ -315,7 +351,7 @@ exports[`11. uses lowressize image as placeholder if passed 1`] = `
 </View>
 `;
 
-exports[`12. handle layout change 1`] = `
+exports[`13. handle layout change 1`] = `
 <View
   aspectRatio={2}
 >

--- a/packages/image/__tests__/shared.native.js
+++ b/packages/image/__tests__/shared.native.js
@@ -78,6 +78,30 @@ export default () => {
       }
     },
     {
+      name: "handle onload event with disabled placeholder",
+      test: () => {
+        jest.useFakeTimers();
+
+        const testInstance = TestRenderer.create(
+          <Image disablePlaceholder {...props} />
+        );
+
+        testInstance.root.children[0].props.onLayout(
+          getLayoutEventForWidth(700)
+        );
+
+        testInstance.root
+          .findAll(node => node.type === ReactNativeImage)[0]
+          .props.onLoad();
+
+        expect(testInstance).toMatchSnapshot();
+
+        jest.runAllTimers();
+
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
       name: "componentWillUnmount cancels animation timer",
       test: () => {
         jest.useFakeTimers();

--- a/packages/image/__tests__/shared.web.js
+++ b/packages/image/__tests__/shared.web.js
@@ -70,6 +70,21 @@ export default () => {
       }
     },
     {
+      name: "with disabled placeholder",
+      test: () => {
+        const testRenderer = TestRenderer.create(
+          <Image
+            aspectRatio={2}
+            disablePlaceholder
+            highResSize={1400}
+            uri="https://image.io"
+          />
+        );
+
+        expect(testRenderer).toMatchSnapshot();
+      }
+    },
+    {
       name:
         "remove the low res image after the high res image has transitioned in",
       test: () => {

--- a/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
@@ -287,7 +287,28 @@ exports[`7. with existing url params 1`] = `
 </div>
 `;
 
-exports[`8. remove the low res image after the high res image has transitioned in 1`] = `
+exports[`8. with disabled placeholder 1`] = `
+.c0 {
+  display: block;
+  opacity: 0;
+  position: absolute;
+  -webkit-transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out;
+  width: 100%;
+  z-index: 2;
+}
+
+<div>
+  <div>
+    <img
+      alt=""
+      src="https://image.io?resize=1400"
+    />
+  </div>
+</div>
+`;
+
+exports[`9. remove the low res image after the high res image has transitioned in 1`] = `
 .c1 {
   display: block;
   opacity: 1;
@@ -322,7 +343,7 @@ exports[`8. remove the low res image after the high res image has transitioned i
 </div>
 `;
 
-exports[`8. remove the low res image after the high res image has transitioned in 2`] = `
+exports[`9. remove the low res image after the high res image has transitioned in 2`] = `
 .c0 {
   display: block;
   opacity: 1;
@@ -343,7 +364,7 @@ exports[`8. remove the low res image after the high res image has transitioned i
 </div>
 `;
 
-exports[`9. only a low res image 1`] = `
+exports[`10. only a low res image 1`] = `
 .c0 {
   display: block;
   opacity: 1;
@@ -384,7 +405,7 @@ exports[`9. only a low res image 1`] = `
 </div>
 `;
 
-exports[`10. fade in the low res image 1`] = `
+exports[`11. fade in the low res image 1`] = `
 .c0 {
   display: block;
   opacity: 0;
@@ -425,7 +446,7 @@ exports[`10. fade in the low res image 1`] = `
 </div>
 `;
 
-exports[`10. fade in the low res image 2`] = `
+exports[`11. fade in the low res image 2`] = `
 .c0 {
   display: block;
   opacity: 1;
@@ -446,7 +467,7 @@ exports[`10. fade in the low res image 2`] = `
 </div>
 `;
 
-exports[`11. both high and low res sizes 1`] = `
+exports[`12. both high and low res sizes 1`] = `
 .c0 {
   display: block;
   opacity: 0;

--- a/packages/image/image.showcase.js
+++ b/packages/image/image.showcase.js
@@ -73,6 +73,11 @@ export default {
       type: "story"
     },
     {
+      component: () => <SquareImage disablePlaceholder />,
+      name: "With disabled placeholder",
+      type: "story"
+    },
+    {
       component: () => (
         <View>
           <SquareImage

--- a/packages/image/src/image-prop-types.js
+++ b/packages/image/src/image-prop-types.js
@@ -5,6 +5,7 @@ export const propTypes = {
   ...Image.PropTypes,
   aspectRatio: PropTypes.number,
   borderRadius: PropTypes.number,
+  disablePlaceholder: PropTypes.bool,
   fadeImageIn: PropTypes.bool,
   highResSize: PropTypes.number,
   lowResSize: PropTypes.number,
@@ -16,6 +17,7 @@ export const propTypes = {
 export const defaultProps = {
   ...Image.defaultImagePropTypes,
   aspectRatio: undefined,
+  disablePlaceholder: false,
   fadeImageIn: false,
   highResSize: null,
   lowResSize: null,

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -58,22 +58,32 @@ class TimesImage extends Component {
   }
 
   handleLoad() {
+    const { disablePlaceholder } = this.props;
+
     clearTimeout(this.fadeAnimTimeout);
 
-    Animated.timing(this.fadeAnim, {
-      toValue: 0,
-      duration: FADE_ANIM_DURATION,
-      useNativeDriver: true
-    }).start();
-
-    this.fadeAnimTimeout = setTimeout(() => {
+    const done = () => {
       this.setState({ isLoaded: true });
-    }, FADE_ANIM_DURATION);
+    };
+
+    if (disablePlaceholder) {
+      this.fadeAnim.setValue(1);
+      done();
+    } else {
+      Animated.timing(this.fadeAnim, {
+        toValue: 0,
+        duration: FADE_ANIM_DURATION,
+        useNativeDriver: true
+      }).start();
+
+      this.fadeAnimTimeout = setTimeout(done, FADE_ANIM_DURATION);
+    }
   }
 
   render() {
     const {
       aspectRatio,
+      disablePlaceholder,
       highResSize,
       lowResSize,
       style,
@@ -89,6 +99,9 @@ class TimesImage extends Component {
       : null;
     const radius = width ? width / 2 : 9999;
     const borderRadius = rounded ? radius : 0;
+    const placeholder = disablePlaceholder ? null : (
+      <Placeholder borderRadius={borderRadius} />
+    );
 
     return (
       <View
@@ -119,7 +132,7 @@ class TimesImage extends Component {
                 />
               </View>
             ) : (
-              <Placeholder borderRadius={borderRadius} />
+              placeholder
             )}
           </Animated.View>
         )}

--- a/packages/image/src/image.web.js
+++ b/packages/image/src/image.web.js
@@ -81,6 +81,7 @@ class TimesImage extends Component {
   render() {
     const {
       aspectRatio,
+      disablePlaceholder,
       highResSize,
       lowResSize,
       style,
@@ -101,7 +102,7 @@ class TimesImage extends Component {
         >
           {this.highResImage({ highResSize, lowResSize, url })}
           {this.lowResImage({ lowResSize, url })}
-          {imageIsLoaded ? null : (
+          {disablePlaceholder || imageIsLoaded ? null : (
             <Placeholder borderRadius={rounded ? "50%" : 0} />
           )}
         </div>


### PR DESCRIPTION
This hides the placeholder during load on puzzle slices so that you don't need an oddly-sized placeholder (as the image is smaller than the slice)

![May-15-2019 18-03-44](https://user-images.githubusercontent.com/719814/57794553-ce558e00-773b-11e9-9b89-3c1a3fd05081.gif)


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
