### PR TITLE
Fix: Set initial interactives wrapper height to 1

### DIFF
--- a/packages/interactive-wrapper/__tests__/android/__snapshots__/interactive-wrapper.test.js.snap
+++ b/packages/interactive-wrapper/__tests__/android/__snapshots__/interactive-wrapper.test.js.snap
@@ -4,7 +4,7 @@ exports[`renders correctly 1`] = `
 <View
   style={
     Object {
-      "height": 0,
+      "height": 1,
     }
   }
 >
@@ -33,7 +33,7 @@ exports[`renders correctly 1`] = `
         Object {
           "backgroundColor": "#ffffff",
           "flex": 1,
-          "height": 0,
+          "height": 1,
           "overflow": "hidden",
         }
       }

--- a/packages/interactive-wrapper/__tests__/ios/__snapshots__/interactive-wrapper.test.js.snap
+++ b/packages/interactive-wrapper/__tests__/ios/__snapshots__/interactive-wrapper.test.js.snap
@@ -4,7 +4,7 @@ exports[`renders correctly 1`] = `
 <View
   style={
     Object {
-      "height": 0,
+      "height": 1,
     }
   }
 >
@@ -29,7 +29,7 @@ exports[`renders correctly 1`] = `
         Object {
           "backgroundColor": "#ffffff",
           "flex": 1,
-          "height": 0,
+          "height": 1,
           "overflow": "hidden",
         }
       }

--- a/packages/interactive-wrapper/src/interactive-wrapper.js
+++ b/packages/interactive-wrapper/src/interactive-wrapper.js
@@ -23,7 +23,7 @@ class InteractiveWrapper extends Component {
   constructor() {
     super();
     this.state = {
-      height: 0
+      height: 1
     };
     this.onMessage = this.onMessage.bind(this);
     this.handleNavigationStateChange = this.handleNavigationStateChange.bind(


### PR DESCRIPTION
We've noticed an issue with the latest webview implementation, where some interactives were not being rendered. This is happening due to the initial height of the interactives being 0. I've changed the initial height to 1 to work around this problem