### PR TITLE
fix: handle the case where an image is already loaded

### DIFF
--- a/packages/image/src/image.web.js
+++ b/packages/image/src/image.web.js
@@ -21,11 +21,32 @@ class TimesImage extends Component {
     this.handleHighResOnLoad = this.handleHighResOnLoad.bind(this);
     this.handleLowResOnLoad = this.handleLowResOnLoad.bind(this);
     this.onHighResTransitionEnd = this.onHighResTransitionEnd.bind(this);
+    this.getLowResImage = this.getLowResImage.bind(this);
+    this.getHighResImage = this.getHighResImage.bind(this);
   }
 
   onHighResTransitionEnd() {
     this.setState({
       highResIsVisible: true
+    });
+  }
+
+  getHighResImage(img) {
+    if (img && img.complete) {
+      this.handleHighResOnLoad();
+    }
+  }
+
+  getLowResImage(img) {
+    if (img && img.complete) {
+      this.handleLowResOnLoad();
+    }
+  }
+
+  handleLowResOnLoad() {
+    this.setState({
+      imageIsLoaded: true,
+      lowResIsLoaded: true
     });
   }
 
@@ -36,19 +57,13 @@ class TimesImage extends Component {
     });
   }
 
-  handleLowResOnLoad() {
-    this.setState({
-      imageIsLoaded: true,
-      lowResIsLoaded: true
-    });
-  }
-
   highResImage({ highResSize, lowResSize, url }) {
     const { highResIsLoaded } = this.state;
     if (!lowResSize || highResSize) {
       return (
         <StyledImage
           alt=""
+          ref={this.getHighResImage}
           isLoaded={highResIsLoaded}
           onLoad={this.handleHighResOnLoad}
           onTransitionEnd={this.onHighResTransitionEnd}
@@ -67,6 +82,7 @@ class TimesImage extends Component {
       return (
         <StyledImage
           alt=""
+          ref={this.getLowResImage}
           isLoaded={lowResIsLoaded}
           onLoad={this.handleLowResOnLoad}
           src={appendToURL(url, "resize", lowResSize)}


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Sometimes an image has already loaded from isomorphic rendering before react starts rehydrating. This is a small fix that also checks the complete property on the image and calls the correct handler on component load.

![image](https://user-images.githubusercontent.com/615608/59602929-edab5680-90ff-11e9-8a2e-868cd92c022f.png)
