### PR TITLE
chore: add fake nav bar to article storybook

### DIFF
--- a/packages/article/article.showcase.web.js
+++ b/packages/article/article.showcase.web.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 /* eslint-env browser */
 import React from "react";
+import { StickyProvider } from "@times-components/sticky";
 import renderArticleConfig from "./showcase-helper";
 
 const link = typeof document === "object" &&
@@ -14,11 +15,32 @@ const link = typeof document === "object" &&
     </a>
   );
 
+function renderWebArticleWithConfig(config) {
+  return (
+    <>
+      <div
+        style={{
+          height: 50,
+          position: "fixed",
+          left: 0,
+          top: 0,
+          width: "100%",
+          backgroundColor: "#13354E",
+          zIndex: 2
+        }}
+      />
+      <StickyProvider style={{ marginTop: 50 }}>
+        {renderArticleConfig(config)}
+      </StickyProvider>
+    </>
+  );
+}
+
 export default {
   children: [
     {
       component: ({ boolean, color, select }, { decorateAction }) =>
-        renderArticleConfig({
+        renderWebArticleWithConfig({
           boolean,
           color,
           decorateAction,
@@ -32,7 +54,7 @@ export default {
     },
     {
       component: ({ boolean, color, select }, { decorateAction }) =>
-        renderArticleConfig({
+        renderWebArticleWithConfig({
           boolean,
           color,
           decorateAction,
@@ -48,7 +70,7 @@ export default {
     },
     {
       component: ({ boolean, color, select }, { decorateAction }) =>
-        renderArticleConfig({
+        renderWebArticleWithConfig({
           boolean,
           color,
           decorateAction,

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "fmt": "eslint . --fix && prettier --write '**/*.*'",
     "prettier:diff": "prettier --list-different '**/*.*'",
-    "depcheck": "depcheck --ignores='babel-*,depcheck,eslint,jest,prettier,react-art,stylelint*,webpack*' --ignore-bin-package=false --skip-missing",
+    "depcheck": "depcheck --ignores='babel-*,depcheck,eslint,jest,prettier,react-art,stylelint*,webpack*,@times-components/sticky' --ignore-bin-package=false --skip-missing",
     "lint": "eslint . && yarn prettier:diff && yarn depcheck",
     "prepublishOnly": "yarn transpile && yarn bundle",
     "test": "jest --config='./__tests__/jest.config.js'",
@@ -36,6 +36,7 @@
     "@times-components/eslint-config-thetimes": "0.8.12",
     "@times-components/jest-configurator": "2.5.12",
     "@times-components/provider-test-tools": "1.17.19",
+    "@times-components/sticky": "0.0.2",
     "@times-components/storybook": "4.0.9",
     "@times-components/tealium-utils": "0.7.51",
     "@times-components/webpack-configurator": "2.0.21",


### PR DESCRIPTION
Add a fake nav bar to article storybook to demo the sticky save and share bar sticking below it. 


<img width="1342" alt="image" src="https://user-images.githubusercontent.com/719814/58806616-7d380c00-860e-11e9-9125-eb91c773bb09.png">


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
