### PR TITLE
Feat/update article save api

### DIFF
--- a/packages/article-in-depth/src/article-in-depth.web.js
+++ b/packages/article-in-depth/src/article-in-depth.web.js
@@ -71,6 +71,7 @@ class ArticlePage extends Component {
       error,
       isLoading,
       receiveChildList,
+      saveApi,
       spotAccountId
     } = this.props;
 
@@ -85,6 +86,7 @@ class ArticlePage extends Component {
         data={article}
         Header={this.renderHeader}
         receiveChildList={receiveChildList}
+        saveApi={saveApi}
         spotAccountId={spotAccountId}
       />
     );

--- a/packages/article-magazine-comment/src/article-magazine-comment.web.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.web.js
@@ -75,6 +75,7 @@ class ArticlePage extends Component {
       error,
       isLoading,
       receiveChildList,
+      saveApi,
       spotAccountId
     } = this.props;
 
@@ -89,6 +90,7 @@ class ArticlePage extends Component {
         data={article}
         Header={this.renderHeader}
         receiveChildList={receiveChildList}
+        saveApi={saveApi}
         spotAccountId={spotAccountId}
       />
     );

--- a/packages/article-magazine-standard/src/article-magazine-standard.web.js
+++ b/packages/article-magazine-standard/src/article-magazine-standard.web.js
@@ -65,6 +65,7 @@ class ArticlePage extends Component {
       error,
       isLoading,
       receiveChildList,
+      saveApi,
       spotAccountId
     } = this.props;
 
@@ -79,6 +80,7 @@ class ArticlePage extends Component {
         data={article}
         Header={this.renderHeader}
         receiveChildList={receiveChildList}
+        saveApi={saveApi}
         spotAccountId={spotAccountId}
       />
     );

--- a/packages/article-main-comment/src/article-main-comment.web.js
+++ b/packages/article-main-comment/src/article-main-comment.web.js
@@ -59,6 +59,7 @@ class ArticlePage extends Component {
       error,
       isLoading,
       receiveChildList,
+      saveApi,
       spotAccountId
     } = this.props;
 
@@ -73,6 +74,7 @@ class ArticlePage extends Component {
         data={article}
         Header={this.renderHeader}
         receiveChildList={receiveChildList}
+        saveApi={saveApi}
         spotAccountId={spotAccountId}
       />
     );

--- a/packages/article-main-standard/src/article-main-standard.web.js
+++ b/packages/article-main-standard/src/article-main-standard.web.js
@@ -75,6 +75,7 @@ class ArticlePage extends Component {
       error,
       isLoading,
       receiveChildList,
+      saveApi,
       spotAccountId
     } = this.props;
 
@@ -89,6 +90,7 @@ class ArticlePage extends Component {
         data={article}
         Header={this.renderHeader}
         receiveChildList={receiveChildList}
+        saveApi={saveApi}
         spotAccountId={spotAccountId}
       />
     );

--- a/packages/article-skeleton/showcase-helper.js
+++ b/packages/article-skeleton/showcase-helper.js
@@ -2,6 +2,7 @@
 import React from "react";
 import { Text, View } from "react-native";
 import invert from "lodash.invert";
+import saveApi from "@times-components/save-star-web/mock-save-api-showcase";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
 import { ContextProviderWithDefaults } from "@times-components/context";
 import { colours, scales } from "@times-components/styleguide";
@@ -81,6 +82,7 @@ const renderArticleSkeleton = ({
         )}
         onVideoPress={preventDefaultedAction(decorateAction)("onVideoPress")}
         onViewableItemsChanged={() => null}
+        saveApi={saveApi}
       />
     </ContextProviderWithDefaults>
   );

--- a/packages/article-skeleton/src/article-skeleton-prop-types.js
+++ b/packages/article-skeleton/src/article-skeleton-prop-types.js
@@ -6,6 +6,7 @@ const articleSkeletonPropTypes = {
   data: PropTypes.shape({}),
   Header: PropTypes.func.isRequired,
   receiveChildList: PropTypes.func,
+  saveApi: PropTypes.func,
   spotAccountId: PropTypes.string
 };
 
@@ -13,7 +14,8 @@ const articleSkeletonDefaultProps = {
   adConfig: {},
   data: null,
   Header: () => null,
-  receiveChildList: () => {}
+  receiveChildList: () => {},
+  saveApi: () => {}
 };
 
 export { articleSkeletonPropTypes, articleSkeletonDefaultProps };

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -76,7 +76,9 @@ class ArticleSkeleton extends Component {
     savingEnabled,
     sharingEnabled
   }) {
-    const saveServiceApi = saveApi || saveArticleApi;
+    const saveServiceApi =
+      saveApi && saveApi.bookmark ? saveApi : saveArticleApi;
+
     if (!allowSaveAndShare) return null;
 
     return (

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -2,11 +2,11 @@ import React, { Component, Fragment } from "react";
 import Ad, { AdComposer } from "@times-components/ad";
 import SaveAndShareBar from "@times-components/save-and-share-bar";
 import ArticleExtras from "@times-components/article-extras";
-import { saveApi } from "@times-components/save-star-web";
 import LazyLoad from "@times-components/lazy-load";
 import { spacing, breakpoints } from "@times-components/styleguide";
 import { withTrackScrollDepth } from "@times-components/tracking";
 import Context from "@times-components/context";
+import saveArticleApi from "@times-components/save-star-web/mock-save-api-showcase";
 import { isLoggedIn, isMeteredExpired } from "@times-components/utils";
 import ArticleBody from "./article-body/article-body";
 import {
@@ -72,9 +72,11 @@ class ArticleSkeleton extends Component {
     url,
     isSticky,
     allowSaveAndShare,
+    saveApi,
     savingEnabled,
     sharingEnabled
   }) {
+    const saveServiceApi = saveApi || saveArticleApi;
     if (!allowSaveAndShare) return null;
 
     return (
@@ -92,7 +94,7 @@ class ArticleSkeleton extends Component {
               onCopyLink={() => {}}
               onSaveToMyArticles={() => {}}
               onShareOnEmail={() => {}}
-              saveApi={saveApi}
+              saveApi={saveServiceApi}
               savingEnabled={savingEnabled}
               sharingEnabled={sharingEnabled}
             />
@@ -109,6 +111,7 @@ class ArticleSkeleton extends Component {
       data: article,
       Header,
       receiveChildList,
+      saveApi,
       spotAccountId
     } = this.props;
 
@@ -182,6 +185,7 @@ class ArticleSkeleton extends Component {
                               url,
                               isSticky,
                               allowSaveAndShare: isUserLoggedIn,
+                              saveApi,
                               savingEnabled,
                               sharingEnabled
                             })}

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -6,7 +6,7 @@ import LazyLoad from "@times-components/lazy-load";
 import { spacing, breakpoints } from "@times-components/styleguide";
 import { withTrackScrollDepth } from "@times-components/tracking";
 import Context from "@times-components/context";
-import saveArticleApi from "@times-components/save-star-web/mock-save-api-showcase";
+import { saveApi as saveArticleApi } from "@times-components/save-star-web";
 import { isLoggedIn, isMeteredExpired } from "@times-components/utils";
 import ArticleBody from "./article-body/article-body";
 import {

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -68,6 +68,7 @@
     "@times-components/message-bar": "0.2.8",
     "@times-components/provider": "1.17.2",
     "@times-components/responsive": "0.4.38",
+    "@times-components/save-star-web": "0.2.0",
     "@times-components/styleguide": "3.28.20"
   },
   "peerDependencies": {

--- a/packages/article/showcase-helper.js
+++ b/packages/article/showcase-helper.js
@@ -12,6 +12,7 @@ import {
   MockedProvider,
   schemaToMocks
 } from "@times-components/provider-test-tools";
+import saveArticleApi from "@times-components/save-star-web/mock-save-api-showcase";
 import { sections } from "@times-components/storybook";
 import { scales, themeFactory } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
@@ -211,6 +212,7 @@ const renderArticle = ({
   id,
   inDepthBackgroundColour,
   inDepthTextColour,
+  saveApi = saveArticleApi,
   scale,
   section,
   template,
@@ -275,6 +277,7 @@ const renderArticle = ({
               onVideoPress={preventDefaultedAction(decorateAction)(
                 "onVideoPress"
               )}
+              saveApi={saveApi}
               refetch={refetch}
             />
           </MessageManager>
@@ -370,6 +373,7 @@ const renderArticleConfig = ({
             inDepthTextColour,
             isTeaser: isTeaser || withTeaser,
             isMeteredExpired: isMeteredExpired || isMeteredExpiredPage,
+            saveApi: saveArticleApi,
             scale,
             section,
             template


### PR DESCRIPTION
This PR enables article to have Save Api working for demonstration purposes, by providing `saveApi` as a prop which you can mock, for render integration we do not need to provide the prop and it can still read from the import inside `ArticleSkeleton`