### PR TITLE
fix: change share-save-bar and topic-links width

### DIFF
--- a/packages/article-extras/src/article-topics/styles/responsive.web.js
+++ b/packages/article-extras/src/article-topics/styles/responsive.web.js
@@ -12,4 +12,8 @@ export default styled(View)`
     padding-left: 0;
     padding-right: 0;
   }
+
+  @media (min-width: ${breakpoints.wide}px) {
+    width: 56.2%;
+  }
 `;

--- a/packages/article-extras/src/styles/responsive.web.js
+++ b/packages/article-extras/src/styles/responsive.web.js
@@ -6,7 +6,7 @@ export const ShareAndSaveContainer = styled.div`
   border-top-color: ${colours.functional.keyline};
   border-top-style: solid;
   border-top-width: 1px;
-  width: 80.8%;
+  width: 56.2%;
   margin: 0 auto;
 
   @media (max-width: ${breakpoints.huge}px) {


### PR DESCRIPTION
JIRA: https://nidigitalsolutions.jira.com/browse/REPLAT-6742

Changed width for topic links and share-save-bar.

Storybook: 
![image](https://user-images.githubusercontent.com/7889661/60080338-60d44e80-9738-11e9-9f59-55db00a489a0.png)

Render:
![image](https://user-images.githubusercontent.com/7889661/60080356-6d58a700-9738-11e9-9596-8059b8040769.png)

Tablet width:
![image](https://user-images.githubusercontent.com/7889661/60080415-8d886600-9738-11e9-8d12-4c4645d89f26.png)
