### PR TITLE
Fix: remove underline from byline

### DIFF
--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links-style.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links-style.android.test.js.snap
@@ -10,7 +10,7 @@ exports[`1. with a single author 1`] = `
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 13,
         "lineHeight": 19,
-        "textDecorationLine": "underline",
+        "textDecorationLine": "none",
       }
     }
   >
@@ -29,7 +29,7 @@ exports[`2. with a very long byline 1`] = `
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 13,
         "lineHeight": 19,
-        "textDecorationLine": "underline",
+        "textDecorationLine": "none",
       }
     }
   >
@@ -56,7 +56,7 @@ exports[`2. with a very long byline 1`] = `
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 13,
         "lineHeight": 19,
-        "textDecorationLine": "underline",
+        "textDecorationLine": "none",
       }
     }
   >
@@ -83,7 +83,7 @@ exports[`2. with a very long byline 1`] = `
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 13,
         "lineHeight": 19,
-        "textDecorationLine": "underline",
+        "textDecorationLine": "none",
       }
     }
   >

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links-style.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links-style.ios.test.js.snap
@@ -10,7 +10,7 @@ exports[`1. with a single author 1`] = `
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 13,
         "lineHeight": 15,
-        "textDecorationLine": "underline",
+        "textDecorationLine": "none",
       }
     }
   >
@@ -29,7 +29,7 @@ exports[`2. with a very long byline 1`] = `
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 13,
         "lineHeight": 15,
-        "textDecorationLine": "underline",
+        "textDecorationLine": "none",
       }
     }
   >
@@ -56,7 +56,7 @@ exports[`2. with a very long byline 1`] = `
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 13,
         "lineHeight": 15,
-        "textDecorationLine": "underline",
+        "textDecorationLine": "none",
       }
     }
   >
@@ -83,7 +83,7 @@ exports[`2. with a very long byline 1`] = `
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 13,
         "lineHeight": 15,
-        "textDecorationLine": "underline",
+        "textDecorationLine": "none",
       }
     }
   >

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links-style.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links-style.web.test.js.snap
@@ -14,7 +14,7 @@ exports[`1. with a single author 1`] = `
   className="css-view-1dbjc4n"
 >
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g S1"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu S1"
     href="/profile/alexandra-frean"
     role="link"
   >
@@ -49,7 +49,7 @@ exports[`2. with a very long byline 1`] = `
   className="css-view-1dbjc4n"
 >
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g S1"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu S1"
     href="/profile/camilla-long"
     role="link"
   >
@@ -61,7 +61,7 @@ exports[`2. with a very long byline 1`] = `
     , Environment Editor | 
   </div>
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g S1"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu S1"
     href="/profile/camilla-long"
     role="link"
   >
@@ -73,7 +73,7 @@ exports[`2. with a very long byline 1`] = `
     , Environment Editor | 
   </div>
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g S1"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu S1"
     href="/profile/camilla-long"
     role="link"
   >

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links.web.test.js.snap
@@ -17,7 +17,7 @@ exports[`2. with the author in the begining 1`] = `
   className="css-view-1dbjc4n"
 >
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
     href="/profile/camilla-long"
     role="link"
   >
@@ -41,7 +41,7 @@ exports[`3. with the author at the end 1`] = `
     RBS Six Nations, 
   </div>
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
     href="/profile/mike-atherton"
     role="link"
   >
@@ -55,7 +55,7 @@ exports[`4. with multiple authors separated by a pipe 1`] = `
   className="css-view-1dbjc4n"
 >
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
     href="/profile/camilla-long"
     role="link"
   >
@@ -67,7 +67,7 @@ exports[`4. with multiple authors separated by a pipe 1`] = `
      | 
   </div>
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
     href="/profile/mike-atherton"
     role="link"
   >
@@ -79,7 +79,7 @@ exports[`4. with multiple authors separated by a pipe 1`] = `
      | 
   </div>
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
     href="/profile/alexandra-frean"
     role="link"
   >
@@ -93,7 +93,7 @@ exports[`5. with multiple authors separated by text with commas 1`] = `
   className="css-view-1dbjc4n"
 >
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
     href="/profile/camilla-long"
     role="link"
   >
@@ -105,7 +105,7 @@ exports[`5. with multiple authors separated by text with commas 1`] = `
     , 
   </div>
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
     href="/profile/mike-atherton"
     role="link"
   >
@@ -117,7 +117,7 @@ exports[`5. with multiple authors separated by text with commas 1`] = `
     , 
   </div>
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
     href="/profile/alexandra-frean"
     role="link"
   >
@@ -131,7 +131,7 @@ exports[`6. with multiple authors separated by spaces 1`] = `
   className="css-view-1dbjc4n"
 >
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
     href="/profile/camilla-long"
     role="link"
   >
@@ -143,14 +143,14 @@ exports[`6. with multiple authors separated by spaces 1`] = `
      
   </div>
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
     href="/profile/mike-atherton"
     role="link"
   >
     Mike Atherton
   </a>
   <a
-    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-1ddef8g"
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-76zvg2 r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
     href="/profile/alexandra-frean"
     role="link"
   >

--- a/packages/article-byline/src/styles/index.android.js
+++ b/packages/article-byline/src/styles/index.android.js
@@ -6,7 +6,6 @@ const styles = StyleSheet.create({
   link: {
     ...sharedStyles.link,
     lineHeight: 19,
-    textDecorationLine: "none"
   },
   nonLinkText: {
     ...sharedStyles.nonLinkText,

--- a/packages/article-byline/src/styles/index.android.js
+++ b/packages/article-byline/src/styles/index.android.js
@@ -5,7 +5,8 @@ const styles = StyleSheet.create({
   ...sharedStyles,
   link: {
     ...sharedStyles.link,
-    lineHeight: 19
+    lineHeight: 19,
+    textDecorationLine: "none"
   },
   nonLinkText: {
     ...sharedStyles.nonLinkText,

--- a/packages/article-byline/src/styles/index.android.js
+++ b/packages/article-byline/src/styles/index.android.js
@@ -5,7 +5,7 @@ const styles = StyleSheet.create({
   ...sharedStyles,
   link: {
     ...sharedStyles.link,
-    lineHeight: 19,
+    lineHeight: 19
   },
   nonLinkText: {
     ...sharedStyles.nonLinkText,

--- a/packages/article-byline/src/styles/shared.js
+++ b/packages/article-byline/src/styles/shared.js
@@ -7,7 +7,8 @@ const shared = {
       font: "supporting",
       fontSize: "cardMeta"
     }),
-    color: colours.functional.action
+    color: colours.functional.action,
+    textDecorationLine: "none"
   },
   nonLinkText: {
     ...fontFactory({


### PR DESCRIPTION
## Changes

- Have set the property `textDecorationLine` to `none` to remove the underline for author bylines
- https://nidigitalsolutions.jira.com/browse/REPLAT-6826


Before
<img width="309" alt="Screen Shot 2019-06-18 at 13 11 38" src="https://user-images.githubusercontent.com/16516378/59680976-accc4400-91ca-11e9-88e1-127ec8f8045d.png">

After
<img width="319" alt="Screen Shot 2019-06-18 at 13 00 54" src="https://user-images.githubusercontent.com/16516378/59680425-37ac3f00-91c9-11e9-84cd-28d3cf30dca4.png">