### PR TITLE
fix: replat 6828 change colon to fullstop in time display

### DIFF
--- a/packages/article-in-depth/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
@@ -80,7 +80,7 @@ exports[`6. article meta uses default section colour 1`] = `
   </View>
   <View>
     <Text>
-      Monday March 23 2015, 7:39pm, The Times
+      Monday March 23 2015, 7.39pm, The Times
     </Text>
   </View>
 </View>

--- a/packages/article-in-depth/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -156,7 +156,7 @@ exports[`1. article in depth - tablet 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-in-depth/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -128,7 +128,7 @@ exports[`full article with style 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -264,7 +264,7 @@ exports[`full article with style in the culture magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -400,7 +400,7 @@ exports[`full article with style in the style magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -536,7 +536,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -672,7 +672,7 @@ exports[`tablet full article with style in the culture magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -808,7 +808,7 @@ exports[`tablet full article with style in the style magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -944,7 +944,7 @@ exports[`tablet full article with style in the sunday times magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-in-depth/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -60,7 +60,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -124,7 +124,7 @@ exports[`4. an article with ads 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
@@ -80,7 +80,7 @@ exports[`6. article meta uses default section colour 1`] = `
   </View>
   <View>
     <Text>
-      Monday March 23 2015, 7:39pm, The Times
+      Monday March 23 2015, 7.39pm, The Times
     </Text>
   </View>
 </View>

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -156,7 +156,7 @@ exports[`1. article in depth - tablet 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -128,7 +128,7 @@ exports[`full article with style 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -264,7 +264,7 @@ exports[`full article with style in the culture magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -400,7 +400,7 @@ exports[`full article with style in the style magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -536,7 +536,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -672,7 +672,7 @@ exports[`tablet full article with style in the culture magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -808,7 +808,7 @@ exports[`tablet full article with style in the style magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -944,7 +944,7 @@ exports[`tablet full article with style in the sunday times magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -60,7 +60,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -124,7 +124,7 @@ exports[`4. an article with ads 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -114,7 +114,7 @@ exports[`1. a full article 1`] = `
   <time
     dateTime="2015-03-13T18:54:58.000Z"
   >
-    Friday March 13 2015, 6:54pm
+    Friday March 13 2015, 6.54pm
   </time>
   <span>
     , The Times

--- a/packages/article-magazine-comment/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
@@ -79,7 +79,7 @@ exports[`6. article meta 1`] = `
   </View>
   <View>
     <Text>
-      Monday March 23 2015, 7:39pm, The Times
+      Monday March 23 2015, 7.39pm, The Times
     </Text>
   </View>
 </View>

--- a/packages/article-magazine-comment/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -124,7 +124,7 @@ exports[`1. article magazine comment - tablet 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-magazine-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -108,7 +108,7 @@ exports[`full article with style 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -234,7 +234,7 @@ exports[`full article with style in the culture magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -360,7 +360,7 @@ exports[`full article with style in the style magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -486,7 +486,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -612,7 +612,7 @@ exports[`tablet full article with style in the culture magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -738,7 +738,7 @@ exports[`tablet full article with style in the style magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -864,7 +864,7 @@ exports[`tablet full article with style in the sunday times magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-magazine-comment/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -42,7 +42,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -107,7 +107,7 @@ exports[`4. an article with ads 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -197,7 +197,7 @@ exports[`7. an article with no author 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-magazine-comment/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
@@ -79,7 +79,7 @@ exports[`6. article meta 1`] = `
   </View>
   <View>
     <Text>
-      Monday March 23 2015, 7:39pm, The Times
+      Monday March 23 2015, 7.39pm, The Times
     </Text>
   </View>
 </View>

--- a/packages/article-magazine-comment/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -124,7 +124,7 @@ exports[`1. article magazine comment - tablet 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-magazine-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -108,7 +108,7 @@ exports[`full article with style 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -234,7 +234,7 @@ exports[`full article with style in the culture magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -360,7 +360,7 @@ exports[`full article with style in the style magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -486,7 +486,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -612,7 +612,7 @@ exports[`tablet full article with style in the culture magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -738,7 +738,7 @@ exports[`tablet full article with style in the style magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -864,7 +864,7 @@ exports[`tablet full article with style in the sunday times magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-magazine-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -42,7 +42,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -107,7 +107,7 @@ exports[`4. an article with ads 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -197,7 +197,7 @@ exports[`7. an article with no author 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -108,7 +108,7 @@ exports[`1. a full article 1`] = `
   <time
     dateTime="2015-03-13T18:54:58.000Z"
   >
-    Friday March 13 2015, 6:54pm
+    Friday March 13 2015, 6.54pm
   </time>
   <span>
     , The Times

--- a/packages/article-magazine-standard/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
@@ -80,7 +80,7 @@ exports[`6. article meta uses default section colour 1`] = `
   </View>
   <View>
     <Text>
-      Monday March 23 2015, 7:39pm, The Times
+      Monday March 23 2015, 7.39pm, The Times
     </Text>
   </View>
 </View>

--- a/packages/article-magazine-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -97,7 +97,7 @@ exports[`full article with style in the culture magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -212,7 +212,7 @@ exports[`full article with style in the style magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -327,7 +327,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -442,7 +442,7 @@ exports[`phone full article with style 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -557,7 +557,7 @@ exports[`tablet full article with style 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-magazine-standard/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -39,7 +39,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -101,7 +101,7 @@ exports[`4. an article with ads 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-magazine-standard/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
@@ -80,7 +80,7 @@ exports[`6. article meta uses default section colour 1`] = `
   </View>
   <View>
     <Text>
-      Monday March 23 2015, 7:39pm, The Times
+      Monday March 23 2015, 7.39pm, The Times
     </Text>
   </View>
 </View>

--- a/packages/article-magazine-standard/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -113,7 +113,7 @@ exports[`1. article magazine standard - tablet 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-magazine-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -97,7 +97,7 @@ exports[`full article with style in the culture magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -212,7 +212,7 @@ exports[`full article with style in the style magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -327,7 +327,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -442,7 +442,7 @@ exports[`phone full article with style 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -557,7 +557,7 @@ exports[`tablet full article with style 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-magazine-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -39,7 +39,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -101,7 +101,7 @@ exports[`4. an article with ads 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -93,7 +93,7 @@ exports[`1. a full article 1`] = `
   <time
     dateTime="2015-03-13T18:54:58.000Z"
   >
-    Friday March 13 2015, 6:54pm
+    Friday March 13 2015, 6.54pm
   </time>
   <span>
     , The Times

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article-internal-components.android.test.js.snap
@@ -79,7 +79,7 @@ exports[`6. article meta 1`] = `
   </View>
   <View>
     <Text>
-      Monday March 23 2015, 7:39pm, The Times
+      Monday March 23 2015, 7.39pm, The Times
     </Text>
   </View>
 </View>

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -137,7 +137,7 @@ exports[`1. article main comment - tablet 1`] = `
               }
             }
           >
-            Friday March 13 2015, 6:54pm, The Times
+            Friday March 13 2015, 6.54pm, The Times
           </Text>
         </View>
       </View>

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -121,7 +121,7 @@ exports[`phone full article with style 1`] = `
               }
             }
           >
-            Friday March 13 2015, 6:54pm, The Times
+            Friday March 13 2015, 6.54pm, The Times
           </Text>
         </View>
       </View>
@@ -251,7 +251,7 @@ exports[`tablet full article with style 1`] = `
               }
             }
           >
-            Friday March 13 2015, 6:54pm, The Times
+            Friday March 13 2015, 6.54pm, The Times
           </Text>
         </View>
       </View>

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -50,7 +50,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         </View>
         <View>
           <Text>
-            Friday March 13 2015, 6:54pm, The Times
+            Friday March 13 2015, 6.54pm, The Times
           </Text>
         </View>
       </View>
@@ -105,7 +105,7 @@ exports[`4. an article with ads 1`] = `
         </View>
         <View>
           <Text>
-            Friday March 13 2015, 6:54pm, The Times
+            Friday March 13 2015, 6.54pm, The Times
           </Text>
         </View>
       </View>

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article-internal-components.ios.test.js.snap
@@ -79,7 +79,7 @@ exports[`6. article meta 1`] = `
   </View>
   <View>
     <Text>
-      Monday March 23 2015, 7:39pm, The Times
+      Monday March 23 2015, 7.39pm, The Times
     </Text>
   </View>
 </View>

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -137,7 +137,7 @@ exports[`1. article main comment - tablet 1`] = `
               }
             }
           >
-            Friday March 13 2015, 6:54pm, The Times
+            Friday March 13 2015, 6.54pm, The Times
           </Text>
         </View>
       </View>

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -121,7 +121,7 @@ exports[`phone full article with style 1`] = `
               }
             }
           >
-            Friday March 13 2015, 6:54pm, The Times
+            Friday March 13 2015, 6.54pm, The Times
           </Text>
         </View>
       </View>
@@ -251,7 +251,7 @@ exports[`tablet full article with style 1`] = `
               }
             }
           >
-            Friday March 13 2015, 6:54pm, The Times
+            Friday March 13 2015, 6.54pm, The Times
           </Text>
         </View>
       </View>

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -50,7 +50,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         </View>
         <View>
           <Text>
-            Friday March 13 2015, 6:54pm, The Times
+            Friday March 13 2015, 6.54pm, The Times
           </Text>
         </View>
       </View>
@@ -105,7 +105,7 @@ exports[`4. an article with ads 1`] = `
         </View>
         <View>
           <Text>
-            Friday March 13 2015, 6:54pm, The Times
+            Friday March 13 2015, 6.54pm, The Times
           </Text>
         </View>
       </View>

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -109,7 +109,7 @@ exports[`1. a full article 1`] = `
   <time
     dateTime="2015-03-13T18:54:58.000Z"
   >
-    Friday March 13 2015, 6:54pm
+    Friday March 13 2015, 6.54pm
   </time>
   <span>
     , The Times

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -128,7 +128,7 @@ exports[`1. article main standard - tablet 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -127,7 +127,7 @@ exports[`full article with style on mobile 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -262,7 +262,7 @@ exports[`full article with style on tablet 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -81,7 +81,7 @@ exports[`1. an article 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -110,7 +110,7 @@ exports[`4. an article with no headline falls back to use shortheadline 1`] = `
     <View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -135,7 +135,7 @@ exports[`5. an article with ads 1`] = `
     <View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -127,7 +127,7 @@ exports[`1. article main standard - tablet 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -126,7 +126,7 @@ exports[`full article with style on mobile 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -260,7 +260,7 @@ exports[`full article with style on tablet 1`] = `
             }
           }
         >
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -81,7 +81,7 @@ exports[`1. an article 1`] = `
       </View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -110,7 +110,7 @@ exports[`4. an article with no headline falls back to use shortheadline 1`] = `
     <View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>
@@ -135,7 +135,7 @@ exports[`5. an article with ads 1`] = `
     <View>
       <View>
         <Text>
-          Friday March 13 2015, 6:54pm, The Times
+          Friday March 13 2015, 6.54pm, The Times
         </Text>
       </View>
     </View>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -98,7 +98,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
     <time
       dateTime="2015-03-13T18:54:58.000Z"
     >
-      Friday March 13 2015, 6:54pm
+      Friday March 13 2015, 6.54pm
     </time>
     <span>
       , The Times

--- a/packages/date-publication/__tests__/android/__snapshots__/date-publication-bst-am.android.test.js.snap
+++ b/packages/date-publication/__tests__/android/__snapshots__/date-publication-bst-am.android.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 5:32am, The Times"`;
+exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 5.32am, The Times"`;
 
-exports[`2. date and sundaytimes publication 1`] = `"Saturday July 01 2017, 5:32am, The Sunday Times"`;
+exports[`2. date and sundaytimes publication 1`] = `"Saturday July 01 2017, 5.32am, The Sunday Times"`;
 
-exports[`3. date and no given publication 1`] = `"Saturday July 01 2017, 5:32am"`;
+exports[`3. date and no given publication 1`] = `"Saturday July 01 2017, 5.32am"`;
 
-exports[`4. date and no day 1`] = `"July 01 2017, 5:32am"`;
+exports[`4. date and no day 1`] = `"July 01 2017, 5.32am"`;

--- a/packages/date-publication/__tests__/android/__snapshots__/date-publication-bst-non-london-am.android.test.js.snap
+++ b/packages/date-publication/__tests__/android/__snapshots__/date-publication-bst-non-london-am.android.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 5:32am BST, The Times"`;
+exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 5.32am BST, The Times"`;

--- a/packages/date-publication/__tests__/android/__snapshots__/date-publication-bst-non-london-pm.android.test.js.snap
+++ b/packages/date-publication/__tests__/android/__snapshots__/date-publication-bst-non-london-pm.android.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 3:32pm BST, The Times"`;
+exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 3.32pm BST, The Times"`;

--- a/packages/date-publication/__tests__/android/__snapshots__/date-publication-bst-pm.android.test.js.snap
+++ b/packages/date-publication/__tests__/android/__snapshots__/date-publication-bst-pm.android.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 3:32pm, The Times"`;
+exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 3.32pm, The Times"`;
 
-exports[`2. date and sundaytimes publication 1`] = `"Saturday July 01 2017, 3:32pm, The Sunday Times"`;
+exports[`2. date and sundaytimes publication 1`] = `"Saturday July 01 2017, 3.32pm, The Sunday Times"`;
 
-exports[`3. date and no given publication 1`] = `"Saturday July 01 2017, 3:32pm"`;
+exports[`3. date and no given publication 1`] = `"Saturday July 01 2017, 3.32pm"`;
 
-exports[`4. date and no day 1`] = `"July 01 2017, 3:32pm"`;
+exports[`4. date and no day 1`] = `"July 01 2017, 3.32pm"`;

--- a/packages/date-publication/__tests__/android/__snapshots__/date-publication-gmt-am.android.test.js.snap
+++ b/packages/date-publication/__tests__/android/__snapshots__/date-publication-gmt-am.android.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 4:32am, The Times"`;
+exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 4.32am, The Times"`;
 
-exports[`2. date and sundaytimes publication 1`] = `"Sunday January 01 2017, 4:32am, The Sunday Times"`;
+exports[`2. date and sundaytimes publication 1`] = `"Sunday January 01 2017, 4.32am, The Sunday Times"`;
 
-exports[`3. date and no given publication 1`] = `"Sunday January 01 2017, 4:32am"`;
+exports[`3. date and no given publication 1`] = `"Sunday January 01 2017, 4.32am"`;
 
-exports[`4. date and no day 1`] = `"January 01 2017, 4:32am"`;
+exports[`4. date and no day 1`] = `"January 01 2017, 4.32am"`;

--- a/packages/date-publication/__tests__/android/__snapshots__/date-publication-gmt-non-london-am.android.test.js.snap
+++ b/packages/date-publication/__tests__/android/__snapshots__/date-publication-gmt-non-london-am.android.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 4:32am GMT, The Times"`;
+exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 4.32am GMT, The Times"`;

--- a/packages/date-publication/__tests__/android/__snapshots__/date-publication-gmt-non-london-pm.android.test.js.snap
+++ b/packages/date-publication/__tests__/android/__snapshots__/date-publication-gmt-non-london-pm.android.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 2:32pm GMT, The Times"`;
+exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 2.32pm GMT, The Times"`;

--- a/packages/date-publication/__tests__/android/__snapshots__/date-publication-gmt-pm.android.test.js.snap
+++ b/packages/date-publication/__tests__/android/__snapshots__/date-publication-gmt-pm.android.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 2:32pm, The Times"`;
+exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 2.32pm, The Times"`;
 
-exports[`2. date and sundaytimes publication 1`] = `"Sunday January 01 2017, 2:32pm, The Sunday Times"`;
+exports[`2. date and sundaytimes publication 1`] = `"Sunday January 01 2017, 2.32pm, The Sunday Times"`;
 
-exports[`3. date and no given publication 1`] = `"Sunday January 01 2017, 2:32pm"`;
+exports[`3. date and no given publication 1`] = `"Sunday January 01 2017, 2.32pm"`;
 
-exports[`4. date and no day 1`] = `"January 01 2017, 2:32pm"`;
+exports[`4. date and no day 1`] = `"January 01 2017, 2.32pm"`;

--- a/packages/date-publication/__tests__/ios/__snapshots__/date-publication-bst-am.ios.test.js.snap
+++ b/packages/date-publication/__tests__/ios/__snapshots__/date-publication-bst-am.ios.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 5:32am, The Times"`;
+exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 5.32am, The Times"`;
 
-exports[`2. date and sundaytimes publication 1`] = `"Saturday July 01 2017, 5:32am, The Sunday Times"`;
+exports[`2. date and sundaytimes publication 1`] = `"Saturday July 01 2017, 5.32am, The Sunday Times"`;
 
-exports[`3. date and no given publication 1`] = `"Saturday July 01 2017, 5:32am"`;
+exports[`3. date and no given publication 1`] = `"Saturday July 01 2017, 5.32am"`;
 
-exports[`4. date and no day 1`] = `"July 01 2017, 5:32am"`;
+exports[`4. date and no day 1`] = `"July 01 2017, 5.32am"`;

--- a/packages/date-publication/__tests__/ios/__snapshots__/date-publication-bst-non-london-am.ios.test.js.snap
+++ b/packages/date-publication/__tests__/ios/__snapshots__/date-publication-bst-non-london-am.ios.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 5:32am BST, The Times"`;
+exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 5.32am BST, The Times"`;

--- a/packages/date-publication/__tests__/ios/__snapshots__/date-publication-bst-non-london-pm.ios.test.js.snap
+++ b/packages/date-publication/__tests__/ios/__snapshots__/date-publication-bst-non-london-pm.ios.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 3:32pm BST, The Times"`;
+exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 3.32pm BST, The Times"`;

--- a/packages/date-publication/__tests__/ios/__snapshots__/date-publication-bst-pm.ios.test.js.snap
+++ b/packages/date-publication/__tests__/ios/__snapshots__/date-publication-bst-pm.ios.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 3:32pm, The Times"`;
+exports[`1. date and times publication 1`] = `"Saturday July 01 2017, 3.32pm, The Times"`;
 
-exports[`2. date and sundaytimes publication 1`] = `"Saturday July 01 2017, 3:32pm, The Sunday Times"`;
+exports[`2. date and sundaytimes publication 1`] = `"Saturday July 01 2017, 3.32pm, The Sunday Times"`;
 
-exports[`3. date and no given publication 1`] = `"Saturday July 01 2017, 3:32pm"`;
+exports[`3. date and no given publication 1`] = `"Saturday July 01 2017, 3.32pm"`;
 
-exports[`4. date and no day 1`] = `"July 01 2017, 3:32pm"`;
+exports[`4. date and no day 1`] = `"July 01 2017, 3.32pm"`;

--- a/packages/date-publication/__tests__/ios/__snapshots__/date-publication-gmt-am.ios.test.js.snap
+++ b/packages/date-publication/__tests__/ios/__snapshots__/date-publication-gmt-am.ios.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 4:32am, The Times"`;
+exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 4.32am, The Times"`;
 
-exports[`2. date and sundaytimes publication 1`] = `"Sunday January 01 2017, 4:32am, The Sunday Times"`;
+exports[`2. date and sundaytimes publication 1`] = `"Sunday January 01 2017, 4.32am, The Sunday Times"`;
 
-exports[`3. date and no given publication 1`] = `"Sunday January 01 2017, 4:32am"`;
+exports[`3. date and no given publication 1`] = `"Sunday January 01 2017, 4.32am"`;
 
-exports[`4. date and no day 1`] = `"January 01 2017, 4:32am"`;
+exports[`4. date and no day 1`] = `"January 01 2017, 4.32am"`;

--- a/packages/date-publication/__tests__/ios/__snapshots__/date-publication-gmt-non-london-am.ios.test.js.snap
+++ b/packages/date-publication/__tests__/ios/__snapshots__/date-publication-gmt-non-london-am.ios.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 4:32am GMT, The Times"`;
+exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 4.32am GMT, The Times"`;

--- a/packages/date-publication/__tests__/ios/__snapshots__/date-publication-gmt-non-london-pm.ios.test.js.snap
+++ b/packages/date-publication/__tests__/ios/__snapshots__/date-publication-gmt-non-london-pm.ios.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 2:32pm GMT, The Times"`;
+exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 2.32pm GMT, The Times"`;

--- a/packages/date-publication/__tests__/ios/__snapshots__/date-publication-gmt-pm.ios.test.js.snap
+++ b/packages/date-publication/__tests__/ios/__snapshots__/date-publication-gmt-pm.ios.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 2:32pm, The Times"`;
+exports[`1. date and times publication 1`] = `"Sunday January 01 2017, 2.32pm, The Times"`;
 
-exports[`2. date and sundaytimes publication 1`] = `"Sunday January 01 2017, 2:32pm, The Sunday Times"`;
+exports[`2. date and sundaytimes publication 1`] = `"Sunday January 01 2017, 2.32pm, The Sunday Times"`;
 
-exports[`3. date and no given publication 1`] = `"Sunday January 01 2017, 2:32pm"`;
+exports[`3. date and no given publication 1`] = `"Sunday January 01 2017, 2.32pm"`;
 
-exports[`4. date and no day 1`] = `"January 01 2017, 2:32pm"`;
+exports[`4. date and no day 1`] = `"January 01 2017, 2.32pm"`;

--- a/packages/date-publication/__tests__/web/__snapshots__/date-publication-bst-am.web.test.js.snap
+++ b/packages/date-publication/__tests__/web/__snapshots__/date-publication-bst-am.web.test.js.snap
@@ -5,7 +5,7 @@ Array [
   <time
     dateTime="2017-07-01T04:32:00.000Z"
   >
-    Saturday July 01 2017, 5:32am
+    Saturday July 01 2017, 5.32am
   </time>,
   <span>
     , The Times
@@ -18,7 +18,7 @@ Array [
   <time
     dateTime="2017-07-01T04:32:00.000Z"
   >
-    Saturday July 01 2017, 5:32am
+    Saturday July 01 2017, 5.32am
   </time>,
   <span>
     , The Sunday Times
@@ -30,7 +30,7 @@ exports[`3. date and no given publication 1`] = `
 <time
   dateTime="2017-07-01T04:32:00.000Z"
 >
-  Saturday July 01 2017, 5:32am
+  Saturday July 01 2017, 5.32am
 </time>
 `;
 
@@ -38,6 +38,6 @@ exports[`4. date and no day 1`] = `
 <time
   dateTime="2017-07-01T04:32:00.000Z"
 >
-  July 01 2017, 5:32am
+  July 01 2017, 5.32am
 </time>
 `;

--- a/packages/date-publication/__tests__/web/__snapshots__/date-publication-bst-non-london-am.web.test.js.snap
+++ b/packages/date-publication/__tests__/web/__snapshots__/date-publication-bst-non-london-am.web.test.js.snap
@@ -5,7 +5,7 @@ Array [
   <time
     dateTime="2017-07-01T04:32:00.000Z"
   >
-    Saturday July 01 2017, 5:32am BST
+    Saturday July 01 2017, 5.32am BST
   </time>,
   <span>
     , The Times

--- a/packages/date-publication/__tests__/web/__snapshots__/date-publication-bst-non-london-pm.web.test.js.snap
+++ b/packages/date-publication/__tests__/web/__snapshots__/date-publication-bst-non-london-pm.web.test.js.snap
@@ -5,7 +5,7 @@ Array [
   <time
     dateTime="2017-07-01T14:32:00.000Z"
   >
-    Saturday July 01 2017, 3:32pm BST
+    Saturday July 01 2017, 3.32pm BST
   </time>,
   <span>
     , The Times

--- a/packages/date-publication/__tests__/web/__snapshots__/date-publication-bst-pm.web.test.js.snap
+++ b/packages/date-publication/__tests__/web/__snapshots__/date-publication-bst-pm.web.test.js.snap
@@ -5,7 +5,7 @@ Array [
   <time
     dateTime="2017-07-01T14:32:00.000Z"
   >
-    Saturday July 01 2017, 3:32pm
+    Saturday July 01 2017, 3.32pm
   </time>,
   <span>
     , The Times
@@ -18,7 +18,7 @@ Array [
   <time
     dateTime="2017-07-01T14:32:00.000Z"
   >
-    Saturday July 01 2017, 3:32pm
+    Saturday July 01 2017, 3.32pm
   </time>,
   <span>
     , The Sunday Times
@@ -30,7 +30,7 @@ exports[`3. date and no given publication 1`] = `
 <time
   dateTime="2017-07-01T14:32:00.000Z"
 >
-  Saturday July 01 2017, 3:32pm
+  Saturday July 01 2017, 3.32pm
 </time>
 `;
 
@@ -38,6 +38,6 @@ exports[`4. date and no day 1`] = `
 <time
   dateTime="2017-07-01T14:32:00.000Z"
 >
-  July 01 2017, 3:32pm
+  July 01 2017, 3.32pm
 </time>
 `;

--- a/packages/date-publication/__tests__/web/__snapshots__/date-publication-gmt-am.web.test.js.snap
+++ b/packages/date-publication/__tests__/web/__snapshots__/date-publication-gmt-am.web.test.js.snap
@@ -5,7 +5,7 @@ Array [
   <time
     dateTime="2017-01-01T04:32:00.000Z"
   >
-    Sunday January 01 2017, 4:32am
+    Sunday January 01 2017, 4.32am
   </time>,
   <span>
     , The Times
@@ -18,7 +18,7 @@ Array [
   <time
     dateTime="2017-01-01T04:32:00.000Z"
   >
-    Sunday January 01 2017, 4:32am
+    Sunday January 01 2017, 4.32am
   </time>,
   <span>
     , The Sunday Times
@@ -30,7 +30,7 @@ exports[`3. date and no given publication 1`] = `
 <time
   dateTime="2017-01-01T04:32:00.000Z"
 >
-  Sunday January 01 2017, 4:32am
+  Sunday January 01 2017, 4.32am
 </time>
 `;
 
@@ -38,6 +38,6 @@ exports[`4. date and no day 1`] = `
 <time
   dateTime="2017-01-01T04:32:00.000Z"
 >
-  January 01 2017, 4:32am
+  January 01 2017, 4.32am
 </time>
 `;

--- a/packages/date-publication/__tests__/web/__snapshots__/date-publication-gmt-non-london-am.web.test.js.snap
+++ b/packages/date-publication/__tests__/web/__snapshots__/date-publication-gmt-non-london-am.web.test.js.snap
@@ -5,7 +5,7 @@ Array [
   <time
     dateTime="2017-01-01T04:32:00.000Z"
   >
-    Sunday January 01 2017, 4:32am GMT
+    Sunday January 01 2017, 4.32am GMT
   </time>,
   <span>
     , The Times

--- a/packages/date-publication/__tests__/web/__snapshots__/date-publication-gmt-non-london-pm.web.test.js.snap
+++ b/packages/date-publication/__tests__/web/__snapshots__/date-publication-gmt-non-london-pm.web.test.js.snap
@@ -5,7 +5,7 @@ Array [
   <time
     dateTime="2017-01-01T14:32:00.000Z"
   >
-    Sunday January 01 2017, 2:32pm GMT
+    Sunday January 01 2017, 2.32pm GMT
   </time>,
   <span>
     , The Times

--- a/packages/date-publication/__tests__/web/__snapshots__/date-publication-gmt-pm.web.test.js.snap
+++ b/packages/date-publication/__tests__/web/__snapshots__/date-publication-gmt-pm.web.test.js.snap
@@ -5,7 +5,7 @@ Array [
   <time
     dateTime="2017-01-01T14:32:00.000Z"
   >
-    Sunday January 01 2017, 2:32pm
+    Sunday January 01 2017, 2.32pm
   </time>,
   <span>
     , The Times
@@ -18,7 +18,7 @@ Array [
   <time
     dateTime="2017-01-01T14:32:00.000Z"
   >
-    Sunday January 01 2017, 2:32pm
+    Sunday January 01 2017, 2.32pm
   </time>,
   <span>
     , The Sunday Times
@@ -30,7 +30,7 @@ exports[`3. date and no given publication 1`] = `
 <time
   dateTime="2017-01-01T14:32:00.000Z"
 >
-  Sunday January 01 2017, 2:32pm
+  Sunday January 01 2017, 2.32pm
 </time>
 `;
 
@@ -38,6 +38,6 @@ exports[`4. date and no day 1`] = `
 <time
   dateTime="2017-01-01T14:32:00.000Z"
 >
-  January 01 2017, 2:32pm
+  January 01 2017, 2.32pm
 </time>
 `;

--- a/packages/date-publication/src/date-time.js
+++ b/packages/date-publication/src/date-time.js
@@ -33,7 +33,7 @@ class DatePublication extends Component {
     const isDateBST = isBST(datetimeUTC);
     const offset = isDateBST ? 60 : 0;
     const datetimeLondonTimezone = addMinutes(datetimeUTC, offset);
-    const baseFormatString = "MMMM DD YYYY, h:mma";
+    const baseFormatString = "MMMM DD YYYY, h.mma";
     const formatString = showDay
       ? `dddd ${baseFormatString}`
       : baseFormatString;

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
@@ -53,7 +53,7 @@ exports[`1. one lead related article 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
@@ -53,7 +53,7 @@ exports[`1. one lead and one support related article 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>
@@ -99,7 +99,7 @@ exports[`1. one lead and one support related article 1`] = `
                   Second Short Headline
                 </Text>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
@@ -53,7 +53,7 @@ exports[`1. one lead and two support related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>
@@ -99,7 +99,7 @@ exports[`1. one lead and two support related articles 1`] = `
                   Second Short Headline
                 </Text>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>
@@ -145,7 +145,7 @@ exports[`1. one lead and two support related articles 1`] = `
                   Third Short Headline
                 </Text>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
@@ -53,7 +53,7 @@ exports[`1. no short headline 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
@@ -121,7 +121,7 @@ exports[`default styles 1`] = `
                     }
                   }
                 >
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
@@ -68,7 +68,7 @@ exports[`1. one opinion related article 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
@@ -68,7 +68,7 @@ exports[`1. one opinion and one support related article 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
               </View>
             </Card>
@@ -109,7 +109,7 @@ exports[`1. one opinion and one support related article 1`] = `
                   Second Short Headline
                 </Text>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
@@ -68,7 +68,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
               </View>
             </Card>
@@ -109,7 +109,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                   Second Short Headline
                 </Text>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>
@@ -155,7 +155,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                   Third Short Headline
                 </Text>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
@@ -68,7 +68,7 @@ exports[`1. no short headline 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
@@ -144,7 +144,7 @@ exports[`default styles 1`] = `
                     }
                   }
                 >
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
@@ -54,7 +54,7 @@ exports[`1. has video 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
@@ -121,7 +121,7 @@ exports[`default styles 1`] = `
                     }
                   }
                 >
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
@@ -54,7 +54,7 @@ exports[`1. a single related article 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
@@ -53,7 +53,7 @@ exports[`1. two related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>
@@ -108,7 +108,7 @@ exports[`1. two related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
@@ -53,7 +53,7 @@ exports[`1. three related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>
@@ -108,7 +108,7 @@ exports[`1. three related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>
@@ -163,7 +163,7 @@ exports[`1. three related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
@@ -54,7 +54,7 @@ exports[`1. no short headline 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
@@ -53,7 +53,7 @@ exports[`1. one lead related article 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
@@ -53,7 +53,7 @@ exports[`1. one lead and one support related article 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>
@@ -99,7 +99,7 @@ exports[`1. one lead and one support related article 1`] = `
                   Second Short Headline
                 </Text>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
@@ -53,7 +53,7 @@ exports[`1. one lead and two support related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>
@@ -99,7 +99,7 @@ exports[`1. one lead and two support related articles 1`] = `
                   Second Short Headline
                 </Text>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>
@@ -145,7 +145,7 @@ exports[`1. one lead and two support related articles 1`] = `
                   Third Short Headline
                 </Text>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
@@ -53,7 +53,7 @@ exports[`1. no short headline 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
@@ -121,7 +121,7 @@ exports[`default styles 1`] = `
                     }
                   }
                 >
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
@@ -68,7 +68,7 @@ exports[`1. one opinion related article 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
@@ -68,7 +68,7 @@ exports[`1. one opinion and one support related article 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
               </View>
             </Card>
@@ -109,7 +109,7 @@ exports[`1. one opinion and one support related article 1`] = `
                   Second Short Headline
                 </Text>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
@@ -68,7 +68,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
               </View>
             </Card>
@@ -109,7 +109,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                   Second Short Headline
                 </Text>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>
@@ -155,7 +155,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                   Third Short Headline
                 </Text>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
@@ -68,7 +68,7 @@ exports[`1. no short headline 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
@@ -144,7 +144,7 @@ exports[`default styles 1`] = `
                     }
                   }
                 >
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
@@ -54,7 +54,7 @@ exports[`1. a single related article 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
@@ -53,7 +53,7 @@ exports[`1. two related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>
@@ -108,7 +108,7 @@ exports[`1. two related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
@@ -53,7 +53,7 @@ exports[`1. three related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>
@@ -108,7 +108,7 @@ exports[`1. three related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>
@@ -163,7 +163,7 @@ exports[`1. three related articles 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  January 17 2018, 12:00pm
+                  January 17 2018, 12.00pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
@@ -54,7 +54,7 @@ exports[`1. has video 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
@@ -54,7 +54,7 @@ exports[`1. no short headline 1`] = `
                   </Text>
                 </View>
                 <Text>
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
@@ -121,7 +121,7 @@ exports[`default styles 1`] = `
                     }
                   }
                 >
-                  March 13 2015, 6:54pm
+                  March 13 2015, 6.54pm
                 </Text>
                 <Text>
                   <Text

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
@@ -57,7 +57,7 @@ exports[`1. one lead related article 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                   <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
@@ -57,7 +57,7 @@ exports[`1. one lead and one support related article 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                   <div>
@@ -108,7 +108,7 @@ exports[`1. one lead and one support related article 1`] = `
                       <time
                         dateTime="2018-01-17T12:00:00.000Z"
                       >
-                        January 17 2018, 12:00pm
+                        January 17 2018, 12.00pm
                       </time>
                     </div>
                     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
@@ -64,7 +64,7 @@ exports[`1. one lead and two support related articles 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                   <div>
@@ -115,7 +115,7 @@ exports[`1. one lead and two support related articles 1`] = `
                       <time
                         dateTime="2018-01-17T12:00:00.000Z"
                       >
-                        January 17 2018, 12:00pm
+                        January 17 2018, 12.00pm
                       </time>
                     </div>
                     <div>
@@ -164,7 +164,7 @@ exports[`1. one lead and two support related articles 1`] = `
                       <time
                         dateTime="2018-01-17T12:00:00.000Z"
                       >
-                        January 17 2018, 12:00pm
+                        January 17 2018, 12.00pm
                       </time>
                     </div>
                     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
@@ -57,7 +57,7 @@ exports[`1. no short headline 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                   <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -304,7 +304,7 @@ exports[`default styles 1`] = `
                     className="css-text-76zvg2 r-color-1khp51w r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-marginBottom-d0pm55 S7"
                   >
                     <time>
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                   <div

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
@@ -69,7 +69,7 @@ exports[`1. one opinion related article 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                 </div>

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
@@ -76,7 +76,7 @@ exports[`1. one opinion and one support related article 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                 </div>
@@ -122,7 +122,7 @@ exports[`1. one opinion and one support related article 1`] = `
                       <time
                         dateTime="2018-01-17T12:00:00.000Z"
                       >
-                        January 17 2018, 12:00pm
+                        January 17 2018, 12.00pm
                       </time>
                     </div>
                     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
@@ -69,7 +69,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                 </div>
@@ -115,7 +115,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                       <time
                         dateTime="2018-01-17T12:00:00.000Z"
                       >
-                        January 17 2018, 12:00pm
+                        January 17 2018, 12.00pm
                       </time>
                     </div>
                     <div>
@@ -164,7 +164,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                       <time
                         dateTime="2018-01-17T12:00:00.000Z"
                       >
-                        January 17 2018, 12:00pm
+                        January 17 2018, 12.00pm
                       </time>
                     </div>
                     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
@@ -69,7 +69,7 @@ exports[`1. no short headline 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                 </div>

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -354,7 +354,7 @@ exports[`default styles 1`] = `
                     className="css-text-76zvg2 r-color-1khp51w r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-marginBottom-d0pm55 S8"
                   >
                     <time>
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                 </div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
@@ -58,7 +58,7 @@ exports[`1. a single related article 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                   <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
@@ -57,7 +57,7 @@ exports[`1. two related articles 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                   <div>
@@ -115,7 +115,7 @@ exports[`1. two related articles 1`] = `
                     <time
                       dateTime="2018-01-17T12:00:00.000Z"
                     >
-                      January 17 2018, 12:00pm
+                      January 17 2018, 12.00pm
                     </time>
                   </div>
                   <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
@@ -64,7 +64,7 @@ exports[`1. three related articles 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                   <div>
@@ -129,7 +129,7 @@ exports[`1. three related articles 1`] = `
                     <time
                       dateTime="2018-01-17T12:00:00.000Z"
                     >
-                      January 17 2018, 12:00pm
+                      January 17 2018, 12.00pm
                     </time>
                   </div>
                   <div>
@@ -194,7 +194,7 @@ exports[`1. three related articles 1`] = `
                     <time
                       dateTime="2018-01-17T12:00:00.000Z"
                     >
-                      January 17 2018, 12:00pm
+                      January 17 2018, 12.00pm
                     </time>
                   </div>
                   <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
@@ -58,7 +58,7 @@ exports[`1. has video 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                   <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
@@ -58,7 +58,7 @@ exports[`1. no short headline 1`] = `
                     <time
                       dateTime="2015-03-13T18:54:58.000Z"
                     >
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                   <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -277,7 +277,7 @@ exports[`default styles 1`] = `
                     className="css-text-76zvg2 r-color-1khp51w r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-marginBottom-d0pm55 S7"
                   >
                     <time>
-                      March 13 2015, 6:54pm
+                      March 13 2015, 6.54pm
                     </time>
                   </div>
                   <div


### PR DESCRIPTION
JIRA ticket: https://nidigitalsolutions.jira.com/browse/REPLAT-6828
based on design review feedback the semicolon is being replaced by a fullstop in the time display.
This:

<img width="342" alt="Screenshot 2019-06-19 at 10 00 56" src="https://user-images.githubusercontent.com/17279130/59751873-333f5f00-9279-11e9-96ea-8709190d43d6.png">

Is becoming this:
<img width="321" alt="Screenshot 2019-06-19 at 09 59 13" src="https://user-images.githubusercontent.com/17279130/59751775-0428ed80-9279-11e9-9b32-28a05b9b952a.png">
