### PR TITLE
chore: Fix dev bundlers via metro config

### DIFF
--- a/android-app/.eslintignore
+++ b/android-app/.eslintignore
@@ -2,3 +2,4 @@
 **/coverage/*
 dist
 rnw.js
+metro.config.js

--- a/android-app/metro.config.js
+++ b/android-app/metro.config.js
@@ -1,0 +1,25 @@
+const path = require("path");
+
+module.exports = (async () => {
+  const root = path.resolve(__dirname, "../");
+  return {
+    resolver: {
+      providesModuleNodeModules: ['react-native'],
+      resolverMainFields: ['react-native', 'dev', 'browser', 'main'],
+      hasteImplModulePath: path.join(root, 'node_modules/react-native/jest/hasteImpl.js'),
+      blacklistRE: /(.*\/__fixtures__\/.*|node_modules[\/\\]react[\/\\]dist[\/\\].*|website\/node_modules\/.*|heapCapture\/bundle\.js|.*\/__tests__\/.*)$/,
+    },
+    transformer: {
+      babelTransformerPath: require.resolve('metro/src/reactNativeTransformer')
+    },
+    serializer: {
+      getModulesRunBeforeMainModule: () => [
+        path.join(root, 'node_modules/react-native/Libraries/Core/InitializeCore.js')
+      ],
+      getPolyfills: require(path.join(root, 'node_modules/react-native/rn-get-polyfills')),
+    },
+    server: {},
+    projectRoot: root,
+    watchFolders: [root, path.join(root, 'node_modules'), path.join(__dirname, 'node_modules')],
+  }
+})();

--- a/android-app/metro.config.js
+++ b/android-app/metro.config.js
@@ -4,22 +4,35 @@ module.exports = (async () => {
   const root = path.resolve(__dirname, "../");
   return {
     resolver: {
-      providesModuleNodeModules: ['react-native'],
-      resolverMainFields: ['react-native', 'dev', 'browser', 'main'],
-      hasteImplModulePath: path.join(root, 'node_modules/react-native/jest/hasteImpl.js'),
-      blacklistRE: /(.*\/__fixtures__\/.*|node_modules[\/\\]react[\/\\]dist[\/\\].*|website\/node_modules\/.*|heapCapture\/bundle\.js|.*\/__tests__\/.*)$/,
+      providesModuleNodeModules: ["react-native"],
+      resolverMainFields: ["react-native", "dev", "browser", "main"],
+      hasteImplModulePath: path.join(
+        root,
+        "node_modules/react-native/jest/hasteImpl.js"
+      ),
+      blacklistRE: /(.*\/__fixtures__\/.*|node_modules[\/\\]react[\/\\]dist[\/\\].*|website\/node_modules\/.*|heapCapture\/bundle\.js|.*\/__tests__\/.*)$/
     },
     transformer: {
-      babelTransformerPath: require.resolve('metro/src/reactNativeTransformer')
+      babelTransformerPath: require.resolve("metro/src/reactNativeTransformer")
     },
     serializer: {
       getModulesRunBeforeMainModule: () => [
-        path.join(root, 'node_modules/react-native/Libraries/Core/InitializeCore.js')
+        path.join(
+          root,
+          "node_modules/react-native/Libraries/Core/InitializeCore.js"
+        )
       ],
-      getPolyfills: require(path.join(root, 'node_modules/react-native/rn-get-polyfills')),
+      getPolyfills: require(path.join(
+        root,
+        "node_modules/react-native/rn-get-polyfills"
+      ))
     },
     server: {},
     projectRoot: root,
-    watchFolders: [root, path.join(root, 'node_modules'), path.join(__dirname, 'node_modules')],
-  }
+    watchFolders: [
+      root,
+      path.join(root, "node_modules"),
+      path.join(__dirname, "node_modules")
+    ]
+  };
 })();

--- a/android-app/package.json
+++ b/android-app/package.json
@@ -8,7 +8,7 @@
     "prettier:diff": "prettier --list-different '**/*.*'",
     "publish-library": "./publish.sh",
     "lint": "eslint . && yarn prettier:diff",
-    "start": "react-native start"
+    "start": "react-native start --config ../../../../android-app/metro.config.js"
   },
   "dependencies": {
     "@times-components/pages": "2.0.35",

--- a/ios-app/.eslintignore
+++ b/ios-app/.eslintignore
@@ -2,3 +2,4 @@
 **/coverage/*
 dist
 rnw.js
+metro.config.js

--- a/ios-app/metro.config.js
+++ b/ios-app/metro.config.js
@@ -1,0 +1,25 @@
+const path = require("path");
+
+module.exports = (async () => {
+  const root = path.resolve(__dirname, "../");
+  return {
+    resolver: {
+      providesModuleNodeModules: ['react-native'],
+      resolverMainFields: ['react-native', 'dev', 'browser', 'main'],
+      hasteImplModulePath: path.join(root, 'node_modules/react-native/jest/hasteImpl.js'),
+      blacklistRE: /(.*\/__fixtures__\/.*|node_modules[\/\\]react[\/\\]dist[\/\\].*|website\/node_modules\/.*|heapCapture\/bundle\.js|.*\/__tests__\/.*)$/,
+    },
+    transformer: {
+      babelTransformerPath: require.resolve('metro/src/reactNativeTransformer')
+    },
+    serializer: {
+      getModulesRunBeforeMainModule: () => [
+        path.join(root, 'node_modules/react-native/Libraries/Core/InitializeCore.js')
+      ],
+      getPolyfills: require(path.join(root, 'node_modules/react-native/rn-get-polyfills')),
+    },
+    server: {},
+    projectRoot: root,
+    watchFolders: [root, path.join(root, 'node_modules'), path.join(__dirname, 'node_modules')],
+  }
+})();

--- a/ios-app/metro.config.js
+++ b/ios-app/metro.config.js
@@ -4,22 +4,35 @@ module.exports = (async () => {
   const root = path.resolve(__dirname, "../");
   return {
     resolver: {
-      providesModuleNodeModules: ['react-native'],
-      resolverMainFields: ['react-native', 'dev', 'browser', 'main'],
-      hasteImplModulePath: path.join(root, 'node_modules/react-native/jest/hasteImpl.js'),
-      blacklistRE: /(.*\/__fixtures__\/.*|node_modules[\/\\]react[\/\\]dist[\/\\].*|website\/node_modules\/.*|heapCapture\/bundle\.js|.*\/__tests__\/.*)$/,
+      providesModuleNodeModules: ["react-native"],
+      resolverMainFields: ["react-native", "dev", "browser", "main"],
+      hasteImplModulePath: path.join(
+        root,
+        "node_modules/react-native/jest/hasteImpl.js"
+      ),
+      blacklistRE: /(.*\/__fixtures__\/.*|node_modules[\/\\]react[\/\\]dist[\/\\].*|website\/node_modules\/.*|heapCapture\/bundle\.js|.*\/__tests__\/.*)$/
     },
     transformer: {
-      babelTransformerPath: require.resolve('metro/src/reactNativeTransformer')
+      babelTransformerPath: require.resolve("metro/src/reactNativeTransformer")
     },
     serializer: {
       getModulesRunBeforeMainModule: () => [
-        path.join(root, 'node_modules/react-native/Libraries/Core/InitializeCore.js')
+        path.join(
+          root,
+          "node_modules/react-native/Libraries/Core/InitializeCore.js"
+        )
       ],
-      getPolyfills: require(path.join(root, 'node_modules/react-native/rn-get-polyfills')),
+      getPolyfills: require(path.join(
+        root,
+        "node_modules/react-native/rn-get-polyfills"
+      ))
     },
     server: {},
     projectRoot: root,
-    watchFolders: [root, path.join(root, 'node_modules'), path.join(__dirname, 'node_modules')],
-  }
+    watchFolders: [
+      root,
+      path.join(root, "node_modules"),
+      path.join(__dirname, "node_modules")
+    ]
+  };
 })();

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -7,7 +7,7 @@
     "fmt": "prettier --write '**/*.*'",
     "prettier:diff": "prettier --list-different '**/*.*'",
     "lint": "eslint . && yarn prettier:diff",
-    "start": "react-native start"
+    "start": "react-native start --config ../../../../ios-app/metro.config.js"
   },
   "dependencies": {
     "@times-components/pages": "2.0.35",

--- a/storybook-native/.eslintignore
+++ b/storybook-native/.eslintignore
@@ -3,3 +3,4 @@
 dist
 rnw.js
 story-loader.js
+metro.config.js

--- a/storybook-native/metro.config.js
+++ b/storybook-native/metro.config.js
@@ -1,0 +1,25 @@
+const path = require("path");
+
+module.exports = (async () => {
+  const root = path.resolve(__dirname, "../");
+  return {
+    resolver: {
+      providesModuleNodeModules: ['react-native'],
+      resolverMainFields: ['react-native', 'dev', 'browser', 'main'],
+      hasteImplModulePath: path.join(root, 'node_modules/react-native/jest/hasteImpl.js'),
+      blacklistRE: /(.*\/__fixtures__\/.*|node_modules[\/\\]react[\/\\]dist[\/\\].*|website\/node_modules\/.*|heapCapture\/bundle\.js|.*\/__tests__\/.*)$/,
+    },
+    transformer: {
+      babelTransformerPath: require.resolve('metro/src/reactNativeTransformer')
+    },
+    serializer: {
+      getModulesRunBeforeMainModule: () => [
+        path.join(root, 'node_modules/react-native/Libraries/Core/InitializeCore.js')
+      ],
+      getPolyfills: require(path.join(root, 'node_modules/react-native/rn-get-polyfills')),
+    },
+    server: {},
+    projectRoot: root,
+    watchFolders: [root, path.join(root, 'node_modules'), path.join(__dirname, 'node_modules')],
+  }
+})();

--- a/storybook-native/metro.config.js
+++ b/storybook-native/metro.config.js
@@ -4,22 +4,35 @@ module.exports = (async () => {
   const root = path.resolve(__dirname, "../");
   return {
     resolver: {
-      providesModuleNodeModules: ['react-native'],
-      resolverMainFields: ['react-native', 'dev', 'browser', 'main'],
-      hasteImplModulePath: path.join(root, 'node_modules/react-native/jest/hasteImpl.js'),
-      blacklistRE: /(.*\/__fixtures__\/.*|node_modules[\/\\]react[\/\\]dist[\/\\].*|website\/node_modules\/.*|heapCapture\/bundle\.js|.*\/__tests__\/.*)$/,
+      providesModuleNodeModules: ["react-native"],
+      resolverMainFields: ["react-native", "dev", "browser", "main"],
+      hasteImplModulePath: path.join(
+        root,
+        "node_modules/react-native/jest/hasteImpl.js"
+      ),
+      blacklistRE: /(.*\/__fixtures__\/.*|node_modules[\/\\]react[\/\\]dist[\/\\].*|website\/node_modules\/.*|heapCapture\/bundle\.js|.*\/__tests__\/.*)$/
     },
     transformer: {
-      babelTransformerPath: require.resolve('metro/src/reactNativeTransformer')
+      babelTransformerPath: require.resolve("metro/src/reactNativeTransformer")
     },
     serializer: {
       getModulesRunBeforeMainModule: () => [
-        path.join(root, 'node_modules/react-native/Libraries/Core/InitializeCore.js')
+        path.join(
+          root,
+          "node_modules/react-native/Libraries/Core/InitializeCore.js"
+        )
       ],
-      getPolyfills: require(path.join(root, 'node_modules/react-native/rn-get-polyfills')),
+      getPolyfills: require(path.join(
+        root,
+        "node_modules/react-native/rn-get-polyfills"
+      ))
     },
     server: {},
     projectRoot: root,
-    watchFolders: [root, path.join(root, 'node_modules'), path.join(__dirname, 'node_modules')],
-  }
+    watchFolders: [
+      root,
+      path.join(root, "node_modules"),
+      path.join(__dirname, "node_modules")
+    ]
+  };
 })();

--- a/storybook-native/package.json
+++ b/storybook-native/package.json
@@ -7,7 +7,7 @@
     "prettier:diff": "prettier --list-different '**/*.*'",
     "lint": "eslint . && yarn prettier:diff",
     "postinstall": "rnstl",
-    "start": "react-native start"
+    "start": "react-native start --config ../../../../storybook-native/metro.config.js"
   },
   "config": {
     "react-native-storybook-loader": {


### PR DESCRIPTION
This PR fixes android:app ios:app and storybook-native bundlers so they pick up dev changes instead of transpiled ones. 