### PR TITLE
REPLAT-6157: Added a new publish script for ios assets

### DIFF
--- a/TimesComponents.podspec
+++ b/TimesComponents.podspec
@@ -50,18 +50,19 @@ podspec_version = package["version"]
 react_native_version = package["dependencies"]["react-native"]
 
 Pod::Spec.new do |s|
-  s.name         = "TimesComponents"
-  s.version      = podspec_version
-  s.summary      = "Times iOS React components"
-  s.description  = "All the things for Times iOS React components including dependencies"
-  s.homepage     = "https://www.news.co.uk"
-  s.license      = { type: 'MIT', file: 'LICENSE' }
-  s.author       = "News UK"
-  s.platform     = :ios, '9.0'
-  s.swift_version = '4.2'
-
-  s.source       = { :git => 'https://github.com/newsuk/times-components.git', :tag => "#{s.version}"}
-  s.resources      = ['ios-app/ios-assets/js/index.ios.bundle', 'ios-app/ios-assets/res/*']
+  s.name             = "TimesComponents"
+  s.version          = podspec_version
+  s.summary          = "Times iOS React components"
+  s.description      = "All the things for Times iOS React components including dependencies"
+  s.homepage         = "https://www.news.co.uk"
+  s.license          = { type: 'MIT', file: 'LICENSE' }
+  s.author           = "News UK"
+  s.platform         = :ios, '9.0'
+  s.swift_version    = '4.2'
+  s.source           = { :git => 'https://github.com/newsuk/times-components-ios-artifacts', :tag => "#{s.version}"}
+  s.resource_bundles = {
+    'TimesComponents' => ['ios-app/ios-assets/js/index.ios.bundle', 'ios-app/ios-assets/res/*']
+  }
   
   # React, and the subspecs we have to use
   s.dependency 'React/Core', react_native_version

--- a/lib/publish-ios-assets.sh
+++ b/lib/publish-ios-assets.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -e
+
+VERBOSE=0
+ASSET_REPO="git@github.com:newsuk/times-pod-specs.git"
+
+function logError () {
+    echo "$@" >&4
+}
+
+function log () {
+    echo "$@"
+}
+
+function logVerbose () {
+    echo "$@" >&3
+}
+
+while getopts "v" OPTION
+do
+  case $OPTION in
+    v) VERBOSE=1
+       ;;
+  esac
+done
+
+if [ "$VERBOSE" = 1 ]; then
+    exec 4>&2 3>&1
+else
+    exec 4>/dev/null 3>/dev/null
+fi
+
+log "Publish IOS Resources ..."
+
+# =======================
+# Find version
+# =======================
+
+log "Checking new version ..."
+VERSION=$(cat ios-app/package.json | grep version | head -1 | sed 's/[\",\t ]//g' | awk -F: '{ print $2 }' 2>&4)
+if [ -z "$VERSION" ]
+then
+  logError "Error: Can't find ios version"
+  exit 1
+fi
+log "Found new version: $VERSION"
+
+# =======================
+# Create Tmp Folder
+# =======================
+
+TMP_ASSET_DIR=$(mktemp -d) || { logError "Failed to create temp file" ; exit 1; }
+logVerbose "Tmp Directory: $TMP_ASSET_DIR"
+
+# ==================================
+# Check out assets repo and validate
+# ==================================
+
+# set up git
+git config user.name "Publish Bot" 2>&4
+git config user.email "publish@ghbot.com" 2>&4
+
+logVerbose "Checking out $ASSET_REPO in $TMP_ASSET_DIR"
+# Fetch the whole repo as we want to check if the tag exists already
+#git clone --single-branch --branch master $ASSET_REPO $TMP_ASSET_DIR  2>&4 1>&3
+git clone --branch master $ASSET_REPO $TMP_ASSET_DIR  2>&4 1>&3
+
+cd $TMP_ASSET_DIR 2>&4 1>&3
+# If tag already present on the repo, abort
+if [ $(git tag -l "$VERSION") ]; then
+    logError "Error: $VERSION already exists in assets repo"
+    exit 1
+fi
+cd - 2>&4 1>&3
+
+# ==================================
+# Update new assets and commit
+# ==================================
+
+log "Update new assets"
+rm -rf $TMP_ASSET_DIR/assets 1>&3
+mkdir -p $TMP_ASSET_DIR/assets 1>&3
+cp -r ios-app/ios-assets $TMP_ASSET_DIR/assets 1>&3
+cp TimesComponents.podspec $TMP_ASSET_DIR/ 1>&3
+
+cd $TMP_ASSET_DIR 2>&4 1>&3
+git add $TMP_ASSET_DIR/assets TimesComponents.podspec 1>&3
+# If there are no changes and we still want to tag the version, ignore error
+git commit -m "IOS assets for version:$VERSION"  1>&3 || true
+log "Create new version tag: $VERSION"
+git tag -a $VERSION -m "IOS assets for version:$VERSION"  1>&3
+
+# push above changes to git
+log "Pushing changes to assets repo"
+git push origin master --tags --quiet 1>&3
+
+# ==================================
+# Cleanup
+# ==================================
+
+logVerbose "Clean up tmp folder"
+#rm -rf $TMP_ASSET_DIR 2>&4 1>&3
+
+log "All done!!"
+exit 0

--- a/lib/publish-ios-assets.sh
+++ b/lib/publish-ios-assets.sh
@@ -2,7 +2,7 @@
 set -e
 
 VERBOSE=0
-ASSET_REPO="git@github.com:newsuk/times-pod-specs.git"
+ASSET_REPO="git@github.com:newsuk/times-components-ios-artifacts.git"
 
 function logError () {
     echo "$@" >&4
@@ -41,7 +41,7 @@ VERSION=$(cat ios-app/package.json | grep version | head -1 | sed 's/[\",\t ]//g
 if [ -z "$VERSION" ]
 then
   logError "Error: Can't find ios version"
-  exit 1
+  exit 2
 fi
 log "Found new version: $VERSION"
 
@@ -49,7 +49,7 @@ log "Found new version: $VERSION"
 # Create Tmp Folder
 # =======================
 
-TMP_ASSET_DIR=$(mktemp -d) || { logError "Failed to create temp file" ; exit 1; }
+TMP_ASSET_DIR=$(mktemp -d) || { logError "Failed to create temp file" ; exit 2; }
 logVerbose "Tmp Directory: $TMP_ASSET_DIR"
 
 # ==================================
@@ -69,7 +69,7 @@ cd $TMP_ASSET_DIR 2>&4 1>&3
 # If tag already present on the repo, abort
 if [ $(git tag -l "$VERSION") ]; then
     logError "Error: $VERSION already exists in assets repo"
-    exit 1
+    exit 2
 fi
 cd - 2>&4 1>&3
 
@@ -80,8 +80,9 @@ cd - 2>&4 1>&3
 log "Update new assets"
 rm -rf $TMP_ASSET_DIR/assets 1>&3
 mkdir -p $TMP_ASSET_DIR/assets 1>&3
-cp -r ios-app/ios-assets $TMP_ASSET_DIR/assets 1>&3
-cp TimesComponents.podspec $TMP_ASSET_DIR/ 1>&3
+cp -r ios-app/ios-assets/* $TMP_ASSET_DIR/assets 1>&3
+# Lets not copy podspec file over as it has path info for this repo
+# and it will be confusing to see it over in assets repo
 
 cd $TMP_ASSET_DIR 2>&4 1>&3
 git add $TMP_ASSET_DIR/assets TimesComponents.podspec 1>&3
@@ -99,7 +100,7 @@ git push origin master --tags --quiet 1>&3
 # ==================================
 
 logVerbose "Clean up tmp folder"
-#rm -rf $TMP_ASSET_DIR 2>&4 1>&3
+rm -rf $TMP_ASSET_DIR 2>&4 1>&3
 
 log "All done!!"
 exit 0

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ios": "react-native run-ios --no-packager",
     "ios:logs": "yarn ios && react-native log-ios",
     "ios:app": "cd ios-app && yarn start",
+    "ios:publish-lib": "yarn ios:build-lib && ./lib/publish-ios-assets.sh",
     "ios:build-lib": "yarn ios:build-lib:js && cd ios-app && yarn build",
     "ios:build-lib:js": "mkdir -p ios-app/ios-assets/js && mkdir -p ios-app/ios-assets/res && react-native bundle --platform ios --dev false --entry-file ios-app/index.ios.js --bundle-output ios-app/ios-assets/js/index.ios.bundle --assets-dest ios-app/ios-assets/res/",
     "start-emulator": "./lib/start_android_emulator.sh",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ios": "react-native run-ios --no-packager",
     "ios:logs": "yarn ios && react-native log-ios",
     "ios:app": "cd ios-app && yarn start",
-    "ios:publish-lib": "yarn ios:build-lib && ./lib/publish-ios-assets.sh",
+    "ios:publish-lib": "./lib/publish-ios-assets.sh",
     "ios:build-lib": "yarn ios:build-lib:js && cd ios-app && yarn build",
     "ios:build-lib:js": "mkdir -p ios-app/ios-assets/js && mkdir -p ios-app/ios-assets/res && react-native bundle --platform ios --dev false --entry-file ios-app/index.ios.js --bundle-output ios-app/ios-assets/js/index.ios.bundle --assets-dest ios-app/ios-assets/res/",
     "start-emulator": "./lib/start_android_emulator.sh",


### PR DESCRIPTION
Why is this needed?
-------------------

- Adds a new publish script for ios assets. The git repo is pointing to a temporary repo right now and will be updated to the right path once the new becomes available.
-  Adds the script to package.json

