### PR TITLE
fix: pass whole userState object by SSR to the TC consumers

### DIFF
--- a/packages/context/__tests__/android/__snapshots__/theme.test.js.snap
+++ b/packages/context/__tests__/android/__snapshots__/theme.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ContextProviderWithDefaults adds defaults to the provided context 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"},\\"user\\":{\\"isLoggedIn\\":false}}"`;
 
-exports[`article context with default values 1`] = `"{\\"theme\\":{\\"imageCaptionAlignment\\":{},\\"scale\\":\\"medium\\"},\\"user\\":{\\"isLoggedIn\\":false}}"`;
+exports[`article context with default values 1`] = `"{\\"theme\\":{\\"imageCaptionAlignment\\":{},\\"scale\\":\\"medium\\"},\\"user\\":{\\"isLoggedIn\\":false,\\"isMetered\\":false,\\"isMeteredExpired\\":false,\\"isShared\\":false,\\"registrationType\\":\\"\\"}}"`;
 
 exports[`article context with inline values 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"},\\"user\\":{\\"isLoggedIn\\":false}}"`;
 

--- a/packages/context/__tests__/ios/__snapshots__/theme.test.js.snap
+++ b/packages/context/__tests__/ios/__snapshots__/theme.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ContextProviderWithDefaults adds defaults to the provided context 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"},\\"user\\":{\\"isLoggedIn\\":false}}"`;
 
-exports[`article context with default values 1`] = `"{\\"theme\\":{\\"imageCaptionAlignment\\":{},\\"scale\\":\\"medium\\"},\\"user\\":{\\"isLoggedIn\\":false}}"`;
+exports[`article context with default values 1`] = `"{\\"theme\\":{\\"imageCaptionAlignment\\":{},\\"scale\\":\\"medium\\"},\\"user\\":{\\"isLoggedIn\\":false,\\"isMetered\\":false,\\"isMeteredExpired\\":false,\\"isShared\\":false,\\"registrationType\\":\\"\\"}}"`;
 
 exports[`article context with inline values 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"},\\"user\\":{\\"isLoggedIn\\":false}}"`;
 

--- a/packages/context/__tests__/web/__snapshots__/theme.test.js.snap
+++ b/packages/context/__tests__/web/__snapshots__/theme.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ContextProviderWithDefaults adds defaults to the provided context 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"},\\"user\\":{\\"isLoggedIn\\":false}}"`;
 
-exports[`article context with default values 1`] = `"{\\"theme\\":{\\"imageCaptionAlignment\\":{},\\"scale\\":\\"medium\\"},\\"user\\":{\\"isLoggedIn\\":false}}"`;
+exports[`article context with default values 1`] = `"{\\"theme\\":{\\"imageCaptionAlignment\\":{},\\"scale\\":\\"medium\\"},\\"user\\":{\\"isLoggedIn\\":false,\\"isMetered\\":false,\\"isMeteredExpired\\":false,\\"isShared\\":false,\\"registrationType\\":\\"\\"}}"`;
 
 exports[`article context with inline values 1`] = `"{\\"theme\\":{\\"scale\\":\\"large\\",\\"sectionColour\\":\\"#FFFFFF\\"},\\"user\\":{\\"isLoggedIn\\":false}}"`;
 

--- a/packages/context/src/defaults/index.js
+++ b/packages/context/src/defaults/index.js
@@ -11,6 +11,10 @@ export default {
     scale: scales.medium
   },
   user: {
-    isLoggedIn: false
+    isLoggedIn: false,
+    isMetered: false,
+    isMeteredExpired: false,
+    isShared: false,
+    registrationType: ""
   }
 };

--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -55,9 +55,7 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
                     ...themeFactory(article.section, article.template),
                     scale: scale || defaults.theme.scale
                   },
-                  user: {
-                    isLoggedIn: userState.isLoggedIn
-                  }
+                  user: userState
                 }
               },
               React.createElement(Article, {


### PR DESCRIPTION

**Currently**, only field 'isLoggedIn' is passed from SSR to packages consumers : 

```
user: {	   
   isLoggedIn: userState.isLoggedIn	
}
```

**Fix**: Pass full user state data from SSR to consumers.

Format: 

```
userState : {
   isLoggedIn: boolean
   isMetered: boolean
   isMeteredExpired: boolean
   isShared: boolean
  registrationTypes: string
}
```