### PR TITLE
fix: replat 6693 twitter metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "packages:publish-dry-run": "yarn packages:publish --no-git-tag-version --no-push",
     "commit": "git-cz",
     "prepublishOnly": "lerna run prepublishOnly",
+    "test:ios": "lerna run test:ios --stream",
+    "test:android": "lerna run test:android --stream",
+    "test:web": "lerna run test:web --stream",
     "test:e2e": "yarn bundle && lerna run test:integration --stream",
     "test:e2e:debug": "yarn bundle && lerna run test:integration:debug --stream",
     "watch": "lerna run watch --stream --no-sort --concurrency 100"

--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -559,7 +559,7 @@ exports[`full article with style 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div
@@ -1299,7 +1299,7 @@ exports[`full article with style in the culture magazine 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div
@@ -2039,7 +2039,7 @@ exports[`full article with style in the style magazine 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div
@@ -2779,7 +2779,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div

--- a/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -38,7 +38,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -54,13 +54,13 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div>
@@ -264,7 +264,7 @@ exports[`4. an article with ads 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -280,13 +280,13 @@ exports[`4. an article with ads 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div>

--- a/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -34,7 +34,7 @@ exports[`1. a full article 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -50,13 +50,13 @@ exports[`1. a full article 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <svg

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -553,7 +553,7 @@ exports[`full article with style 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div
@@ -1296,7 +1296,7 @@ exports[`full article with style in the culture magazine 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div
@@ -2039,7 +2039,7 @@ exports[`full article with style in the style magazine 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div
@@ -2782,7 +2782,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -38,7 +38,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -54,13 +54,13 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div>
@@ -259,7 +259,7 @@ exports[`4. an article with ads 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -275,13 +275,13 @@ exports[`4. an article with ads 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div>
@@ -482,7 +482,7 @@ exports[`7. an article with no author 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -498,13 +498,13 @@ exports[`7. an article with no author 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div>

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -34,7 +34,7 @@ exports[`1. a full article 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -50,13 +50,13 @@ exports[`1. a full article 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <svg

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -520,7 +520,7 @@ exports[`full article with style 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div
@@ -1208,7 +1208,7 @@ exports[`full article with style in the culture magazine 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div
@@ -1896,7 +1896,7 @@ exports[`full article with style in the style magazine 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div
@@ -2584,7 +2584,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -38,7 +38,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -54,13 +54,13 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div>
@@ -254,7 +254,7 @@ exports[`4. an article with ads 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -270,13 +270,13 @@ exports[`4. an article with ads 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div>

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -34,7 +34,7 @@ exports[`1. a full article 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -50,13 +50,13 @@ exports[`1. a full article 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <svg

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -514,7 +514,7 @@ exports[`full article with style 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -38,7 +38,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -54,13 +54,13 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Short Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div>
@@ -245,7 +245,7 @@ exports[`4. an article with ads 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -261,13 +261,13 @@ exports[`4. an article with ads 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div>

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -34,7 +34,7 @@ exports[`1. a full article 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -50,13 +50,13 @@ exports[`1. a full article 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <svg

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -536,7 +536,7 @@ exports[`full article with style 1`] = `
     <meta />
     <meta />
     <script>
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -34,7 +34,7 @@ exports[`1. an article 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -50,13 +50,13 @@ exports[`1. an article 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div>
@@ -471,7 +471,7 @@ exports[`6. should show topics when logged in or shared 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -487,13 +487,13 @@ exports[`6. should show topics when logged in or shared 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <div>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -34,7 +34,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       property="og:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       property="og:image"
     />
     <meta
@@ -50,13 +50,13 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       name="twitter:url"
     />
     <meta
-      content="https://crop169.io"
+      content="https://crop169.io?resize=685"
       name="twitter:image"
     />
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+      {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".undefined"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
     </script>
   </Helmet>
   <svg

--- a/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
@@ -41,7 +41,7 @@ exports[`Head outputs correct metadata 1`] = `
     property="og:description"
   />
   <meta
-    content="https://crop169.io"
+    content="https://crop169.io?resize=685"
     property="og:image"
   />
   <meta
@@ -61,13 +61,13 @@ exports[`Head outputs correct metadata 1`] = `
     name="twitter:description"
   />
   <meta
-    content="https://crop169.io"
+    content="https://crop169.io?resize=685"
     name="twitter:image"
   />
   <script
     type="application/ld+json"
   >
-    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","logo":"https://www.thetimes.co.uk/d/img/icons/favicon.ico","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"image":{"@type":"ImageObject","url":"https://crop169.io","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
+    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","logo":"https://www.thetimes.co.uk/d/img/icons/favicon.ico","publisher":{"@type":"Organization","name":"The Times"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io"}
   </script>
 </Helmet>
 `;

--- a/packages/article-skeleton/src/head.web.js
+++ b/packages/article-skeleton/src/head.web.js
@@ -72,7 +72,7 @@ function appendToUrl(uriString, key, value) {
   }
 
   return `${uriString}?${key}=${value}`;
-};
+}
 
 const PUBLICATION_NAMES = {
   SUNDAYTIMES: "The Sunday Times",
@@ -119,7 +119,11 @@ function Head({ article, paidContentClassName, faviconUrl }) {
       ? renderTreeAsText({ children: descriptionMarkup })
       : null;
   const sectionname = getSectionName(article);
-  const leadassetUrl = appendToUrl(get(leadAsset, "crop169.url", null), "resize", 685);
+  const leadassetUrl = appendToUrl(
+    get(leadAsset, "crop169.url", null),
+    "resize",
+    685
+  );
   const caption = get(leadAsset, "caption", null);
   const title = headline || shortHeadline;
   const datePublished = new Date(publishedTime).toISOString().split("T")[0];

--- a/packages/article-skeleton/src/head.web.js
+++ b/packages/article-skeleton/src/head.web.js
@@ -51,6 +51,29 @@ function getAuthorAsText(article) {
   return renderTreeAsText({ children });
 }
 
+function appendToUrl(uriString, key, value) {
+  if (!uriString || !key || !value) {
+    return uriString;
+  }
+
+  if (uriString.includes(`?${key}`) || uriString.includes(`&${key}`)) {
+    return uriString;
+  }
+
+  let url;
+  try {
+    url = new URL(uriString);
+  } catch (e) {
+    return uriString;
+  }
+
+  if (url.search) {
+    return `${uriString}&${key}=${value}`;
+  }
+
+  return `${uriString}?${key}=${value}`;
+};
+
 const PUBLICATION_NAMES = {
   SUNDAYTIMES: "The Sunday Times",
   TIMES: "The Times"
@@ -96,7 +119,7 @@ function Head({ article, paidContentClassName, faviconUrl }) {
       ? renderTreeAsText({ children: descriptionMarkup })
       : null;
   const sectionname = getSectionName(article);
-  const leadassetUrl = get(leadAsset, "crop169.url", null);
+  const leadassetUrl = appendToUrl(get(leadAsset, "crop169.url", null), "resize", 685);
   const caption = get(leadAsset, "caption", null);
   const title = headline || shortHeadline;
   const datePublished = new Date(publishedTime).toISOString().split("T")[0];


### PR DESCRIPTION
jira: https://nidigitalsolutions.jira.com/browse/REPLAT-6693

- use smaller lead asset image for social media meta tag