### PR TITLE
feat: implement lead asset to use the passed width

### DIFF
--- a/packages/article-in-depth/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -22,6 +22,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={1194}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"
@@ -85,6 +86,7 @@ exports[`4. an article with ads 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={1194}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -22,6 +22,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={1194}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"
@@ -85,6 +86,7 @@ exports[`4. an article with ads 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={1194}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"

--- a/packages/article-lead-asset/__tests__/android/__snapshots__/article-lead-asset.test.js.snap
+++ b/packages/article-lead-asset/__tests__/android/__snapshots__/article-lead-asset.test.js.snap
@@ -10,6 +10,7 @@ exports[`1. renders correctly with an image lead asset 1`] = `
         text="Chris Reynolds Gordon at one of his party venues in London"
       />
     }
+    highResSize={600}
     index={0}
     uri="https://crop169.io/"
   />

--- a/packages/article-lead-asset/__tests__/ios/__snapshots__/article-lead-asset.test.js.snap
+++ b/packages/article-lead-asset/__tests__/ios/__snapshots__/article-lead-asset.test.js.snap
@@ -10,6 +10,7 @@ exports[`1. renders correctly with an image lead asset 1`] = `
         text="Chris Reynolds Gordon at one of his party venues in London"
       />
     }
+    highResSize={600}
     index={0}
     uri="https://crop169.io/"
   />

--- a/packages/article-lead-asset/src/article-lead-asset.js
+++ b/packages/article-lead-asset/src/article-lead-asset.js
@@ -13,8 +13,15 @@ const ArticleLeadAssetModalImage = ({
   aspectRatio,
   caption,
   onImagePress,
-  uri
-}) => <ModalImage {...{ aspectRatio, caption, onImagePress, uri }} index={0} />;
+  uri,
+  width
+}) => (
+  <ModalImage
+    highResSize={width}
+    {...{ aspectRatio, caption, onImagePress, uri }}
+    index={0}
+  />
+);
 
 const ArticleLeadAsset = ({
   getImageCrop,

--- a/packages/article-magazine-comment/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -56,6 +56,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={660}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"
@@ -120,6 +121,7 @@ exports[`4. an article with ads 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={660}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"
@@ -209,6 +211,7 @@ exports[`7. an article with no author 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={660}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"

--- a/packages/article-magazine-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -56,6 +56,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={660}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"
@@ -120,6 +121,7 @@ exports[`4. an article with ads 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={660}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"
@@ -209,6 +211,7 @@ exports[`7. an article with no author 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={660}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"

--- a/packages/article-magazine-standard/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -53,6 +53,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={660}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"
@@ -114,6 +115,7 @@ exports[`4. an article with ads 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={660}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"

--- a/packages/article-magazine-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -53,6 +53,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={660}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"
@@ -114,6 +115,7 @@ exports[`4. an article with ads 1`] = `
           text="Some Caption"
         />
       }
+      highResSize={660}
       index={0}
       onImagePress={null}
       uri="https://crop169.io"

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -13,6 +13,7 @@ exports[`1. an article 1`] = `
               text="Some Caption"
             />
           }
+          highResSize={660}
           index={0}
           onImagePress={null}
           uri="https://crop169.io"

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -13,6 +13,7 @@ exports[`1. an article 1`] = `
               text="Some Caption"
             />
           }
+          highResSize={660}
           index={0}
           onImagePress={null}
           uri="https://crop169.io"

--- a/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
@@ -723,16 +723,21 @@ exports[`3. tablet landscape default modal 1`] = `
         <View
           style={
             Object {
-              "alignItems": "center",
-              "backgroundColor": "#EDEDED",
-              "justifyContent": "center",
+              "borderRadius": 0,
+              "height": "100%",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "100%",
             }
           }
         >
           <Image
             style={
               Object {
-                "width": "25%",
+                "height": "100%",
+                "position": "absolute",
+                "resizeMode": "contain",
+                "width": "100%",
               }
             }
           />
@@ -974,16 +979,21 @@ exports[`4. tablet portrait default modal 1`] = `
         <View
           style={
             Object {
-              "alignItems": "center",
-              "backgroundColor": "#EDEDED",
-              "justifyContent": "center",
+              "borderRadius": 0,
+              "height": "100%",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "100%",
             }
           }
         >
           <Image
             style={
               Object {
-                "width": "25%",
+                "height": "100%",
+                "position": "absolute",
+                "resizeMode": "contain",
+                "width": "100%",
               }
             }
           />

--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -115,16 +115,16 @@ exports[`1. modal image 1`] = `
       <View
         collapsable={false}
       >
-        <View
-          height="100%"
-          width="100%"
-        >
+        <View>
           <Image
+            caption={<MockCaption />}
             fadeDuration={0}
-            resizeMode="contain"
+            fadeImageIn={false}
+            onImagePress={null}
+            show={false}
             source={
               Object {
-                "testUri": "../../../packages/image/assets/t.png",
+                "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
               }
             }
           />
@@ -371,16 +371,16 @@ exports[`3. modal image with custom highressize 1`] = `
       <View
         collapsable={false}
       >
-        <View
-          height="100%"
-          width="100%"
-        >
+        <View>
           <Image
+            caption={<MockCaption />}
             fadeDuration={0}
-            resizeMode="contain"
+            fadeImageIn={false}
+            onImagePress={null}
+            show={false}
             source={
               Object {
-                "testUri": "../../../packages/image/assets/t.png",
+                "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
               }
             }
           />

--- a/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
@@ -753,16 +753,21 @@ exports[`3. tablet landscape default modal 1`] = `
         <View
           style={
             Object {
-              "alignItems": "center",
-              "backgroundColor": "#EDEDED",
-              "justifyContent": "center",
+              "borderRadius": 0,
+              "height": "100%",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "100%",
             }
           }
         >
           <Image
             style={
               Object {
-                "width": "25%",
+                "height": "100%",
+                "position": "absolute",
+                "resizeMode": "contain",
+                "width": "100%",
               }
             }
           />
@@ -1014,16 +1019,21 @@ exports[`4. tablet portrait default modal 1`] = `
         <View
           style={
             Object {
-              "alignItems": "center",
-              "backgroundColor": "#EDEDED",
-              "justifyContent": "center",
+              "borderRadius": 0,
+              "height": "100%",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "100%",
             }
           }
         >
           <Image
             style={
               Object {
-                "width": "25%",
+                "height": "100%",
+                "position": "absolute",
+                "resizeMode": "contain",
+                "width": "100%",
               }
             }
           />

--- a/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
@@ -129,16 +129,16 @@ exports[`1. modal image 1`] = `
       <View
         collapsable={false}
       >
-        <View
-          height="100%"
-          width="100%"
-        >
+        <View>
           <Image
+            caption={<MockCaption />}
             fadeDuration={0}
-            resizeMode="contain"
+            fadeImageIn={false}
+            onImagePress={null}
+            show={false}
             source={
               Object {
-                "testUri": "../../../packages/image/assets/t.png",
+                "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
               }
             }
           />
@@ -413,16 +413,16 @@ exports[`3. modal image with custom highressize 1`] = `
       <View
         collapsable={false}
       >
-        <View
-          height="100%"
-          width="100%"
-        >
+        <View>
           <Image
+            caption={<MockCaption />}
             fadeDuration={0}
-            resizeMode="contain"
+            fadeImageIn={false}
+            onImagePress={null}
+            show={false}
             source={
               Object {
-                "testUri": "../../../packages/image/assets/t.png",
+                "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1080",
               }
             }
           />

--- a/packages/image/src/modal-image/modal-image.js
+++ b/packages/image/src/modal-image/modal-image.js
@@ -55,6 +55,7 @@ class ModalImage extends Component {
 
   render() {
     const { highResSize, index, onImagePress } = this.props;
+
     if (onImagePress) {
       return (
         <Button onPress={() => onImagePress(index)}>
@@ -130,7 +131,11 @@ class ModalImage extends Component {
           </View>
         </Modal>
         <Button onPress={this.showModal}>
-          <Image {...this.props} onLayout={this.onLowResLayout} />
+          <Image
+            {...this.props}
+            lowResSize={lowResSize}
+            onLayout={this.onLowResLayout}
+          />
         </Button>
       </View>
     );


### PR DESCRIPTION
Implement Article Perf - Lead Asset not waiting for onLayout.
Story: https://nidigitalsolutions.jira.com/browse/REPLAT-6648

In this PR we are passing the width from the `article-lead-asset` component down to the image as a `hightResSize` prop. This way the `image` component won't use the onLayout to calculate the size it's being rendered at, which will lead to faster request for the image.
