### PR TITLE
Fix: Subscript/Superscript markup fallback scenario

### DIFF
--- a/packages/markup/__tests__/android/__snapshots__/markup.android.test.js.snap
+++ b/packages/markup/__tests__/android/__snapshots__/markup.android.test.js.snap
@@ -116,10 +116,34 @@ exports[`10. subscript 1`] = `
 </Text>
 `;
 
-exports[`11. superscript 1`] = `
+exports[`11. subscript with fallback 1`] = `
+<Text
+  style={
+    Object {
+      "fontSize": 10,
+    }
+  }
+>
+  without unicode support
+</Text>
+`;
+
+exports[`12. superscript 1`] = `
 <Text>
   ²
 </Text>
 `;
 
-exports[`12. does not render a script tag 1`] = `<View />`;
+exports[`13. superscript with fallback 1`] = `
+<Text
+  style={
+    Object {
+      "fontSize": 10,
+    }
+  }
+>
+  without unicode support
+</Text>
+`;
+
+exports[`14. does not render a script tag 1`] = `<View />`;

--- a/packages/markup/__tests__/ios/__snapshots__/markup.ios.test.js.snap
+++ b/packages/markup/__tests__/ios/__snapshots__/markup.ios.test.js.snap
@@ -116,10 +116,34 @@ exports[`10. subscript 1`] = `
 </Text>
 `;
 
-exports[`11. superscript 1`] = `
+exports[`11. subscript with fallback 1`] = `
+<Text
+  style={
+    Object {
+      "fontSize": 10,
+    }
+  }
+>
+  without unicode support
+</Text>
+`;
+
+exports[`12. superscript 1`] = `
 <Text>
   ²
 </Text>
 `;
 
-exports[`12. does not render a script tag 1`] = `<View />`;
+exports[`13. superscript with fallback 1`] = `
+<Text
+  style={
+    Object {
+      "fontSize": 10,
+    }
+  }
+>
+  without unicode support
+</Text>
+`;
+
+exports[`14. does not render a script tag 1`] = `<View />`;

--- a/packages/markup/__tests__/shared.base.js
+++ b/packages/markup/__tests__/shared.base.js
@@ -14,7 +14,9 @@ import lineBreak from "../fixtures/break.json";
 import script from "../fixtures/script.json";
 import strong from "../fixtures/strong.json";
 import subscript from "../fixtures/subscript.json";
+import subscriptWithFallback from "../fixtures/subscript-fallback.json";
 import superscript from "../fixtures/superscript.json";
+import superscriptWithFallback from "../fixtures/superscript-fallback.json";
 
 export default renderComponent => {
   const tests = [
@@ -101,9 +103,29 @@ export default renderComponent => {
       }
     },
     {
+      name: "subscript with fallback",
+      test: () => {
+        const output = renderComponent(
+          renderTree(subscriptWithFallback, coreRenderers)
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
       name: "superscript",
       test: () => {
         const output = renderComponent(renderTree(superscript, coreRenderers));
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "superscript with fallback",
+      test: () => {
+        const output = renderComponent(
+          renderTree(superscriptWithFallback, coreRenderers)
+        );
 
         expect(output).toMatchSnapshot();
       }

--- a/packages/markup/__tests__/web/__snapshots__/markup.web.test.js.snap
+++ b/packages/markup/__tests__/web/__snapshots__/markup.web.test.js.snap
@@ -67,13 +67,25 @@ exports[`10. subscript 1`] = `
 </sub>
 `;
 
-exports[`11. superscript 1`] = `
+exports[`11. subscript with fallback 1`] = `
+<sub>
+  without unicode support
+</sub>
+`;
+
+exports[`12. superscript 1`] = `
 <sup>
   2
 </sup>
 `;
 
-exports[`12. does not render a script tag 1`] = `
+exports[`13. superscript with fallback 1`] = `
+<sup>
+  without unicode support
+</sup>
+`;
+
+exports[`14. does not render a script tag 1`] = `
 <div
   className="css-view-1dbjc4n"
 />

--- a/packages/markup/src/markup-flow.js
+++ b/packages/markup/src/markup-flow.js
@@ -70,7 +70,7 @@ export default ({ fontFamily, Bold, Italic, Body }) => ({
       };
     }
     return {
-      element: new Markup.StyledText({
+      element: new Markup.Styled({
         children: renderedChildren,
         style: new Markup.TextStyle({
           size: 10
@@ -87,7 +87,7 @@ export default ({ fontFamily, Bold, Italic, Body }) => ({
       };
     }
     return {
-      element: new Markup.StyledText({
+      element: new Markup.Styled({
         children: renderedChildren,
         style: new Markup.TextStyle({
           size: 10


### PR DESCRIPTION
TextLayout implementation was causing a crash on subscript fallbacks (whenever the subscript markup is used with a character without an unicode subscript). Did a quick fix on this and added a test case