### PR TITLE
feat: article design review amends REPLAT-6102 

### DIFF
--- a/packages/article-in-depth/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -78,14 +78,13 @@ exports[`1. article in depth - tablet 1`] = `
     style={
       Object {
         "alignSelf": "center",
-        "marginBottom": 20,
+        "marginBottom": 0,
         "maxWidth": 1194,
         "width": "100%",
       }
     }
   >
     <ModalImage />
-    <CenteredCaption />
   </View>
   <View
     style={

--- a/packages/article-in-depth/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -74,7 +74,7 @@ exports[`full article with style 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -210,7 +210,7 @@ exports[`full article with style in the culture magazine 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -346,7 +346,7 @@ exports[`full article with style in the style magazine 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -482,7 +482,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -618,7 +618,7 @@ exports[`tablet full article with style in the culture magazine 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -754,7 +754,7 @@ exports[`tablet full article with style in the style magazine 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -890,7 +890,7 @@ exports[`tablet full article with style in the sunday times magazine 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -78,14 +78,13 @@ exports[`1. article in depth - tablet 1`] = `
     style={
       Object {
         "alignSelf": "center",
-        "marginBottom": 20,
+        "marginBottom": 0,
         "maxWidth": 1194,
         "width": "100%",
       }
     }
   >
     <ModalImage />
-    <CenteredCaption />
   </View>
   <View
     style={

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -74,7 +74,7 @@ exports[`full article with style 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -210,7 +210,7 @@ exports[`full article with style in the culture magazine 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -346,7 +346,7 @@ exports[`full article with style in the style magazine 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -482,7 +482,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -618,7 +618,7 @@ exports[`tablet full article with style in the culture magazine 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -754,7 +754,7 @@ exports[`tablet full article with style in the style magazine 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -890,7 +890,7 @@ exports[`tablet full article with style in the sunday times magazine 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 20,
+        "marginBottom": 0,
       }
     }
   >

--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -488,7 +488,7 @@ exports[`full article with style 1`] = `
 }
 
 .IS6 {
-  margin-bottom: 20px;
+  margin-bottom: 0px;
 }
 
 .IS7 {
@@ -1228,7 +1228,7 @@ exports[`full article with style in the culture magazine 1`] = `
 }
 
 .IS6 {
-  margin-bottom: 20px;
+  margin-bottom: 0px;
 }
 
 .IS7 {
@@ -1968,7 +1968,7 @@ exports[`full article with style in the style magazine 1`] = `
 }
 
 .IS6 {
-  margin-bottom: 20px;
+  margin-bottom: 0px;
 }
 
 .IS7 {
@@ -2708,7 +2708,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
 }
 
 .IS6 {
-  margin-bottom: 20px;
+  margin-bottom: 0px;
 }
 
 .IS7 {

--- a/packages/article-in-depth/src/article-in-depth.js
+++ b/packages/article-in-depth/src/article-in-depth.js
@@ -61,7 +61,9 @@ class ArticleInDepth extends Component {
               getImageCrop={getStandardTemplateCrop}
               onImagePress={onImagePress}
               onVideoPress={onVideoPress}
-              renderCaption={({ caption }) => <CentredCaption {...caption} />}
+              renderCaption={({ caption }) =>
+                caption.text && <CentredCaption {...caption} />
+              }
               style={[styles.leadAsset, isTablet && styles.leadAssetTablet]}
               width={width}
             />

--- a/packages/article-in-depth/src/article-in-depth.js
+++ b/packages/article-in-depth/src/article-in-depth.js
@@ -62,7 +62,7 @@ class ArticleInDepth extends Component {
               onImagePress={onImagePress}
               onVideoPress={onVideoPress}
               renderCaption={({ caption }) =>
-                caption.text && <CentredCaption {...caption} />
+                caption && caption.text && <CentredCaption {...caption} />
               }
               style={[styles.leadAsset, isTablet && styles.leadAssetTablet]}
               width={width}

--- a/packages/article-in-depth/src/styles/shared.js
+++ b/packages/article-in-depth/src/styles/shared.js
@@ -49,7 +49,7 @@ const sharedStyles = {
     marginBottom: spacing(2)
   },
   leadAsset: {
-    marginBottom: spacing(4)
+    marginBottom: spacing(0)
   },
   leadAssetTablet: {
     alignSelf: "center",

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -117,7 +117,7 @@ exports[`phone full article with style 1`] = `
                 "fontFamily": "GillSansMTStd-Medium",
                 "fontSize": 13,
                 "lineHeight": 15,
-                "marginTop": 15,
+                "marginTop": 5,
               }
             }
           >
@@ -247,7 +247,7 @@ exports[`tablet full article with style 1`] = `
                 "fontFamily": "GillSansMTStd-Medium",
                 "fontSize": 13,
                 "lineHeight": 15,
-                "marginTop": 15,
+                "marginTop": 5,
               }
             }
           >

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -117,7 +117,7 @@ exports[`phone full article with style 1`] = `
                 "fontFamily": "GillSansMTStd-Medium",
                 "fontSize": 13,
                 "lineHeight": 15,
-                "marginTop": 15,
+                "marginTop": 5,
               }
             }
           >
@@ -247,7 +247,7 @@ exports[`tablet full article with style 1`] = `
                 "fontFamily": "GillSansMTStd-Medium",
                 "fontSize": 13,
                 "lineHeight": 15,
-                "marginTop": 15,
+                "marginTop": 5,
               }
             }
           >

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -429,7 +429,7 @@ exports[`full article with style 1`] = `
 
 .S6 {
   line-height: 15px;
-  margin-top: 15px;
+  margin-top: 5px;
 }
 
 .S7 {
@@ -574,7 +574,7 @@ exports[`full article with style 1`] = `
           className="c8 responsiveweb__Meta-tglil3-6 c8 css-view-1dbjc4n r-flexDirection-18u37iz r-flexWrap-1w6e6rj"
         >
           <div
-            className="c10 responsiveweb__DatePublicationContainer-tglil3-1 c10 css-text-76zvg2 r-color-1khp51w r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-marginTop-19h5ruw S6"
+            className="c10 responsiveweb__DatePublicationContainer-tglil3-1 c10 css-text-76zvg2 r-color-1khp51w r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-marginTop-1g94qm0 S6"
           >
             <DatePublication />
           </div>

--- a/packages/article-main-comment/src/article-meta/article-meta.js
+++ b/packages/article-main-comment/src/article-meta/article-meta.js
@@ -8,7 +8,7 @@ import styles from "../styles";
 
 const Separator = () => <View style={styles.separator} />;
 
-const hasBylineElement = (bylines) => bylines && bylines[0].byline.length > 0;
+const hasBylineElement = bylines => bylines && bylines[0].byline.length > 0;
 
 const ArticleMeta = ({
   bylines,
@@ -18,34 +18,33 @@ const ArticleMeta = ({
   publicationName,
   publishedTime
 }) => (
-    <View
-      style={[
-        styles.metaContainer,
-        !hasStandfirst && styles.metaFlagSpacer,
-        isTablet && styles.metaContainerTablet
-      ]}
-    >
-      {hasBylineElement(bylines) && (
-        <Fragment>
-          <View style={styles.meta}>
-            <ArticleBylineWithLinks ast={bylines} onAuthorPress={onAuthorPress} />
-          </View>
-        </Fragment>
-
-      )}
-      {isTablet ? <Separator /> : null}
-      <View style={styles.meta}>
-        <Text
-          style={[
-            styles.datePublication,
-            isTablet && styles.datePublicationTablet
-          ]}
-        >
-          <DatePublication date={publishedTime} publication={publicationName} />
-        </Text>
-      </View>
+  <View
+    style={[
+      styles.metaContainer,
+      !hasStandfirst && styles.metaFlagSpacer,
+      isTablet && styles.metaContainerTablet
+    ]}
+  >
+    {hasBylineElement(bylines) && (
+      <Fragment>
+        <View style={styles.meta}>
+          <ArticleBylineWithLinks ast={bylines} onAuthorPress={onAuthorPress} />
+        </View>
+      </Fragment>
+    )}
+    {isTablet ? <Separator /> : null}
+    <View style={styles.meta}>
+      <Text
+        style={[
+          styles.datePublication,
+          isTablet && styles.datePublicationTablet
+        ]}
+      >
+        <DatePublication date={publishedTime} publication={publicationName} />
+      </Text>
     </View>
-  );
+  </View>
+);
 
 ArticleMeta.propTypes = {
   ...metaPropTypes,

--- a/packages/article-main-comment/src/article-meta/article-meta.js
+++ b/packages/article-main-comment/src/article-meta/article-meta.js
@@ -8,6 +8,8 @@ import styles from "../styles";
 
 const Separator = () => <View style={styles.separator} />;
 
+const hasBylineElement = (bylines) => bylines && bylines[0].byline.length > 0;
+
 const ArticleMeta = ({
   bylines,
   hasStandfirst,
@@ -16,33 +18,34 @@ const ArticleMeta = ({
   publicationName,
   publishedTime
 }) => (
-  <View
-    style={[
-      styles.metaContainer,
-      !hasStandfirst && styles.metaFlagSpacer,
-      isTablet && styles.metaContainerTablet
-    ]}
-  >
-    {bylines && (
-      <Fragment>
-        <View style={styles.meta}>
-          <ArticleBylineWithLinks ast={bylines} onAuthorPress={onAuthorPress} />
-        </View>
-      </Fragment>
-    )}
-    {isTablet ? <Separator /> : null}
-    <View style={styles.meta}>
-      <Text
-        style={[
-          styles.datePublication,
-          isTablet && styles.datePublicationTablet
-        ]}
-      >
-        <DatePublication date={publishedTime} publication={publicationName} />
-      </Text>
+    <View
+      style={[
+        styles.metaContainer,
+        !hasStandfirst && styles.metaFlagSpacer,
+        isTablet && styles.metaContainerTablet
+      ]}
+    >
+      {hasBylineElement(bylines) && (
+        <Fragment>
+          <View style={styles.meta}>
+            <ArticleBylineWithLinks ast={bylines} onAuthorPress={onAuthorPress} />
+          </View>
+        </Fragment>
+
+      )}
+      {isTablet ? <Separator /> : null}
+      <View style={styles.meta}>
+        <Text
+          style={[
+            styles.datePublication,
+            isTablet && styles.datePublicationTablet
+          ]}
+        >
+          <DatePublication date={publishedTime} publication={publicationName} />
+        </Text>
+      </View>
     </View>
-  </View>
-);
+  );
 
 ArticleMeta.propTypes = {
   ...metaPropTypes,

--- a/packages/article-main-comment/src/article-meta/article-meta.js
+++ b/packages/article-main-comment/src/article-meta/article-meta.js
@@ -8,7 +8,8 @@ import styles from "../styles";
 
 const Separator = () => <View style={styles.separator} />;
 
-const hasBylineElement = bylines => bylines && bylines[0].byline.length > 0;
+const hasBylineData = bylines =>
+  Array.isArray(bylines) && bylines[0].byline && bylines[0].byline.length > 0;
 
 const ArticleMeta = ({
   bylines,
@@ -25,7 +26,7 @@ const ArticleMeta = ({
       isTablet && styles.metaContainerTablet
     ]}
   >
-    {hasBylineElement(bylines) && (
+    {hasBylineData(bylines) && (
       <Fragment>
         <View style={styles.meta}>
           <ArticleBylineWithLinks ast={bylines} onAuthorPress={onAuthorPress} />

--- a/packages/article-main-comment/src/article-meta/article-meta.js
+++ b/packages/article-main-comment/src/article-meta/article-meta.js
@@ -9,7 +9,7 @@ import styles from "../styles";
 const Separator = () => <View style={styles.separator} />;
 
 const hasBylineData = bylines =>
-  Array.isArray(bylines) && bylines[0].byline && bylines[0].byline.length > 0;
+  bylines.length > 0 && bylines[0].byline && bylines[0].byline.length > 0;
 
 const ArticleMeta = ({
   bylines,

--- a/packages/article-main-comment/src/styles/shared.js
+++ b/packages/article-main-comment/src/styles/shared.js
@@ -35,7 +35,7 @@ const sharedStyles = {
       fontSize: "cardMeta"
     }),
     color: colours.functional.secondary,
-    marginTop: spacing(3)
+    marginTop: spacing(1)
   },
   datePublicationTablet: {
     marginTop: "auto"

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -108,16 +108,7 @@ exports[`1. article main standard - tablet 1`] = `
           <ArticleBylineWithLinks />
         </Text>
       </View>
-      <View
-        style={
-          Object {
-            "borderTopColor": "#DBDBDB",
-            "borderTopWidth": 1,
-            "paddingBottom": 6,
-            "paddingTop": 7,
-          }
-        }
-      >
+      <View>
         <Text
           style={
             Object {

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -107,16 +107,7 @@ exports[`full article with style on mobile 1`] = `
           <ArticleBylineWithLinks />
         </Text>
       </View>
-      <View
-        style={
-          Object {
-            "borderTopColor": "#DBDBDB",
-            "borderTopWidth": 1,
-            "paddingBottom": 6,
-            "paddingTop": 7,
-          }
-        }
-      >
+      <View>
         <Text
           style={
             Object {
@@ -242,16 +233,7 @@ exports[`full article with style on tablet 1`] = `
           <ArticleBylineWithLinks />
         </Text>
       </View>
-      <View
-        style={
-          Object {
-            "borderTopColor": "#DBDBDB",
-            "borderTopWidth": 1,
-            "paddingBottom": 6,
-            "paddingTop": 7,
-          }
-        }
-      >
+      <View>
         <Text
           style={
             Object {

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -107,16 +107,7 @@ exports[`1. article main standard - tablet 1`] = `
           <ArticleBylineWithLinks />
         </Text>
       </View>
-      <View
-        style={
-          Object {
-            "borderTopColor": "#DBDBDB",
-            "borderTopWidth": 1,
-            "paddingBottom": 4,
-            "paddingTop": 9,
-          }
-        }
-      >
+      <View>
         <Text
           style={
             Object {

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -106,16 +106,7 @@ exports[`full article with style on mobile 1`] = `
           <ArticleBylineWithLinks />
         </Text>
       </View>
-      <View
-        style={
-          Object {
-            "borderTopColor": "#DBDBDB",
-            "borderTopWidth": 1,
-            "paddingBottom": 4,
-            "paddingTop": 9,
-          }
-        }
-      >
+      <View>
         <Text
           style={
             Object {
@@ -240,16 +231,7 @@ exports[`full article with style on tablet 1`] = `
           <ArticleBylineWithLinks />
         </Text>
       </View>
-      <View
-        style={
-          Object {
-            "borderTopColor": "#DBDBDB",
-            "borderTopWidth": 1,
-            "paddingBottom": 4,
-            "paddingTop": 9,
-          }
-        }
-      >
+      <View>
         <Text
           style={
             Object {

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -597,7 +597,7 @@ exports[`full article with style 1`] = `
           </span>
         </div>
         <div
-          className="c7 responsiveweb__MetaTextElement-jtjuw7-0 c7 css-text-76zvg2 r-borderTopColor-1ozwgwe r-borderTopWidth-5kkj8d r-paddingBottom-1inuy60 r-paddingTop-glunga S2"
+          className="c7 responsiveweb__MetaTextElement-jtjuw7-0 c7 css-text-76zvg2"
         >
           <span
             className="css-text-76zvg2 css-textHasAncestor-16my406 r-color-1khp51w r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n S6"

--- a/packages/article-main-standard/src/article-meta/article-meta-base.js
+++ b/packages/article-main-standard/src/article-meta/article-meta-base.js
@@ -17,7 +17,7 @@ const ArticleMetaRow = (
   </RowWrapper>
 );
 
-const hasBylineElement = bylines => bylines && bylines.length > 0;
+const hasBylineData = bylines => Array.isArray(bylines) && bylines.length > 0;
 
 const ArticleMetaBase = ({
   bylines,
@@ -29,14 +29,14 @@ const ArticleMetaBase = ({
   const data = [
     ArticleMetaRow(
       styles.datePublication,
-      !hasBylineElement(bylines) ? styles.articleMetaElement : {},
+      !hasBylineData(bylines) ? styles.articleMetaElement : {},
       <DatePublication date={publishedTime} publication={publicationName} />,
       "articleDatePublication",
       RowWrapper
     )
   ];
 
-  if (hasBylineElement(bylines)) {
+  if (hasBylineData(bylines)) {
     return [
       ArticleMetaRow(
         styles.byline,

--- a/packages/article-main-standard/src/article-meta/article-meta-base.js
+++ b/packages/article-main-standard/src/article-meta/article-meta-base.js
@@ -5,11 +5,13 @@ import { ArticleBylineWithLinks } from "@times-components/article-byline";
 import DatePublication from "@times-components/date-publication";
 import styles from "../styles/article-meta";
 
-const ArticleMetaRow = (textStyle, component, key, RowWrapper) => (
-  <RowWrapper key={key} style={styles.articleMetaElement}>
+const ArticleMetaRow = (textStyle, rowWrapperStyles = {}, component, key, RowWrapper) => (
+  <RowWrapper key={key} style={rowWrapperStyles}>
     <Text style={textStyle}>{component}</Text>
   </RowWrapper>
 );
+
+const hasBylineElement = (bylines) => (bylines && bylines.length > 0);
 
 const ArticleMetaBase = ({
   bylines,
@@ -18,19 +20,23 @@ const ArticleMetaBase = ({
   RowWrapper,
   onAuthorPress
 }) => {
+
+
   const data = [
     ArticleMetaRow(
       styles.datePublication,
+      !hasBylineElement(bylines) ? styles.articleMetaElement : {},
       <DatePublication date={publishedTime} publication={publicationName} />,
       "articleDatePublication",
       RowWrapper
     )
   ];
 
-  if (bylines && bylines.length > 0) {
+  if (hasBylineElement(bylines)) {
     return [
       ArticleMetaRow(
         styles.byline,
+        styles.articleMetaElement,
         <ArticleBylineWithLinks ast={bylines} onAuthorPress={onAuthorPress} />,
         "articleByline",
         RowWrapper

--- a/packages/article-main-standard/src/article-meta/article-meta-base.js
+++ b/packages/article-main-standard/src/article-meta/article-meta-base.js
@@ -17,7 +17,8 @@ const ArticleMetaRow = (
   </RowWrapper>
 );
 
-const hasBylineData = bylines => Array.isArray(bylines) && bylines.length > 0;
+const hasBylineData = bylines =>
+  bylines.length > 0 && bylines[0].byline && bylines[0].byline.length > 0;
 
 const ArticleMetaBase = ({
   bylines,

--- a/packages/article-main-standard/src/article-meta/article-meta-base.js
+++ b/packages/article-main-standard/src/article-meta/article-meta-base.js
@@ -5,13 +5,19 @@ import { ArticleBylineWithLinks } from "@times-components/article-byline";
 import DatePublication from "@times-components/date-publication";
 import styles from "../styles/article-meta";
 
-const ArticleMetaRow = (textStyle, rowWrapperStyles = {}, component, key, RowWrapper) => (
+const ArticleMetaRow = (
+  textStyle,
+  rowWrapperStyles = {},
+  component,
+  key,
+  RowWrapper
+) => (
   <RowWrapper key={key} style={rowWrapperStyles}>
     <Text style={textStyle}>{component}</Text>
   </RowWrapper>
 );
 
-const hasBylineElement = (bylines) => (bylines && bylines.length > 0);
+const hasBylineElement = bylines => bylines && bylines.length > 0;
 
 const ArticleMetaBase = ({
   bylines,
@@ -20,8 +26,6 @@ const ArticleMetaBase = ({
   RowWrapper,
   onAuthorPress
 }) => {
-
-
   const data = [
     ArticleMetaRow(
       styles.datePublication,


### PR DESCRIPTION
### Apply Article design review amends

JIRA Story : https://nidigitalsolutions.jira.com/browse/REPLAT-6102

- In depth template - remove padding below image if there is no caption and credit (this fixes the uneven spacing issue on cartoons) 

**Before**
![Screen Shot 2019-06-13 at 09 54 11](https://user-images.githubusercontent.com/10476819/59927910-33408a00-9446-11e9-8170-60880e3c1632.png)

**After**
<img width="225" alt="Screenshot 2019-06-20 at 17 47 19" src="https://user-images.githubusercontent.com/10476819/59928800-30469900-9448-11e9-880b-87eb32785afd.png">


- Main standard template - remove extra keyline between byline and pub info on article main standard template

**Before**
![Screen Shot 2019-06-13 at 09 56 00](https://user-images.githubusercontent.com/10476819/59928116-b6fa7680-9446-11e9-8829-5cf9eae75cf3.png)

**After**
![Untitled](https://user-images.githubusercontent.com/10476819/59928889-59672980-9448-11e9-828b-3970688aafce.png)


- Default, comment and In depth template (which have the pub/ byline between 2 keylines - padding looks wrong and we need to allow for a missing byline. 
If both byline and pub info:
-padding above and below 10px
-padding between 10px
If pub info only:
-padding above and below 10px

**Before**
![Screen Shot 2019-06-13 at 08 42 01](https://user-images.githubusercontent.com/10476819/59928517-9d0d6380-9447-11e9-915b-3e55b40ccfcf.png)

**After**
- pub info only
<img width="200" alt="Screenshot 2019-06-21 at 13 42 29" src="https://user-images.githubusercontent.com/10476819/59928657-e6f64980-9447-11e9-8502-fc359891e8b2.png">

- both byline and pub info
<img width="200" alt="Screenshot 2019-06-21 at 13 42 42" src="https://user-images.githubusercontent.com/10476819/59928670-eb226700-9447-11e9-993a-388fb8b4d5c8.png">


