### PR TITLE
Feat Add jsonLD to Helmet on article pages

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -558,6 +558,9 @@ exports[`full article with style 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"
@@ -1295,6 +1298,9 @@ exports[`full article with style in the culture magazine 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"
@@ -2032,6 +2038,9 @@ exports[`full article with style in the style magazine 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"
@@ -2769,6 +2778,9 @@ exports[`full article with style in the sunday times magazine 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"

--- a/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -57,6 +57,11 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div>
     <Ad
@@ -265,6 +270,11 @@ exports[`4. an article with ads 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div>
     <Ad

--- a/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -53,6 +53,11 @@ exports[`1. a full article 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <svg
     height={250}

--- a/packages/article-in-depth/src/article-in-depth.web.js
+++ b/packages/article-in-depth/src/article-in-depth.web.js
@@ -72,7 +72,8 @@ class ArticlePage extends Component {
       isLoading,
       receiveChildList,
       saveApi,
-      spotAccountId
+      spotAccountId,
+      faviconPath
     } = this.props;
 
     if (error || isLoading) {
@@ -88,6 +89,7 @@ class ArticlePage extends Component {
         receiveChildList={receiveChildList}
         saveApi={saveApi}
         spotAccountId={spotAccountId}
+        faviconPath={faviconPath}
       />
     );
   }

--- a/packages/article-in-depth/src/article-in-depth.web.js
+++ b/packages/article-in-depth/src/article-in-depth.web.js
@@ -73,7 +73,7 @@ class ArticlePage extends Component {
       receiveChildList,
       saveApi,
       spotAccountId,
-      faviconPath
+      faviconUrl
     } = this.props;
 
     if (error || isLoading) {
@@ -89,7 +89,7 @@ class ArticlePage extends Component {
         receiveChildList={receiveChildList}
         saveApi={saveApi}
         spotAccountId={spotAccountId}
-        faviconPath={faviconPath}
+        faviconUrl={faviconUrl}
       />
     );
   }

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -552,6 +552,9 @@ exports[`full article with style 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"
@@ -1292,6 +1295,9 @@ exports[`full article with style in the culture magazine 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"
@@ -2032,6 +2038,9 @@ exports[`full article with style in the style magazine 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"
@@ -2772,6 +2781,9 @@ exports[`full article with style in the sunday times magazine 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -57,6 +57,11 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div>
     <Ad
@@ -260,6 +265,11 @@ exports[`4. an article with ads 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div>
     <Ad
@@ -465,6 +475,11 @@ exports[`7. an article with no author 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div>
     <Ad

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -53,6 +53,11 @@ exports[`1. a full article 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <svg
     height={250}

--- a/packages/article-magazine-comment/src/article-magazine-comment.web.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.web.js
@@ -78,7 +78,7 @@ class ArticlePage extends Component {
       saveApi,
       spotAccountId,
       paidContentClassName,
-      faviconPath
+      faviconUrl
     } = this.props;
 
     if (error || isLoading) {
@@ -95,7 +95,7 @@ class ArticlePage extends Component {
         saveApi={saveApi}
         spotAccountId={spotAccountId}
         paidContentClassName={paidContentClassName}
-        faviconPath={faviconPath}
+        faviconUrl={faviconUrl}
       />
     );
   }

--- a/packages/article-magazine-comment/src/article-magazine-comment.web.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.web.js
@@ -77,7 +77,8 @@ class ArticlePage extends Component {
       receiveChildList,
       saveApi,
       spotAccountId,
-      paidContentClassName
+      paidContentClassName,
+      faviconPath
     } = this.props;
 
     if (error || isLoading) {
@@ -94,6 +95,7 @@ class ArticlePage extends Component {
         saveApi={saveApi}
         spotAccountId={spotAccountId}
         paidContentClassName={paidContentClassName}
+        faviconPath={faviconPath}
       />
     );
   }

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -519,6 +519,9 @@ exports[`full article with style 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"
@@ -1204,6 +1207,9 @@ exports[`full article with style in the culture magazine 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"
@@ -1889,6 +1895,9 @@ exports[`full article with style in the style magazine 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"
@@ -2574,6 +2583,9 @@ exports[`full article with style in the sunday times magazine 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -57,6 +57,11 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div>
     <Ad
@@ -255,6 +260,11 @@ exports[`4. an article with ads 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div>
     <Ad

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -53,6 +53,11 @@ exports[`1. a full article 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <svg
     height={250}

--- a/packages/article-magazine-standard/src/article-magazine-standard.web.js
+++ b/packages/article-magazine-standard/src/article-magazine-standard.web.js
@@ -68,7 +68,7 @@ class ArticlePage extends Component {
       saveApi,
       spotAccountId,
       paidContentClassName,
-      faviconPath
+      faviconUrl
     } = this.props;
 
     if (error || isLoading) {
@@ -85,7 +85,7 @@ class ArticlePage extends Component {
         saveApi={saveApi}
         spotAccountId={spotAccountId}
         paidContentClassName={paidContentClassName}
-        faviconPath={faviconPath}
+        faviconUrl={faviconUrl}
       />
     );
   }

--- a/packages/article-magazine-standard/src/article-magazine-standard.web.js
+++ b/packages/article-magazine-standard/src/article-magazine-standard.web.js
@@ -67,7 +67,8 @@ class ArticlePage extends Component {
       receiveChildList,
       saveApi,
       spotAccountId,
-      paidContentClassName
+      paidContentClassName,
+      faviconPath
     } = this.props;
 
     if (error || isLoading) {
@@ -84,6 +85,7 @@ class ArticlePage extends Component {
         saveApi={saveApi}
         spotAccountId={spotAccountId}
         paidContentClassName={paidContentClassName}
+        faviconPath={faviconPath}
       />
     );
   }

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -513,6 +513,9 @@ exports[`full article with style 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -57,6 +57,11 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div>
     <Ad
@@ -247,6 +252,11 @@ exports[`4. an article with ads 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div>
     <Ad

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -53,6 +53,11 @@ exports[`1. a full article 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <svg
     height={250}

--- a/packages/article-main-comment/src/article-main-comment.web.js
+++ b/packages/article-main-comment/src/article-main-comment.web.js
@@ -61,7 +61,8 @@ class ArticlePage extends Component {
       receiveChildList,
       saveApi,
       spotAccountId,
-      paidContentClassName
+      paidContentClassName,
+      faviconPath
     } = this.props;
 
     if (error || isLoading) {
@@ -78,6 +79,7 @@ class ArticlePage extends Component {
         saveApi={saveApi}
         spotAccountId={spotAccountId}
         paidContentClassName={paidContentClassName}
+        faviconPath={faviconPath}
       />
     );
   }

--- a/packages/article-main-comment/src/article-main-comment.web.js
+++ b/packages/article-main-comment/src/article-main-comment.web.js
@@ -62,7 +62,7 @@ class ArticlePage extends Component {
       saveApi,
       spotAccountId,
       paidContentClassName,
-      faviconPath
+      faviconUrl
     } = this.props;
 
     if (error || isLoading) {
@@ -79,7 +79,7 @@ class ArticlePage extends Component {
         saveApi={saveApi}
         spotAccountId={spotAccountId}
         paidContentClassName={paidContentClassName}
-        faviconPath={faviconPath}
+        faviconUrl={faviconUrl}
       />
     );
   }

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -535,6 +535,9 @@ exports[`full article with style 1`] = `
     <meta />
     <meta />
     <meta />
+    <script>
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div
     className="c0 responsiveweb__HeaderAdContainer-sc-1exejum-1 c0 css-view-1dbjc4n"

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -53,6 +53,11 @@ exports[`1. an article 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <div>
     <Ad
@@ -273,6 +278,11 @@ exports[`4. an article with no headline falls back to use shortheadline 1`] = `
       content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
       name="twitter:url"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":null,"caption":null},"thumbnailUrl":null}
+    </script>
   </Helmet>
   <div>
     <Ad
@@ -365,6 +375,11 @@ exports[`5. an article with ads 1`] = `
       content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
       name="twitter:url"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":null,"caption":null},"thumbnailUrl":null}
+    </script>
   </Helmet>
   <div>
     <Ad

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -53,6 +53,11 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       content="https://crop169.io"
       name="twitter:image"
     />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    </script>
   </Helmet>
   <svg
     height={250}

--- a/packages/article-main-standard/src/article-main-standard.web.js
+++ b/packages/article-main-standard/src/article-main-standard.web.js
@@ -78,7 +78,7 @@ class ArticlePage extends Component {
       saveApi,
       spotAccountId,
       paidContentClassName,
-      faviconPath
+      faviconUrl
     } = this.props;
 
     if (error || isLoading) {
@@ -95,7 +95,7 @@ class ArticlePage extends Component {
         saveApi={saveApi}
         spotAccountId={spotAccountId}
         paidContentClassName={paidContentClassName}
-        faviconPath={faviconPath}
+        faviconUrl={faviconUrl}
       />
     );
   }

--- a/packages/article-main-standard/src/article-main-standard.web.js
+++ b/packages/article-main-standard/src/article-main-standard.web.js
@@ -77,7 +77,8 @@ class ArticlePage extends Component {
       receiveChildList,
       saveApi,
       spotAccountId,
-      paidContentClassName
+      paidContentClassName,
+      faviconPath
     } = this.props;
 
     if (error || isLoading) {
@@ -94,6 +95,7 @@ class ArticlePage extends Component {
         saveApi={saveApi}
         spotAccountId={spotAccountId}
         paidContentClassName={paidContentClassName}
+        faviconPath={faviconPath}
       />
     );
   }

--- a/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
@@ -64,6 +64,11 @@ exports[`Head outputs correct metadata 1`] = `
     content="https://crop169.io"
     name="twitter:image"
   />
+  <script
+    type="application/ld+json"
+  >
+    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","logo":"https://www.thetimes.co.uk/d/img/icons/icon_1_5x-a13ee0bf9a.png","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+  </script>
 </Helmet>
 `;
 

--- a/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
@@ -67,7 +67,7 @@ exports[`Head outputs correct metadata 1`] = `
   <script
     type="application/ld+json"
   >
-    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","logo":"https://www.thetimes.co.ukfavicon/path","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","logo":"https://www.thetimes.co.uk/d/img/icons/favicon.ico","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
   </script>
 </Helmet>
 `;

--- a/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
@@ -67,7 +67,7 @@ exports[`Head outputs correct metadata 1`] = `
   <script
     type="application/ld+json"
   >
-    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","logo":"https://www.thetimes.co.ukundefined","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","logo":"https://www.thetimes.co.ukfavicon/path","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
   </script>
 </Helmet>
 `;

--- a/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
@@ -67,7 +67,7 @@ exports[`Head outputs correct metadata 1`] = `
   <script
     type="application/ld+json"
   >
-    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","logo":"https://www.thetimes.co.uk/d/img/icons/icon_1_5x-a13ee0bf9a.png","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","logo":"https://www.thetimes.co.ukundefined","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
   </script>
 </Helmet>
 `;

--- a/packages/article-skeleton/__tests__/web/head.web.test.js
+++ b/packages/article-skeleton/__tests__/web/head.web.test.js
@@ -34,11 +34,12 @@ addSerializers(
 
 const article = articleFixture({ ...testFixture });
 const paidContentClassName = "class-name";
+const faviconPath = 'favicon/path'
 
 describe("Head", () => {
   it("outputs correct metadata", () => {
     const testRenderer = TestRenderer.create(
-      <Head article={article} paidContentClassName={paidContentClassName} />
+      <Head article={article} paidContentClassName={paidContentClassName} faviconPath={faviconPath} />
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-skeleton/__tests__/web/head.web.test.js
+++ b/packages/article-skeleton/__tests__/web/head.web.test.js
@@ -34,7 +34,7 @@ addSerializers(
 
 const article = articleFixture({ ...testFixture });
 const paidContentClassName = "class-name";
-const faviconPath = "favicon/path";
+const faviconUrl = "https://www.thetimes.co.uk/d/img/icons/favicon.ico";
 
 describe("Head", () => {
   it("outputs correct metadata", () => {
@@ -42,7 +42,7 @@ describe("Head", () => {
       <Head
         article={article}
         paidContentClassName={paidContentClassName}
-        faviconPath={faviconPath}
+        faviconUrl={faviconUrl}
       />
     );
 

--- a/packages/article-skeleton/__tests__/web/head.web.test.js
+++ b/packages/article-skeleton/__tests__/web/head.web.test.js
@@ -33,10 +33,13 @@ addSerializers(
 );
 
 const article = articleFixture({ ...testFixture });
+const paidContentClassName = "class-name";
 
 describe("Head", () => {
   it("outputs correct metadata", () => {
-    const testRenderer = TestRenderer.create(<Head article={article} />);
+    const testRenderer = TestRenderer.create(
+      <Head article={article} paidContentClassName={paidContentClassName} />
+    );
 
     expect(testRenderer).toMatchSnapshot();
   });

--- a/packages/article-skeleton/__tests__/web/head.web.test.js
+++ b/packages/article-skeleton/__tests__/web/head.web.test.js
@@ -34,12 +34,16 @@ addSerializers(
 
 const article = articleFixture({ ...testFixture });
 const paidContentClassName = "class-name";
-const faviconPath = 'favicon/path'
+const faviconPath = "favicon/path";
 
 describe("Head", () => {
   it("outputs correct metadata", () => {
     const testRenderer = TestRenderer.create(
-      <Head article={article} paidContentClassName={paidContentClassName} faviconPath={faviconPath} />
+      <Head
+        article={article}
+        paidContentClassName={paidContentClassName}
+        faviconPath={faviconPath}
+      />
     );
 
     expect(testRenderer).toMatchSnapshot();

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -52,7 +52,8 @@ class ArticleSkeleton extends Component {
       receiveChildList,
       saveApi,
       spotAccountId,
-      paidContentClassName
+      paidContentClassName,
+      faviconPath
     } = this.props;
 
     const {
@@ -106,6 +107,7 @@ class ArticleSkeleton extends Component {
                 <Head
                   article={article}
                   paidContentClassName={paidContentClassName}
+                  faviconPath={faviconPath}
                 />
                 <AdComposer adConfig={adConfig}>
                   <LazyLoad rootMargin={spacing(10)} threshold={0.5}>

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -103,7 +103,10 @@ class ArticleSkeleton extends Component {
 
             return (
               <Fragment>
-                <Head article={article} />
+                <Head
+                  article={article}
+                  paidContentClassName={paidContentClassName}
+                />
                 <AdComposer adConfig={adConfig}>
                   <LazyLoad rootMargin={spacing(10)} threshold={0.5}>
                     {({ observed, registerNode }) => (

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -53,7 +53,7 @@ class ArticleSkeleton extends Component {
       saveApi,
       spotAccountId,
       paidContentClassName,
-      faviconPath
+      faviconUrl
     } = this.props;
 
     const {
@@ -107,7 +107,7 @@ class ArticleSkeleton extends Component {
                 <Head
                   article={article}
                   paidContentClassName={paidContentClassName}
-                  faviconPath={faviconPath}
+                  faviconUrl={faviconUrl}
                 />
                 <AdComposer adConfig={adConfig}>
                   <LazyLoad rootMargin={spacing(10)} threshold={0.5}>

--- a/packages/article-skeleton/src/head.web.js
+++ b/packages/article-skeleton/src/head.web.js
@@ -5,6 +5,9 @@ import PropTypes from "prop-types";
 import Context from "@times-components/context";
 import { renderTreeAsText } from "@times-components/markup-forest";
 
+const FAVICON_URL =
+  "https://www.thetimes.co.uk/d/img/icons/icon_1_5x-a13ee0bf9a.png";
+
 // Get the section for an article, preferring it not to be News
 function getSectionName(article) {
   const { tiles } = article;
@@ -56,14 +59,39 @@ const PUBLICATION_NAMES = {
   TIMES: "The Times"
 };
 
-function Head({ article }) {
+const getThumbnailUrlFromVideo = article =>
+  get(article.leadAsset.posterImage, "crop169.url", null);
+
+const getThumbnailUrlFromImage = article => {
+  const tileUrl =
+    article.tiles &&
+    article.tiles.find(tile => get(tile.leadAsset, "crop169.url", null));
+
+  if (tileUrl) {
+    return tileUrl;
+  }
+
+  const listingAssetUrl = get(article.listingAsset, "crop169.url", null);
+
+  if (listingAssetUrl) {
+    return listingAssetUrl;
+  }
+
+  return get(article.leadAsset, "crop169.url", null);
+};
+
+function Head({ article, paidContentClassName }) {
   const {
     descriptionMarkup,
     headline,
     leadAsset,
     publicationName,
-    shortHeadline
+    shortHeadline,
+    publishedTime,
+    updatedTime,
+    hasVideo
   } = article;
+
   const publication = PUBLICATION_NAMES[publicationName];
   const authorName = getAuthorAsText(article);
   const desc =
@@ -72,34 +100,79 @@ function Head({ article }) {
       : null;
   const sectionname = getSectionName(article);
   const leadassetUrl = get(leadAsset, "crop169.url", null);
+  const caption = get(leadAsset, "caption", null);
   const title = headline || shortHeadline;
+  const datePublished = new Date(publishedTime).toISOString().split("T")[0];
+  const thumbnailUrl = hasVideo
+    ? getThumbnailUrlFromVideo(article)
+    : getThumbnailUrlFromImage(article);
+
+  const jsonLD = {
+    "@context": "http://schema.org",
+    "@type": "NewsArticle",
+    headline: title,
+    logo: FAVICON_URL,
+    publisher: {
+      "@type": "Organization",
+      name: publication
+    },
+    mainEntityOfPage: {
+      "@type": "WebPage"
+    },
+    dateCreated: publishedTime,
+    datePublished,
+    isAccessibleForFree: false,
+    hasPart: {
+      "@type": "WebPageElement",
+      isAccessibleForFree: false,
+      cssSelector: `.${paidContentClassName}`
+    },
+    image: {
+      "@type": "ImageObject",
+      url: leadassetUrl,
+      caption
+    },
+    thumbnailUrl
+  };
+
+  if (updatedTime) {
+    jsonLD.dateUpdated = updatedTime;
+  }
 
   return (
     <Context.Consumer>
-      {({ makeArticleUrl }) => (
-        <Helmet>
-          <title>
-            {title} | {sectionname ? `${sectionname} | ` : ""}
-            {publication}
-          </title>
-          <meta content={title} name="article:title" />
-          <meta content={publication} name="article:publication" />
-          {desc && <meta content={desc} name="description" />}
-          {authorName && <meta content={authorName} name="author" />}
+      {({ makeArticleUrl }) => {
+        jsonLD.mainEntityOfPage["@id"] = makeArticleUrl(article);
+        return (
+          <Helmet>
+            <title>
+              {title} | {sectionname ? `${sectionname} | ` : ""}
+              {publication}
+            </title>
+            <meta content={title} name="article:title" />
+            <meta content={publication} name="article:publication" />
+            {desc && <meta content={desc} name="description" />}
+            {authorName && <meta content={authorName} name="author" />}
 
-          <meta content={title} property="og:title" />
-          <meta content="article" property="og:type" />
-          <meta content={makeArticleUrl(article)} property="og:url" />
-          {desc && <meta content={desc} property="og:description" />}
-          {leadassetUrl && <meta content={leadassetUrl} property="og:image" />}
+            <meta content={title} property="og:title" />
+            <meta content="article" property="og:type" />
+            <meta content={makeArticleUrl(article)} property="og:url" />
+            {desc && <meta content={desc} property="og:description" />}
+            {leadassetUrl && (
+              <meta content={leadassetUrl} property="og:image" />
+            )}
 
-          <meta content={title} name="twitter:title" />
-          <meta content="summary_large_image" name="twitter:card" />
-          <meta content={makeArticleUrl(article)} name="twitter:url" />
-          {desc && <meta content={desc} name="twitter:description" />}
-          {leadassetUrl && <meta content={leadassetUrl} name="twitter:image" />}
-        </Helmet>
-      )}
+            <meta content={title} name="twitter:title" />
+            <meta content="summary_large_image" name="twitter:card" />
+            <meta content={makeArticleUrl(article)} name="twitter:url" />
+            {desc && <meta content={desc} name="twitter:description" />}
+            {leadassetUrl && (
+              <meta content={leadassetUrl} name="twitter:image" />
+            )}
+            <script type="application/ld+json">{JSON.stringify(jsonLD)}</script>
+          </Helmet>
+        );
+      }}
     </Context.Consumer>
   );
 }
@@ -115,7 +188,8 @@ Head.propTypes = {
     shortHeadline: PropTypes.string,
     shortIdentifier: PropTypes.string.isRequired,
     tiles: PropTypes.array
-  }).isRequired
+  }).isRequired,
+  paidContentClassName: PropTypes.string.isRequired
 };
 
 export default Head;

--- a/packages/article-skeleton/src/head.web.js
+++ b/packages/article-skeleton/src/head.web.js
@@ -5,8 +5,6 @@ import PropTypes from "prop-types";
 import Context from "@times-components/context";
 import { renderTreeAsText } from "@times-components/markup-forest";
 
-const DOMAIN = "https://www.thetimes.co.uk";
-
 // Get the section for an article, preferring it not to be News
 function getSectionName(article) {
   const { tiles } = article;
@@ -79,7 +77,7 @@ const getThumbnailUrlFromImage = article => {
   return get(article.leadAsset, "crop169.url", null);
 };
 
-function Head({ article, paidContentClassName, faviconPath }) {
+function Head({ article, paidContentClassName, faviconUrl }) {
   const {
     descriptionMarkup,
     headline,
@@ -110,7 +108,7 @@ function Head({ article, paidContentClassName, faviconPath }) {
     "@context": "http://schema.org",
     "@type": "NewsArticle",
     headline: title,
-    logo: `${DOMAIN}${faviconPath}`,
+    logo: faviconUrl,
     publisher: {
       "@type": "Organization",
       name: publication
@@ -189,7 +187,7 @@ Head.propTypes = {
     tiles: PropTypes.array
   }).isRequired,
   paidContentClassName: PropTypes.string.isRequired,
-  faviconPath: PropTypes.string.isRequired
+  faviconUrl: PropTypes.string.isRequired
 };
 
 export default Head;

--- a/packages/article-skeleton/src/head.web.js
+++ b/packages/article-skeleton/src/head.web.js
@@ -5,8 +5,7 @@ import PropTypes from "prop-types";
 import Context from "@times-components/context";
 import { renderTreeAsText } from "@times-components/markup-forest";
 
-const FAVICON_URL =
-  "https://www.thetimes.co.uk/d/img/icons/icon_1_5x-a13ee0bf9a.png";
+const DOMAIN = "https://www.thetimes.co.uk";
 
 // Get the section for an article, preferring it not to be News
 function getSectionName(article) {
@@ -80,7 +79,7 @@ const getThumbnailUrlFromImage = article => {
   return get(article.leadAsset, "crop169.url", null);
 };
 
-function Head({ article, paidContentClassName }) {
+function Head({ article, paidContentClassName, faviconPath }) {
   const {
     descriptionMarkup,
     headline,
@@ -111,7 +110,7 @@ function Head({ article, paidContentClassName }) {
     "@context": "http://schema.org",
     "@type": "NewsArticle",
     headline: title,
-    logo: FAVICON_URL,
+    logo: `${DOMAIN}${faviconPath}`,
     publisher: {
       "@type": "Organization",
       name: publication
@@ -189,7 +188,8 @@ Head.propTypes = {
     shortIdentifier: PropTypes.string.isRequired,
     tiles: PropTypes.array
   }).isRequired,
-  paidContentClassName: PropTypes.string.isRequired
+  paidContentClassName: PropTypes.string.isRequired,
+  faviconPath: PropTypes.string.isRequired
 };
 
 export default Head;

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -31,6 +31,7 @@ const Article = props => {
   }
 
   const Component = templates[template] || ArticleMainStandard;
+
   return (
     <Responsive>
       <MessageManager animate delay={3000} scale={scales.medium}>

--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -25,7 +25,7 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
     getCookieValue,
     userState,
     paidContentClassName,
-    faviconPath
+    faviconUrl
   } = data;
 
   return React.createElement(
@@ -73,7 +73,7 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
                 refetch,
                 spotAccountId,
                 paidContentClassName,
-                faviconPath
+                faviconUrl
               })
             )
         )

--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -24,7 +24,8 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
     spotAccountId,
     getCookieValue,
     userState,
-    paidContentClassName
+    paidContentClassName,
+    faviconPath
   } = data;
 
   return React.createElement(
@@ -71,7 +72,8 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
                 onTopicPress: () => {},
                 refetch,
                 spotAccountId,
-                paidContentClassName
+                paidContentClassName,
+                faviconPath
               })
             )
         )

--- a/packages/ssr/src/lib/run-server.js
+++ b/packages/ssr/src/lib/run-server.js
@@ -60,7 +60,7 @@ const renderData = (app, helmetContext = {}) =>
 
     const { helmet } = helmetContext;
     const headMarkup = helmet
-      ? ["title", "meta", "link"].reduce(
+      ? ["title", "meta", "link", "script"].reduce(
           (head, key) => head + helmet[key].toString(),
           ""
         )

--- a/packages/ssr/src/server/article.js
+++ b/packages/ssr/src/server/article.js
@@ -13,7 +13,7 @@ module.exports = (
     makeTopicUrl,
     spotAccountId,
     paidContentClassName,
-    faviconPath
+    faviconUrl
   },
   userState
 ) => {
@@ -57,7 +57,7 @@ module.exports = (
       spotAccountId,
       userState,
       paidContentClassName,
-      faviconPath
+      faviconUrl
     },
     name: "article"
   };

--- a/packages/ssr/src/server/article.js
+++ b/packages/ssr/src/server/article.js
@@ -12,7 +12,8 @@ module.exports = (
     makeArticleUrl,
     makeTopicUrl,
     spotAccountId,
-    paidContentClassName
+    paidContentClassName,
+    faviconPath
   },
   userState
 ) => {
@@ -55,7 +56,8 @@ module.exports = (
       mapArticleToAdConfig: defaultAdConfig,
       spotAccountId,
       userState,
-      paidContentClassName
+      paidContentClassName,
+      faviconPath
     },
     name: "article"
   };


### PR DESCRIPTION
Json LD is removed from render and added to TC. This is done, because we need to add some data from TPA to json LD in order to improve the SEO.

Render PR: https://github.com/newsuk/cps-content-render/pull/2759