### PR TITLE
feat: Changed tealium script tag from async to defer

### DIFF
--- a/packages/tealium/src/tealium-send-scheduler.js
+++ b/packages/tealium/src/tealium-send-scheduler.js
@@ -30,7 +30,7 @@ export default class TealiumSendScheduler {
     this.disableAutoPageViewTracking();
 
     const utag = this.d.createElement("script");
-    utag.async = true;
+    utag.defer = true;
     utag.type = "text/javascript";
     utag.onload = () => {
       TealiumSendScheduler.scriptLoaded = true;


### PR DESCRIPTION
As part of the lighthouse report recommendation, just want to try out loading tealium script with defer instead of async