### PR TITLE
fix: native edition query

### DIFF
--- a/packages/provider-queries/src/article-fragment.js
+++ b/packages/provider-queries/src/article-fragment.js
@@ -52,31 +52,31 @@ export default gql`
     caption
     credits
     crop169: crop(ratio: "16:9") {
-      ...cropProps
+      ...articleCropProps
     }
     crop32: crop(ratio: "3:2") {
-      ...cropProps
+      ...articleCropProps
     }
     crop1251: crop(ratio: "1.25:1") {
-      ...cropProps
+      ...articleCropProps
     }
     crop11: crop(ratio: "1:1") {
-      ...cropProps
+      ...articleCropProps
     }
     crop45: crop(ratio: "4:5") {
-      ...cropProps
+      ...articleCropProps
     }
     crop23: crop(ratio: "2:3") {
-      ...cropProps
+      ...articleCropProps
     }
     crop2251: crop(ratio: "2.25:1") {
-      ...cropProps
+      ...articleCropProps
     }
     id
     title
   }
 
-  fragment cropProps on Crop {
+  fragment articleCropProps on Crop {
     ratio
     relativeHorizontalOffset
     relativeVerticalOffset

--- a/packages/provider-queries/src/section-fragment.js
+++ b/packages/provider-queries/src/section-fragment.js
@@ -1314,13 +1314,13 @@ export default gql`
     ... on Video {
       posterImage {
         crop169: crop(ratio: "16:9") {
-          ...cropProps
+          ...sectionCropProps
         }
       }
     }
     ... on Image {
       crop169: crop(ratio: "16:9") {
-        ...cropProps
+        ...sectionCropProps
       }
     }
   }
@@ -1330,13 +1330,13 @@ export default gql`
     ... on Video {
       posterImage {
         crop32: crop(ratio: "3:2") {
-          ...cropProps
+          ...sectionCropProps
         }
       }
     }
     ... on Image {
       crop32: crop(ratio: "3:2") {
-        ...cropProps
+        ...sectionCropProps
       }
     }
   }
@@ -1346,13 +1346,13 @@ export default gql`
     ... on Video {
       posterImage {
         crop11: crop(ratio: "1:1") {
-          ...cropProps
+          ...sectionCropProps
         }
       }
     }
     ... on Image {
       crop11: crop(ratio: "1:1") {
-        ...cropProps
+        ...sectionCropProps
       }
     }
   }
@@ -1362,13 +1362,13 @@ export default gql`
     ... on Video {
       posterImage {
         crop45: crop(ratio: "4:5") {
-          ...cropProps
+          ...sectionCropProps
         }
       }
     }
     ... on Image {
       crop45: crop(ratio: "4:5") {
-        ...cropProps
+        ...sectionCropProps
       }
     }
   }
@@ -1378,13 +1378,13 @@ export default gql`
     ... on Video {
       posterImage {
         crop23: crop(ratio: "2:3") {
-          ...cropProps
+          ...sectionCropProps
         }
       }
     }
     ... on Image {
       crop23: crop(ratio: "2:3") {
-        ...cropProps
+        ...sectionCropProps
       }
     }
   }
@@ -1394,19 +1394,19 @@ export default gql`
     ... on Video {
       posterImage {
         crop32: crop(ratio: "3:2") {
-          ...cropProps
+          ...sectionCropProps
         }
         crop169: crop(ratio: "16:9") {
-          ...cropProps
+          ...sectionCropProps
         }
       }
     }
     ... on Image {
       crop32: crop(ratio: "3:2") {
-        ...cropProps
+        ...sectionCropProps
       }
       crop169: crop(ratio: "16:9") {
-        ...cropProps
+        ...sectionCropProps
       }
     }
   }
@@ -1416,13 +1416,13 @@ export default gql`
     ... on Video {
       posterImage {
         crop32: crop(ratio: "3:2") {
-          ...cropProps
+          ...sectionCropProps
         }
       }
     }
     ... on Image {
       crop32: crop(ratio: "3:2") {
-        ...cropProps
+        ...sectionCropProps
       }
     }
   }
@@ -1432,13 +1432,13 @@ export default gql`
     ... on Video {
       posterImage {
         crop11: crop(ratio: "1:1") {
-          ...cropProps
+          ...sectionCropProps
         }
       }
     }
     ... on Image {
       crop11: crop(ratio: "1:1") {
-        ...cropProps
+        ...sectionCropProps
       }
     }
   }
@@ -1448,13 +1448,13 @@ export default gql`
     ... on Video {
       posterImage {
         crop45: crop(ratio: "4:5") {
-          ...cropProps
+          ...sectionCropProps
         }
       }
     }
     ... on Image {
       crop45: crop(ratio: "4:5") {
-        ...cropProps
+        ...sectionCropProps
       }
     }
   }
@@ -1464,13 +1464,13 @@ export default gql`
     ... on Video {
       posterImage {
         crop23: crop(ratio: "2:3") {
-          ...cropProps
+          ...sectionCropProps
         }
       }
     }
     ... on Image {
       crop23: crop(ratio: "2:3") {
-        ...cropProps
+        ...sectionCropProps
       }
     }
   }
@@ -1480,13 +1480,13 @@ export default gql`
     ... on Video {
       posterImage {
         crop169: crop(ratio: "16:9") {
-          ...cropProps
+          ...sectionCropProps
         }
       }
     }
     ... on Image {
       crop169: crop(ratio: "16:9") {
-        ...cropProps
+        ...sectionCropProps
       }
     }
   }
@@ -1496,23 +1496,24 @@ export default gql`
     ... on Video {
       posterImage {
         crop32: crop(ratio: "3:2") {
-          ...cropProps
+          ...sectionCropProps
         }
         crop169: crop(ratio: "16:9") {
-          ...cropProps
+          ...sectionCropProps
         }
       }
     }
     ... on Image {
       crop32: crop(ratio: "3:2") {
-        ...cropProps
+        ...sectionCropProps
       }
       crop169: crop(ratio: "16:9") {
-        ...cropProps
+        ...sectionCropProps
       }
     }
   }
-  fragment cropProps on Crop {
+
+  fragment sectionCropProps on Crop {
     ratio
     relativeHorizontalOffset
     relativeVerticalOffset


### PR DESCRIPTION
This is fixing the native edition query

Error:
```
{“errors”:[{“message”:“There can be only one fragment named \“cropProps\“.”,“locations”:[{“line”:132,“column”:12},{“line”:1655,“column”:12}],“extensions”:{“code”:“GRAPHQL_VALIDATION_FAILED”}}]}
```

Explanation: 
In the native-edition we are using both section and article query. Thats why these fragments needs to be with different names. 