### PR TITLE
fix: make unruly ads work correctly in the new webview component

### DIFF
--- a/packages/ad/__tests__/android/__snapshots__/ad-with-style.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad-with-style.android.test.js.snap
@@ -14,7 +14,7 @@ Array [
         <RNCWebView
           allowFileAccess={false}
           allowsFullscreenVideo={false}
-          androidHardwareAccelerationDisabled={true}
+          androidHardwareAccelerationDisabled={false}
           cacheEnabled={true}
           className="IS1"
           javaScriptEnabled={true}
@@ -39,7 +39,7 @@ Array [
         <RNCWebView
           allowFileAccess={false}
           allowsFullscreenVideo={false}
-          androidHardwareAccelerationDisabled={true}
+          androidHardwareAccelerationDisabled={false}
           cacheEnabled={true}
           className="IS1"
           javaScriptEnabled={true}

--- a/packages/ad/__tests__/ios/__snapshots__/ad-with-style.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad-with-style.ios.test.js.snap
@@ -12,7 +12,6 @@ Array [
         className="IS2"
       >
         <RNCWKWebView
-          androidHardwareAccelerationDisabled={true}
           cacheEnabled={true}
           className="IS1"
           messagingEnabled={true}
@@ -31,7 +30,6 @@ Array [
         className="IS2"
       >
         <RNCWKWebView
-          androidHardwareAccelerationDisabled={true}
           cacheEnabled={true}
           className="IS1"
           messagingEnabled={true}

--- a/packages/ad/src/dom-context.js
+++ b/packages/ad/src/dom-context.js
@@ -123,7 +123,7 @@ class DOMContext extends PureComponent {
         }}
       >
         <WebView
-          androidHardwareAccelerationDisabled
+          originWhitelist={["http://.*", "https://.*"]}
           onMessage={this.handleMessageEvent}
           onNavigationStateChange={this.handleNavigationStateChange}
           ref={ref => {


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
This updates the properties on the webview component has the new one has different defaults to the old one.

![image](https://user-images.githubusercontent.com/615608/59500893-3cec4f80-8e92-11e9-97db-5caa77f43a45.png)
