### PR TITLE
spike: fix user states

### DIFF
--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@times-components/ssr",
   "main": "src",
-  "version": "2.3.0",
+  "version": "3.1.0",
   "scripts": {
     "bundle:dev": "yarn cleanup-dist && webpack --config=webpack.config.js",
     "bundle:prod": "yarn cleanup-dist && NODE_ENV=production webpack --config=webpack.config.js -p",

--- a/packages/ssr/src/client/article.js
+++ b/packages/ssr/src/client/article.js
@@ -12,7 +12,8 @@ if (window.nuk && window.nuk.ssr && window.nuk.article) {
     articleId,
     debounceTimeMs,
     spotAccountId,
-    paidContentClassName
+    paidContentClassName,
+    userState
   } = window.nuk.article;
   const { getCookieValue } = window.nuk;
 
@@ -25,7 +26,7 @@ if (window.nuk && window.nuk.ssr && window.nuk.article) {
     mapArticleToAdConfig,
     spotAccountId,
     paidContentClassName,
-    userState: window.nuk.user
+    userState
   };
 
   const clientOptions = {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -49,6 +49,7 @@
     "webpack-cli": "3.3.1"
   },
   "dependencies": {
+    "@times-components/context": "1.0.14",
     "@times-components/schema": "0.6.12",
     "@times-components/styleguide": "3.28.21",
     "apollo-cache-inmemory": "1.5.1",

--- a/packages/utils/src/client-user-state-consumer.js
+++ b/packages/utils/src/client-user-state-consumer.js
@@ -1,0 +1,57 @@
+/**
+ * This is a component to allow you to access the client user
+ * state in a server-side-render compatible manner.
+ *
+ * If you use anything in `window.nuk.user` in the initial
+ * client side render, you could break React hydration as
+ * it could cause a difference between the initial renders
+ * on the front end and on the server.
+ *
+ * This uses two-pass rendering to prevent differences in the
+ * initial render on server and client.
+ *
+ * https://reactjs.org/docs/react-dom.html#hydrate
+ */
+
+/* eslint-env browser */
+
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import Context from "@times-components/context";
+
+class ClientUserStateConsumer extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { isClient: false };
+  }
+
+  componentDidMount() {
+    this.setState({ isClient: true });
+  }
+
+  render() {
+    return (
+      <Context.Consumer>
+        {({ user }) => {
+          const { isClient } = this.state;
+          const { twoPassRenderSlowly } = this.props;
+
+          return twoPassRenderSlowly({
+            user: isClient
+              ? {
+                  ...user,
+                  ...window.nuk.user
+                }
+              : user
+          });
+        }}
+      </Context.Consumer>
+    );
+  }
+}
+
+ClientUserStateConsumer.propTypes = {
+  twoPassRenderSlowly: PropTypes.func.isRequired
+};
+
+export default ClientUserStateConsumer;

--- a/packages/utils/src/index.web.js
+++ b/packages/utils/src/index.web.js
@@ -12,3 +12,6 @@ export { default as getHeadline } from "./get-headline";
 export { default as gqlRgbaToHex } from "./gql-rgba-to-hex";
 export { default as gqlRgbaToStyle } from "./gql-rgba-to-style";
 export { default as HoverIcon } from "./hover-icon";
+export {
+  default as ClientUserStateConsumer
+} from "./client-user-state-consumer";


### PR DESCRIPTION
This PR is a spike showing how we can use two pass rendering to ensure that the initial render on the client and the server don't differ even though we need some information that is only available on the client to render properly. 

I've also fixed some of the bugs I've noticed in how we've implemented user states. While this went a bit beyond what I strictly needed to do, I want to ensure this approach could handle ever state. There may be more issues with our implementation of user states even after merging this, but I fixed all of the ones I found. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
