### PR TITLE
Fix/360 video react article

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -502,6 +502,8 @@ exports[`full article with style 1`] = `
 }
 
 .IS9 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 
@@ -1237,6 +1239,8 @@ exports[`full article with style in the culture magazine 1`] = `
 }
 
 .IS9 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 
@@ -1972,6 +1976,8 @@ exports[`full article with style in the style magazine 1`] = `
 }
 
 .IS9 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 
@@ -2707,6 +2713,8 @@ exports[`full article with style in the sunday times magazine 1`] = `
 }
 
 .IS9 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 

--- a/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -273,7 +273,7 @@ exports[`1. a full article 1`] = `
       data-embed="default"
       data-player="default"
       data-video-id="4084164751001"
-      id="4084164751001-57838016001-1"
+      id="4084164751001-57838016001-3dbfe6b8-680b-11e9-b277-88f3d445182c"
       poster="https://image.io"
     />
     <figcaption>

--- a/packages/article-in-depth/__tests__/web/semantic.web.test.js
+++ b/packages/article-in-depth/__tests__/web/semantic.web.test.js
@@ -109,9 +109,12 @@ const tests = [
           },
           {
             attributes: {
+              id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+              is360: false,
               brightcoveAccountId: "57838016001",
               brightcovePolicyKey: "1.2.3.4",
               brightcoveVideoId: "4084164751001",
+              brightcovePlayerId: "default",
               caption: "This is video caption",
               display: "primary",
               paidOnly: "false",

--- a/packages/article-in-depth/fixtures/full-article.js
+++ b/packages/article-in-depth/fixtures/full-article.js
@@ -658,9 +658,12 @@ export const videoLeadAsset = ({
   brightcovePolicyKey = defaultBrightcovePolicyKey
 } = {}) => ({
   __typename: "Video",
+  id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+  is360: false,
   brightcoveAccountId: "5436121857001",
   brightcovePolicyKey,
   brightcoveVideoId: "5831024132001",
+  brightcovePlayerId: "default",
   caption: "This is video caption",
   paidOnly: "false",
   posterImage: {

--- a/packages/article-lead-asset/__tests__/shared.base.js
+++ b/packages/article-lead-asset/__tests__/shared.base.js
@@ -47,9 +47,12 @@ const videoProps = {
   ...props,
   isVideo: true,
   leadAsset: {
+    id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    is360: false,
     brightcoveAccountId: "1234",
     brightcovePolicyKey: "policyKey",
     brightcoveVideoId: "5678",
+    brightcovePlayerId: "3456",
     posterImage: imageLeadAsset
   },
   onVideoPress() {}

--- a/packages/article-lead-asset/__tests__/web/__snapshots__/article-lead-asset.test.js.snap
+++ b/packages/article-lead-asset/__tests__/web/__snapshots__/article-lead-asset.test.js.snap
@@ -87,6 +87,9 @@ exports[`2. renders correctly with a video lead asset 1`] = `
         <Video
           accountId="1234"
           height="100%"
+          id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+          is360={false}
+          playerId="3456"
           policyKey="policyKey"
           position="absolute"
           poster={

--- a/packages/article-lead-asset/src/article-lead-asset.web.js
+++ b/packages/article-lead-asset/src/article-lead-asset.web.js
@@ -31,7 +31,10 @@ const ArticleLeadAsset = ({
     <Video
       accountId={leadAsset.brightcoveAccountId}
       height="100%"
+      id={leadAsset.id}
+      is360={leadAsset.is360}
       paidOnly={leadAsset.paidOnly}
+      playerId={leadAsset.brightcovePlayerId}
       policyKey={leadAsset.brightcovePolicyKey}
       position="absolute"
       poster={{ uri: displayImage.url }}

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -496,6 +496,8 @@ exports[`full article with style 1`] = `
 }
 
 .IS7 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 
@@ -1234,6 +1236,8 @@ exports[`full article with style in the culture magazine 1`] = `
 }
 
 .IS9 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 
@@ -1972,6 +1976,8 @@ exports[`full article with style in the style magazine 1`] = `
 }
 
 .IS9 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 
@@ -2710,6 +2716,8 @@ exports[`full article with style in the sunday times magazine 1`] = `
 }
 
 .IS9 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -290,7 +290,7 @@ exports[`1. a full article 1`] = `
       data-embed="default"
       data-player="default"
       data-video-id="4084164751001"
-      id="4084164751001-57838016001-1"
+      id="4084164751001-57838016001-3dbfe6b8-680b-11e9-b277-88f3d445182c"
       poster="https://image.io"
     />
     <figcaption>

--- a/packages/article-magazine-comment/__tests__/web/semantic.web.test.js
+++ b/packages/article-magazine-comment/__tests__/web/semantic.web.test.js
@@ -109,9 +109,12 @@ const tests = [
           },
           {
             attributes: {
+              id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+              is360: false,
               brightcoveAccountId: "57838016001",
               brightcovePolicyKey: "1.2.3.4",
               brightcoveVideoId: "4084164751001",
+              brightcovePlayerId: "default",
               caption: "This is video caption",
               display: "primary",
               paidOnly: "false",

--- a/packages/article-magazine-comment/fixtures/full-article.js
+++ b/packages/article-magazine-comment/fixtures/full-article.js
@@ -647,9 +647,12 @@ export const videoLeadAsset = ({
   brightcovePolicyKey = defaultBrightcovePolicyKey
 } = {}) => ({
   __typename: "Video",
+  id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+  is360: false,
   brightcoveAccountId: "5436121857001",
   brightcovePolicyKey,
   brightcoveVideoId: "5831024132001",
+  brightcovePlayerId: "default",
   caption: "This is video caption",
   paidOnly: "false",
   posterImage: {

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -463,6 +463,8 @@ exports[`full article with style 1`] = `
 }
 
 .IS5 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 
@@ -1146,6 +1148,8 @@ exports[`full article with style in the culture magazine 1`] = `
 }
 
 .IS7 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 
@@ -1829,6 +1833,8 @@ exports[`full article with style in the style magazine 1`] = `
 }
 
 .IS7 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 
@@ -2512,6 +2518,8 @@ exports[`full article with style in the sunday times magazine 1`] = `
 }
 
 .IS7 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -274,7 +274,7 @@ exports[`1. a full article 1`] = `
       data-embed="default"
       data-player="default"
       data-video-id="4084164751001"
-      id="4084164751001-57838016001-1"
+      id="4084164751001-57838016001-3dbfe6b8-680b-11e9-b277-88f3d445182c"
       poster="https://image.io"
     />
     <figcaption>

--- a/packages/article-magazine-standard/__tests__/web/semantic.web.test.js
+++ b/packages/article-magazine-standard/__tests__/web/semantic.web.test.js
@@ -109,9 +109,12 @@ const tests = [
           },
           {
             attributes: {
+              id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+              is360: false,
               brightcoveAccountId: "57838016001",
               brightcovePolicyKey: "1.2.3.4",
               brightcoveVideoId: "4084164751001",
+              brightcovePlayerId: "default",
               caption: "This is video caption",
               display: "primary",
               paidOnly: "false",

--- a/packages/article-magazine-standard/fixtures/full-article.js
+++ b/packages/article-magazine-standard/fixtures/full-article.js
@@ -647,9 +647,12 @@ export const videoLeadAsset = ({
   brightcovePolicyKey = defaultBrightcovePolicyKey
 } = {}) => ({
   __typename: "Video",
+  id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+  is360: false,
   brightcoveAccountId: "5436121857001",
   brightcovePolicyKey,
   brightcoveVideoId: "5831024132001",
+  brightcovePlayerId: "default",
   caption: "This is video caption",
   paidOnly: "false",
   posterImage: {

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -457,6 +457,8 @@ exports[`full article with style 1`] = `
 }
 
 .IS4 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -269,7 +269,7 @@ exports[`1. a full article 1`] = `
       data-embed="default"
       data-player="default"
       data-video-id="4084164751001"
-      id="4084164751001-57838016001-1"
+      id="4084164751001-57838016001-3dbfe6b8-680b-11e9-b277-88f3d445182c"
       poster="https://image.io"
     />
     <figcaption>

--- a/packages/article-main-comment/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-comment/__tests__/web/semantic.web.test.js
@@ -109,9 +109,12 @@ const tests = [
           },
           {
             attributes: {
+              id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+              is360: false,
               brightcoveAccountId: "57838016001",
               brightcovePolicyKey: "1.2.3.4",
               brightcoveVideoId: "4084164751001",
+              brightcovePlayerId: "default",
               caption: "This is video caption",
               display: "primary",
               paidOnly: "false",

--- a/packages/article-main-comment/fixtures/full-article.js
+++ b/packages/article-main-comment/fixtures/full-article.js
@@ -647,9 +647,12 @@ export const videoLeadAsset = ({
   brightcovePolicyKey = defaultBrightcovePolicyKey
 } = {}) => ({
   __typename: "Video",
+  id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+  is360: false,
   brightcoveAccountId: "5436121857001",
   brightcovePolicyKey,
   brightcoveVideoId: "5831024132001",
+  brightcovePlayerId: "default",
   caption: "This is video caption",
   paidOnly: "false",
   posterImage: {

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -479,6 +479,8 @@ exports[`full article with style 1`] = `
 }
 
 .IS5 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -287,7 +287,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       data-embed="default"
       data-player="default"
       data-video-id="4084164751001"
-      id="4084164751001-57838016001-1"
+      id="4084164751001-57838016001-3dbfe6b8-680b-11e9-b277-88f3d445182c"
       poster="https://image.io"
     />
     <figcaption>

--- a/packages/article-main-standard/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-standard/__tests__/web/semantic.web.test.js
@@ -109,9 +109,12 @@ const tests = [
           },
           {
             attributes: {
+              id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+              is360: false,
               brightcoveAccountId: "57838016001",
               brightcovePolicyKey: "1.2.3.4",
               brightcoveVideoId: "4084164751001",
+              brightcovePlayerId: "default",
               caption: "This is video caption",
               display: "primary",
               paidOnly: "false",

--- a/packages/article-main-standard/fixtures/full-article.js
+++ b/packages/article-main-standard/fixtures/full-article.js
@@ -647,9 +647,12 @@ export const videoLeadAsset = ({
   brightcovePolicyKey = defaultBrightcovePolicyKey
 } = {}) => ({
   __typename: "Video",
+  id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+  is360: false,
   brightcoveAccountId: "5436121857001",
   brightcovePolicyKey,
   brightcoveVideoId: "5831024132001",
+  brightcovePlayerId: "default",
   caption: "This is video caption",
   paidOnly: "false",
   posterImage: {

--- a/packages/article-skeleton/__tests__/shared.base.js
+++ b/packages/article-skeleton/__tests__/shared.base.js
@@ -156,9 +156,12 @@ export const fixtureArgs = {
     },
     {
       attributes: {
+        id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+        is360: false,
         brightcoveAccountId: "57838016001",
         brightcovePolicyKey: "1.2.3.4",
         brightcoveVideoId: "4084164751001",
+        brightcovePlayerId: "default",
         caption: "This is video caption",
         display: "primary",
         imageIndex: 4,

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -328,6 +328,8 @@ exports[`full article with style 1`] = `
 }
 
 .IS5 {
+  height: 100%;
+  width: 100%;
   position: relative;
 }
 

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-user-state.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-user-state.web.test.js.snap
@@ -264,7 +264,7 @@ exports[`Article with user state Render Metered expired article when user is log
                       data-embed="default"
                       data-player="default"
                       data-video-id="4084164751001"
-                      id="4084164751001-57838016001-4"
+                      id="4084164751001-57838016001-3dbfe6b8-680b-11e9-b277-88f3d445182c"
                       poster="https://image.io"
                     />
                   </div>
@@ -718,7 +718,7 @@ exports[`Article with user state Render full article when user is logged in 1`] 
                       data-embed="default"
                       data-player="default"
                       data-video-id="4084164751001"
-                      id="4084164751001-57838016001-1"
+                      id="4084164751001-57838016001-3dbfe6b8-680b-11e9-b277-88f3d445182c"
                       poster="https://image.io"
                     />
                   </div>
@@ -1043,7 +1043,7 @@ exports[`Article with user state Render teaser article when user is not logged i
                       data-embed="default"
                       data-player="default"
                       data-video-id="4084164751001"
-                      id="4084164751001-57838016001-2"
+                      id="4084164751001-57838016001-3dbfe6b8-680b-11e9-b277-88f3d445182c"
                       poster="https://image.io"
                     />
                   </div>
@@ -1368,7 +1368,7 @@ exports[`Article with user state Render teaser article when user is null 1`] = `
                       data-embed="default"
                       data-player="default"
                       data-video-id="4084164751001"
-                      id="4084164751001-57838016001-3"
+                      id="4084164751001-57838016001-3dbfe6b8-680b-11e9-b277-88f3d445182c"
                       poster="https://image.io"
                     />
                   </div>

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -154,7 +154,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     data-embed="default"
                     data-player="default"
                     data-video-id="4084164751001"
-                    id="4084164751001-57838016001-1"
+                    id="4084164751001-57838016001-3dbfe6b8-680b-11e9-b277-88f3d445182c"
                     poster="https://image.io"
                   />
                 </div>

--- a/packages/article-skeleton/__tests__/web/article-with-user-state.web.test.js
+++ b/packages/article-skeleton/__tests__/web/article-with-user-state.web.test.js
@@ -159,9 +159,12 @@ const article = articleFixture({
         },
         {
           attributes: {
+            id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+            is360: false,
             brightcoveAccountId: "57838016001",
             brightcovePolicyKey: "1.2.3.4",
             brightcoveVideoId: "4084164751001",
+            brightcovePlayerId: "default",
             caption: "This is video caption",
             display: "primary",
             paidOnly: "false",

--- a/packages/article-skeleton/fixtures/full-article-content.js
+++ b/packages/article-skeleton/fixtures/full-article-content.js
@@ -194,9 +194,12 @@ export default [
   },
   {
     attributes: {
+      id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+      is360: false,
       brightcoveAccountId: "5436121857001",
       brightcovePolicyKey: "1.2.3.4",
       brightcoveVideoId: "5831024132001",
+      brightcovePlayerId: "default",
       caption: "This is video caption",
       display: "primary",
       imageIndex: 1,

--- a/packages/article-skeleton/fixtures/full-article-content.web.js
+++ b/packages/article-skeleton/fixtures/full-article-content.web.js
@@ -196,9 +196,12 @@ export default [
       },
       {
         attributes: {
+          id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+          is360: false,
           brightcoveAccountId: "5436121857001",
           brightcovePolicyKey: "1.2.3.4",
           brightcoveVideoId: "5831024132001",
+          brightcovePlayerId: "default",
           caption: "This is video caption",
           display: "primary",
           paidOnly: "false",

--- a/packages/article-skeleton/fixtures/full-article.js
+++ b/packages/article-skeleton/fixtures/full-article.js
@@ -649,9 +649,12 @@ export const videoLeadAsset = ({
   brightcovePolicyKey = defaultBrightcovePolicyKey
 } = {}) => ({
   __typename: "Video",
+  id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+  is360: false,
   brightcoveAccountId: "5436121857001",
   brightcovePolicyKey,
   brightcoveVideoId: "5831024132001",
+  brightcovePlayerId: "default",
   caption: "This is video caption",
   paidOnly: "false",
   posterImage: {

--- a/packages/article-skeleton/src/article-body/article-body.web.js
+++ b/packages/article-skeleton/src/article-body/article-body.web.js
@@ -169,9 +169,12 @@ const renderers = ({ observed, registerNode }) => ({
   video(
     key,
     {
+      id,
+      is360,
       brightcovePolicyKey,
       brightcoveVideoId,
       brightcoveAccountId,
+      brightcovePlayerId,
       caption,
       posterImageUrl,
       skysports
@@ -184,8 +187,11 @@ const renderers = ({ observed, registerNode }) => ({
           <figure style={{ margin: 0 }}>
             <AspectRatioContainer aspectRatio="16:9">
               <Video
+                id={id}
+                is360={is360}
                 accountId={brightcoveAccountId}
                 height="100%"
+                playerId={brightcovePlayerId}
                 policyKey={brightcovePolicyKey}
                 poster={{ uri: posterImageUrl }}
                 skySports={skysports}

--- a/packages/article/fixtures/full-article.js
+++ b/packages/article/fixtures/full-article.js
@@ -647,9 +647,12 @@ export const videoLeadAsset = ({
   brightcovePolicyKey = defaultBrightcovePolicyKey
 } = {}) => ({
   __typename: "Video",
+  id: "3dbfe6b8-680b-11e9-b277-88f3d445182c",
+  is360: false,
   brightcoveAccountId: "5436121857001",
   brightcovePolicyKey,
   brightcoveVideoId: "5831024132001",
+  brightcovePlayerId: "default",
   caption: "This is video caption",
   paidOnly: "false",
   posterImage: {

--- a/packages/provider-queries/src/article.web.js
+++ b/packages/provider-queries/src/article.web.js
@@ -23,13 +23,16 @@ export default addTypenameToDocument(gql`
       keywords
       leadAsset {
         ... on Video {
+          id
           brightcoveAccountId
           brightcovePolicyKey
           brightcoveVideoId
+          brightcovePlayerId
           posterImage {
             ...imageProps
           }
           skySports
+          is360
         }
         ... on Image {
           ...imageProps

--- a/packages/video/__tests__/default-video-props.js
+++ b/packages/video/__tests__/default-video-props.js
@@ -1,6 +1,8 @@
 const videoProps = {
   accountId: "[account id]",
   height: 200,
+  id: "[tpa video id]",
+  is360: false,
   onVideoPress: () => {},
   paidOnly: false,
   playerId: "default",

--- a/packages/video/__tests__/web/__snapshots__/video-with-data-attributes.web.test.js.snap
+++ b/packages/video/__tests__/web/__snapshots__/video-with-data-attributes.web.test.js.snap
@@ -16,3 +16,26 @@ exports[`1. video with data attributes 1`] = `
   </div>
 </div>
 `;
+
+exports[`2. 360 video with data attributes 1`] = `
+<div
+  data-is-360={true}
+  data-testid="video-component"
+>
+  <div>
+    <div>
+      <IconVideo360Player
+        fillColour="#FFFFFF"
+        height={100}
+      />
+    </div>
+    <video
+      data-account="[account id]"
+      data-application-id={true}
+      data-embed="default"
+      data-player="default"
+      data-video-id="[video id]"
+    />
+  </div>
+</div>
+`;

--- a/packages/video/__tests__/web/__snapshots__/video-with-provider.web.test.js.snap
+++ b/packages/video/__tests__/web/__snapshots__/video-with-provider.web.test.js.snap
@@ -19,7 +19,7 @@ exports[`2. paidonly video for paid users 1`] = `
   <div>
     <video
       controls={true}
-      id="[video id]-[account id]-1"
+      id="[video id]-[account id]-[tpa video id]"
       poster="fa3ca0da118e3184f45765fbc02fb72f"
     />
   </div>
@@ -31,7 +31,7 @@ exports[`3. non-paidonly video for unpaid users 1`] = `
   <div>
     <video
       controls={true}
-      id="[video id]-[account id]-2"
+      id="[video id]-[account id]-[tpa video id]"
       poster="fa3ca0da118e3184f45765fbc02fb72f"
     />
   </div>
@@ -43,7 +43,7 @@ exports[`4. non-paidonly video for paid users 1`] = `
   <div>
     <video
       controls={true}
-      id="[video id]-[account id]-3"
+      id="[video id]-[account id]-[tpa video id]"
       poster="fa3ca0da118e3184f45765fbc02fb72f"
     />
   </div>
@@ -55,7 +55,7 @@ exports[`5. video without a poster image 1`] = `
   <div>
     <video
       controls={true}
-      id="[video id]-[account id]-4"
+      id="[video id]-[account id]-[tpa video id]"
     />
   </div>
 </div>

--- a/packages/video/__tests__/web/__snapshots__/video-with-style.web.test.js.snap
+++ b/packages/video/__tests__/web/__snapshots__/video-with-style.web.test.js.snap
@@ -12,7 +12,9 @@ exports[`1. video marked as sky sports 1`] = `
   <div
     style={
       Object {
+        "height": 200,
         "position": "relative",
+        "width": 300,
       }
     }
   >
@@ -61,7 +63,9 @@ exports[`2. 360 video 1`] = `
   <div
     style={
       Object {
+        "height": 200,
         "position": "relative",
+        "width": 300,
       }
     }
   >

--- a/packages/video/__tests__/web/__snapshots__/video.web.test.js.snap
+++ b/packages/video/__tests__/web/__snapshots__/video.web.test.js.snap
@@ -49,7 +49,7 @@ exports[`3. 360 video 1`] = `
 </div>
 `;
 
-exports[`4. no sky banner displayed on play 1`] = `
+exports[`4. player icon for 360 video not displayed after play 1`] = `
 <div>
   <div>
     <video

--- a/packages/video/__tests__/web/inline-video-player.web.test.js
+++ b/packages/video/__tests__/web/inline-video-player.web.test.js
@@ -8,7 +8,6 @@ describe("InlineVideoPlayer", () => {
   afterEach(() => {
     delete window.bc;
     delete window.videojs;
-    InlineVideoPlayer.index = 0;
     InlineVideoPlayer.scriptLoadError = false;
     InlineVideoPlayer.activePlayers = [];
     InlineVideoPlayer.brightcoveSDKLoadedStarted = false;
@@ -95,7 +94,9 @@ describe("InlineVideoPlayer", () => {
     addBrightcoveSDKGlobals();
 
     renderer.create(<InlineVideoPlayer {...defaultVideoProps} />);
-    renderer.create(<InlineVideoPlayer {...defaultVideoProps} />);
+    renderer.create(
+      <InlineVideoPlayer {...defaultVideoProps} id="[tpa video id 2]" />
+    );
 
     const [component1, component2] = InlineVideoPlayer.activePlayers;
     jest.spyOn(component1.player, "pause");
@@ -109,7 +110,9 @@ describe("InlineVideoPlayer", () => {
 
   it("doesn't hold references to players after they have been unmounted", () => {
     renderer.create(<InlineVideoPlayer {...defaultVideoProps} />);
-    const p2 = renderer.create(<InlineVideoPlayer {...defaultVideoProps} />);
+    const p2 = renderer.create(
+      <InlineVideoPlayer {...defaultVideoProps} id="[tpa video id 2]" />
+    );
 
     expect(InlineVideoPlayer.activePlayers.length).toBe(2);
     const [component1] = InlineVideoPlayer.activePlayers;
@@ -129,7 +132,9 @@ describe("InlineVideoPlayer", () => {
     jest.spyOn(InlineVideoPlayer, "appendScript").mockImplementation();
 
     renderer.create(<InlineVideoPlayer {...defaultVideoProps} />);
-    renderer.create(<InlineVideoPlayer {...defaultVideoProps} />);
+    renderer.create(
+      <InlineVideoPlayer {...defaultVideoProps} id="[tpa video id 2]" />
+    );
     const [component1, component2] = InlineVideoPlayer.activePlayers;
 
     jest.spyOn(component1, methodName).mockImplementation();

--- a/packages/video/__tests__/web/video-with-data-attributes.web.test.js
+++ b/packages/video/__tests__/web/video-with-data-attributes.web.test.js
@@ -47,6 +47,18 @@ const tests = [
 
       expect(testInstance.toJSON()).toMatchSnapshot();
     }
+  },
+  {
+    name: "360 video with data attributes",
+    test: () => {
+      const testInstance = TestRenderer.create(
+        <IsPaidSubscriber.Provider value>
+          <Video {...defaultVideoProps} paidOnly={false} poster={null} is360 />
+        </IsPaidSubscriber.Provider>
+      );
+
+      expect(testInstance.toJSON()).toMatchSnapshot();
+    }
   }
 ];
 

--- a/packages/video/__tests__/web/video-with-style.web.test.js
+++ b/packages/video/__tests__/web/video-with-style.web.test.js
@@ -62,7 +62,7 @@ const tests = [
     name: "360 video",
     test: () => {
       const testInstance = TestRenderer.create(
-        <Video {...defaultVideoProps} playerId="foo" />
+        <Video {...defaultVideoProps} is360 />
       );
 
       expect(testInstance.toJSON()).toMatchSnapshot();

--- a/packages/video/__tests__/web/video.web.test.js
+++ b/packages/video/__tests__/web/video.web.test.js
@@ -72,7 +72,7 @@ const tests = [
     }
   },
   {
-    name: "no sky banner displayed on play",
+    name: "player icon for 360 video not displayed after play",
     test: () => {
       const testInstance = TestRenderer.create(
         <Video {...defaultVideoProps} is360 />

--- a/packages/video/__tests__/web/video.web.test.js
+++ b/packages/video/__tests__/web/video.web.test.js
@@ -65,7 +65,7 @@ const tests = [
     name: "360 video",
     test: () => {
       const testInstance = TestRenderer.create(
-        <Video {...defaultVideoProps} playerId="foo" />
+        <Video {...defaultVideoProps} is360 />
       );
 
       expect(testInstance.toJSON()).toMatchSnapshot();
@@ -75,7 +75,7 @@ const tests = [
     name: "no sky banner displayed on play",
     test: () => {
       const testInstance = TestRenderer.create(
-        <Video {...defaultVideoProps} playerId="foo" />
+        <Video {...defaultVideoProps} is360 />
       );
 
       const VideoComponent = testInstance.root.findAllByType(InlineVideoPlayer);

--- a/packages/video/src/inline-video-player.web.js
+++ b/packages/video/src/inline-video-player.web.js
@@ -44,8 +44,6 @@ div[data-is-360="true"] button.vjs-big-play-button {
 `;
 
 class InlineVideoPlayer extends Component {
-  static index = 0;
-
   static scriptLoadError = false;
 
   static activePlayers = [];
@@ -76,8 +74,7 @@ class InlineVideoPlayer extends Component {
       hasVideoPlayed: false
     };
 
-    InlineVideoPlayer.index += 1;
-    this.id = `${props.videoId}-${props.accountId}-${InlineVideoPlayer.index}`;
+    this.id = `${props.videoId}-${props.accountId}-${props.id}`;
   }
 
   componentDidMount() {
@@ -169,11 +166,10 @@ class InlineVideoPlayer extends Component {
       videoId,
       accountId,
       playerId,
-      skySports
+      skySports,
+      is360
     } = this.props;
     const { error, hasVideoPlayed } = this.state;
-    const is360Video = playerId !== "default"; // Will get an explicit boolean from CMS and this inference can then go
-
     if (error) {
       throw new Error(); // caught by parent ErrorView
     }
@@ -182,15 +178,15 @@ class InlineVideoPlayer extends Component {
       /* eslint jsx-a11y/media-has-caption: "off" */
       // Added a wrapping div as brightcove adds siblings to the video tag
       <div
-        data-is-360={is360Video}
+        data-is-360={is360}
         data-testid="video-component"
         style={{ height, width }}
       >
-        <div style={{ position: "relative" }}>
+        <div style={{ height, width, position: "relative" }}>
           {!hasVideoPlayed && (
             <Fragment>
               {skySports && <SkySportsBanner />}
-              {is360Video && <Video360Icon />}
+              {is360 && <Video360Icon />}
             </Fragment>
           )}
           <video

--- a/packages/video/src/inline-video-player.web.js
+++ b/packages/video/src/inline-video-player.web.js
@@ -171,7 +171,7 @@ class InlineVideoPlayer extends Component {
     } = this.props;
     const { error, hasVideoPlayed } = this.state;
     if (error) {
-      throw new Error('Can\'t load video'); // caught by parent ErrorView
+      throw new Error("Can't load video"); // caught by parent ErrorView
     }
 
     return (

--- a/packages/video/src/inline-video-player.web.js
+++ b/packages/video/src/inline-video-player.web.js
@@ -171,7 +171,7 @@ class InlineVideoPlayer extends Component {
     } = this.props;
     const { error, hasVideoPlayed } = this.state;
     if (error) {
-      throw new Error(); // caught by parent ErrorView
+      throw new Error('Can\'t load video'); // caught by parent ErrorView
     }
 
     return (

--- a/packages/video/src/video-prop-types.js
+++ b/packages/video/src/video-prop-types.js
@@ -8,6 +8,8 @@ const numberOrString = PropTypes.oneOfType([
 export const propTypes = {
   accountId: PropTypes.string.isRequired,
   height: numberOrString.isRequired,
+  id: PropTypes.string,
+  is360: PropTypes.bool,
   paidOnly: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   playerId: PropTypes.string,
   policyKey: PropTypes.string.isRequired,
@@ -18,6 +20,7 @@ export const propTypes = {
 };
 
 export const defaultProps = {
+  is360: false,
   paidOnly: false,
   playerId: "default",
   poster: null,

--- a/packages/video/video.showcase.js
+++ b/packages/video/video.showcase.js
@@ -4,6 +4,7 @@ import React from "react";
 import Video from "./src/video";
 import IsPaidSubscriber from "./src/is-paid-subscriber";
 
+const id = "3dbfe6b8-680b-11e9-b277-88f3d445182c";
 const policyKey =
   "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U";
 const accountId = "5436121857001";
@@ -17,6 +18,8 @@ const skySportsPosterImageURI =
 const defaultVideoProps = {
   accountId,
   height: 180,
+  id,
+  is360: false,
   onVideoPress: () => {
     Alert.alert(
       "onVideoPress called",
@@ -68,7 +71,12 @@ export default {
     },
     {
       component: () => {
-        const props = { playerId: "y4yoiFCf1", videoId: "5992442066001" };
+        const mockId = "3dbfe6b8-680b-11e9-b277-88f3d445182d";
+        const props = {
+          playerId: "y4yoiFCf1",
+          videoId: "5992442066001",
+          is360: true
+        };
         return (
           <View>
             <Text
@@ -88,7 +96,13 @@ export default {
             >
               Desktop size:
             </Text>
-            <Video {...defaultVideoProps} {...props} height={374} width={664} />
+            <Video
+              {...defaultVideoProps}
+              {...props}
+              height={374}
+              width={664}
+              id={mockId}
+            />
           </View>
         );
       },
@@ -97,13 +111,17 @@ export default {
       type: "story"
     },
     {
-      component: () => (
-        <View>
-          <Video {...defaultVideoProps} />
-          <View style={{ height: 20 }} />
-          <Video {...defaultVideoProps} videoId="5612887446001" />
-        </View>
-      ),
+      component: () => {
+        const mockId = "3dbfe6b8-680b-11e9-b277-88f3d445182d";
+
+        return (
+          <View>
+            <Video {...defaultVideoProps} />
+            <View style={{ height: 20 }} />
+            <Video {...defaultVideoProps} videoId="5612887446001" id={mockId} />
+          </View>
+        );
+      },
       name: "two players with different videos",
       type: "story"
     },

--- a/packages/video/video.showcase.js
+++ b/packages/video/video.showcase.js
@@ -41,6 +41,8 @@ const skySportsVideoProps = {
   }
 };
 
+const mockId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
 export default {
   children: [
     {
@@ -71,7 +73,6 @@ export default {
     },
     {
       component: () => {
-        const mockId = "3dbfe6b8-680b-11e9-b277-88f3d445182d";
         const props = {
           playerId: "y4yoiFCf1",
           videoId: "5992442066001",
@@ -111,17 +112,13 @@ export default {
       type: "story"
     },
     {
-      component: () => {
-        const mockId = "3dbfe6b8-680b-11e9-b277-88f3d445182d";
-
-        return (
-          <View>
-            <Video {...defaultVideoProps} />
-            <View style={{ height: 20 }} />
-            <Video {...defaultVideoProps} videoId="5612887446001" id={mockId} />
-          </View>
-        );
-      },
+      component: () => (
+        <View>
+          <Video {...defaultVideoProps} />
+          <View style={{ height: 20 }} />
+          <Video {...defaultVideoProps} videoId="5612887446001" id={mockId} />
+        </View>
+      ),
       name: "two players with different videos",
       type: "story"
     },


### PR DESCRIPTION
The 360 video article was present only on CAPI.
Also the InlineVideoPlayer component used a static field index to count its instances. The server side rendered component hold one value for this index prop and the client side rendering of the component had another value. Thus the served value id was different than the id value used in the client scripts. That value is also used as part of the video tag id and helps controlling the 360 icon button and other overlays.

Solution: Keep the id value the same in ssr and client rendering. Id is now composed of the following variables: brightcoveVideoID , brightcoveAccountID and TPAVideoID.

Result: 
![Story-with-360-_-The-Times-_1_](https://user-images.githubusercontent.com/16742525/58717209-5f329780-83d3-11e9-9759-d7c90eb2d59d.gif)

