### PR TITLE
fix: Change message bar layout to fix flicker issue

### DIFF
--- a/packages/message-bar/__tests__/android/__snapshots__/message-bar.test.js.snap
+++ b/packages/message-bar/__tests__/android/__snapshots__/message-bar.test.js.snap
@@ -121,14 +121,14 @@ exports[`1. renders correctly 1`] = `
 `;
 
 exports[`5. renders correctly 1`] = `
-Array [
-  <View />,
+<View>
+  <View />
   <View>
     <View>
       <Text>
         test child content
       </Text>
     </View>
-  </View>,
-]
+  </View>
+</View>
 `;

--- a/packages/message-bar/__tests__/ios/__snapshots__/message-bar.test.js.snap
+++ b/packages/message-bar/__tests__/ios/__snapshots__/message-bar.test.js.snap
@@ -105,14 +105,14 @@ exports[`1. renders correctly 1`] = `
 `;
 
 exports[`5. renders correctly 1`] = `
-Array [
-  <View />,
+<View>
+  <View />
   <View>
     <View>
       <Text>
         test child content
       </Text>
     </View>
-  </View>,
-]
+  </View>
+</View>
 `;

--- a/packages/message-bar/__tests__/web/__snapshots__/message-bar.test.js.snap
+++ b/packages/message-bar/__tests__/web/__snapshots__/message-bar.test.js.snap
@@ -33,14 +33,14 @@ exports[`1. renders correctly 1`] = `
 `;
 
 exports[`5. renders correctly 1`] = `
-Array [
-  <div />,
+<div>
+  <div />
   <div>
     <div>
       <div>
         test child content
       </div>
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;

--- a/packages/message-bar/src/message-manager.js
+++ b/packages/message-bar/src/message-manager.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unused-state */
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import { View, Platform } from "react-native";
 import PropTypes from "prop-types";
 import styleFactory from "./styles";
@@ -57,7 +57,7 @@ class MessageManager extends Component {
       : {};
 
     return (
-      <Fragment>
+      <View>
         <View style={[styles.messageManager, offsetStyle]}>
           {message && (
             <MessageBar
@@ -74,7 +74,7 @@ class MessageManager extends Component {
             {children}
           </MessageContext.Provider>
         </View>
-      </Fragment>
+      </View>
     );
   }
 }


### PR DESCRIPTION
The absolute positioning was not working on android when put inside a fragment. Replaced it with a View to fix flickering issue on cartoons

Before: 
![cartoons](https://user-images.githubusercontent.com/1849590/58250271-ef7c3700-7d58-11e9-8553-791650a49c65.gif)

After:
![Screenshot_1558612062](https://user-images.githubusercontent.com/1849590/58250291-f99e3580-7d58-11e9-9981-81929e8d50c7.png)
