### PR TITLE
fix: message bar consumed and styled in web

### DIFF
--- a/packages/article-skeleton/package.json
+++ b/packages/article-skeleton/package.json
@@ -86,6 +86,7 @@
     "@times-components/link": "3.4.13",
     "@times-components/markup": "3.3.69",
     "@times-components/markup-forest": "1.7.12",
+    "@times-components/message-bar": "0.2.8",
     "@times-components/pull-quote": "3.4.89",
     "@times-components/responsive": "0.4.38",
     "@times-components/save-and-share-bar": "0.6.2",

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -6,6 +6,7 @@ import { spacing } from "@times-components/styleguide";
 import { withTrackScrollDepth } from "@times-components/tracking";
 import Context from "@times-components/context";
 import { isLoggedIn, isMeteredExpired } from "@times-components/utils";
+import { MessageContext } from "@times-components/message-bar";
 import ArticleBody from "./article-body/article-body";
 import {
   articleSkeletonDefaultProps,
@@ -119,17 +120,23 @@ class ArticleSkeleton extends Component {
                             width={articleWidth}
                           />
                           {shouldRenderSaveAndShare && (
-                            <StickySaveAndShareBar
-                              articleId={articleId}
-                              articleHeadline={headline}
-                              articleUrl={url}
-                              onCopyLink={() => {}}
-                              onSaveToMyArticles={() => {}}
-                              onShareOnEmail={() => {}}
-                              saveApi={saveApi}
-                              savingEnabled={savingEnabled}
-                              sharingEnabled={sharingEnabled}
-                            />
+                            <MessageContext.Consumer>
+                              {({ showMessage }) => (
+                                <StickySaveAndShareBar
+                                  articleId={articleId}
+                                  articleHeadline={headline}
+                                  articleUrl={url}
+                                  onCopyLink={() =>
+                                    showMessage("Article link copied")
+                                  }
+                                  onSaveToMyArticles={() => {}}
+                                  onShareOnEmail={() => {}}
+                                  saveApi={saveApi}
+                                  savingEnabled={savingEnabled}
+                                  sharingEnabled={sharingEnabled}
+                                />
+                              )}
+                            </MessageContext.Consumer>
                           )}
                           <BodyContainer>
                             <ArticleBody

--- a/packages/article/showcase-helper.js
+++ b/packages/article/showcase-helper.js
@@ -16,7 +16,6 @@ import saveArticleApi from "@times-components/save-star-web/mock-save-api-showca
 import { sections } from "@times-components/storybook";
 import { scales, themeFactory } from "@times-components/styleguide";
 import storybookReporter from "@times-components/tealium-utils";
-import { MessageManager } from "@times-components/message-bar";
 import Article, { templates } from "./src/article";
 
 const preventDefaultedAction = decorateAction =>
@@ -246,41 +245,37 @@ const renderArticle = ({
             }
           }}
         >
-          <MessageManager animate delay={30000} scale={scales.medium}>
-            <Article
-              adConfig={adConfig}
-              analyticsStream={analyticsStream}
-              article={data}
-              error={error}
-              isLoading={false}
-              onAuthorPress={preventDefaultedAction(decorateAction)(
-                "onAuthorPress"
-              )}
-              onCommentGuidelinesPress={preventDefaultedAction(decorateAction)(
-                "onCommentGuidelinesPress"
-              )}
-              onCommentsPress={preventDefaultedAction(decorateAction)(
-                "onCommentsPress"
-              )}
-              onLinkPress={preventDefaultedAction(decorateAction)(
-                "onLinkPress"
-              )}
-              onRelatedArticlePress={preventDefaultedAction(decorateAction)(
-                "onRelatedArticlePress"
-              )}
-              onTopicPress={preventDefaultedAction(decorateAction)(
-                "onTopicPress"
-              )}
-              onTwitterLinkPress={preventDefaultedAction(decorateAction)(
-                "onTwitterLinkPress"
-              )}
-              onVideoPress={preventDefaultedAction(decorateAction)(
-                "onVideoPress"
-              )}
-              saveApi={saveApi}
-              refetch={refetch}
-            />
-          </MessageManager>
+          <Article
+            adConfig={adConfig}
+            analyticsStream={analyticsStream}
+            article={data}
+            error={error}
+            isLoading={false}
+            onAuthorPress={preventDefaultedAction(decorateAction)(
+              "onAuthorPress"
+            )}
+            onCommentGuidelinesPress={preventDefaultedAction(decorateAction)(
+              "onCommentGuidelinesPress"
+            )}
+            onCommentsPress={preventDefaultedAction(decorateAction)(
+              "onCommentsPress"
+            )}
+            onLinkPress={preventDefaultedAction(decorateAction)("onLinkPress")}
+            onRelatedArticlePress={preventDefaultedAction(decorateAction)(
+              "onRelatedArticlePress"
+            )}
+            onTopicPress={preventDefaultedAction(decorateAction)(
+              "onTopicPress"
+            )}
+            onTwitterLinkPress={preventDefaultedAction(decorateAction)(
+              "onTwitterLinkPress"
+            )}
+            onVideoPress={preventDefaultedAction(decorateAction)(
+              "onVideoPress"
+            )}
+            saveApi={saveApi}
+            refetch={refetch}
+          />
         </ContextProviderWithDefaults>
       );
     }}

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -32,11 +32,11 @@ const Article = props => {
 
   const Component = templates[template] || ArticleMainStandard;
   return (
-    <MessageManager animate delay={3000} scale={scales.medium}>
-      <Responsive>
-        <Component {...props} onImagePress={onImagePressArticle} />
-      </Responsive>
-    </MessageManager>
+    <Responsive>
+      <MessageManager animate delay={3000} scale={scales.medium}>
+          <Component {...props} onImagePress={onImagePressArticle} />
+      </MessageManager>
+    </Responsive>
   );
 };
 

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -34,7 +34,7 @@ const Article = props => {
   return (
     <Responsive>
       <MessageManager animate delay={3000} scale={scales.medium}>
-          <Component {...props} onImagePress={onImagePressArticle} />
+        <Component {...props} onImagePress={onImagePressArticle} />
       </MessageManager>
     </Responsive>
   );

--- a/packages/message-bar/README.md
+++ b/packages/message-bar/README.md
@@ -14,9 +14,9 @@ const TestConsumer = () => (
 
 ...
 
-<MessageQueue animate delay={3000} scale={scales.medium}>
+<MessageManager animate delay={3000} scale={scales.medium}>
     <TestConsumer />
-</MessageQueue>
+</MessageManager>
 ```
 
 ## Contributing

--- a/packages/message-bar/__tests__/android/__snapshots__/message-bar.test.js.snap
+++ b/packages/message-bar/__tests__/android/__snapshots__/message-bar.test.js.snap
@@ -3,70 +3,31 @@
 exports[`1. renders correctly 1`] = `
 <View>
   <View>
-    <Text>
-      test message
-    </Text>
     <View>
+      <Text>
+        test message
+      </Text>
       <View>
-        <RNSVGSvgView
-          align="xMidYMid"
-          bbHeight="28"
-          bbWidth="28"
-          height="28"
-          meetOrSlice={0}
-          minX={0}
-          minY={0}
-          role="img"
-          title="Close Icon"
-          vbHeight={28}
-          vbWidth={28}
-          width="28"
-        >
-          <RNSVGGroup
-            fill={
-              Array [
-                0,
-                -16777216,
-              ]
-            }
-            fillOpacity={1}
-            fillRule={1}
-            matrix={
-              Array [
-                1,
-                0,
-                0,
-                1,
-                0,
-                0,
-              ]
-            }
-            opacity={1}
-            originX={0}
-            originY={0}
-            rotation={0}
-            scaleX={1}
-            scaleY={1}
-            skewX={0}
-            skewY={0}
-            stroke={null}
-            strokeDasharray={null}
-            strokeDashoffset={null}
-            strokeLinecap={0}
-            strokeLinejoin={0}
-            strokeMiterlimit={4}
-            strokeOpacity={1}
-            strokeWidth={1}
-            vectorEffect={0}
-            x={0}
-            y={0}
+        <View>
+          <RNSVGSvgView
+            align="xMidYMid"
+            bbHeight="28"
+            bbWidth="28"
+            height="28"
+            meetOrSlice={0}
+            minX={0}
+            minY={0}
+            role="img"
+            title="Close Icon"
+            vbHeight={28}
+            vbWidth={28}
+            width="28"
           >
-            <RNSVGPath
-              d="M15.617 14l4.683 5.838-.462.462L14 15.617 8.162 20.3l-.462-.462L12.383 14 7.7 8.162l.462-.462L14 12.383 19.838 7.7l.462.462z"
+            <RNSVGGroup
               fill={
                 Array [
                   0,
-                  -1,
+                  -16777216,
                 ]
               }
               fillOpacity={1}
@@ -84,23 +45,12 @@ exports[`1. renders correctly 1`] = `
               opacity={1}
               originX={0}
               originY={0}
-              propList={
-                Array [
-                  "fill",
-                  "stroke",
-                ]
-              }
               rotation={0}
               scaleX={1}
               scaleY={1}
               skewX={0}
               skewY={0}
-              stroke={
-                Array [
-                  0,
-                  -1,
-                ]
-              }
+              stroke={null}
               strokeDasharray={null}
               strokeDashoffset={null}
               strokeLinecap={0}
@@ -111,9 +61,61 @@ exports[`1. renders correctly 1`] = `
               vectorEffect={0}
               x={0}
               y={0}
-            />
-          </RNSVGGroup>
-        </RNSVGSvgView>
+            >
+              <RNSVGPath
+                d="M15.617 14l4.683 5.838-.462.462L14 15.617 8.162 20.3l-.462-.462L12.383 14 7.7 8.162l.462-.462L14 12.383 19.838 7.7l.462.462z"
+                fill={
+                  Array [
+                    0,
+                    -1,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                    "stroke",
+                  ]
+                }
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={
+                  Array [
+                    0,
+                    -1,
+                  ]
+                }
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/message-bar/__tests__/ios/__snapshots__/message-bar.test.js.snap
+++ b/packages/message-bar/__tests__/ios/__snapshots__/message-bar.test.js.snap
@@ -3,88 +3,15 @@
 exports[`1. renders correctly 1`] = `
 <View>
   <View>
-    <Text>
-      test message
-    </Text>
     <View>
+      <Text>
+        test message
+      </Text>
       <View>
-        <ARTSurfaceView>
-          <ARTGroup
-            opacity={1}
-            transform={
-              Array [
-                1,
-                0,
-                0,
-                1,
-                0,
-                0,
-              ]
-            }
-          >
-            <ARTShape
-              d={
-                Array [
-                  0,
-                  15.617,
-                  14,
-                  2,
-                  20.3,
-                  19.838,
-                  2,
-                  NaN,
-                  NaN,
-                  2,
-                  NaN,
-                  NaN,
-                  2,
-                  NaN,
-                  NaN,
-                  2,
-                  NaN,
-                  NaN,
-                  2,
-                  12.383,
-                  14,
-                  2,
-                  7.7,
-                  8.162,
-                  2,
-                  8.162,
-                  7.700000000000001,
-                  2,
-                  14,
-                  12.383,
-                  2,
-                  19.838,
-                  7.7,
-                  2,
-                  NaN,
-                  NaN,
-                ]
-              }
-              fill={
-                Array [
-                  0,
-                  1,
-                  1,
-                  1,
-                  1,
-                ]
-              }
+        <View>
+          <ARTSurfaceView>
+            <ARTGroup
               opacity={1}
-              stroke={
-                Array [
-                  1,
-                  1,
-                  1,
-                  1,
-                ]
-              }
-              strokeCap={1}
-              strokeDash={null}
-              strokeJoin={1}
-              strokeWidth={1}
               transform={
                 Array [
                   1,
@@ -95,9 +22,84 @@ exports[`1. renders correctly 1`] = `
                   0,
                 ]
               }
-            />
-          </ARTGroup>
-        </ARTSurfaceView>
+            >
+              <ARTShape
+                d={
+                  Array [
+                    0,
+                    15.617,
+                    14,
+                    2,
+                    20.3,
+                    19.838,
+                    2,
+                    NaN,
+                    NaN,
+                    2,
+                    NaN,
+                    NaN,
+                    2,
+                    NaN,
+                    NaN,
+                    2,
+                    NaN,
+                    NaN,
+                    2,
+                    12.383,
+                    14,
+                    2,
+                    7.7,
+                    8.162,
+                    2,
+                    8.162,
+                    7.700000000000001,
+                    2,
+                    14,
+                    12.383,
+                    2,
+                    19.838,
+                    7.7,
+                    2,
+                    NaN,
+                    NaN,
+                  ]
+                }
+                fill={
+                  Array [
+                    0,
+                    1,
+                    1,
+                    1,
+                    1,
+                  ]
+                }
+                opacity={1}
+                stroke={
+                  Array [
+                    1,
+                    1,
+                    1,
+                    1,
+                  ]
+                }
+                strokeCap={1}
+                strokeDash={null}
+                strokeJoin={1}
+                strokeWidth={1}
+                transform={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+              />
+            </ARTGroup>
+          </ARTSurfaceView>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/message-bar/__tests__/message-bar.base.js
+++ b/packages/message-bar/__tests__/message-bar.base.js
@@ -58,12 +58,13 @@ export default animate => [
         />
       );
 
-      const prevTimeout = testInstance.state("timeout");
+      const prevTimeout = testInstance.instance().timeout;
+
       testInstance.setProps({
         message: "test message"
       });
 
-      const newTimeout = testInstance.state("timeout");
+      const newTimeout = testInstance.instance().timeout;
 
       expect(prevTimeout).not.toEqual(newTimeout);
     }
@@ -81,13 +82,12 @@ export default animate => [
         />
       );
 
-      const prevTimeout = testInstance.state("timeout");
+      const prevTimeout = testInstance.instance().timeout;
       testInstance.setProps({
         message: "new test message"
       });
 
-      const newTimeout = testInstance.state("timeout");
-
+      const newTimeout = testInstance.instance().timeout;
       expect(prevTimeout).toEqual(newTimeout);
     }
   }

--- a/packages/message-bar/__tests__/web/__snapshots__/message-bar.test.js.snap
+++ b/packages/message-bar/__tests__/web/__snapshots__/message-bar.test.js.snap
@@ -4,28 +4,30 @@ exports[`1. renders correctly 1`] = `
 <div>
   <div>
     <div>
-      test message
-    </div>
-    <div>
-      <div
-        tabIndex="0"
-      >
-        <svg
-          aria-label="[title]"
-          height="28"
-          role="img"
-          viewBox="0 0 28 28"
-          width="28"
+      <div>
+        test message
+      </div>
+      <div>
+        <div
+          tabIndex="0"
         >
-          <title>
-            Close Icon
-          </title>
-          <path
-            d="M15.617 14l4.683 5.838-.462.462L14 15.617 8.162 20.3l-.462-.462L12.383 14 7.7 8.162l.462-.462L14 12.383 19.838 7.7l.462.462z"
-            fill="white"
-            stroke="white"
-          />
-        </svg>
+          <svg
+            aria-label="[title]"
+            height="28"
+            role="img"
+            viewBox="0 0 28 28"
+            width="28"
+          >
+            <title>
+              Close Icon
+            </title>
+            <path
+              d="M15.617 14l4.683 5.838-.462.462L14 15.617 8.162 20.3l-.462-.462L12.383 14 7.7 8.162l.462-.462L14 12.383 19.838 7.7l.462.462z"
+              fill="white"
+              stroke="white"
+            />
+          </svg>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/message-bar/message-bar.showcase.js
+++ b/packages/message-bar/message-bar.showcase.js
@@ -8,6 +8,7 @@ export default {
       component: () => (
         <MessageBar
           animate
+          close={() => {}}
           delay={3000}
           message="Article link copied"
           scale={scales.medium}

--- a/packages/message-bar/message-bar.showcase.js
+++ b/packages/message-bar/message-bar.showcase.js
@@ -9,7 +9,7 @@ export default {
         <MessageBar
           animate
           delay={3000}
-          message="Test message"
+          message="Article link copied"
           scale={scales.medium}
         />
       ),

--- a/packages/message-bar/package.json
+++ b/packages/message-bar/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "@times-components/icons": "2.11.9",
+    "@times-components/responsive": "0.4.38",
     "@times-components/styleguide": "3.28.20",
     "prop-types": "15.7.2"
   },

--- a/packages/message-bar/src/message-bar.js
+++ b/packages/message-bar/src/message-bar.js
@@ -18,18 +18,20 @@ class MessageBar extends Component {
   }
 
   componentDidMount() {
-    const { delay } = this.props;
+    const { delay, close } = this.props;
 
     this.animateOpen(() => {});
     this.setState({
       timeout: setTimeout(() => {
-        this.animateClosed();
+        this.animateClosed(() => {
+          close();
+        });
       }, delay)
     });
   }
 
   componentWillReceiveProps(props) {
-    const { message, delay } = props;
+    const { message, delay, close } = props;
     const { message: oldMessage } = this.props;
 
     if (message === oldMessage) {
@@ -37,7 +39,9 @@ class MessageBar extends Component {
       clearTimeout(timeout);
       this.setState({
         timeout: setTimeout(() => {
-          this.animateClosed();
+          this.animateClosed(() => {
+            close();
+          });
         }, delay)
       });
     }
@@ -74,9 +78,9 @@ class MessageBar extends Component {
   }
 
   render() {
-    const { message, scale, animate } = this.props;
+    const { message, scale, animate, breakpoint } = this.props;
     const { yValue } = this.state;
-    const styles = styleFactory(scale);
+    const styles = styleFactory(scale, breakpoint);
 
     return (
       <Animated.View
@@ -93,12 +97,14 @@ class MessageBar extends Component {
           }
         }
       >
-        <View style={styles.messageBarBody}>
-          <Text style={styles.messageBarText}>{message}</Text>
-          <View style={styles.messageBarCloseButton}>
-            <TouchableOpacity onPress={this.close}>
-              <CloseIcon width="28" height="28" />
-            </TouchableOpacity>
+        <View style={styles.messageBarBodyContainer}>
+          <View style={styles.messageBarBody}>
+            <Text style={styles.messageBarText}>{message}</Text>
+            <View style={styles.messageBarCloseButton}>
+              <TouchableOpacity onPress={this.close}>
+                <CloseIcon width="28" height="28" />
+              </TouchableOpacity>
+            </View>
           </View>
         </View>
       </Animated.View>
@@ -108,6 +114,7 @@ class MessageBar extends Component {
 
 MessageBar.propTypes = {
   animate: PropTypes.bool.isRequired,
+  breakpoint: PropTypes.string.isRequired,
   close: PropTypes.func.isRequired,
   delay: PropTypes.number.isRequired,
   message: PropTypes.string.isRequired,

--- a/packages/message-bar/src/message-bar.js
+++ b/packages/message-bar/src/message-bar.js
@@ -47,6 +47,13 @@ class MessageBar extends Component {
     }
   }
 
+  componentWillUnmount() {
+    const { timeout } = this.state;
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+
   animateOpen(cb) {
     const { yValue } = this.state;
     Animated.spring(yValue, {

--- a/packages/message-bar/src/message-bar.js
+++ b/packages/message-bar/src/message-bar.js
@@ -6,7 +6,6 @@ import styleFactory from "./styles";
 
 class MessageBar extends Component {
   state = {
-    timeout: null,
     yValue: new Animated.Value(0)
   };
 
@@ -21,13 +20,11 @@ class MessageBar extends Component {
     const { delay, close } = this.props;
 
     this.animateOpen(() => {});
-    this.setState({
-      timeout: setTimeout(() => {
-        this.animateClosed(() => {
-          close();
-        });
-      }, delay)
-    });
+    this.timeout = setTimeout(() => {
+      this.animateClosed(() => {
+        close();
+      });
+    }, delay);
   }
 
   componentWillReceiveProps(props) {
@@ -35,22 +32,18 @@ class MessageBar extends Component {
     const { message: oldMessage } = this.props;
 
     if (message === oldMessage) {
-      const { timeout } = this.state;
-      clearTimeout(timeout);
-      this.setState({
-        timeout: setTimeout(() => {
-          this.animateClosed(() => {
-            close();
-          });
-        }, delay)
-      });
+      clearTimeout(this.timeout);
+      this.timeout = setTimeout(() => {
+        this.animateClosed(() => {
+          close();
+        });
+      }, delay);
     }
   }
 
   componentWillUnmount() {
-    const { timeout } = this.state;
-    if (timeout) {
-      clearTimeout(timeout);
+    if (this.timeout) {
+      clearTimeout(this.timeout);
     }
   }
 
@@ -70,18 +63,11 @@ class MessageBar extends Component {
 
   close() {
     const { close } = this.props;
-    const { timeout } = this.state;
-    clearTimeout(timeout);
-    this.setState(
-      {
-        timeout: null
-      },
-      () => {
-        this.animateClosed(() => {
-          close();
-        });
-      }
-    );
+    clearTimeout(this.timeout);
+    this.timeout = null;
+    this.animateClosed(() => {
+      close();
+    });
   }
 
   render() {

--- a/packages/message-bar/src/message-manager.js
+++ b/packages/message-bar/src/message-manager.js
@@ -2,7 +2,7 @@
 import React, { Component } from "react";
 import { View, Platform } from "react-native";
 import PropTypes from "prop-types";
-import Responsive, { ResponsiveContext } from "@times-components/responsive";
+import { ResponsiveContext } from "@times-components/responsive";
 import styleFactory from "./styles";
 import MessageBar from "./message-bar";
 import MessageContext from "./message-context";

--- a/packages/message-bar/src/message-manager.js
+++ b/packages/message-bar/src/message-manager.js
@@ -2,6 +2,7 @@
 import React, { Component } from "react";
 import { View, Platform } from "react-native";
 import PropTypes from "prop-types";
+import Responsive, { ResponsiveContext } from "@times-components/responsive";
 import styleFactory from "./styles";
 import MessageBar from "./message-bar";
 import MessageContext from "./message-context";
@@ -60,13 +61,20 @@ class MessageManager extends Component {
       <View>
         <View style={[styles.messageManager, offsetStyle]}>
           {message && (
-            <MessageBar
-              animate={animate}
-              close={this.removeMessage}
-              delay={delay}
-              message={message}
-              scale={scale}
-            />
+            <Responsive>
+              <ResponsiveContext.Consumer>
+                {({ editionBreakpoint }) => (
+                  <MessageBar
+                    animate={animate}
+                    close={this.removeMessage}
+                    delay={delay}
+                    message={message}
+                    scale={scale}
+                    breakpoint={editionBreakpoint}
+                  />
+                )}
+              </ResponsiveContext.Consumer>
+            </Responsive>
           )}
         </View>
         <View onLayout={this.onLayout}>

--- a/packages/message-bar/src/message-manager.js
+++ b/packages/message-bar/src/message-manager.js
@@ -61,20 +61,18 @@ class MessageManager extends Component {
       <View>
         <View style={[styles.messageManager, offsetStyle]}>
           {message && (
-            <Responsive>
-              <ResponsiveContext.Consumer>
-                {({ editionBreakpoint }) => (
-                  <MessageBar
-                    animate={animate}
-                    close={this.removeMessage}
-                    delay={delay}
-                    message={message}
-                    scale={scale}
-                    breakpoint={editionBreakpoint}
-                  />
-                )}
-              </ResponsiveContext.Consumer>
-            </Responsive>
+            <ResponsiveContext.Consumer>
+              {({ editionBreakpoint }) => (
+                <MessageBar
+                  animate={animate}
+                  close={this.removeMessage}
+                  delay={delay}
+                  message={message}
+                  scale={scale}
+                  breakpoint={editionBreakpoint}
+                />
+              )}
+            </ResponsiveContext.Consumer>
           )}
         </View>
         <View onLayout={this.onLayout}>

--- a/packages/message-bar/src/styles/index.android.js
+++ b/packages/message-bar/src/styles/index.android.js
@@ -1,6 +1,7 @@
 import { StyleSheet } from "react-native";
 import sharedStyles from "./shared";
 
-const styles = scale => StyleSheet.create(sharedStyles(scale));
+const styles = (scale, breakpoint) =>
+  StyleSheet.create(sharedStyles(scale, breakpoint));
 
 export default styles;

--- a/packages/message-bar/src/styles/index.js
+++ b/packages/message-bar/src/styles/index.js
@@ -1,6 +1,7 @@
 import { StyleSheet } from "react-native";
 import sharedStyles from "./shared";
 
-const styles = scale => StyleSheet.create(sharedStyles(scale));
+const styles = (scale, breakpoint) =>
+  StyleSheet.create(sharedStyles(scale, breakpoint));
 
 export default styles;

--- a/packages/message-bar/src/styles/index.web.js
+++ b/packages/message-bar/src/styles/index.web.js
@@ -1,6 +1,14 @@
 import { StyleSheet } from "react-native";
 import sharedStyles from "./shared";
 
-const styles = scale => StyleSheet.create(sharedStyles(scale));
+const styles = (scale, breakpoint) =>
+  StyleSheet.create({
+    ...sharedStyles(scale, breakpoint),
+    messageManager: {
+      ...sharedStyles(scale, breakpoint).messageManager,
+      position: "fixed",
+      left: 0
+    }
+  });
 
 export default styles;

--- a/packages/message-bar/src/styles/shared.js
+++ b/packages/message-bar/src/styles/shared.js
@@ -2,40 +2,58 @@ import { colours, fontFactory } from "@times-components/styleguide";
 
 const height = 50;
 
-const sharedStyle = scale => ({
-  messageBarBody: {
-    alignItems: "center",
+const messageBarBody = {
+  maxWidth: 1182,
+  width: "100%",
+  flexDirection: "row",
+  alignItems: "center",
+  height,
+  flexGrow: 1,
+  flexShrink: 0,
+  marginLeft: "auto",
+  marginRight: "auto"
+};
+
+const messageBarCloseButton = {
+  alignItems: "center",
+  backgroundColor: "rgba(255, 255, 255, 0.3)",
+  borderRadius: 28 / 2,
+  height: 28,
+  justifyContent: "center",
+  marginLeft: "auto",
+  marginRight: 20,
+  width: 28
+};
+
+const messageBarText = scale => ({
+  color: colours.functional.white,
+  ...fontFactory({
+    font: "headline",
+    fontSize: "secondary",
+    scale
+  }),
+  marginLeft: 20
+});
+
+export const sharedStyle = scale => ({
+  messageBarBodyContainer: {
     backgroundColor: colours.functional.articleFlagUpdated,
-    flexDirection: "row",
-    height,
     shadowColor: "rgba(0, 0, 0, 0.2)",
     shadowOffset: {
       height: 2,
       width: 0
     },
     shadowRadius: 5,
-    flexGrow: 1,
-    flexShrink: 0,
     zIndex: 10
   },
+  messageBarBody: {
+    ...messageBarBody
+  },
   messageBarCloseButton: {
-    alignItems: "center",
-    backgroundColor: "rgba(255, 255, 255, 0.3)",
-    borderRadius: 28 / 2,
-    height: 28,
-    justifyContent: "center",
-    marginLeft: "auto",
-    marginRight: 20,
-    width: 28
+    ...messageBarCloseButton
   },
   messageBarText: {
-    color: colours.functional.white,
-    ...fontFactory({
-      font: "headline",
-      fontSize: "secondary",
-      scale
-    }),
-    marginLeft: 20
+    ...messageBarText(scale)
   },
   messageManager: {
     flex: 1,
@@ -44,4 +62,48 @@ const sharedStyle = scale => ({
   }
 });
 
-export default sharedStyle;
+const smallBreakpointStyles = scale => ({
+  ...sharedStyle(scale),
+  messageBarCloseButton: {
+    ...messageBarCloseButton,
+    marginRight: 10
+  },
+  messageBarText: {
+    ...messageBarText(scale),
+    marginLeft: 10
+  }
+});
+
+const mediumBreakpointStyles = scale => ({
+  ...sharedStyle(scale),
+  messageBarCloseButton: {
+    ...messageBarCloseButton,
+    marginRight: 10
+  },
+  messageBarText: {
+    ...messageBarText(scale),
+    marginLeft: 60
+  }
+});
+
+const wideBreakpointStyles = scale => ({
+  ...sharedStyle(scale),
+  messageBarBody: {
+    ...messageBarBody,
+    maxWidth: 1024
+  }
+});
+
+const hugeBreakpointStyles = scale => ({
+  ...sharedStyle(scale)
+});
+
+const stylesResolver = {
+  small: smallBreakpointStyles,
+  medium: mediumBreakpointStyles,
+  wide: wideBreakpointStyles,
+  huge: hugeBreakpointStyles
+};
+
+export default (scale, breakpoint = "huge") =>
+  stylesResolver[breakpoint](scale);

--- a/packages/message-bar/src/styles/shared.js
+++ b/packages/message-bar/src/styles/shared.js
@@ -10,14 +10,13 @@ const messageBarBody = {
   height,
   flexGrow: 1,
   flexShrink: 0,
-  marginLeft: "auto",
-  marginRight: "auto"
+  marginHorizontal: "auto"
 };
 
 const messageBarCloseButton = {
   alignItems: "center",
-  backgroundColor: "rgba(255, 255, 255, 0.3)",
-  borderRadius: 28 / 2,
+  backgroundColor: colours.functional.transparentWhite,
+  borderRadius: 14,
   height: 28,
   justifyContent: "center",
   marginLeft: "auto",
@@ -46,12 +45,8 @@ export const sharedStyle = scale => ({
     shadowRadius: 5,
     zIndex: 10
   },
-  messageBarBody: {
-    ...messageBarBody
-  },
-  messageBarCloseButton: {
-    ...messageBarCloseButton
-  },
+  messageBarBody,
+  messageBarCloseButton,
   messageBarText: {
     ...messageBarText(scale)
   },

--- a/packages/save-and-share-bar/package.json
+++ b/packages/save-and-share-bar/package.json
@@ -37,6 +37,7 @@
     "@times-components/link": "3.4.13",
     "@times-components/provider-queries": "2.2.2",
     "@times-components/save-star-web": "0.2.2",
+    "@times-components/message-bar": "0.2.8",
     "@times-components/styleguide": "3.28.20",
     "@times-components/tracking": "2.4.39",
     "@times-components/utils": "4.11.7",

--- a/packages/save-and-share-bar/save-and-share-bar.showcase.js
+++ b/packages/save-and-share-bar/save-and-share-bar.showcase.js
@@ -1,5 +1,7 @@
 import React from "react";
 import saveApi from "@times-components/save-star-web/mock-save-api-showcase";
+import { scales } from "@times-components/styleguide";
+import { MessageManager, MessageContext } from "@times-components/message-bar";
 import SaveAndShareBar from "./src/save-and-share-bar";
 
 const mockGetTokenisedArticleUrl = id =>
@@ -21,16 +23,22 @@ export default {
   children: [
     {
       component: () => (
-        <SaveAndShareBar
-          articleId="9bd029d2-49a1-11e9-b472-f58a50a13bbb"
-          articleHeadline="test-headline"
-          articleUrl="https://www.thetimes.co.uk/"
-          onCopyLink={() => {}}
-          getTokenisedShareUrl={mockGetTokenisedArticleUrl}
-          saveApi={saveApi}
-          savingEnabled
-          sharingEnabled
-        />
+        <MessageManager animate delay={3000} scale={scales.medium}>
+          <MessageContext.Consumer>
+            {({ showMessage }) => (
+              <SaveAndShareBar
+                articleId="9bd029d2-49a1-11e9-b472-f58a50a13bbb"
+                articleHeadline="test-headline"
+                articleUrl="https://www.thetimes.co.uk/"
+                onCopyLink={() => showMessage("Article link copied")}
+                getTokenisedShareUrl={mockGetTokenisedArticleUrl}
+                saveApi={saveApi}
+                savingEnabled
+                sharingEnabled
+              />
+            )}
+          </MessageContext.Consumer>
+        </MessageManager>
       ),
       name: "Save and Share bar",
       type: "story"

--- a/packages/styleguide/src/colours/functional.js
+++ b/packages/styleguide/src/colours/functional.js
@@ -22,6 +22,7 @@ const functionalColours = {
   secondary: "#696969",
   tertiary: "#4D4D4D",
   transparentBlack: "rgba(0, 0, 0, 0.6)",
+  transparentWhite: "rgba(255, 255, 255, 0.3)",
   white: "#FFFFFF",
   whiteGrey: "#F5F5F5"
 };


### PR DESCRIPTION
[Jira link](https://nidigitalsolutions.jira.com/browse/REPLAT-6594)

Message bar consumed by save and share bar and trigger with click on copy link.
Fixed the component to unmount after 3 seconds.
Styling for all breakpoints applied.

Huge:
<img width="1593" alt="huge-message-bar-render" src="https://user-images.githubusercontent.com/8720661/58628867-7e51fc00-82e3-11e9-8124-5c3230d6b605.png">

Wide:
<img width="1173" alt="wide-message-bar-render" src="https://user-images.githubusercontent.com/8720661/58628883-90339f00-82e3-11e9-9704-6182f7a6e2a0.png">

Medium:
<img width="852" alt="medium-message-bar-render" src="https://user-images.githubusercontent.com/8720661/58628882-8d38ae80-82e3-11e9-814d-b36d3db8dfcd.png">

Small:
<img width="485" alt="small-message-bar-render" src="https://user-images.githubusercontent.com/8720661/58628899-988bda00-82e3-11e9-9bc1-8446795d02e5.png">

