### PR TITLE
fix: article meta layout when bylines are empty

### DIFF
--- a/packages/article-in-depth/src/article-meta/article-meta.js
+++ b/packages/article-in-depth/src/article-meta/article-meta.js
@@ -17,7 +17,7 @@ const ArticleMeta = ({
   publishedTime
 }) => (
   <View style={isTablet && styles.metaContainerTabletFlow}>
-    {bylines && (
+    {bylines.length && (
       <Fragment>
         <View style={styles.meta}>
           <Context.Consumer>

--- a/packages/article-in-depth/src/article-meta/article-meta.web.js
+++ b/packages/article-in-depth/src/article-meta/article-meta.web.js
@@ -15,7 +15,7 @@ import styles from "../styles";
 
 const ArticleMeta = ({ bylines, publicationName, publishedTime }) => (
   <MetaContainer>
-    {bylines && (
+    {bylines.length && (
       <Fragment>
         <Meta style={styles.meta}>
           <Context.Consumer>

--- a/packages/article-magazine-comment/src/article-meta/article-meta.js
+++ b/packages/article-magazine-comment/src/article-meta/article-meta.js
@@ -24,7 +24,7 @@ const ArticleMeta = ({
       isTablet && styles.metaContainerTablet
     ]}
   >
-    {bylines && (
+    {bylines.length && (
       <View style={[styles.meta, isTablet && styles.metaTablet]}>
         <ArticleBylineWithLinks ast={bylines} onAuthorPress={onAuthorPress} />
       </View>

--- a/packages/article-magazine-comment/src/article-meta/article-meta.web.js
+++ b/packages/article-magazine-comment/src/article-meta/article-meta.web.js
@@ -13,7 +13,7 @@ import styles from "../styles";
 
 const ArticleMeta = ({ bylines, publicationName, publishedTime }) => (
   <MetaContainer>
-    {bylines && (
+    {bylines.length && (
       <Fragment>
         <Meta style={styles.meta}>
           <ArticleBylineWithLinks ast={bylines} />

--- a/packages/article-magazine-standard/src/article-meta/article-meta.js
+++ b/packages/article-magazine-standard/src/article-meta/article-meta.js
@@ -19,7 +19,7 @@ const ArticleMeta = ({
   publishedTime
 }) => (
   <View style={[styles.metaContainer, isTablet && styles.metaContainerTablet]}>
-    {bylines && (
+    {bylines.length && (
       <View style={[styles.meta, isTablet && styles.metaTablet]}>
         <Context.Consumer>
           {({ theme: { sectionColour } }) => (

--- a/packages/article-magazine-standard/src/article-meta/article-meta.web.js
+++ b/packages/article-magazine-standard/src/article-meta/article-meta.web.js
@@ -15,7 +15,7 @@ import styles from "../styles";
 
 const ArticleMeta = ({ bylines, publicationName, publishedTime }) => (
   <MetaContainer>
-    {bylines && (
+    {bylines.length && (
       <Fragment>
         <Meta style={styles.meta}>
           <Context.Consumer>


### PR DESCRIPTION
- Currently getting broken layout when bylines are an empty array.

<img width="756" alt="Screenshot 2019-06-26 at 17 43 29" src="https://user-images.githubusercontent.com/1736782/60199123-230c1e80-983b-11e9-84e0-770c2ff6a2e6.png">

- https://nidigitalsolutions.jira.com/browse/REPLAT-6899