### PR TITLE
fix: REPLAT-6745 list-2-and-6-no-pic tablet teaser

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -181,9 +181,9 @@ exports[`3. tile c 1`] = `
         Object {
           "color": "#333333",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 20,
+          "fontSize": 22,
           "fontWeight": "400",
-          "lineHeight": 20,
+          "lineHeight": 22,
           "marginBottom": 5,
           "paddingBottom": 5,
         }
@@ -2534,6 +2534,87 @@ exports[`38. tile ac 1`] = `
       }
     >
       This is tile headline
+    </Text>
+    <ArticleFlags />
+  </View>
+</Link>
+`;
+
+exports[`39. tile aq 1`] = `
+<Link>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <Image />
+  </View>
+  <View
+    style={
+      Object {
+        "paddingBottom": 25,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "marginBottom": 5,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#005B8D",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 0.6,
+            "lineHeight": 12,
+            "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 0,
+          }
+        }
+      >
+        LABEL
+      </Text>
+    </View>
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 22,
+          "fontWeight": "400",
+          "lineHeight": 22,
+          "marginBottom": 5,
+        }
+      }
+    >
+      This is tile headline
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
+          "marginBottom": 10,
+        }
+      }
+    >
+      <Text>
+        
+        Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+        ...
+      </Text>
     </Text>
     <ArticleFlags />
   </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -1550,6 +1550,56 @@ exports[`38. tile ac 1`] = `
 </Link>
 `;
 
+exports[`39. tile aq 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingTop": 10,
+    }
+  }
+  url="/article/123"
+>
+  <View>
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </View>
+  <View>
+    <View>
+      <Text>
+        LABEL
+      </Text>
+    </View>
+    <Text
+      accessibilityRole="header"
+      aria-level="3"
+    >
+      This is tile headline
+    </Text>
+    <Text>
+      <Text>
+        
+        Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+        ...
+      </Text>
+    </Text>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
+  </View>
+</Link>
+`;
+
 exports[`tiles that change logic based on breakpoints TileW with teaser for wider screens 1`] = `
 <Link
   linkStyle={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -181,9 +181,9 @@ exports[`3. tile c 1`] = `
         Object {
           "color": "#333333",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 20,
+          "fontSize": 22,
           "fontWeight": "900",
-          "lineHeight": 20,
+          "lineHeight": 22,
           "marginBottom": 5,
           "paddingBottom": 5,
         }
@@ -2534,6 +2534,87 @@ exports[`38. tile ac 1`] = `
       }
     >
       This is tile headline
+    </Text>
+    <ArticleFlags />
+  </View>
+</Link>
+`;
+
+exports[`39. tile aq 1`] = `
+<Link>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <Image />
+  </View>
+  <View
+    style={
+      Object {
+        "paddingBottom": 25,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#005B8D",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 0.6,
+            "lineHeight": 11,
+            "marginBottom": 0,
+            "marginTop": -1,
+            "paddingTop": 1,
+          }
+        }
+      >
+        LABEL
+      </Text>
+    </View>
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 22,
+          "fontWeight": "900",
+          "lineHeight": 22,
+          "marginBottom": 5,
+        }
+      }
+    >
+      This is tile headline
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
+          "marginBottom": 10,
+        }
+      }
+    >
+      <Text>
+        
+        Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+        ...
+      </Text>
     </Text>
     <ArticleFlags />
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -1550,6 +1550,56 @@ exports[`38. tile ac 1`] = `
 </Link>
 `;
 
+exports[`39. tile aq 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingTop": 10,
+    }
+  }
+  url="/article/123"
+>
+  <View>
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </View>
+  <View>
+    <View>
+      <Text>
+        LABEL
+      </Text>
+    </View>
+    <Text
+      accessibilityRole="header"
+      aria-level="3"
+    >
+      This is tile headline
+    </Text>
+    <Text>
+      <Text>
+        
+        Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+        ...
+      </Text>
+    </Text>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
+  </View>
+</Link>
+`;
+
 exports[`tiles that change logic based on breakpoints TileW with teaser for wider screens 1`] = `
 <Link
   linkStyle={

--- a/packages/edition-slices/__tests__/shared-tiles.base.js
+++ b/packages/edition-slices/__tests__/shared-tiles.base.js
@@ -46,7 +46,8 @@ import {
   TileAN,
   TileAP,
   TileAD,
-  TileAC
+  TileAC,
+  TileAQ
 } from "../src/tiles";
 
 jest.mock("@times-components/article-flag", () => ({
@@ -233,6 +234,10 @@ export default () => {
     {
       name: "tile ac",
       test: () => testTile(TileAC)
+    },
+    {
+      name: "tile aq",
+      test: () => testTile(TileAQ)
     }
   ];
 

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -203,8 +203,8 @@ exports[`3. tile c 1`] = `
 .S4 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
+  font-size: 22px;
   font-weight: 400;
-  line-height: 20px;
   margin-bottom: 5px;
 }
 
@@ -217,7 +217,7 @@ exports[`3. tile c 1`] = `
 }
 
 .IS3 {
-  font-size: 20px;
+  line-height: 22px;
   padding-bottom: 5px;
 }
 
@@ -258,7 +258,7 @@ exports[`3. tile c 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-76zvg2 r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS3 S4"
+      className="css-reset-4rbku5 css-text-76zvg2 r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS3 S4"
       role="heading"
     >
       This is tile headline
@@ -3537,6 +3537,123 @@ exports[`38. tile ac 1`] = `
     >
       This is tile headline
     </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
+  </div>
+</Link>
+`;
+
+exports[`39. tile aq 1`] = `
+<style>
+.S1 {
+  margin-bottom: 10px;
+}
+
+.S2 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 12px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  margin-bottom: 0px;
+}
+
+.S4 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  margin-bottom: 5px;
+}
+
+.S5 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.IS1 {
+  width: 100%;
+}
+
+.IS2 {
+  color: rgba(0,91,141,1.00);
+}
+
+.IS3 {
+  line-height: 22px;
+}
+
+.IS4 {
+  padding-bottom: 25px;
+}
+</style>
+
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": "10px",
+      "paddingTop": "10px",
+    }
+  }
+  url="/article/123"
+>
+  <div
+    className="css-view-1dbjc4n r-marginBottom-15d164r IS1 S1"
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </div>
+  <div
+    className="css-view-1dbjc4n IS4"
+  >
+    <div
+      className="css-view-1dbjc4n r-marginBottom-p1pxzi S3"
+    >
+      <div
+        className="css-text-76zvg2 r-fontFamily-j2s0nr r-fontSize-1enofrn r-fontWeight-16dba41 r-letterSpacing-3b040n r-lineHeight-56xrmm r-marginBottom-p1pxzi r-marginTop-19i43ro r-paddingTop-njp1lv IS2 S2"
+      >
+        LABEL
+      </div>
+    </div>
+    <h3
+      aria-level="3"
+      className="css-reset-4rbku5 css-text-76zvg2 r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS3 S4"
+      role="heading"
+    >
+      This is tile headline
+    </h3>
+    <div
+      className="css-text-76zvg2 r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S5"
+    >
+      <span
+        className="css-text-76zvg2 css-textHasAncestor-16my406"
+      >
+        
+        Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+        ...
+      </span>
+    </div>
     <ArticleFlags
       flags={
         Array [

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -1550,6 +1550,56 @@ exports[`38. tile ac 1`] = `
 </Link>
 `;
 
+exports[`39. tile aq 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": "10px",
+      "paddingTop": "10px",
+    }
+  }
+  url="/article/123"
+>
+  <div>
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </div>
+  <div>
+    <div>
+      <div>
+        LABEL
+      </div>
+    </div>
+    <h3
+      aria-level="3"
+      role="heading"
+    >
+      This is tile headline
+    </h3>
+    <div>
+      <span>
+        
+        Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+        ...
+      </span>
+    </div>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
+  </div>
+</Link>
+`;
+
 exports[`tiles that change logic based on breakpoints TileW with teaser for wider screens 1`] = `
 <Link
   linkStyle={

--- a/packages/edition-slices/edition-slices.showcase.js
+++ b/packages/edition-slices/edition-slices.showcase.js
@@ -145,7 +145,8 @@ const sliceStories = [
   },
   {
     mock: mockListTwoAndSixNoPicSlice(),
-    name: "List Two And Six No Pic (Mobile, Tablet: C,C,L,L,L,L,L,L)",
+    name:
+      "List Two And Six No Pic (Mobile: : C,C,L,L,L,L,L,L, Tablet: AQ,AQ,L,L,L,L,L,L, Wide Tablet: C,C,L,L,L,L,L,L)",
     Slice: ListTwoAndSixNoPicSlice
   },
   {

--- a/packages/edition-slices/edition-tiles.showcase.js
+++ b/packages/edition-slices/edition-tiles.showcase.js
@@ -43,7 +43,8 @@ import {
   TileAL,
   TileAM,
   TileAN,
-  TileAP
+  TileAP,
+  TileAQ
 } from "./src/tiles";
 
 const tile = mockEditionSlice(1).items[0];
@@ -232,6 +233,10 @@ const tileStories = [
   {
     name: "Tile AP - Vertical Aligned - Roundel Img on top of Article Summary",
     Tile: TileAP
+  },
+  {
+    name: "Tile AQ - Top image, 22pt headline, with teaser",
+    Tile: TileAQ
   }
 ];
 

--- a/packages/edition-slices/src/slices/listtwoandsixnopic/index.js
+++ b/packages/edition-slices/src/slices/listtwoandsixnopic/index.js
@@ -2,12 +2,13 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { ListTwoAndSixNoPic } from "@times-components/slice-layout";
 import { ResponsiveSlice } from "../shared";
-import { TileL, TileC } from "../../tiles";
+import { TileL, TileC, TileAQ } from "../../tiles";
 
 class ListTwoAndSixNoPicSlice extends Component {
   constructor(props) {
     super(props);
     this.renderSlice = this.renderSlice.bind(this);
+    this.renderMedium = this.renderMedium.bind(this);
   }
 
   renderSlice(breakpoint) {
@@ -52,10 +53,53 @@ class ListTwoAndSixNoPicSlice extends Component {
     );
   }
 
+  renderMedium(breakpoint) {
+    const {
+      onPress,
+      slice: {
+        lead1,
+        lead2,
+        support1,
+        support2,
+        support3,
+        support4,
+        support5,
+        support6
+      }
+    } = this.props;
+
+    return (
+      <ListTwoAndSixNoPic
+        breakpoint={breakpoint}
+        lead1={<TileAQ onPress={onPress} tile={lead1} tileName="lead1" />}
+        lead2={<TileAQ onPress={onPress} tile={lead2} tileName="lead2" />}
+        support1={
+          <TileL onPress={onPress} tile={support1} tileName="support1" />
+        }
+        support2={
+          <TileL onPress={onPress} tile={support2} tileName="support2" />
+        }
+        support3={
+          <TileL onPress={onPress} tile={support3} tileName="support3" />
+        }
+        support4={
+          <TileL onPress={onPress} tile={support4} tileName="support4" />
+        }
+        support5={
+          <TileL onPress={onPress} tile={support5} tileName="support5" />
+        }
+        support6={
+          <TileL onPress={onPress} tile={support6} tileName="support6" />
+        }
+      />
+    );
+  }
+
   render() {
     return (
       <ResponsiveSlice
-        renderMedium={this.renderSlice}
+        renderWide={this.renderSlice}
+        renderMedium={this.renderMedium}
         renderSmall={this.renderSlice}
       />
     );

--- a/packages/edition-slices/src/tiles/index.js
+++ b/packages/edition-slices/src/tiles/index.js
@@ -38,3 +38,4 @@ export { default as TileAB } from "./tile-ab";
 export { default as TileAG } from "./tile-ag";
 export { default as TileAH } from "./tile-ah";
 export { default as TileAI } from "./tile-ai";
+export { default as TileAQ } from "./tile-aq";

--- a/packages/edition-slices/src/tiles/tile-aq/index.js
+++ b/packages/edition-slices/src/tiles/tile-aq/index.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { View } from "react-native";
+import PropTypes from "prop-types";
+import Image from "@times-components/image";
+import {
+  getTileImage,
+  getTileSummary,
+  TileLink,
+  TileSummary,
+  withTileTracking
+} from "../shared";
+import styles from "./styles";
+
+const TileAQ = ({ onPress, tile }) => {
+  const crop = getTileImage(tile, "crop169");
+
+  return (
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
+      <View style={styles.imageContainer}>
+        <Image
+          aspectRatio={16 / 9}
+          uri={crop.url}
+          relativeWidth={crop.relativeWidth}
+          relativeHeight={crop.relativeHeight}
+          relativeHorizontalOffset={crop.relativeHorizontalOffset}
+          relativeVerticalOffset={crop.relativeVerticalOffset}
+        />
+      </View>
+      <TileSummary
+        headlineStyle={styles.headline}
+        summary={getTileSummary(tile, 125)}
+        tile={tile}
+      />
+    </TileLink>
+  );
+};
+
+TileAQ.propTypes = {
+  onPress: PropTypes.func.isRequired,
+  tile: PropTypes.shape({}).isRequired
+};
+
+export default withTileTracking(TileAQ);

--- a/packages/edition-slices/src/tiles/tile-aq/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-aq/styles/index.js
@@ -9,8 +9,7 @@ const styles = {
   headline: {
     fontFamily: fonts.headline,
     fontSize: 22,
-    lineHeight: 22,
-    paddingBottom: spacing(1)
+    lineHeight: 22
   },
   imageContainer: {
     marginBottom: spacing(2),


### PR DESCRIPTION
[Jira story](https://nidigitalsolutions.jira.com/browse/REPLAT-6745)

List 2 and 6 no pic

1. Teaser added for medium breakpoint
2. New tile created and [doc](https://docs.google.com/spreadsheets/d/1NBC-dOAGcF1sgfrkfFH7uslKG7eEU4o3n3Og5T1WNC8/edit#gid=255055858) updated.
3. Font size of list-2 headlines updated according to design.

More info [here](https://docs.google.com/spreadsheets/d/1NBC-dOAGcF1sgfrkfFH7uslKG7eEU4o3n3Og5T1WNC8/edit#gid=2068129030) - Samsung Tablet sheet - row 12

![image](https://user-images.githubusercontent.com/8720661/59834940-87b60d80-9351-11e9-8257-334685f17a4e.png)
