### PR TITLE
fix: make drop caps consistent across browsers + fix two line paras

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -12,6 +12,12 @@ exports[`full article with style 1`] = `
   padding-left: 10px;
 }
 
+.c15:after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 .c18 {
   padding-left: 10px;
 }
@@ -690,6 +696,12 @@ exports[`full article with style in the culture magazine 1`] = `
   margin: 0 auto 25px;
   padding-right: 10px;
   padding-left: 10px;
+}
+
+.c15:after {
+  content: "";
+  clear: both;
+  display: table;
 }
 
 .c18 {
@@ -1373,6 +1385,12 @@ exports[`full article with style in the style magazine 1`] = `
   padding-left: 10px;
 }
 
+.c15:after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 .c18 {
   padding-left: 10px;
 }
@@ -2052,6 +2070,12 @@ exports[`full article with style in the sunday times magazine 1`] = `
   margin: 0 auto 25px;
   padding-right: 10px;
   padding-left: 10px;
+}
+
+.c15:after {
+  content: "";
+  clear: both;
+  display: table;
 }
 
 .c18 {

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -12,6 +12,12 @@ exports[`full article with style 1`] = `
   padding-left: 10px;
 }
 
+.c16:after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 .c19 {
   padding-left: 10px;
 }
@@ -687,6 +693,12 @@ exports[`full article with style in the culture magazine 1`] = `
   margin: 0 auto 25px;
   padding-right: 10px;
   padding-left: 10px;
+}
+
+.c16:after {
+  content: "";
+  clear: both;
+  display: table;
 }
 
 .c19 {
@@ -1374,6 +1386,12 @@ exports[`full article with style in the style magazine 1`] = `
   padding-left: 10px;
 }
 
+.c16:after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 .c19 {
   padding-left: 10px;
 }
@@ -2057,6 +2075,12 @@ exports[`full article with style in the sunday times magazine 1`] = `
   margin: 0 auto 25px;
   padding-right: 10px;
   padding-left: 10px;
+}
+
+.c16:after {
+  content: "";
+  clear: both;
+  display: table;
 }
 
 .c19 {

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -12,6 +12,12 @@ exports[`full article with style 1`] = `
   padding-left: 10px;
 }
 
+.c15:after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 .c18 {
   padding-left: 10px;
 }
@@ -632,6 +638,12 @@ exports[`full article with style in the culture magazine 1`] = `
   margin: 0 auto 25px;
   padding-right: 10px;
   padding-left: 10px;
+}
+
+.c15:after {
+  content: "";
+  clear: both;
+  display: table;
 }
 
 .c18 {
@@ -1264,6 +1276,12 @@ exports[`full article with style in the style magazine 1`] = `
   padding-left: 10px;
 }
 
+.c15:after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 .c18 {
   padding-left: 10px;
 }
@@ -1892,6 +1910,12 @@ exports[`full article with style in the sunday times magazine 1`] = `
   margin: 0 auto 25px;
   padding-right: 10px;
   padding-left: 10px;
+}
+
+.c15:after {
+  content: "";
+  clear: both;
+  display: table;
 }
 
 .c18 {

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -12,6 +12,12 @@ exports[`full article with style 1`] = `
   padding-left: 10px;
 }
 
+.c15:after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 .c18 {
   padding-left: 10px;
 }

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -12,6 +12,12 @@ exports[`full article with style 1`] = `
   padding-left: 10px;
 }
 
+.c14:after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 .c17 {
   padding-left: 10px;
 }

--- a/packages/article-paragraph/__tests__/web/__snapshots__/article-paragraph-with-style.web.test.js.snap
+++ b/packages/article-paragraph/__tests__/web/__snapshots__/article-paragraph-with-style.web.test.js.snap
@@ -12,6 +12,12 @@ exports[`1. mpu config 1`] = `
   padding-left: 10px;
 }
 
+.c0:after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 @media (min-width:768px) {
   .c0 {
     font-size: 18px;

--- a/packages/article-paragraph/__tests__/web/__snapshots__/themes-with-style.web.test.js.snap
+++ b/packages/article-paragraph/__tests__/web/__snapshots__/themes-with-style.web.test.js.snap
@@ -12,6 +12,12 @@ exports[`1. paragraph with a drop cap in culture magazine 1`] = `
   padding-left: 10px;
 }
 
+.c0:after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 @media (min-width:768px) {
   .c0 {
     font-size: 18px;
@@ -47,6 +53,12 @@ exports[`2. paragraph with a drop cap in style magazine 1`] = `
   padding-left: 10px;
 }
 
+.c0:after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 @media (min-width:768px) {
   .c0 {
     font-size: 18px;
@@ -80,6 +92,12 @@ exports[`3. paragraph with a drop cap in the sunday times magazine 1`] = `
   margin: 0 auto 25px;
   padding-right: 10px;
   padding-left: 10px;
+}
+
+.c0:after {
+  content: "";
+  clear: both;
+  display: table;
 }
 
 @media (min-width:768px) {

--- a/packages/article-paragraph/article-paragraph.showcase.web.js
+++ b/packages/article-paragraph/article-paragraph.showcase.web.js
@@ -1,9 +1,8 @@
 /* eslint-disable react/prop-types */
-import React from "react";
-import invert from "lodash.invert";
+import React, { Fragment } from "react";
 import coreRenderers from "@times-components/markup";
 import { renderTree } from "@times-components/markup-forest";
-import { colours } from "@times-components/styleguide";
+import { colours, themeFactory } from "@times-components/styleguide";
 import paragraphData from "./fixtures/paragraph-showcase.json";
 import dropCapData from "./fixtures/drop-cap-showcase.json";
 import dropCapShortTextData from "./fixtures/drop-cap-short-text-showcase.json";
@@ -11,21 +10,18 @@ import ArticleParagraph from "./src";
 import DropCapView from "./src/drop-cap";
 
 const renderParagraph = (select, ast) => {
-  const colour = select(
-    "Section",
-    invert(colours.section),
-    colours.section.default
-  );
+  const sections = Object.keys(colours.section).sort();
+  const sectionIdx = select("Section", sections, 0);
+  const section = sections[sectionIdx];
+  const theme = themeFactory(section, "magazinecomment");
+  const colour = theme.sectionColour;
+  const font = theme.dropCapFont;
 
   return renderTree(ast, {
     ...coreRenderers,
     dropCap(key, { value }) {
       return {
-        element: (
-          <DropCapView colour={colour} key={key}>
-            {value}
-          </DropCapView>
-        )
+        element: <DropCapView {...{ colour, font, key }}>{value}</DropCapView>
       };
     },
     paragraph(key, attributes, children, indx, node) {
@@ -55,7 +51,13 @@ export default {
       type: "story"
     },
     {
-      component: ({ select }) => renderParagraph(select, dropCapShortTextData),
+      component: ({ select }) => (
+        <Fragment>
+          {renderParagraph(select, dropCapShortTextData)}
+          {renderParagraph(select, paragraphData)}
+          {renderParagraph(select, paragraphData)}
+        </Fragment>
+      ),
       name: "DropCap paragraph with short text",
       platform: "web",
       type: "story"

--- a/packages/article-paragraph/fixtures/drop-cap-short-text-showcase.json
+++ b/packages/article-paragraph/fixtures/drop-cap-short-text-showcase.json
@@ -11,7 +11,7 @@
     {
       "name": "text",
       "attributes": {
-        "value": "his being Black History Month, last week"
+        "value": "his being Black History Month, last week was Politicians In Search Of An Eye-Catching Race-Related Policy Week. Both Theresa May and Jeremy Corbyn"
       },
       "children": []
     }

--- a/packages/article-paragraph/package.json
+++ b/packages/article-paragraph/package.json
@@ -40,7 +40,6 @@
     "@times-components/markup-forest": "1.7.11",
     "@times-components/responsive": "0.4.37",
     "@times-components/styleguide": "3.28.19",
-    "lodash.invert": "4.3.0",
     "prop-types": "15.7.2",
     "styled-components": "4.2.0"
   },

--- a/packages/article-paragraph/src/article-paragraph.web.js
+++ b/packages/article-paragraph/src/article-paragraph.web.js
@@ -1,13 +1,3 @@
-import React from "react";
-import PropTypes from "prop-types";
-import { Paragraph } from "./styles/responsive";
+import { Paragraph } from "./styles/responsive.web";
 
-const BodyParagraph = ({ children }) => <Paragraph>{children}</Paragraph>;
-
-BodyParagraph.propTypes = {
-  children: PropTypes.arrayOf(
-    PropTypes.oneOfType([PropTypes.string, PropTypes.element])
-  ).isRequired
-};
-
-export default BodyParagraph;
+export default Paragraph;

--- a/packages/article-paragraph/src/drop-cap.web.js
+++ b/packages/article-paragraph/src/drop-cap.web.js
@@ -1,14 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { dropCap } from "./styles/responsive";
+import { DropCap } from "./styles/responsive.web";
 import { propTypes, defaultProps } from "./drop-cap-prop-types";
 
-const DropCapView = ({ colour, children, font }) => {
-  const DropCapWithFont = dropCap(font);
+function DropCapView({ colour, children, font }) {
   return (
-    <DropCapWithFont style={{ color: colour }}>{children}</DropCapWithFont>
+    <DropCap font={font} style={{ color: colour }}>
+      {children}
+    </DropCap>
   );
-};
+}
 
 DropCapView.propTypes = {
   ...propTypes,

--- a/packages/article-paragraph/src/styles/responsive.web.js
+++ b/packages/article-paragraph/src/styles/responsive.web.js
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import {
   breakpoints,
   colours,
@@ -8,17 +8,24 @@ import {
 } from "@times-components/styleguide";
 
 const dropCapFontSizes = {
-  cultureMagazine: 100,
+  cultureMagazine: 104,
   dropCap: 110,
-  stMagazine: 110,
-  styleMagazine: 110
+  stMagazine: 105,
+  styleMagazine: 103
 };
 
-const dropCapTopPaddings = {
-  cultureMagazine: { bottom: 15, top: 0 },
-  dropCap: { bottom: 0, top: 9 },
-  stMagazine: { bottom: 10, top: 0 },
-  styleMagazine: { bottom: 10, top: 0 }
+const lineHeights = {
+  cultureMagazine: 0.85,
+  dropCap: 0.55,
+  stMagazine: 0.7,
+  styleMagazine: 0.8
+};
+
+const dropCapMargins = {
+  cultureMagazine: -0.06,
+  dropCap: 0.2,
+  stMagazine: 0.065,
+  styleMagazine: -0.01
 };
 
 export const Paragraph = styled.p`
@@ -30,6 +37,13 @@ export const Paragraph = styled.p`
   margin: 0 auto ${spacing(5)};
   padding-right: ${spacing(2)};
   padding-left: ${spacing(2)};
+   
+  // Clear fix for floated dropcap
+  &:after {
+    content: "";
+    clear: both;
+    display: table;
+  }
 
   @media (min-width: ${breakpoints.medium}px) {
     font-size: ${fontSizes.body}px;
@@ -44,14 +58,16 @@ export const Paragraph = styled.p`
   }
 `;
 
-export const dropCap = (font = "dropCap") => styled.span`
+export const DropCap = styled.span`
   float: left;
-  -webkit-margin-before: 11px !important;
-  padding: ${dropCapTopPaddings[font].top}px 10px ${
-  dropCapTopPaddings[font].bottom
-}px 0;
-  line-height: 0.6em;
-  font-size: ${dropCapFontSizes[font]}px;
-  font-family: "${fonts[font]}";
   color: ${colours.functional.primary};
+  padding-right: 10px;
+  line-height: 1em;
+
+  ${({ font = "dropCap" }) => css`
+    margin-top: ${dropCapMargins[font]}em;
+    line-height: ${lineHeights[font]}em;
+    font-size: ${dropCapFontSizes[font]}px;
+    font-family: "${fonts[font]}";
+  `};
 `;

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -12,6 +12,23 @@ exports[`full article with style 1`] = `
   padding-left: 10px;
 }
 
+.c5:after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
+.c6 {
+  float: left;
+  color: #333333;
+  padding-right: 10px;
+  line-height: 1em;
+  margin-top: 0.2em;
+  line-height: 0.55em;
+  font-size: 110px;
+  font-family: "TimesModern-Regular";
+}
+
 .c13 {
   padding-left: 10px;
 }
@@ -92,16 +109,6 @@ exports[`full article with style 1`] = `
   border-top: 1px solid;
   border-bottom: 1px solid;
   border-color: #DBDBDB;
-}
-
-.c6 {
-  float: left;
-  -webkit-margin-before: 11px !important;
-  padding: 9px 10px 0px 0;
-  line-height: 0.6em;
-  font-size: 110px;
-  font-family: "TimesModern-Regular";
-  color: #333333;
 }
 
 @media (min-width:768px) {


### PR DESCRIPTION
This fixes drop cap positioning on web so that

- The drop cap is always the height of 3 regular sized lines across different fonts
- The drop cap position is consistent across browsers
- Two line paragraphs with a drop cap no longer break the position of the next paragraph

**TimesModern-Regular**

![Screen Shot 2019-05-22 at 15 09 32](https://user-images.githubusercontent.com/719814/58181443-b8981980-7ca3-11e9-90a6-52d18a6eb44c.png)

**Flama-Bold**

![Screen Shot 2019-05-22 at 15 11 01](https://user-images.githubusercontent.com/719814/58181513-d796ab80-7ca3-11e9-9c66-34705e82824f.png)

**Tiempos-Headline-Bold**

![Screen Shot 2019-05-22 at 15 11 35](https://user-images.githubusercontent.com/719814/58181550-e9784e80-7ca3-11e9-873c-7e5ae4b41694.png)

**CenturyGothic-Bold**

![Screen Shot 2019-05-22 at 15 12 14](https://user-images.githubusercontent.com/719814/58181600-014fd280-7ca4-11e9-80f9-6ea980d066e7.png)

**Two line paragraphs**

![image](https://user-images.githubusercontent.com/719814/58181652-19275680-7ca4-11e9-9631-239f50f968f5.png)



<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
