### PR TITLE
feat:web-add analytics to inline links

### DIFF
--- a/packages/article-skeleton/__tests__/web/__snapshots__/tracking.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/tracking.web.test.js.snap
@@ -51,3 +51,14 @@ Array [
   ],
 ]
 `;
+
+exports[`should track ArticleLink clicks in analytics 1`] = `
+Object {
+  "action": "Pressed",
+  "attrs": Object {
+    "target": "t-target",
+    "url": "test.io",
+  },
+  "component": "ArticleLink",
+}
+`;

--- a/packages/article-skeleton/src/article-body/article-link-tracking-events.web.js
+++ b/packages/article-skeleton/src/article-body/article-link-tracking-events.web.js
@@ -1,0 +1,16 @@
+import { withTrackEvents } from "@times-components/tracking";
+
+export default Component =>
+  withTrackEvents(Component, {
+    analyticsEvents: [
+      {
+        actionName: "Pressed",
+        eventName: "onPress",
+        getAttrs: ({ target, url }) => ({
+          url,
+          target
+        }),
+        trackingName: "ArticleLink"
+      }
+    ]
+  });

--- a/packages/article-skeleton/src/article-body/article-link.web.js
+++ b/packages/article-skeleton/src/article-body/article-link.web.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Link from "@times-components/link";
 import { colours, fonts, fontSizes } from "@times-components/styleguide";
+import withTrackEvents from "./article-link-tracking-events";
 
 // SHOULD BE IN STYLES
 const responsiveLinkStyles = {
@@ -18,17 +19,23 @@ const responsiveLinkStyles = {
   `
 };
 
-const ArticleLink = ({ children, target, url }) => (
-  <Link responsiveLinkStyles={responsiveLinkStyles} target={target} url={url}>
+const ArticleLink = ({ children, target, url, onPress }) => (
+  <Link
+    responsiveLinkStyles={responsiveLinkStyles}
+    target={target}
+    url={url}
+    onPress={onPress}
+  >
     {children}
   </Link>
 );
 
 ArticleLink.defaultProps = {
-  ...Link.defaultProps
+  ...Link.defaultProps,
+  onPress: () => {}
 };
 
 ArticleLink.propTypes = {
   ...Link.propTypes
 };
-export default ArticleLink;
+export default withTrackEvents(ArticleLink);

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
@@ -78,28 +78,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "lead-one-and-two",
           },
         ],

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
@@ -124,53 +124,13 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "lead-one-and-two",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "e121aac6-d15d-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "lead-one-and-two-supporting-1",
           },
         ],

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
@@ -170,78 +170,18 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "lead-one-and-two",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "7bd4be00-d15e-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "lead-one-and-two-supporting-1",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Third Short Headline",
             "id": "e121aac6-d15d-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "lead-one-and-two-supporting-2",
           },
         ],

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
@@ -78,28 +78,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "lead-one-and-two",
           },
         ],

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
@@ -88,28 +88,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Sathnam Sanghera",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "opinion-one-and-two",
           },
         ],

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
@@ -134,53 +134,13 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Sathnam Sanghera",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "opinion-one-and-two",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "e121aac6-d15d-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "opinion-one-and-two-supporting-1",
           },
         ],

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
@@ -180,78 +180,18 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Sathnam Sanghera",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "opinion-one-and-two",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "7bd4be00-d15e-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "opinion-one-and-two-supporting-1",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Third Short Headline",
             "id": "e121aac6-d15d-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "opinion-one-and-two-supporting-2",
           },
         ],

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
@@ -88,28 +88,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Sathnam Sanghera",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "opinion-one-and-two",
           },
         ],

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
@@ -82,47 +82,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {
-                      "slug": "camilla-long",
-                    },
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "author",
-                  },
-                ],
-              },
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": ", Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Short Headline",
             "id": "48604618-fb0e-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "standard-1",
           },
         ],

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
@@ -133,53 +133,13 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "58604618-fb0e-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "standard-1",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "8b47c1b8-fb05-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "standard-2",
           },
         ],

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
@@ -188,78 +188,18 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "58604618-fb0e-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "standard-1",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "8b47c1b8-fb05-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "standard-2",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Third Short Headline",
             "id": "8b47c1b8-fb05-11e7-a987-7fcf5e99898c",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "standard-3",
           },
         ],

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
@@ -82,47 +82,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {
-                      "slug": "camilla-long",
-                    },
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "author",
-                  },
-                ],
-              },
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": ", Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Headline",
             "id": "48604618-fb0e-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "standard-1",
           },
         ],

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
@@ -78,28 +78,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "lead-one-and-two",
           },
         ],

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
@@ -124,53 +124,13 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "lead-one-and-two",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "e121aac6-d15d-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "lead-one-and-two-supporting-1",
           },
         ],

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
@@ -170,78 +170,18 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "lead-one-and-two",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "7bd4be00-d15e-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "lead-one-and-two-supporting-1",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Third Short Headline",
             "id": "e121aac6-d15d-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "lead-one-and-two-supporting-2",
           },
         ],

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
@@ -78,28 +78,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "lead-one-and-two",
           },
         ],

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
@@ -88,28 +88,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Sathnam Sanghera",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "opinion-one-and-two",
           },
         ],

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
@@ -134,53 +134,13 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Sathnam Sanghera",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "opinion-one-and-two",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "e121aac6-d15d-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "opinion-one-and-two-supporting-1",
           },
         ],

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
@@ -180,78 +180,18 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Sathnam Sanghera",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "opinion-one-and-two",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "7bd4be00-d15e-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "opinion-one-and-two-supporting-1",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Third Short Headline",
             "id": "e121aac6-d15d-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "opinion-one-and-two-supporting-2",
           },
         ],

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
@@ -88,28 +88,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Sathnam Sanghera",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "opinion-one-and-two",
           },
         ],

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
@@ -82,47 +82,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {
-                      "slug": "camilla-long",
-                    },
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "author",
-                  },
-                ],
-              },
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": ", Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Short Headline",
             "id": "48604618-fb0e-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "standard-1",
           },
         ],

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
@@ -133,53 +133,13 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "58604618-fb0e-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "standard-1",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "8b47c1b8-fb05-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "standard-2",
           },
         ],

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
@@ -188,78 +188,18 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "58604618-fb0e-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "standard-1",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "8b47c1b8-fb05-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "standard-2",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Third Short Headline",
             "id": "8b47c1b8-fb05-11e7-a987-7fcf5e99898c",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "standard-3",
           },
         ],

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
@@ -82,47 +82,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {
-                      "slug": "camilla-long",
-                    },
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "author",
-                  },
-                ],
-              },
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": ", Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Headline",
             "id": "48604618-fb0e-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "standard-1",
           },
         ],

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
@@ -84,28 +84,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "lead-one-and-two",
           },
         ],

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
@@ -136,53 +136,13 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "lead-one-and-two",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "e121aac6-d15d-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "lead-one-and-two-supporting-1",
           },
         ],

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
@@ -192,78 +192,18 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "lead-one-and-two",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "7bd4be00-d15e-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "lead-one-and-two-supporting-1",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Third Short Headline",
             "id": "e121aac6-d15d-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "lead-one-and-two-supporting-2",
           },
         ],

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
@@ -84,28 +84,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "lead-one-and-two",
           },
         ],

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
@@ -91,28 +91,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Sathnam Sanghera",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "opinion-one-and-two",
           },
         ],

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
@@ -150,53 +150,13 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Sathnam Sanghera",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "opinion-one-and-two",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "e121aac6-d15d-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "opinion-one-and-two-supporting-1",
           },
         ],

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
@@ -192,78 +192,18 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Sathnam Sanghera",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "opinion-one-and-two",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "7bd4be00-d15e-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "opinion-one-and-two-supporting-1",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Deborah Haynes",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Third Short Headline",
             "id": "e121aac6-d15d-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "opinion-one-and-two-supporting-2",
           },
         ],

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
@@ -91,28 +91,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Sathnam Sanghera",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Headline",
             "id": "a88b0330-d14c-11e7-b1ec-8503a5941b97",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "opinion-one-and-two",
           },
         ],

--- a/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
@@ -88,47 +88,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {
-                      "slug": "camilla-long",
-                    },
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "author",
-                  },
-                ],
-              },
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": ", Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Short Headline",
             "id": "48604618-fb0e-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "standard-1",
           },
         ],

--- a/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
@@ -142,53 +142,13 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "58604618-fb0e-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "standard-1",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "8b47c1b8-fb05-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "standard-2",
           },
         ],

--- a/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
@@ -221,78 +221,18 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "First Short Headline",
             "id": "58604618-fb0e-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "standard-1",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Second Short Headline",
             "id": "8b47c1b8-fb05-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "standard-2",
           },
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long, Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Third Short Headline",
             "id": "8b47c1b8-fb05-11e7-a987-7fcf5e99898c",
-            "publishedTime": "2018-01-17T12:00:00.000Z",
             "role": "standard-3",
           },
         ],

--- a/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
@@ -88,47 +88,8 @@ Array [
       "attrs": Object {
         "articles": Array [
           Object {
-            "bylines": Array [
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {
-                      "slug": "camilla-long",
-                    },
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Camilla Long",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "author",
-                  },
-                ],
-              },
-              Object {
-                "byline": Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": ", Environment Editor",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ],
-              },
-            ],
             "headline": "Test Headline",
             "id": "48604618-fb0e-11e7-a987-7fcf5e9983dc",
-            "publishedTime": "2015-03-13T18:54:58.000Z",
             "role": "standard-1",
           },
         ],

--- a/packages/related-articles/src/related-articles-tracking-context.js
+++ b/packages/related-articles/src/related-articles-tracking-context.js
@@ -17,48 +17,30 @@ export default Component =>
         supports
           .filter(support => support !== undefined)
           .map(({ article }, index) => {
-            const {
-              bylines,
-              headline,
-              id,
-              publishedTime,
-              shortHeadline
-            } = article;
+            const { headline, id, shortHeadline } = article;
             return {
-              bylines,
               headline: getHeadline(headline, shortHeadline),
               id,
-              publishedTime,
               role: roles[index + 1]
             };
           });
 
       const standardTracking = () =>
         items.map(({ article }, index) => {
-          const {
-            bylines,
-            headline,
-            id,
-            publishedTime,
-            shortHeadline
-          } = article;
+          const { headline, id, shortHeadline } = article;
           return {
-            bylines,
             headline: getHeadline(headline, shortHeadline),
             id,
-            publishedTime,
             role: standardRoles[index]
           };
         });
 
       const leadOneAndTwoTracking = () => {
         const { article } = lead;
-        const { bylines, headline, id, publishedTime, shortHeadline } = article;
+        const { headline, id, shortHeadline } = article;
         const leadOneAndTwoTrackingObject = {
-          bylines,
           headline: getHeadline(headline, shortHeadline),
           id,
-          publishedTime,
           role: leadOneAndTwoRoles[0]
         };
 
@@ -69,12 +51,10 @@ export default Component =>
 
       const opinionOneAndTwoTracking = () => {
         const { article } = opinion;
-        const { bylines, headline, id, publishedTime, shortHeadline } = article;
+        const { headline, id, shortHeadline } = article;
         const opinionOneAndTwoTrackingObject = {
-          bylines,
           headline: getHeadline(headline, shortHeadline),
           id,
-          publishedTime,
           role: opinionOneAndTwoRoles[0]
         };
 


### PR DESCRIPTION
This is for [Add analytics to inline web links](https://nidigitalsolutions.jira.com/browse/REPLAT-4505)

`New:`
Inline links should be tracked on web now.

`Changed:`
Simplified tracking on related articles on both mobile and web.