### PR TITLE
fix: move knobs in storybook web on the right side

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -15,6 +15,7 @@ addDecorator(withInfo({
 }));
 addDecorator(withKnobs);
 addDecorator(withOptions({
+  addonPanelInRight: true,
   name: 'Times Components',
   hierarchySeparator: /\//
 }));


### PR DESCRIPTION
Move storybook knobs on the right panel as expected. WEB

JIRA task : https://nidigitalsolutions.jira.com/browse/REPLAT-6879
