### PR TITLE
fix: api calls for save unsave

### DIFF
--- a/packages/save-and-share-bar/save-and-share-bar.showcase.js
+++ b/packages/save-and-share-bar/save-and-share-bar.showcase.js
@@ -13,6 +13,8 @@ export default {
           onCopyLink={() => {}}
           onShareOnEmail={() => {}}
           saveApi={saveApi}
+          savingEnabled
+          sharingEnabled
         />
       ),
       name: "Save and Share bar",

--- a/packages/save-star-web/__tests__/shared.base.js
+++ b/packages/save-star-web/__tests__/shared.base.js
@@ -163,6 +163,48 @@ export default () => {
 
         expect(wrapper.state("savedStatus")).toEqual(true);
       }
+    },
+    {
+      name: "Clicks on saved link calls unsave api",
+      test: async () => {
+        const apiSave = mockSaveApi;
+
+        const unsaveSpy = jest.spyOn(apiSave, "unBookmark");
+
+        const wrapper = shallow(
+          <SaveStarWeb
+            articleId="96508c84-6611-11e9-adc2-05e1b87efaea"
+            saveApi={apiSave}
+          />
+        );
+        await delay(0);
+        const event = Object.assign(jest.fn(), { preventDefault: jest.fn() });
+        wrapper.find(Link).simulate("press", event);
+        await delay(0);
+
+        expect(unsaveSpy).toHaveBeenCalled();
+      }
+    },
+    {
+      name: "Clicks on save link to call save api",
+      test: async () => {
+        const apiSave = mockSaveApi;
+
+        const saveSpy = jest.spyOn(apiSave, "bookmark");
+
+        const wrapper = shallow(
+          <SaveStarWeb
+            articleId="9bd029d2-49a1-11e9-b472-f58a50a13bbb"
+            saveApi={apiSave}
+          />
+        );
+        await delay(0);
+        const event = Object.assign(jest.fn(), { preventDefault: jest.fn() });
+        wrapper.find(Link).simulate("press", event);
+        await delay(0);
+
+        expect(saveSpy).toHaveBeenCalled();
+      }
     }
   ];
 

--- a/packages/save-star-web/src/save-star-web.js
+++ b/packages/save-star-web/src/save-star-web.js
@@ -33,9 +33,9 @@ class SaveStarWeb extends Component {
     const { saveApi } = this.props;
 
     if (savedStatus) {
-      this.saveUnsaveBookmark(saveApi.bookmark, false, true);
+      this.saveUnsaveBookmark(saveApi.unBookmark, false, true);
     } else {
-      this.saveUnsaveBookmark(saveApi.unBookmark, true, false);
+      this.saveUnsaveBookmark(saveApi.bookmark, true, false);
     }
   }
 
@@ -106,7 +106,7 @@ class SaveStarWeb extends Component {
       return <ActivityIndicator size="small" style={styles.activityLoader} />;
     }
 
-    return this.renderSaveButton(!!savedStatus);
+    return this.renderSaveButton(savedStatus);
   }
 
   render() {


### PR DESCRIPTION
This PR fixes a bug in Save Star wherein the incorrect api methods were getting invoked on save, unsave