### PR TITLE
Stop animated values as well as timers onunmount as it can leak memory

### DIFF
--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -43,6 +43,7 @@ class TimesImage extends Component {
 
   componentWillUnmount() {
     clearTimeout(this.fadeAnimTimeout);
+    this.fadeAnim.stopAnimation(() => {});
   }
 
   onImageLayout(evt) {

--- a/packages/section/src/section.js
+++ b/packages/section/src/section.js
@@ -118,7 +118,7 @@ class Section extends Component {
               }
               renderItem={this.renderItem}
               style={isTablet ? styles.tabletSpacing : null}
-              windowSize={5}
+              windowSize={2}
             />
           )}
         </ResponsiveContext.Consumer>

--- a/packages/section/src/section.js
+++ b/packages/section/src/section.js
@@ -105,7 +105,7 @@ class Section extends Component {
           {({ isTablet }) => (
             <FlatList
               data={data}
-              initialNumToRender={5}
+              initialNumToRender={isTablet ? 5 : 2}
               ItemSeparatorComponent={this.renderItemSeperator}
               keyExtractor={item => item.elementId}
               ListHeaderComponent={this.getHeaderComponent(
@@ -118,7 +118,7 @@ class Section extends Component {
               }
               renderItem={this.renderItem}
               style={isTablet ? styles.tabletSpacing : null}
-              windowSize={2}
+              windowSize={3}
             />
           )}
         </ResponsiveContext.Consumer>

--- a/packages/styleguide/src/animations/index.js
+++ b/packages/styleguide/src/animations/index.js
@@ -16,6 +16,11 @@ class FadeIn extends Component {
     }).start();
   }
 
+  componentWillUnmount() {
+    const { fadeAnim } = this.state;
+    fadeAnim.stopAnimation(() => {});
+  }
+
   render() {
     const { fadeAnim } = this.state;
     const { children } = this.props;


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Animated values use timers internally which can cause javascript objects to be kept in the heap when unmounting a react app.
