### PR TITLE
fix: remove teaser text from secondary one slice on 768px breakpoint

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -2539,3 +2539,145 @@ exports[`38. tile ac 1`] = `
   </View>
 </Link>
 `;
+
+exports[`tiles that change logic based on breakpoints TileW with teaser for wider screens 1`] = `
+<Link>
+  <View
+    style={
+      Object {
+        "paddingBottom": 5,
+        "paddingRight": 20,
+        "width": "33.33%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "marginBottom": 5,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#005B8D",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 0.6,
+            "lineHeight": 12,
+            "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 0,
+          }
+        }
+      >
+        LABEL
+      </Text>
+    </View>
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 35,
+          "fontWeight": "400",
+          "lineHeight": 35,
+          "marginBottom": 5,
+        }
+      }
+    >
+      This is tile headline
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
+          "marginBottom": 10,
+        }
+      }
+    >
+      <Text>
+        
+        Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+        ...
+      </Text>
+    </Text>
+    <ArticleFlags />
+  </View>
+  <Image
+    style={
+      Object {
+        "width": "66.66%",
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`tiles that change logic based on breakpoints TileW without teaser for tablet 1`] = `
+<Link>
+  <View
+    style={
+      Object {
+        "paddingBottom": 5,
+        "paddingRight": 20,
+        "width": "33.33%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "marginBottom": 5,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#005B8D",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 0.6,
+            "lineHeight": 12,
+            "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 0,
+          }
+        }
+      >
+        LABEL
+      </Text>
+    </View>
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 35,
+          "fontWeight": "400",
+          "lineHeight": 35,
+          "marginBottom": 5,
+        }
+      }
+    >
+      This is tile headline
+    </Text>
+    <ArticleFlags />
+  </View>
+  <Image
+    style={
+      Object {
+        "width": "66.66%",
+      }
+    }
+  />
+</Link>
+`;

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -1549,3 +1549,92 @@ exports[`38. tile ac 1`] = `
   </View>
 </Link>
 `;
+
+exports[`tiles that change logic based on breakpoints TileW with teaser for wider screens 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flexDirection": "row",
+      "paddingHorizontal": 20,
+      "paddingVertical": 10,
+    }
+  }
+  url="/article/123"
+>
+  <View>
+    <View>
+      <Text>
+        LABEL
+      </Text>
+    </View>
+    <Text
+      accessibilityRole="header"
+      aria-level="3"
+    >
+      This is tile headline
+    </Text>
+    <Text>
+      <Text>
+        
+        Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+        ...
+      </Text>
+    </Text>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
+  </View>
+  <Image
+    aspectRatio={1.7777777777777777}
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+</Link>
+`;
+
+exports[`tiles that change logic based on breakpoints TileW without teaser for tablet 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flexDirection": "row",
+      "paddingHorizontal": 20,
+      "paddingVertical": 10,
+    }
+  }
+  url="/article/123"
+>
+  <View>
+    <View>
+      <Text>
+        LABEL
+      </Text>
+    </View>
+    <Text
+      accessibilityRole="header"
+      aria-level="3"
+    >
+      This is tile headline
+    </Text>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
+  </View>
+  <Image
+    aspectRatio={1.7777777777777777}
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+</Link>
+`;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -2539,3 +2539,145 @@ exports[`38. tile ac 1`] = `
   </View>
 </Link>
 `;
+
+exports[`tiles that change logic based on breakpoints TileW with teaser for wider screens 1`] = `
+<Link>
+  <View
+    style={
+      Object {
+        "paddingBottom": 5,
+        "paddingRight": 20,
+        "width": "33.33%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#005B8D",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 0.6,
+            "lineHeight": 11,
+            "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 1,
+          }
+        }
+      >
+        LABEL
+      </Text>
+    </View>
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 35,
+          "fontWeight": "900",
+          "lineHeight": 35,
+          "marginBottom": 5,
+        }
+      }
+    >
+      This is tile headline
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
+          "marginBottom": 10,
+        }
+      }
+    >
+      <Text>
+        
+        Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+        ...
+      </Text>
+    </Text>
+    <ArticleFlags />
+  </View>
+  <Image
+    style={
+      Object {
+        "width": "66.66%",
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`tiles that change logic based on breakpoints TileW without teaser for tablet 1`] = `
+<Link>
+  <View
+    style={
+      Object {
+        "paddingBottom": 5,
+        "paddingRight": 20,
+        "width": "33.33%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#005B8D",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 0.6,
+            "lineHeight": 11,
+            "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 1,
+          }
+        }
+      >
+        LABEL
+      </Text>
+    </View>
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 35,
+          "fontWeight": "900",
+          "lineHeight": 35,
+          "marginBottom": 5,
+        }
+      }
+    >
+      This is tile headline
+    </Text>
+    <ArticleFlags />
+  </View>
+  <Image
+    style={
+      Object {
+        "width": "66.66%",
+      }
+    }
+  />
+</Link>
+`;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -1549,3 +1549,92 @@ exports[`38. tile ac 1`] = `
   </View>
 </Link>
 `;
+
+exports[`tiles that change logic based on breakpoints TileW with teaser for wider screens 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flexDirection": "row",
+      "paddingHorizontal": 20,
+      "paddingVertical": 10,
+    }
+  }
+  url="/article/123"
+>
+  <View>
+    <View>
+      <Text>
+        LABEL
+      </Text>
+    </View>
+    <Text
+      accessibilityRole="header"
+      aria-level="3"
+    >
+      This is tile headline
+    </Text>
+    <Text>
+      <Text>
+        
+        Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+        ...
+      </Text>
+    </Text>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
+  </View>
+  <Image
+    aspectRatio={1.7777777777777777}
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+</Link>
+`;
+
+exports[`tiles that change logic based on breakpoints TileW without teaser for tablet 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flexDirection": "row",
+      "paddingHorizontal": 20,
+      "paddingVertical": 10,
+    }
+  }
+  url="/article/123"
+>
+  <View>
+    <View>
+      <Text>
+        LABEL
+      </Text>
+    </View>
+    <Text
+      accessibilityRole="header"
+      aria-level="3"
+    >
+      This is tile headline
+    </Text>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
+  </View>
+  <Image
+    aspectRatio={1.7777777777777777}
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+</Link>
+`;

--- a/packages/edition-slices/__tests__/shared-tiles.base.js
+++ b/packages/edition-slices/__tests__/shared-tiles.base.js
@@ -6,6 +6,7 @@ import {
   mockDailyRegisterSlice,
   mockPuzzleSlice
 } from "@times-components/fixture-generator";
+import { editionBreakpoints } from "@times-components/styleguide";
 
 import {
   TileA,
@@ -236,4 +237,28 @@ export default () => {
   ];
 
   iterator(tests);
+
+  describe("tiles that change logic based on breakpoints", () => {
+    test("TileW without teaser for tablet", () => {
+      const output = TestRenderer.create(
+        <TileW
+          onPress={() => {}}
+          tile={tile}
+          breakpoint={editionBreakpoints.medium}
+        />
+      );
+      expect(output).toMatchSnapshot();
+    });
+
+    test("TileW with teaser for wider screens", () => {
+      const output = TestRenderer.create(
+        <TileW
+          onPress={() => {}}
+          tile={tile}
+          breakpoint={editionBreakpoints.wide}
+        />
+      );
+      expect(output).toMatchSnapshot();
+    });
+  });
 };

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -3550,3 +3550,204 @@ exports[`38. tile ac 1`] = `
   </div>
 </Link>
 `;
+
+exports[`tiles that change logic based on breakpoints TileW with teaser for wider screens 1`] = `
+<style>
+.S1 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 12px;
+  margin-bottom: 0px;
+}
+
+.S2 {
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-weight: 400;
+  margin-bottom: 5px;
+}
+
+.S4 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.IS1 {
+  color: rgba(0,91,141,1.00);
+}
+
+.IS2 {
+  font-size: 35px;
+  line-height: 35px;
+}
+
+.IS3 {
+  padding-bottom: 5px;
+  padding-right: 20px;
+  width: 33.33%;
+}
+
+.IS4 {
+  width: 66.66%;
+}
+</style>
+
+<Link
+  linkStyle={
+    Object {
+      "flexDirection": "row",
+      "paddingHorizontal": "20px",
+      "paddingVertical": "10px",
+    }
+  }
+  url="/article/123"
+>
+  <div
+    className="css-view-1dbjc4n IS3"
+  >
+    <div
+      className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
+    >
+      <div
+        className="css-text-76zvg2 r-fontFamily-j2s0nr r-fontSize-1enofrn r-fontWeight-16dba41 r-letterSpacing-3b040n r-lineHeight-56xrmm r-marginBottom-p1pxzi r-marginTop-19i43ro r-paddingTop-njp1lv IS1 S1"
+      >
+        LABEL
+      </div>
+    </div>
+    <h3
+      aria-level="3"
+      className="css-reset-4rbku5 css-text-76zvg2 r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S3"
+      role="heading"
+    >
+      This is tile headline
+    </h3>
+    <div
+      className="css-text-76zvg2 r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S4"
+    >
+      <span
+        className="css-text-76zvg2 css-textHasAncestor-16my406"
+      >
+        
+        Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+        ...
+      </span>
+    </div>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
+  </div>
+  <Image
+    aspectRatio={1.7777777777777777}
+    className="IS4"
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+</Link>
+`;
+
+exports[`tiles that change logic based on breakpoints TileW without teaser for tablet 1`] = `
+<style>
+.S1 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 12px;
+  margin-bottom: 0px;
+}
+
+.S2 {
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-weight: 400;
+  margin-bottom: 5px;
+}
+
+.IS1 {
+  color: rgba(0,91,141,1.00);
+}
+
+.IS2 {
+  font-size: 35px;
+  line-height: 35px;
+}
+
+.IS3 {
+  padding-bottom: 5px;
+  padding-right: 20px;
+  width: 33.33%;
+}
+
+.IS4 {
+  width: 66.66%;
+}
+</style>
+
+<Link
+  linkStyle={
+    Object {
+      "flexDirection": "row",
+      "paddingHorizontal": "20px",
+      "paddingVertical": "10px",
+    }
+  }
+  url="/article/123"
+>
+  <div
+    className="css-view-1dbjc4n IS3"
+  >
+    <div
+      className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
+    >
+      <div
+        className="css-text-76zvg2 r-fontFamily-j2s0nr r-fontSize-1enofrn r-fontWeight-16dba41 r-letterSpacing-3b040n r-lineHeight-56xrmm r-marginBottom-p1pxzi r-marginTop-19i43ro r-paddingTop-njp1lv IS1 S1"
+      >
+        LABEL
+      </div>
+    </div>
+    <h3
+      aria-level="3"
+      className="css-reset-4rbku5 css-text-76zvg2 r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S3"
+      role="heading"
+    >
+      This is tile headline
+    </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
+  </div>
+  <Image
+    aspectRatio={1.7777777777777777}
+    className="IS4"
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+</Link>
+`;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -1549,3 +1549,92 @@ exports[`38. tile ac 1`] = `
   </div>
 </Link>
 `;
+
+exports[`tiles that change logic based on breakpoints TileW with teaser for wider screens 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flexDirection": "row",
+      "paddingHorizontal": "20px",
+      "paddingVertical": "10px",
+    }
+  }
+  url="/article/123"
+>
+  <div>
+    <div>
+      <div>
+        LABEL
+      </div>
+    </div>
+    <h3
+      aria-level="3"
+      role="heading"
+    >
+      This is tile headline
+    </h3>
+    <div>
+      <span>
+        
+        Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+        ...
+      </span>
+    </div>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
+  </div>
+  <Image
+    aspectRatio={1.7777777777777777}
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+</Link>
+`;
+
+exports[`tiles that change logic based on breakpoints TileW without teaser for tablet 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flexDirection": "row",
+      "paddingHorizontal": "20px",
+      "paddingVertical": "10px",
+    }
+  }
+  url="/article/123"
+>
+  <div>
+    <div>
+      <div>
+        LABEL
+      </div>
+    </div>
+    <h3
+      aria-level="3"
+      role="heading"
+    >
+      This is tile headline
+    </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
+  </div>
+  <Image
+    aspectRatio={1.7777777777777777}
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+</Link>
+`;

--- a/packages/edition-slices/src/tiles/tile-w/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
+import { editionBreakpoints } from "@times-components/styleguide";
 import {
   getTileImage,
   getTileSummary,
@@ -13,7 +14,8 @@ import stylesFactory from "./styles";
 const TileW = ({ onPress, tile, breakpoint }) => {
   const styles = stylesFactory(breakpoint);
   const crop = getTileImage(tile, "crop169");
-
+  const summary =
+    breakpoint !== editionBreakpoints.medium ? getTileSummary(tile, 125) : null;
   return (
     <TileLink
       onPress={onPress}
@@ -24,7 +26,7 @@ const TileW = ({ onPress, tile, breakpoint }) => {
       <TileSummary
         headlineStyle={styles.headline}
         style={styles.summaryContainer}
-        summary={getTileSummary(tile, 125)}
+        summary={summary}
         summaryStyle={styles.summary}
         tile={tile}
         withStar


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/REPLAT-6747

Remove the teaser text on Secondary 1 Slice on 768 tablet breakpoint

between 768px and 1024px:
<img width="529" alt="Screenshot 2019-06-19 at 13 36 06" src="https://user-images.githubusercontent.com/16742525/59759164-29792400-9298-11e9-8285-95e13b6f3116.png">

wider than 1024px:
<img width="778" alt="Screenshot 2019-06-19 at 13 35 37" src="https://user-images.githubusercontent.com/16742525/59759178-2ed66e80-9298-11e9-841f-615671640189.png">
