### PR TITLE
fix: REPLAT-6745 section fragment query updated

### DIFF
--- a/packages/provider-queries/src/section-fragment.js
+++ b/packages/provider-queries/src/section-fragment.js
@@ -585,7 +585,9 @@ export default gql`
             listingAsset {
               ...listingAsset169
             }
+            summary125: summary(maxCharCount: 125)
           }
+          teaser125: teaser(maxCharCount: 125)
         }
         lead2 {
           headline
@@ -600,7 +602,9 @@ export default gql`
             listingAsset {
               ...listingAsset169
             }
+            summary125: summary(maxCharCount: 125)
           }
+          teaser125: teaser(maxCharCount: 125)
         }
         support1 {
           headline
@@ -1209,7 +1213,9 @@ export default gql`
             listingAsset {
               ...listingAsset169
             }
+            summary125: summary(maxCharCount: 125)
           }
+          teaser125: teaser(maxCharCount: 125)
         }
         lead2 {
           headline
@@ -1224,7 +1230,9 @@ export default gql`
             listingAsset {
               ...listingAsset169
             }
+            summary125: summary(maxCharCount: 125)
           }
+          teaser125: teaser(maxCharCount: 125)
         }
         support1 {
           headline


### PR DESCRIPTION
[Jira story](https://nidigitalsolutions.jira.com/browse/REPLAT-6745)

Summary and teaser added lead1 and lead2 of TwoPicAndSixNoPicSlice section query.
By [design](https://app.zeplin.io/project/5c531dcd1dfb92353b64e7dc/screen/5c5dbb7ce0c3e72caed16ea4) the slice should show summary on tablet portrait (medium breakpoint).

![image](https://user-images.githubusercontent.com/8720661/60028968-edcfc700-96a8-11e9-9834-5e2d19d603c0.png)


Attaching screenshots of mobile and tablet landscape to show that summary is not visible.

![image](https://user-images.githubusercontent.com/8720661/60029015-04761e00-96a9-11e9-8251-0489ad26499f.png)

