### PR TITLE
fix: prevent sticky story styles clashing with other stories

### DIFF
--- a/packages/sticky/sticky.showcase.web.css
+++ b/packages/sticky/sticky.showcase.web.css
@@ -1,20 +1,20 @@
-.bar {
+.sticky-story .bar {
   height: 30px;
   background: red;
   position: sticky;
 }
 
-.container {
+.sticky-story .container {
   margin: 0 auto;
   padding: 10px;
   max-width: 400px;
 }
 
-.sticky {
+.sticky-story .sticky {
   background: blue;
 }
 
-.fixed {
+.sticky-story .fixed {
   position: fixed;
   background: yellow;
   left: 0;
@@ -22,6 +22,6 @@
   top: 0;
 }
 
-.fixed + .container {
+.sticky-story .fixed + .container {
   margin-top: 30px;
 }

--- a/packages/sticky/sticky.showcase.web.js
+++ b/packages/sticky/sticky.showcase.web.js
@@ -7,7 +7,7 @@ export default {
   children: [
     {
       component: () => (
-        <>
+        <div className="sticky-story">
           <div className="container">
             <h2>Scroll down…</h2>
             <Sticky className="bar" />
@@ -90,14 +90,14 @@ export default {
               qui reiciendis, sunt vel vitae?
             </p>
           </div>
-        </>
+        </div>
       ),
       name: "Sticky without fixed sibling",
       type: "story"
     },
     {
       component: () => (
-        <>
+        <div className="sticky-story">
           <div className="bar fixed" />
           <StickyProvider className="container">
             <h2>Scroll down…</h2>
@@ -181,7 +181,7 @@ export default {
               qui reiciendis, sunt vel vitae?
             </p>
           </StickyProvider>
-        </>
+        </div>
       ),
       name: "Sticky with fixed sibling",
       type: "story"


### PR DESCRIPTION
Prevents the save/share bar going blue when sticky in the storybook as it currently does as shown below.

![image](https://user-images.githubusercontent.com/719814/58805511-1c0f3900-860c-11e9-9d65-ba3f3bc5c979.png)


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
