### PR TITLE
fix: REPLAT-6745 dailyRegisterLeadFour and secondaryOne styling updates

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
@@ -4,93 +4,101 @@ exports[`1. daily universal register 1`] = `
 <View
   style={
     Object {
-      "alignItems": "center",
       "backgroundColor": "#F0F0F0",
-      "flex": 1,
-      "padding": 10,
     }
   }
 >
-  <Image
+  <View
     style={
       Object {
-        "height": 73,
-        "marginVertical": 10,
-        "width": 285,
-      }
-    }
-  />
-  <Text
-    style={
-      Object {
-        "color": "#850029",
-        "fontFamily": "TimesDigitalW04",
-        "fontSize": 16,
-        "marginBottom": 25,
+        "alignItems": "center",
+        "backgroundColor": "#F0F0F0",
+        "flex": 1,
+        "padding": 10,
       }
     }
   >
-    Daily Universal Register
-  </Text>
-  <TileS />
-  <View
-    style={
-      Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderColor": "#DBDBDB",
-        "borderStyle": "solid",
-        "marginHorizontal": 10,
-        "marginVertical": 25,
-        "width": "100%",
+    <Image
+      style={
+        Object {
+          "height": 73,
+          "marginVertical": 10,
+          "width": 285,
+        }
       }
-    }
-  />
-  <TileS />
-  <View
-    style={
-      Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderColor": "#DBDBDB",
-        "borderStyle": "solid",
-        "marginHorizontal": 10,
-        "marginVertical": 25,
-        "width": "100%",
+    />
+    <Text
+      style={
+        Object {
+          "color": "#850029",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 16,
+          "marginBottom": 25,
+        }
       }
-    }
-  />
-  <Image
-    style={
-      Object {
-        "height": 45,
-        "width": 60,
+    >
+      Daily Universal Register
+    </Text>
+    <TileS />
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#DBDBDB",
+          "borderBottomWidth": 1,
+          "borderColor": "#DBDBDB",
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+          "marginVertical": 25,
+          "width": "100%",
+        }
       }
-    }
-  />
-  <TileS />
-  <View
-    style={
-      Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderColor": "#DBDBDB",
-        "borderStyle": "solid",
-        "marginHorizontal": 10,
-        "marginVertical": 25,
-        "width": "100%",
+    />
+    <TileS />
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#DBDBDB",
+          "borderBottomWidth": 1,
+          "borderColor": "#DBDBDB",
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+          "marginVertical": 25,
+          "width": "100%",
+        }
       }
-    }
-  />
-  <Image
-    style={
-      Object {
-        "height": 45,
-        "width": 60,
+    />
+    <Image
+      style={
+        Object {
+          "height": 45,
+          "width": 60,
+        }
       }
-    }
-  />
-  <TileS />
+    />
+    <TileS />
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#DBDBDB",
+          "borderBottomWidth": 1,
+          "borderColor": "#DBDBDB",
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+          "marginVertical": 25,
+          "width": "100%",
+        }
+      }
+    />
+    <Image
+      style={
+        Object {
+          "height": 45,
+          "width": 60,
+        }
+      }
+    />
+    <TileS />
+  </View>
 </View>
 `;
 

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
@@ -2,40 +2,42 @@
 
 exports[`1. daily universal register 1`] = `
 <View>
-  <Image
-    resizeMode="contain"
-    source={
-      Object {
-        "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+  <View>
+    <Image
+      resizeMode="contain"
+      source={
+        Object {
+          "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+        }
       }
-    }
-  />
-  <Text>
-    Daily Universal Register
-  </Text>
-  <TileS />
-  <View />
-  <TileS />
-  <View />
-  <Image
-    resizeMode="contain"
-    source={
-      Object {
-        "testUri": "../../../packages/edition-slices/assets/leaves.png",
+    />
+    <Text>
+      Daily Universal Register
+    </Text>
+    <TileS />
+    <View />
+    <TileS />
+    <View />
+    <Image
+      resizeMode="contain"
+      source={
+        Object {
+          "testUri": "../../../packages/edition-slices/assets/leaves.png",
+        }
       }
-    }
-  />
-  <TileS />
-  <View />
-  <Image
-    resizeMode="contain"
-    source={
-      Object {
-        "testUri": "../../../packages/edition-slices/assets/cake.png",
+    />
+    <TileS />
+    <View />
+    <Image
+      resizeMode="contain"
+      source={
+        Object {
+          "testUri": "../../../packages/edition-slices/assets/cake.png",
+        }
       }
-    }
-  />
-  <TileS />
+    />
+    <TileS />
+  </View>
 </View>
 `;
 

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -57,102 +57,112 @@ exports[`2. daily universal register - medium 1`] = `
 <View
   style={
     Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 10,
-      "width": 1366,
+      "backgroundColor": "#F0F0F0",
     }
   }
 >
   <View
     style={
       Object {
-        "alignItems": "center",
-        "backgroundColor": "#F0F0F0",
-        "flex": 1,
-        "paddingHorizontal": "20%",
+        "alignSelf": "center",
+        "maxWidth": "100%",
+        "paddingHorizontal": 10,
+        "width": 1366,
       }
     }
   >
-    <Image
+    <View
       style={
         Object {
-          "height": 97,
-          "width": 380,
-        }
-      }
-    />
-    <Text
-      style={
-        Object {
-          "color": "#850029",
-          "fontFamily": "TimesDigitalW04",
-          "fontSize": 16,
-          "marginBottom": 25,
+          "alignItems": "center",
+          "backgroundColor": "#F0F0F0",
+          "flex": 1,
+          "paddingHorizontal": "20%",
+          "paddingVertical": 10,
         }
       }
     >
-      Daily Universal Register
-    </Text>
-    <TileS />
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginHorizontal": 10,
-          "marginVertical": 25,
-          "width": "100%",
+      <Image
+        style={
+          Object {
+            "height": 97,
+            "marginVertical": 10,
+            "width": 380,
+          }
         }
-      }
-    />
-    <TileS />
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginHorizontal": 10,
-          "marginVertical": 25,
-          "width": "100%",
+      />
+      <Text
+        style={
+          Object {
+            "color": "#850029",
+            "fontFamily": "TimesDigitalW04",
+            "fontSize": 16,
+            "marginBottom": 25,
+          }
         }
-      }
-    />
-    <Image
-      style={
-        Object {
-          "height": 45,
-          "width": 60,
+      >
+        Daily Universal Register
+      </Text>
+      <TileS />
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+            "marginHorizontal": 10,
+            "marginVertical": 25,
+            "width": "100%",
+          }
         }
-      }
-    />
-    <TileS />
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginHorizontal": 10,
-          "marginVertical": 25,
-          "width": "100%",
+      />
+      <TileS />
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+            "marginHorizontal": 10,
+            "marginVertical": 25,
+            "width": "100%",
+          }
         }
-      }
-    />
-    <Image
-      style={
-        Object {
-          "height": 45,
-          "width": 60,
+      />
+      <Image
+        style={
+          Object {
+            "height": 45,
+            "width": 60,
+          }
         }
-      }
-    />
-    <TileS />
+      />
+      <TileS />
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+            "marginHorizontal": 10,
+            "marginVertical": 25,
+            "width": "100%",
+          }
+        }
+      />
+      <Image
+        style={
+          Object {
+            "height": 45,
+            "width": 60,
+          }
+        }
+      />
+      <TileS />
+    </View>
   </View>
 </View>
 `;
@@ -1197,103 +1207,112 @@ exports[`17. daily universal register - wide 1`] = `
 <View
   style={
     Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 10,
-      "width": 1366,
+      "backgroundColor": "#F0F0F0",
     }
   }
 >
   <View
     style={
       Object {
-        "alignItems": "center",
-        "backgroundColor": "#F0F0F0",
-        "flex": 1,
-        "paddingHorizontal": "25%",
+        "alignSelf": "center",
+        "maxWidth": "100%",
+        "paddingHorizontal": 10,
+        "width": 1366,
       }
     }
   >
-    <Image
+    <View
       style={
         Object {
-          "height": 73,
-          "marginVertical": 10,
-          "width": 285,
-        }
-      }
-    />
-    <Text
-      style={
-        Object {
-          "color": "#850029",
-          "fontFamily": "TimesDigitalW04",
-          "fontSize": 16,
-          "marginBottom": 25,
+          "alignItems": "center",
+          "backgroundColor": "#F0F0F0",
+          "flex": 1,
+          "paddingHorizontal": "25%",
+          "paddingVertical": 10,
         }
       }
     >
-      Daily Universal Register
-    </Text>
-    <TileS />
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginHorizontal": 10,
-          "marginVertical": 25,
-          "width": "100%",
+      <Image
+        style={
+          Object {
+            "height": 73,
+            "marginVertical": 10,
+            "width": 285,
+          }
         }
-      }
-    />
-    <TileS />
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginHorizontal": 10,
-          "marginVertical": 25,
-          "width": "100%",
+      />
+      <Text
+        style={
+          Object {
+            "color": "#850029",
+            "fontFamily": "TimesDigitalW04",
+            "fontSize": 16,
+            "marginBottom": 25,
+          }
         }
-      }
-    />
-    <Image
-      style={
-        Object {
-          "height": 45,
-          "width": 60,
+      >
+        Daily Universal Register
+      </Text>
+      <TileS />
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+            "marginHorizontal": 10,
+            "marginVertical": 25,
+            "width": "100%",
+          }
         }
-      }
-    />
-    <TileS />
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginHorizontal": 10,
-          "marginVertical": 25,
-          "width": "100%",
+      />
+      <TileS />
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+            "marginHorizontal": 10,
+            "marginVertical": 25,
+            "width": "100%",
+          }
         }
-      }
-    />
-    <Image
-      style={
-        Object {
-          "height": 45,
-          "width": 60,
+      />
+      <Image
+        style={
+          Object {
+            "height": 45,
+            "width": 60,
+          }
         }
-      }
-    />
-    <TileS />
+      />
+      <TileS />
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+            "marginHorizontal": 10,
+            "marginVertical": 25,
+            "width": "100%",
+          }
+        }
+      />
+      <Image
+        style={
+          Object {
+            "height": 45,
+            "width": 60,
+          }
+        }
+      />
+      <TileS />
+    </View>
   </View>
 </View>
 `;
@@ -2318,186 +2337,194 @@ exports[`32. daily universal register - huge 1`] = `
 <View
   style={
     Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 10,
-      "width": 1366,
+      "backgroundColor": "#F0F0F0",
     }
   }
 >
   <View
     style={
       Object {
-        "alignItems": "center",
         "alignSelf": "center",
-        "backgroundColor": "#F0F0F0",
-        "flex": 1,
-        "width": "86%",
+        "maxWidth": "100%",
+        "paddingHorizontal": 10,
+        "width": 1366,
       }
     }
   >
-    <Image
-      style={
-        Object {
-          "height": 73,
-          "marginVertical": 10,
-          "width": 285,
-        }
-      }
-    />
-    <Text
-      style={
-        Object {
-          "color": "#850029",
-          "fontFamily": "TimesDigitalW04",
-          "fontSize": 16,
-          "marginBottom": 25,
-        }
-      }
-    >
-      Daily Universal Register
-    </Text>
     <View
       style={
         Object {
-          "flexDirection": "row",
-          "paddingHorizontal": "8%",
-          "width": "100%",
+          "alignItems": "center",
+          "alignSelf": "center",
+          "backgroundColor": "#F0F0F0",
+          "flex": 1,
+          "width": "86%",
         }
       }
     >
+      <Image
+        style={
+          Object {
+            "height": 73,
+            "marginVertical": 10,
+            "width": 285,
+          }
+        }
+      />
+      <Text
+        style={
+          Object {
+            "color": "#850029",
+            "fontFamily": "TimesDigitalW04",
+            "fontSize": 16,
+            "marginBottom": 25,
+          }
+        }
+      >
+        Daily Universal Register
+      </Text>
       <View
         style={
           Object {
-            "alignItems": "center",
-            "flex": 1,
-            "flexDirection": "column",
-            "paddingHorizontal": 25,
+            "flexDirection": "row",
+            "paddingHorizontal": "8%",
+            "width": "100%",
           }
         }
       >
         <View
           style={
             Object {
-              "borderBottomColor": "#DBDBDB",
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-              "marginHorizontal": 10,
-              "marginVertical": 25,
-              "width": "100%",
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "column",
+              "paddingHorizontal": 25,
             }
           }
-        />
-        <View>
-          <TileS />
+        >
+          <View
+            style={
+              Object {
+                "borderBottomColor": "#DBDBDB",
+                "borderBottomWidth": 1,
+                "borderColor": "#DBDBDB",
+                "borderStyle": "solid",
+                "marginHorizontal": 10,
+                "marginVertical": 25,
+                "width": "100%",
+              }
+            }
+          />
+          <View>
+            <TileS />
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "column",
+              "paddingHorizontal": 25,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "borderBottomColor": "#DBDBDB",
+                "borderBottomWidth": 1,
+                "borderColor": "#DBDBDB",
+                "borderStyle": "solid",
+                "marginHorizontal": 10,
+                "marginVertical": 25,
+                "width": "100%",
+              }
+            }
+          />
+          <View>
+            <TileS />
+          </View>
         </View>
       </View>
       <View
         style={
           Object {
-            "alignItems": "center",
-            "flex": 1,
-            "flexDirection": "column",
-            "paddingHorizontal": 25,
+            "flexDirection": "row",
+            "paddingHorizontal": "8%",
+            "width": "100%",
           }
         }
       >
         <View
           style={
             Object {
-              "borderBottomColor": "#DBDBDB",
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-              "marginHorizontal": 10,
-              "marginVertical": 25,
-              "width": "100%",
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "column",
+              "paddingHorizontal": 25,
             }
           }
-        />
-        <View>
-          <TileS />
+        >
+          <View
+            style={
+              Object {
+                "borderBottomColor": "#DBDBDB",
+                "borderBottomWidth": 1,
+                "borderColor": "#DBDBDB",
+                "borderStyle": "solid",
+                "marginHorizontal": 10,
+                "marginVertical": 25,
+                "width": "100%",
+              }
+            }
+          />
+          <Image
+            style={
+              Object {
+                "height": 45,
+                "width": 60,
+              }
+            }
+          />
+          <View>
+            <TileS />
+          </View>
         </View>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "paddingHorizontal": "8%",
-          "width": "100%",
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "flexDirection": "column",
-            "paddingHorizontal": 25,
-          }
-        }
-      >
         <View
           style={
             Object {
-              "borderBottomColor": "#DBDBDB",
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-              "marginHorizontal": 10,
-              "marginVertical": 25,
-              "width": "100%",
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "column",
+              "paddingHorizontal": 25,
             }
           }
-        />
-        <Image
-          style={
-            Object {
-              "height": 45,
-              "width": 60,
+        >
+          <View
+            style={
+              Object {
+                "borderBottomColor": "#DBDBDB",
+                "borderBottomWidth": 1,
+                "borderColor": "#DBDBDB",
+                "borderStyle": "solid",
+                "marginHorizontal": 10,
+                "marginVertical": 25,
+                "width": "100%",
+              }
             }
-          }
-        />
-        <View>
-          <TileS />
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "flexDirection": "column",
-            "paddingHorizontal": 25,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderBottomColor": "#DBDBDB",
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-              "marginHorizontal": 10,
-              "marginVertical": 25,
-              "width": "100%",
+          />
+          <Image
+            style={
+              Object {
+                "height": 45,
+                "width": 60,
+              }
             }
-          }
-        />
-        <Image
-          style={
-            Object {
-              "height": 45,
-              "width": 60,
-            }
-          }
-        />
-        <View>
-          <TileS />
+          />
+          <View>
+            <TileS />
+          </View>
         </View>
       </View>
     </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -21,40 +21,42 @@ exports[`1. comment lead and cartoon - medium 1`] = `
 exports[`2. daily universal register - medium 1`] = `
 <View>
   <View>
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+    <View>
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+          }
         }
-      }
-    />
-    <Text>
-      Daily Universal Register
-    </Text>
-    <TileS />
-    <View />
-    <TileS />
-    <View />
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/leaves.png",
+      />
+      <Text>
+        Daily Universal Register
+      </Text>
+      <TileS />
+      <View />
+      <TileS />
+      <View />
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/leaves.png",
+          }
         }
-      }
-    />
-    <TileS />
-    <View />
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/cake.png",
+      />
+      <TileS />
+      <View />
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/cake.png",
+          }
         }
-      }
-    />
-    <TileS />
+      />
+      <TileS />
+    </View>
   </View>
 </View>
 `;
@@ -480,40 +482,42 @@ exports[`16. comment lead and cartoon - wide 1`] = `
 exports[`17. daily universal register - wide 1`] = `
 <View>
   <View>
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+    <View>
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+          }
         }
-      }
-    />
-    <Text>
-      Daily Universal Register
-    </Text>
-    <TileS />
-    <View />
-    <TileS />
-    <View />
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/leaves.png",
+      />
+      <Text>
+        Daily Universal Register
+      </Text>
+      <TileS />
+      <View />
+      <TileS />
+      <View />
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/leaves.png",
+          }
         }
-      }
-    />
-    <TileS />
-    <View />
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/cake.png",
+      />
+      <TileS />
+      <View />
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/cake.png",
+          }
         }
-      }
-    />
-    <TileS />
+      />
+      <TileS />
+    </View>
   </View>
 </View>
 `;
@@ -935,58 +939,60 @@ exports[`31. comment lead and cartoon - huge 1`] = `
 exports[`32. daily universal register - huge 1`] = `
 <View>
   <View>
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+    <View>
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+          }
         }
-      }
-    />
-    <Text>
-      Daily Universal Register
-    </Text>
-    <View>
+      />
+      <Text>
+        Daily Universal Register
+      </Text>
       <View>
-        <View />
         <View>
-          <TileS />
+          <View />
+          <View>
+            <TileS />
+          </View>
+        </View>
+        <View>
+          <View />
+          <View>
+            <TileS />
+          </View>
         </View>
       </View>
       <View>
-        <View />
         <View>
-          <TileS />
-        </View>
-      </View>
-    </View>
-    <View>
-      <View>
-        <View />
-        <Image
-          resizeMode="contain"
-          source={
-            Object {
-              "testUri": "../../../packages/edition-slices/assets/leaves.png",
+          <View />
+          <Image
+            resizeMode="contain"
+            source={
+              Object {
+                "testUri": "../../../packages/edition-slices/assets/leaves.png",
+              }
             }
-          }
-        />
-        <View>
-          <TileS />
+          />
+          <View>
+            <TileS />
+          </View>
         </View>
-      </View>
-      <View>
-        <View />
-        <Image
-          resizeMode="contain"
-          source={
-            Object {
-              "testUri": "../../../packages/edition-slices/assets/cake.png",
-            }
-          }
-        />
         <View>
-          <TileS />
+          <View />
+          <Image
+            resizeMode="contain"
+            source={
+              Object {
+                "testUri": "../../../packages/edition-slices/assets/cake.png",
+              }
+            }
+          />
+          <View>
+            <TileS />
+          </View>
         </View>
       </View>
     </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -929,8 +929,9 @@ exports[`23. tile w 1`] = `
   linkStyle={
     Object {
       "flexDirection": "row",
+      "paddingBottom": 15,
       "paddingHorizontal": 20,
-      "paddingVertical": 10,
+      "paddingTop": 10,
     }
   }
   url="/article/123"
@@ -1673,8 +1674,9 @@ exports[`tiles that change logic based on breakpoints TileW with teaser for wide
   linkStyle={
     Object {
       "flexDirection": "row",
+      "paddingBottom": 15,
       "paddingHorizontal": 20,
-      "paddingVertical": 10,
+      "paddingTop": 10,
     }
   }
   url="/article/123"
@@ -1723,8 +1725,9 @@ exports[`tiles that change logic based on breakpoints TileW without teaser for t
   linkStyle={
     Object {
       "flexDirection": "row",
+      "paddingBottom": 15,
       "paddingHorizontal": 20,
-      "paddingVertical": 10,
+      "paddingTop": 10,
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
@@ -4,93 +4,101 @@ exports[`1. daily universal register 1`] = `
 <View
   style={
     Object {
-      "alignItems": "center",
       "backgroundColor": "#F0F0F0",
-      "flex": 1,
-      "padding": 10,
     }
   }
 >
-  <Image
+  <View
     style={
       Object {
-        "height": 73,
-        "marginVertical": 10,
-        "width": 285,
-      }
-    }
-  />
-  <Text
-    style={
-      Object {
-        "color": "#850029",
-        "fontFamily": "TimesDigitalW04",
-        "fontSize": 16,
-        "marginBottom": 25,
+        "alignItems": "center",
+        "backgroundColor": "#F0F0F0",
+        "flex": 1,
+        "padding": 10,
       }
     }
   >
-    Daily Universal Register
-  </Text>
-  <TileS />
-  <View
-    style={
-      Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderColor": "#DBDBDB",
-        "borderStyle": "solid",
-        "marginHorizontal": 10,
-        "marginVertical": 25,
-        "width": "100%",
+    <Image
+      style={
+        Object {
+          "height": 73,
+          "marginVertical": 10,
+          "width": 285,
+        }
       }
-    }
-  />
-  <TileS />
-  <View
-    style={
-      Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderColor": "#DBDBDB",
-        "borderStyle": "solid",
-        "marginHorizontal": 10,
-        "marginVertical": 25,
-        "width": "100%",
+    />
+    <Text
+      style={
+        Object {
+          "color": "#850029",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 16,
+          "marginBottom": 25,
+        }
       }
-    }
-  />
-  <Image
-    style={
-      Object {
-        "height": 45,
-        "width": 60,
+    >
+      Daily Universal Register
+    </Text>
+    <TileS />
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#DBDBDB",
+          "borderBottomWidth": 1,
+          "borderColor": "#DBDBDB",
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+          "marginVertical": 25,
+          "width": "100%",
+        }
       }
-    }
-  />
-  <TileS />
-  <View
-    style={
-      Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderColor": "#DBDBDB",
-        "borderStyle": "solid",
-        "marginHorizontal": 10,
-        "marginVertical": 25,
-        "width": "100%",
+    />
+    <TileS />
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#DBDBDB",
+          "borderBottomWidth": 1,
+          "borderColor": "#DBDBDB",
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+          "marginVertical": 25,
+          "width": "100%",
+        }
       }
-    }
-  />
-  <Image
-    style={
-      Object {
-        "height": 45,
-        "width": 60,
+    />
+    <Image
+      style={
+        Object {
+          "height": 45,
+          "width": 60,
+        }
       }
-    }
-  />
-  <TileS />
+    />
+    <TileS />
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#DBDBDB",
+          "borderBottomWidth": 1,
+          "borderColor": "#DBDBDB",
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+          "marginVertical": 25,
+          "width": "100%",
+        }
+      }
+    />
+    <Image
+      style={
+        Object {
+          "height": 45,
+          "width": 60,
+        }
+      }
+    />
+    <TileS />
+  </View>
 </View>
 `;
 

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
@@ -2,40 +2,42 @@
 
 exports[`1. daily universal register 1`] = `
 <View>
-  <Image
-    resizeMode="contain"
-    source={
-      Object {
-        "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+  <View>
+    <Image
+      resizeMode="contain"
+      source={
+        Object {
+          "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+        }
       }
-    }
-  />
-  <Text>
-    Daily Universal Register
-  </Text>
-  <TileS />
-  <View />
-  <TileS />
-  <View />
-  <Image
-    resizeMode="contain"
-    source={
-      Object {
-        "testUri": "../../../packages/edition-slices/assets/leaves.png",
+    />
+    <Text>
+      Daily Universal Register
+    </Text>
+    <TileS />
+    <View />
+    <TileS />
+    <View />
+    <Image
+      resizeMode="contain"
+      source={
+        Object {
+          "testUri": "../../../packages/edition-slices/assets/leaves.png",
+        }
       }
-    }
-  />
-  <TileS />
-  <View />
-  <Image
-    resizeMode="contain"
-    source={
-      Object {
-        "testUri": "../../../packages/edition-slices/assets/cake.png",
+    />
+    <TileS />
+    <View />
+    <Image
+      resizeMode="contain"
+      source={
+        Object {
+          "testUri": "../../../packages/edition-slices/assets/cake.png",
+        }
       }
-    }
-  />
-  <TileS />
+    />
+    <TileS />
+  </View>
 </View>
 `;
 

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -57,102 +57,112 @@ exports[`2. daily universal register - medium 1`] = `
 <View
   style={
     Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 10,
-      "width": 1366,
+      "backgroundColor": "#F0F0F0",
     }
   }
 >
   <View
     style={
       Object {
-        "alignItems": "center",
-        "backgroundColor": "#F0F0F0",
-        "flex": 1,
-        "paddingHorizontal": "20%",
+        "alignSelf": "center",
+        "maxWidth": "100%",
+        "paddingHorizontal": 10,
+        "width": 1366,
       }
     }
   >
-    <Image
+    <View
       style={
         Object {
-          "height": 97,
-          "width": 380,
-        }
-      }
-    />
-    <Text
-      style={
-        Object {
-          "color": "#850029",
-          "fontFamily": "TimesDigitalW04",
-          "fontSize": 16,
-          "marginBottom": 25,
+          "alignItems": "center",
+          "backgroundColor": "#F0F0F0",
+          "flex": 1,
+          "paddingHorizontal": "20%",
+          "paddingVertical": 10,
         }
       }
     >
-      Daily Universal Register
-    </Text>
-    <TileS />
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginHorizontal": 10,
-          "marginVertical": 25,
-          "width": "100%",
+      <Image
+        style={
+          Object {
+            "height": 97,
+            "marginVertical": 10,
+            "width": 380,
+          }
         }
-      }
-    />
-    <TileS />
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginHorizontal": 10,
-          "marginVertical": 25,
-          "width": "100%",
+      />
+      <Text
+        style={
+          Object {
+            "color": "#850029",
+            "fontFamily": "TimesDigitalW04",
+            "fontSize": 16,
+            "marginBottom": 25,
+          }
         }
-      }
-    />
-    <Image
-      style={
-        Object {
-          "height": 45,
-          "width": 60,
+      >
+        Daily Universal Register
+      </Text>
+      <TileS />
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+            "marginHorizontal": 10,
+            "marginVertical": 25,
+            "width": "100%",
+          }
         }
-      }
-    />
-    <TileS />
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginHorizontal": 10,
-          "marginVertical": 25,
-          "width": "100%",
+      />
+      <TileS />
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+            "marginHorizontal": 10,
+            "marginVertical": 25,
+            "width": "100%",
+          }
         }
-      }
-    />
-    <Image
-      style={
-        Object {
-          "height": 45,
-          "width": 60,
+      />
+      <Image
+        style={
+          Object {
+            "height": 45,
+            "width": 60,
+          }
         }
-      }
-    />
-    <TileS />
+      />
+      <TileS />
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+            "marginHorizontal": 10,
+            "marginVertical": 25,
+            "width": "100%",
+          }
+        }
+      />
+      <Image
+        style={
+          Object {
+            "height": 45,
+            "width": 60,
+          }
+        }
+      />
+      <TileS />
+    </View>
   </View>
 </View>
 `;
@@ -1197,103 +1207,112 @@ exports[`17. daily universal register - wide 1`] = `
 <View
   style={
     Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 10,
-      "width": 1366,
+      "backgroundColor": "#F0F0F0",
     }
   }
 >
   <View
     style={
       Object {
-        "alignItems": "center",
-        "backgroundColor": "#F0F0F0",
-        "flex": 1,
-        "paddingHorizontal": "25%",
+        "alignSelf": "center",
+        "maxWidth": "100%",
+        "paddingHorizontal": 10,
+        "width": 1366,
       }
     }
   >
-    <Image
+    <View
       style={
         Object {
-          "height": 73,
-          "marginVertical": 10,
-          "width": 285,
-        }
-      }
-    />
-    <Text
-      style={
-        Object {
-          "color": "#850029",
-          "fontFamily": "TimesDigitalW04",
-          "fontSize": 16,
-          "marginBottom": 25,
+          "alignItems": "center",
+          "backgroundColor": "#F0F0F0",
+          "flex": 1,
+          "paddingHorizontal": "25%",
+          "paddingVertical": 10,
         }
       }
     >
-      Daily Universal Register
-    </Text>
-    <TileS />
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginHorizontal": 10,
-          "marginVertical": 25,
-          "width": "100%",
+      <Image
+        style={
+          Object {
+            "height": 73,
+            "marginVertical": 10,
+            "width": 285,
+          }
         }
-      }
-    />
-    <TileS />
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginHorizontal": 10,
-          "marginVertical": 25,
-          "width": "100%",
+      />
+      <Text
+        style={
+          Object {
+            "color": "#850029",
+            "fontFamily": "TimesDigitalW04",
+            "fontSize": 16,
+            "marginBottom": 25,
+          }
         }
-      }
-    />
-    <Image
-      style={
-        Object {
-          "height": 45,
-          "width": 60,
+      >
+        Daily Universal Register
+      </Text>
+      <TileS />
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+            "marginHorizontal": 10,
+            "marginVertical": 25,
+            "width": "100%",
+          }
         }
-      }
-    />
-    <TileS />
-    <View
-      style={
-        Object {
-          "borderBottomColor": "#DBDBDB",
-          "borderBottomWidth": 1,
-          "borderColor": "#DBDBDB",
-          "borderStyle": "solid",
-          "marginHorizontal": 10,
-          "marginVertical": 25,
-          "width": "100%",
+      />
+      <TileS />
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+            "marginHorizontal": 10,
+            "marginVertical": 25,
+            "width": "100%",
+          }
         }
-      }
-    />
-    <Image
-      style={
-        Object {
-          "height": 45,
-          "width": 60,
+      />
+      <Image
+        style={
+          Object {
+            "height": 45,
+            "width": 60,
+          }
         }
-      }
-    />
-    <TileS />
+      />
+      <TileS />
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+            "marginHorizontal": 10,
+            "marginVertical": 25,
+            "width": "100%",
+          }
+        }
+      />
+      <Image
+        style={
+          Object {
+            "height": 45,
+            "width": 60,
+          }
+        }
+      />
+      <TileS />
+    </View>
   </View>
 </View>
 `;
@@ -2318,186 +2337,194 @@ exports[`32. daily universal register - huge 1`] = `
 <View
   style={
     Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 10,
-      "width": 1366,
+      "backgroundColor": "#F0F0F0",
     }
   }
 >
   <View
     style={
       Object {
-        "alignItems": "center",
         "alignSelf": "center",
-        "backgroundColor": "#F0F0F0",
-        "flex": 1,
-        "width": "86%",
+        "maxWidth": "100%",
+        "paddingHorizontal": 10,
+        "width": 1366,
       }
     }
   >
-    <Image
-      style={
-        Object {
-          "height": 73,
-          "marginVertical": 10,
-          "width": 285,
-        }
-      }
-    />
-    <Text
-      style={
-        Object {
-          "color": "#850029",
-          "fontFamily": "TimesDigitalW04",
-          "fontSize": 16,
-          "marginBottom": 25,
-        }
-      }
-    >
-      Daily Universal Register
-    </Text>
     <View
       style={
         Object {
-          "flexDirection": "row",
-          "paddingHorizontal": "8%",
-          "width": "100%",
+          "alignItems": "center",
+          "alignSelf": "center",
+          "backgroundColor": "#F0F0F0",
+          "flex": 1,
+          "width": "86%",
         }
       }
     >
+      <Image
+        style={
+          Object {
+            "height": 73,
+            "marginVertical": 10,
+            "width": 285,
+          }
+        }
+      />
+      <Text
+        style={
+          Object {
+            "color": "#850029",
+            "fontFamily": "TimesDigitalW04",
+            "fontSize": 16,
+            "marginBottom": 25,
+          }
+        }
+      >
+        Daily Universal Register
+      </Text>
       <View
         style={
           Object {
-            "alignItems": "center",
-            "flex": 1,
-            "flexDirection": "column",
-            "paddingHorizontal": 25,
+            "flexDirection": "row",
+            "paddingHorizontal": "8%",
+            "width": "100%",
           }
         }
       >
         <View
           style={
             Object {
-              "borderBottomColor": "#DBDBDB",
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-              "marginHorizontal": 10,
-              "marginVertical": 25,
-              "width": "100%",
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "column",
+              "paddingHorizontal": 25,
             }
           }
-        />
-        <View>
-          <TileS />
+        >
+          <View
+            style={
+              Object {
+                "borderBottomColor": "#DBDBDB",
+                "borderBottomWidth": 1,
+                "borderColor": "#DBDBDB",
+                "borderStyle": "solid",
+                "marginHorizontal": 10,
+                "marginVertical": 25,
+                "width": "100%",
+              }
+            }
+          />
+          <View>
+            <TileS />
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "column",
+              "paddingHorizontal": 25,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "borderBottomColor": "#DBDBDB",
+                "borderBottomWidth": 1,
+                "borderColor": "#DBDBDB",
+                "borderStyle": "solid",
+                "marginHorizontal": 10,
+                "marginVertical": 25,
+                "width": "100%",
+              }
+            }
+          />
+          <View>
+            <TileS />
+          </View>
         </View>
       </View>
       <View
         style={
           Object {
-            "alignItems": "center",
-            "flex": 1,
-            "flexDirection": "column",
-            "paddingHorizontal": 25,
+            "flexDirection": "row",
+            "paddingHorizontal": "8%",
+            "width": "100%",
           }
         }
       >
         <View
           style={
             Object {
-              "borderBottomColor": "#DBDBDB",
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-              "marginHorizontal": 10,
-              "marginVertical": 25,
-              "width": "100%",
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "column",
+              "paddingHorizontal": 25,
             }
           }
-        />
-        <View>
-          <TileS />
+        >
+          <View
+            style={
+              Object {
+                "borderBottomColor": "#DBDBDB",
+                "borderBottomWidth": 1,
+                "borderColor": "#DBDBDB",
+                "borderStyle": "solid",
+                "marginHorizontal": 10,
+                "marginVertical": 25,
+                "width": "100%",
+              }
+            }
+          />
+          <Image
+            style={
+              Object {
+                "height": 45,
+                "width": 60,
+              }
+            }
+          />
+          <View>
+            <TileS />
+          </View>
         </View>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "paddingHorizontal": "8%",
-          "width": "100%",
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "flexDirection": "column",
-            "paddingHorizontal": 25,
-          }
-        }
-      >
         <View
           style={
             Object {
-              "borderBottomColor": "#DBDBDB",
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-              "marginHorizontal": 10,
-              "marginVertical": 25,
-              "width": "100%",
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "column",
+              "paddingHorizontal": 25,
             }
           }
-        />
-        <Image
-          style={
-            Object {
-              "height": 45,
-              "width": 60,
+        >
+          <View
+            style={
+              Object {
+                "borderBottomColor": "#DBDBDB",
+                "borderBottomWidth": 1,
+                "borderColor": "#DBDBDB",
+                "borderStyle": "solid",
+                "marginHorizontal": 10,
+                "marginVertical": 25,
+                "width": "100%",
+              }
             }
-          }
-        />
-        <View>
-          <TileS />
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "flexDirection": "column",
-            "paddingHorizontal": 25,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderBottomColor": "#DBDBDB",
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-              "marginHorizontal": 10,
-              "marginVertical": 25,
-              "width": "100%",
+          />
+          <Image
+            style={
+              Object {
+                "height": 45,
+                "width": 60,
+              }
             }
-          }
-        />
-        <Image
-          style={
-            Object {
-              "height": 45,
-              "width": 60,
-            }
-          }
-        />
-        <View>
-          <TileS />
+          />
+          <View>
+            <TileS />
+          </View>
         </View>
       </View>
     </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -21,40 +21,42 @@ exports[`1. comment lead and cartoon - medium 1`] = `
 exports[`2. daily universal register - medium 1`] = `
 <View>
   <View>
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+    <View>
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+          }
         }
-      }
-    />
-    <Text>
-      Daily Universal Register
-    </Text>
-    <TileS />
-    <View />
-    <TileS />
-    <View />
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/leaves.png",
+      />
+      <Text>
+        Daily Universal Register
+      </Text>
+      <TileS />
+      <View />
+      <TileS />
+      <View />
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/leaves.png",
+          }
         }
-      }
-    />
-    <TileS />
-    <View />
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/cake.png",
+      />
+      <TileS />
+      <View />
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/cake.png",
+          }
         }
-      }
-    />
-    <TileS />
+      />
+      <TileS />
+    </View>
   </View>
 </View>
 `;
@@ -480,40 +482,42 @@ exports[`16. comment lead and cartoon - wide 1`] = `
 exports[`17. daily universal register - wide 1`] = `
 <View>
   <View>
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+    <View>
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+          }
         }
-      }
-    />
-    <Text>
-      Daily Universal Register
-    </Text>
-    <TileS />
-    <View />
-    <TileS />
-    <View />
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/leaves.png",
+      />
+      <Text>
+        Daily Universal Register
+      </Text>
+      <TileS />
+      <View />
+      <TileS />
+      <View />
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/leaves.png",
+          }
         }
-      }
-    />
-    <TileS />
-    <View />
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/cake.png",
+      />
+      <TileS />
+      <View />
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/cake.png",
+          }
         }
-      }
-    />
-    <TileS />
+      />
+      <TileS />
+    </View>
   </View>
 </View>
 `;
@@ -935,58 +939,60 @@ exports[`31. comment lead and cartoon - huge 1`] = `
 exports[`32. daily universal register - huge 1`] = `
 <View>
   <View>
-    <Image
-      resizeMode="contain"
-      source={
-        Object {
-          "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+    <View>
+      <Image
+        resizeMode="contain"
+        source={
+          Object {
+            "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+          }
         }
-      }
-    />
-    <Text>
-      Daily Universal Register
-    </Text>
-    <View>
+      />
+      <Text>
+        Daily Universal Register
+      </Text>
       <View>
-        <View />
         <View>
-          <TileS />
+          <View />
+          <View>
+            <TileS />
+          </View>
+        </View>
+        <View>
+          <View />
+          <View>
+            <TileS />
+          </View>
         </View>
       </View>
       <View>
-        <View />
         <View>
-          <TileS />
-        </View>
-      </View>
-    </View>
-    <View>
-      <View>
-        <View />
-        <Image
-          resizeMode="contain"
-          source={
-            Object {
-              "testUri": "../../../packages/edition-slices/assets/leaves.png",
+          <View />
+          <Image
+            resizeMode="contain"
+            source={
+              Object {
+                "testUri": "../../../packages/edition-slices/assets/leaves.png",
+              }
             }
-          }
-        />
-        <View>
-          <TileS />
+          />
+          <View>
+            <TileS />
+          </View>
         </View>
-      </View>
-      <View>
-        <View />
-        <Image
-          resizeMode="contain"
-          source={
-            Object {
-              "testUri": "../../../packages/edition-slices/assets/cake.png",
-            }
-          }
-        />
         <View>
-          <TileS />
+          <View />
+          <Image
+            resizeMode="contain"
+            source={
+              Object {
+                "testUri": "../../../packages/edition-slices/assets/cake.png",
+              }
+            }
+          />
+          <View>
+            <TileS />
+          </View>
         </View>
       </View>
     </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -929,8 +929,9 @@ exports[`23. tile w 1`] = `
   linkStyle={
     Object {
       "flexDirection": "row",
+      "paddingBottom": 15,
       "paddingHorizontal": 20,
-      "paddingVertical": 10,
+      "paddingTop": 10,
     }
   }
   url="/article/123"
@@ -1673,8 +1674,9 @@ exports[`tiles that change logic based on breakpoints TileW with teaser for wide
   linkStyle={
     Object {
       "flexDirection": "row",
+      "paddingBottom": 15,
       "paddingHorizontal": 20,
-      "paddingVertical": 10,
+      "paddingTop": 10,
     }
   }
   url="/article/123"
@@ -1723,8 +1725,9 @@ exports[`tiles that change logic based on breakpoints TileW without teaser for t
   linkStyle={
     Object {
       "flexDirection": "row",
+      "paddingBottom": 15,
       "paddingHorizontal": 20,
-      "paddingVertical": 10,
+      "paddingTop": 10,
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -88,6 +88,8 @@ exports[`1. daily universal register 1`] = `
   flex-basis: 0%;
   padding-right: 25%;
   padding-left: 25%;
+  padding-top: 10px;
+  padding-bottom: 10px;
   -ms-flex-align: center;
   -webkit-box-align: center;
   -ms-flex-positive: 1;
@@ -105,47 +107,55 @@ exports[`1. daily universal register 1`] = `
   width: 1366px;
   -ms-flex-item-align: center;
 }
+
+.IS10 {
+  background-color: rgba(240,240,240,1.00);
+}
 </style>
 
 <div
-  className="css-view-1dbjc4n IS9"
+  className="css-view-1dbjc4n IS10"
 >
   <div
-    className="css-view-1dbjc4n IS8"
+    className="css-view-1dbjc4n IS9"
   >
-    <Image
-      aspectRatio={1}
-      className="IS1"
-      uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-    />
     <div
-      className="css-text-76zvg2 IS2"
+      className="css-view-1dbjc4n IS8"
     >
-      Daily Universal Register
+      <Image
+        aspectRatio={1}
+        className="IS1"
+        uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
+      />
+      <div
+        className="css-text-76zvg2 IS2"
+      >
+        Daily Universal Register
+      </div>
+      <TileS />
+      <div
+        className="css-view-1dbjc4n IS3"
+      />
+      <TileS />
+      <div
+        className="css-view-1dbjc4n IS4"
+      />
+      <Image
+        aspectRatio={1}
+        className="IS5"
+        uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
+      />
+      <TileS />
+      <div
+        className="css-view-1dbjc4n IS6"
+      />
+      <Image
+        aspectRatio={1}
+        className="IS7"
+        uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
+      />
+      <TileS />
     </div>
-    <TileS />
-    <div
-      className="css-view-1dbjc4n IS3"
-    />
-    <TileS />
-    <div
-      className="css-view-1dbjc4n IS4"
-    />
-    <Image
-      aspectRatio={1}
-      className="IS5"
-      uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
-    />
-    <TileS />
-    <div
-      className="css-view-1dbjc4n IS6"
-    />
-    <Image
-      aspectRatio={1}
-      className="IS7"
-      uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
-    />
-    <TileS />
   </div>
 </div>
 `;

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -3,28 +3,30 @@
 exports[`1. daily universal register 1`] = `
 <div>
   <div>
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-    />
     <div>
-      Daily Universal Register
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
+      />
+      <div>
+        Daily Universal Register
+      </div>
+      <TileS />
+      <div />
+      <TileS />
+      <div />
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
+      />
+      <TileS />
+      <div />
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
+      />
+      <TileS />
     </div>
-    <TileS />
-    <div />
-    <TileS />
-    <div />
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
-    />
-    <TileS />
-    <div />
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
-    />
-    <TileS />
   </div>
 </div>
 `;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -170,6 +170,8 @@ exports[`2. daily universal register - medium 1`] = `
   flex-basis: 0%;
   padding-right: 25%;
   padding-left: 25%;
+  padding-top: 10px;
+  padding-bottom: 10px;
   -ms-flex-align: center;
   -webkit-box-align: center;
   -ms-flex-positive: 1;
@@ -187,47 +189,55 @@ exports[`2. daily universal register - medium 1`] = `
   width: 1366px;
   -ms-flex-item-align: center;
 }
+
+.IS10 {
+  background-color: rgba(240,240,240,1.00);
+}
 </style>
 
 <div
-  className="css-view-1dbjc4n IS9"
+  className="css-view-1dbjc4n IS10"
 >
   <div
-    className="css-view-1dbjc4n IS8"
+    className="css-view-1dbjc4n IS9"
   >
-    <Image
-      aspectRatio={1}
-      className="IS1"
-      uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-    />
     <div
-      className="css-text-76zvg2 IS2"
+      className="css-view-1dbjc4n IS8"
     >
-      Daily Universal Register
+      <Image
+        aspectRatio={1}
+        className="IS1"
+        uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
+      />
+      <div
+        className="css-text-76zvg2 IS2"
+      >
+        Daily Universal Register
+      </div>
+      <TileS />
+      <div
+        className="css-view-1dbjc4n IS3"
+      />
+      <TileS />
+      <div
+        className="css-view-1dbjc4n IS4"
+      />
+      <Image
+        aspectRatio={1}
+        className="IS5"
+        uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
+      />
+      <TileS />
+      <div
+        className="css-view-1dbjc4n IS6"
+      />
+      <Image
+        aspectRatio={1}
+        className="IS7"
+        uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
+      />
+      <TileS />
     </div>
-    <TileS />
-    <div
-      className="css-view-1dbjc4n IS3"
-    />
-    <TileS />
-    <div
-      className="css-view-1dbjc4n IS4"
-    />
-    <Image
-      aspectRatio={1}
-      className="IS5"
-      uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
-    />
-    <TileS />
-    <div
-      className="css-view-1dbjc4n IS6"
-    />
-    <Image
-      aspectRatio={1}
-      className="IS7"
-      uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
-    />
-    <TileS />
   </div>
 </div>
 `;
@@ -1967,6 +1977,8 @@ exports[`17. daily universal register - wide 1`] = `
   flex-basis: 0%;
   padding-right: 25%;
   padding-left: 25%;
+  padding-top: 10px;
+  padding-bottom: 10px;
   -ms-flex-align: center;
   -webkit-box-align: center;
   -ms-flex-positive: 1;
@@ -1984,47 +1996,55 @@ exports[`17. daily universal register - wide 1`] = `
   width: 1366px;
   -ms-flex-item-align: center;
 }
+
+.IS10 {
+  background-color: rgba(240,240,240,1.00);
+}
 </style>
 
 <div
-  className="css-view-1dbjc4n IS9"
+  className="css-view-1dbjc4n IS10"
 >
   <div
-    className="css-view-1dbjc4n IS8"
+    className="css-view-1dbjc4n IS9"
   >
-    <Image
-      aspectRatio={1}
-      className="IS1"
-      uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-    />
     <div
-      className="css-text-76zvg2 IS2"
+      className="css-view-1dbjc4n IS8"
     >
-      Daily Universal Register
+      <Image
+        aspectRatio={1}
+        className="IS1"
+        uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
+      />
+      <div
+        className="css-text-76zvg2 IS2"
+      >
+        Daily Universal Register
+      </div>
+      <TileS />
+      <div
+        className="css-view-1dbjc4n IS3"
+      />
+      <TileS />
+      <div
+        className="css-view-1dbjc4n IS4"
+      />
+      <Image
+        aspectRatio={1}
+        className="IS5"
+        uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
+      />
+      <TileS />
+      <div
+        className="css-view-1dbjc4n IS6"
+      />
+      <Image
+        aspectRatio={1}
+        className="IS7"
+        uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
+      />
+      <TileS />
     </div>
-    <TileS />
-    <div
-      className="css-view-1dbjc4n IS3"
-    />
-    <TileS />
-    <div
-      className="css-view-1dbjc4n IS4"
-    />
-    <Image
-      aspectRatio={1}
-      className="IS5"
-      uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
-    />
-    <TileS />
-    <div
-      className="css-view-1dbjc4n IS6"
-    />
-    <Image
-      aspectRatio={1}
-      className="IS7"
-      uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
-    />
-    <TileS />
   </div>
 </div>
 `;
@@ -3764,6 +3784,8 @@ exports[`32. daily universal register - huge 1`] = `
   flex-basis: 0%;
   padding-right: 25%;
   padding-left: 25%;
+  padding-top: 10px;
+  padding-bottom: 10px;
   -ms-flex-align: center;
   -webkit-box-align: center;
   -ms-flex-positive: 1;
@@ -3781,47 +3803,55 @@ exports[`32. daily universal register - huge 1`] = `
   width: 1366px;
   -ms-flex-item-align: center;
 }
+
+.IS10 {
+  background-color: rgba(240,240,240,1.00);
+}
 </style>
 
 <div
-  className="css-view-1dbjc4n IS9"
+  className="css-view-1dbjc4n IS10"
 >
   <div
-    className="css-view-1dbjc4n IS8"
+    className="css-view-1dbjc4n IS9"
   >
-    <Image
-      aspectRatio={1}
-      className="IS1"
-      uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-    />
     <div
-      className="css-text-76zvg2 IS2"
+      className="css-view-1dbjc4n IS8"
     >
-      Daily Universal Register
+      <Image
+        aspectRatio={1}
+        className="IS1"
+        uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
+      />
+      <div
+        className="css-text-76zvg2 IS2"
+      >
+        Daily Universal Register
+      </div>
+      <TileS />
+      <div
+        className="css-view-1dbjc4n IS3"
+      />
+      <TileS />
+      <div
+        className="css-view-1dbjc4n IS4"
+      />
+      <Image
+        aspectRatio={1}
+        className="IS5"
+        uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
+      />
+      <TileS />
+      <div
+        className="css-view-1dbjc4n IS6"
+      />
+      <Image
+        aspectRatio={1}
+        className="IS7"
+        uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
+      />
+      <TileS />
     </div>
-    <TileS />
-    <div
-      className="css-view-1dbjc4n IS3"
-    />
-    <TileS />
-    <div
-      className="css-view-1dbjc4n IS4"
-    />
-    <Image
-      aspectRatio={1}
-      className="IS5"
-      uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
-    />
-    <TileS />
-    <div
-      className="css-view-1dbjc4n IS6"
-    />
-    <Image
-      aspectRatio={1}
-      className="IS7"
-      uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
-    />
-    <TileS />
   </div>
 </div>
 `;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -21,28 +21,30 @@ exports[`1. comment lead and cartoon - medium 1`] = `
 exports[`2. daily universal register - medium 1`] = `
 <div>
   <div>
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-    />
     <div>
-      Daily Universal Register
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
+      />
+      <div>
+        Daily Universal Register
+      </div>
+      <TileS />
+      <div />
+      <TileS />
+      <div />
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
+      />
+      <TileS />
+      <div />
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
+      />
+      <TileS />
     </div>
-    <TileS />
-    <div />
-    <TileS />
-    <div />
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
-    />
-    <TileS />
-    <div />
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
-    />
-    <TileS />
   </div>
 </div>
 `;
@@ -460,28 +462,30 @@ exports[`16. comment lead and cartoon - wide 1`] = `
 exports[`17. daily universal register - wide 1`] = `
 <div>
   <div>
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-    />
     <div>
-      Daily Universal Register
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
+      />
+      <div>
+        Daily Universal Register
+      </div>
+      <TileS />
+      <div />
+      <TileS />
+      <div />
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
+      />
+      <TileS />
+      <div />
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
+      />
+      <TileS />
     </div>
-    <TileS />
-    <div />
-    <TileS />
-    <div />
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
-    />
-    <TileS />
-    <div />
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
-    />
-    <TileS />
   </div>
 </div>
 `;
@@ -899,28 +903,30 @@ exports[`31. comment lead and cartoon - huge 1`] = `
 exports[`32. daily universal register - huge 1`] = `
 <div>
   <div>
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-    />
     <div>
-      Daily Universal Register
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
+      />
+      <div>
+        Daily Universal Register
+      </div>
+      <TileS />
+      <div />
+      <TileS />
+      <div />
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
+      />
+      <TileS />
+      <div />
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
+      />
+      <TileS />
     </div>
-    <TileS />
-    <div />
-    <TileS />
-    <div />
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
-    />
-    <TileS />
-    <div />
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
-    />
-    <TileS />
   </div>
 </div>
 `;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -1836,8 +1836,9 @@ exports[`23. tile w 1`] = `
   linkStyle={
     Object {
       "flexDirection": "row",
+      "paddingBottom": "15px",
       "paddingHorizontal": "20px",
-      "paddingVertical": "10px",
+      "paddingTop": "10px",
     }
   }
   url="/article/123"
@@ -3323,8 +3324,9 @@ exports[`tiles that change logic based on breakpoints TileW with teaser for wide
   linkStyle={
     Object {
       "flexDirection": "row",
+      "paddingBottom": "15px",
       "paddingHorizontal": "20px",
-      "paddingVertical": "10px",
+      "paddingTop": "10px",
     }
   }
   url="/article/123"
@@ -3411,8 +3413,9 @@ exports[`tiles that change logic based on breakpoints TileW without teaser for t
   linkStyle={
     Object {
       "flexDirection": "row",
+      "paddingBottom": "15px",
       "paddingHorizontal": "20px",
-      "paddingVertical": "10px",
+      "paddingTop": "10px",
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -929,8 +929,9 @@ exports[`23. tile w 1`] = `
   linkStyle={
     Object {
       "flexDirection": "row",
+      "paddingBottom": "15px",
       "paddingHorizontal": "20px",
-      "paddingVertical": "10px",
+      "paddingTop": "10px",
     }
   }
   url="/article/123"
@@ -1673,8 +1674,9 @@ exports[`tiles that change logic based on breakpoints TileW with teaser for wide
   linkStyle={
     Object {
       "flexDirection": "row",
+      "paddingBottom": "15px",
       "paddingHorizontal": "20px",
-      "paddingVertical": "10px",
+      "paddingTop": "10px",
     }
   }
   url="/article/123"
@@ -1723,8 +1725,9 @@ exports[`tiles that change logic based on breakpoints TileW without teaser for t
   linkStyle={
     Object {
       "flexDirection": "row",
+      "paddingBottom": "15px",
       "paddingHorizontal": "20px",
-      "paddingVertical": "10px",
+      "paddingTop": "10px",
     }
   }
   url="/article/123"

--- a/packages/edition-slices/src/slices/dailyregisterleadfour/index.js
+++ b/packages/edition-slices/src/slices/dailyregisterleadfour/index.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import { ItemRowSeparator } from "@times-components/slice-layout";
 import { ResponsiveSlice } from "../shared";
 import { TileS } from "../../tiles";
-import styleFactory from "./styles";
+import styleFactory, { backgroundColor } from "./styles";
 import Logo from "./logo";
 
 class DailyRegisterLeadFour extends Component {
@@ -114,12 +114,14 @@ class DailyRegisterLeadFour extends Component {
 
   render() {
     return (
-      <ResponsiveSlice
-        renderHuge={this.renderHuge}
-        renderMedium={this.renderSlice}
-        renderSmall={this.renderSlice}
-        renderWide={this.renderSlice}
-      />
+      <View style={backgroundColor}>
+        <ResponsiveSlice
+          renderHuge={this.renderHuge}
+          renderMedium={this.renderSlice}
+          renderSmall={this.renderSlice}
+          renderWide={this.renderSlice}
+        />
+      </View>
     );
   }
 }

--- a/packages/edition-slices/src/slices/dailyregisterleadfour/index.js
+++ b/packages/edition-slices/src/slices/dailyregisterleadfour/index.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import { ItemRowSeparator } from "@times-components/slice-layout";
 import { ResponsiveSlice } from "../shared";
 import { TileS } from "../../tiles";
-import styleFactory, { backgroundColor } from "./styles";
+import styleFactory, { backgroundColour } from "./styles";
 import Logo from "./logo";
 
 class DailyRegisterLeadFour extends Component {
@@ -114,7 +114,7 @@ class DailyRegisterLeadFour extends Component {
 
   render() {
     return (
-      <View style={backgroundColor}>
+      <View style={backgroundColour}>
         <ResponsiveSlice
           renderHuge={this.renderHuge}
           renderMedium={this.renderSlice}

--- a/packages/edition-slices/src/slices/dailyregisterleadfour/styles.js
+++ b/packages/edition-slices/src/slices/dailyregisterleadfour/styles.js
@@ -101,6 +101,6 @@ export default breakpoint => ({
   ...(stylesResolver[breakpoint] || {})
 });
 
-export const backgroundColor = {
+export const backgroundColour = {
   backgroundColor: main.container.backgroundColor
 };

--- a/packages/edition-slices/src/slices/dailyregisterleadfour/styles.js
+++ b/packages/edition-slices/src/slices/dailyregisterleadfour/styles.js
@@ -48,11 +48,13 @@ const mediumBreakpointStyles = {
     alignItems: "center",
     backgroundColor: colours.functional.border,
     flex: 1,
-    paddingHorizontal: "20%"
+    paddingHorizontal: "20%",
+    paddingVertical: spacing(2)
   },
   mastheadLogo: {
     height: 97,
-    width: 380
+    width: 380,
+    marginVertical: spacing(2)
   }
 };
 
@@ -61,7 +63,8 @@ const wideBreakpointStyle = {
     alignItems: "center",
     backgroundColor: colours.functional.border,
     flex: 1,
-    paddingHorizontal: "25%"
+    paddingHorizontal: "25%",
+    paddingVertical: spacing(2)
   }
 };
 
@@ -97,3 +100,7 @@ export default breakpoint => ({
   ...main,
   ...(stylesResolver[breakpoint] || {})
 });
+
+export const backgroundColor = {
+  backgroundColor: main.container.backgroundColor
+};

--- a/packages/edition-slices/src/tiles/tile-w/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/styles/index.js
@@ -8,7 +8,8 @@ const styles = fontSize => ({
   container: {
     flexDirection: "row",
     paddingHorizontal: spacing(4),
-    paddingVertical: spacing(2)
+    paddingTop: spacing(2),
+    paddingBottom: spacing(3)
   },
   headline: {
     ...fontFactory({


### PR DESCRIPTION
[Jira](https://nidigitalsolutions.jira.com/browse/REPLAT-6745). Fixes for tablet rows 9, 10, 11

1. Comment leader padding bottom added:

![image](https://user-images.githubusercontent.com/8720661/59918143-8c032900-942c-11e9-8e3c-7187be75c23d.png)


2. Comment Universal Register margin colour updated:

![image](https://user-images.githubusercontent.com/8720661/59918212-b48b2300-942c-11e9-9745-30a59aad652e.png)


3. Comment Universal Register padding added - masthead and header:

![image](https://user-images.githubusercontent.com/8720661/59918251-d1275b00-942c-11e9-9e60-35b7e31793c6.png)
