### PR TITLE
docs: Add link to readme.md for depend help

### DIFF
--- a/packages/depend/src/cli-parser.js
+++ b/packages/depend/src/cli-parser.js
@@ -66,4 +66,10 @@ export default commander
   .option("-sr --show-rules", "prints rules that will be applied")
   .option("-l --list", "prints all dependencies in use")
   .option("-b --bail", "returns 1 if packages need fixing")
-  .option("--hint", "print fix suggestions");
+  .option("--hint", "print fix suggestions")
+  .on("--help", () => {
+    console.log(
+      "  For more details see https://github.com/newsuk/times-components/tree/master/packages/depend"
+    );
+    console.log("");
+  });


### PR DESCRIPTION
This PR adds the link to the help command output.
It looks like this

<img width="693" alt="link-to-md" src="https://user-images.githubusercontent.com/836735/58341738-9c3cde00-7e57-11e9-90a0-581a38114416.png">
