### PR TITLE
feat: REPLAT-6900 article main standart design amends

### DIFF
--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -80,6 +80,7 @@ exports[`1. article main standard - tablet 1`] = `
           "marginBottom": 20,
           "marginLeft": 0,
           "marginRight": 0,
+          "paddingBottom": 10,
           "paddingLeft": 0,
           "paddingRight": 0,
         }
@@ -90,8 +91,7 @@ exports[`1. article main standard - tablet 1`] = `
           Object {
             "borderTopColor": "#DBDBDB",
             "borderTopWidth": 1,
-            "paddingBottom": 6,
-            "paddingTop": 7,
+            "paddingTop": 10,
           }
         }
       >
@@ -108,7 +108,14 @@ exports[`1. article main standard - tablet 1`] = `
           <ArticleBylineWithLinks />
         </Text>
       </View>
-      <View>
+      <View
+        style={
+          Object {
+            "paddingBottom": 6,
+            "paddingTop": 7,
+          }
+        }
+      >
         <Text
           style={
             Object {

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -111,8 +111,7 @@ exports[`1. article main standard - tablet 1`] = `
       <View
         style={
           Object {
-            "paddingBottom": 6,
-            "paddingTop": 7,
+            "paddingTop": 10,
           }
         }
       >

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -79,6 +79,7 @@ exports[`full article with style on mobile 1`] = `
           "marginBottom": 20,
           "marginLeft": 10,
           "marginRight": 10,
+          "paddingBottom": 10,
           "paddingLeft": 0,
           "paddingRight": 0,
         }
@@ -89,8 +90,7 @@ exports[`full article with style on mobile 1`] = `
           Object {
             "borderTopColor": "#DBDBDB",
             "borderTopWidth": 1,
-            "paddingBottom": 6,
-            "paddingTop": 7,
+            "paddingTop": 10,
           }
         }
       >
@@ -107,7 +107,14 @@ exports[`full article with style on mobile 1`] = `
           <ArticleBylineWithLinks />
         </Text>
       </View>
-      <View>
+      <View
+        style={
+          Object {
+            "paddingBottom": 6,
+            "paddingTop": 7,
+          }
+        }
+      >
         <Text
           style={
             Object {
@@ -205,6 +212,7 @@ exports[`full article with style on tablet 1`] = `
           "marginBottom": 20,
           "marginLeft": 10,
           "marginRight": 10,
+          "paddingBottom": 10,
           "paddingLeft": 0,
           "paddingRight": 0,
         }
@@ -215,8 +223,7 @@ exports[`full article with style on tablet 1`] = `
           Object {
             "borderTopColor": "#DBDBDB",
             "borderTopWidth": 1,
-            "paddingBottom": 6,
-            "paddingTop": 7,
+            "paddingTop": 10,
           }
         }
       >
@@ -233,7 +240,14 @@ exports[`full article with style on tablet 1`] = `
           <ArticleBylineWithLinks />
         </Text>
       </View>
-      <View>
+      <View
+        style={
+          Object {
+            "paddingBottom": 6,
+            "paddingTop": 7,
+          }
+        }
+      >
         <Text
           style={
             Object {

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -110,8 +110,7 @@ exports[`full article with style on mobile 1`] = `
       <View
         style={
           Object {
-            "paddingBottom": 6,
-            "paddingTop": 7,
+            "paddingTop": 10,
           }
         }
       >
@@ -243,8 +242,7 @@ exports[`full article with style on tablet 1`] = `
       <View
         style={
           Object {
-            "paddingBottom": 6,
-            "paddingTop": 7,
+            "paddingTop": 10,
           }
         }
       >

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -79,6 +79,7 @@ exports[`1. article main standard - tablet 1`] = `
           "marginBottom": 20,
           "marginLeft": 0,
           "marginRight": 0,
+          "paddingBottom": 10,
           "paddingLeft": 0,
           "paddingRight": 0,
         }
@@ -89,8 +90,7 @@ exports[`1. article main standard - tablet 1`] = `
           Object {
             "borderTopColor": "#DBDBDB",
             "borderTopWidth": 1,
-            "paddingBottom": 4,
-            "paddingTop": 9,
+            "paddingTop": 10,
           }
         }
       >
@@ -107,7 +107,14 @@ exports[`1. article main standard - tablet 1`] = `
           <ArticleBylineWithLinks />
         </Text>
       </View>
-      <View>
+      <View
+        style={
+          Object {
+            "paddingBottom": 4,
+            "paddingTop": 9,
+          }
+        }
+      >
         <Text
           style={
             Object {

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -110,8 +110,7 @@ exports[`1. article main standard - tablet 1`] = `
       <View
         style={
           Object {
-            "paddingBottom": 4,
-            "paddingTop": 9,
+            "paddingTop": 10,
           }
         }
       >

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -78,6 +78,7 @@ exports[`full article with style on mobile 1`] = `
           "marginBottom": 20,
           "marginLeft": 10,
           "marginRight": 10,
+          "paddingBottom": 10,
           "paddingLeft": 0,
           "paddingRight": 0,
         }
@@ -88,8 +89,7 @@ exports[`full article with style on mobile 1`] = `
           Object {
             "borderTopColor": "#DBDBDB",
             "borderTopWidth": 1,
-            "paddingBottom": 4,
-            "paddingTop": 9,
+            "paddingTop": 10,
           }
         }
       >
@@ -106,7 +106,14 @@ exports[`full article with style on mobile 1`] = `
           <ArticleBylineWithLinks />
         </Text>
       </View>
-      <View>
+      <View
+        style={
+          Object {
+            "paddingBottom": 4,
+            "paddingTop": 9,
+          }
+        }
+      >
         <Text
           style={
             Object {
@@ -203,6 +210,7 @@ exports[`full article with style on tablet 1`] = `
           "marginBottom": 20,
           "marginLeft": 10,
           "marginRight": 10,
+          "paddingBottom": 10,
           "paddingLeft": 0,
           "paddingRight": 0,
         }
@@ -213,8 +221,7 @@ exports[`full article with style on tablet 1`] = `
           Object {
             "borderTopColor": "#DBDBDB",
             "borderTopWidth": 1,
-            "paddingBottom": 4,
-            "paddingTop": 9,
+            "paddingTop": 10,
           }
         }
       >
@@ -231,7 +238,14 @@ exports[`full article with style on tablet 1`] = `
           <ArticleBylineWithLinks />
         </Text>
       </View>
-      <View>
+      <View
+        style={
+          Object {
+            "paddingBottom": 4,
+            "paddingTop": 9,
+          }
+        }
+      >
         <Text
           style={
             Object {

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -109,8 +109,7 @@ exports[`full article with style on mobile 1`] = `
       <View
         style={
           Object {
-            "paddingBottom": 4,
-            "paddingTop": 9,
+            "paddingTop": 10,
           }
         }
       >
@@ -241,8 +240,7 @@ exports[`full article with style on tablet 1`] = `
       <View
         style={
           Object {
-            "paddingBottom": 4,
-            "paddingTop": 9,
+            "paddingTop": 10,
           }
         }
       >

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -129,10 +129,6 @@ exports[`full article with style 1`] = `
   line-height: 30px;
 }
 
-.c7 {
-  border-top: 1px solid #DBDBDB;
-}
-
 .c6 {
   margin-left: 10px;
   margin-right: 10px;
@@ -307,15 +303,9 @@ exports[`full article with style 1`] = `
   }
 }
 
-@media (min-width:768px) {
-  .c7 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
 @media (min-width:1024px) {
   .c7 {
+    border-top: 1px solid #DBDBDB;
     line-height: 18px;
     padding-bottom: 25px;
   }
@@ -323,15 +313,16 @@ exports[`full article with style 1`] = `
 
 @media (min-width:768px) {
   .c6 {
-    margin-left: 0;
-    margin-right: 0;
+    margin-left: 0px;
+    margin-right: 0px;
   }
 }
 
 @media (min-width:1024px) {
   .c6 {
     padding-top: 0px;
-    margin-bottom: 0;
+    margin-bottom: 0px;
+    padding-bottom: 0px;
   }
 }
 
@@ -425,15 +416,16 @@ exports[`full article with style 1`] = `
 }
 
 .S7 {
-  margin-bottom: 20px;
+  padding-top: 10px;
 }
 
 .S8 {
-  line-height: 17px;
+  margin-bottom: 20px;
+  padding-bottom: 10px;
 }
 
 .S9 {
-  padding-top: 10px;
+  line-height: 17px;
 }
 
 .IS1 {
@@ -560,10 +552,10 @@ exports[`full article with style 1`] = `
       className="c5 responsiveweb__MetaContainer-sc-1gngn7q-3 c5 css-view-1dbjc4n"
     >
       <div
-        className="c6 responsiveweb__Meta-jtjuw7-1 c6 css-view-1dbjc4n r-borderBottomColor-91l5k4 r-borderBottomWidth-qklmqi r-marginBottom-117bsoe r-marginLeft-1n0xq6e r-marginRight-zso239 r-paddingLeft-gy4na3 r-paddingRight-9aemit S7"
+        className="c6 responsiveweb__Meta-jtjuw7-1 c6 css-view-1dbjc4n r-borderBottomColor-91l5k4 r-borderBottomWidth-qklmqi r-marginBottom-117bsoe r-marginLeft-1n0xq6e r-marginRight-zso239 r-paddingBottom-1mi0q7o r-paddingLeft-gy4na3 r-paddingRight-9aemit S8"
       >
         <div
-          className="c7 responsiveweb__MetaTextElement-jtjuw7-0 c7 css-text-901oao r-borderTopColor-1ozwgwe r-borderTopWidth-5kkj8d r-paddingBottom-1inuy60 r-paddingTop-glunga S2"
+          className="c7 responsiveweb__MetaTextElement-jtjuw7-0 c7 css-text-901oao r-borderTopColor-1ozwgwe r-borderTopWidth-5kkj8d r-paddingTop-m611by S7"
         >
           <span
             className="css-text-901oao css-textHasAncestor-16my406 r-color-1khp51w r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n S6"
@@ -572,7 +564,7 @@ exports[`full article with style 1`] = `
           </span>
         </div>
         <div
-          className="c7 responsiveweb__MetaTextElement-jtjuw7-0 c7 css-text-901oao"
+          className="c7 responsiveweb__MetaTextElement-jtjuw7-0 c7 css-text-901oao r-paddingTop-m611by S7"
         >
           <span
             className="css-text-901oao css-textHasAncestor-16my406 r-color-1khp51w r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n S6"
@@ -672,10 +664,10 @@ exports[`full article with style 1`] = `
                 className="css-view-1dbjc4n"
               >
                 <div
-                  className="css-view-1dbjc4n r-paddingTop-m611by S9"
+                  className="css-view-1dbjc4n r-paddingTop-m611by S7"
                 >
                   <div
-                    className="css-text-901oao r-color-1khp51w r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-5fcqz0 S8"
+                    className="css-text-901oao r-color-1khp51w r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-5fcqz0 S9"
                   >
                     This is video caption
                   </div>

--- a/packages/article-main-standard/src/article-meta/article-meta-base.js
+++ b/packages/article-main-standard/src/article-meta/article-meta-base.js
@@ -30,7 +30,9 @@ const ArticleMetaBase = ({
   const data = [
     ArticleMetaRow(
       styles.datePublication,
-      !hasBylineData(bylines) ? styles.articleMetaElement : {},
+      !hasBylineData(bylines)
+        ? styles.articleMetaElementWithBorder
+        : styles.articleMetaElement,
       <DatePublication date={publishedTime} publication={publicationName} />,
       "articleDatePublication",
       RowWrapper
@@ -41,7 +43,7 @@ const ArticleMetaBase = ({
     return [
       ArticleMetaRow(
         styles.byline,
-        styles.articleMetaElement,
+        styles.articleMetaElementWithBorder,
         <ArticleBylineWithLinks ast={bylines} onAuthorPress={onAuthorPress} />,
         "articleByline",
         RowWrapper

--- a/packages/article-main-standard/src/styles/article-meta/index.android.js
+++ b/packages/article-main-standard/src/styles/article-meta/index.android.js
@@ -6,9 +6,7 @@ const styles = StyleSheet.create({
   ...globalStyle,
   ...sharedStyles,
   articleMetaElement: {
-    ...sharedStyles.articleMetaElement,
-    paddingBottom: 6,
-    paddingTop: 7
+    ...sharedStyles.articleMetaElement
   },
   byline: {
     ...sharedStyles.byline,

--- a/packages/article-main-standard/src/styles/article-meta/index.js
+++ b/packages/article-main-standard/src/styles/article-meta/index.js
@@ -6,9 +6,7 @@ const styles = StyleSheet.create({
   ...globalStyle,
   ...sharedStyles,
   articleMetaElement: {
-    ...sharedStyles.articleMetaElement,
-    paddingBottom: 4,
-    paddingTop: 9
+    ...sharedStyles.articleMetaElement
   },
   byline: {
     ...sharedStyles.byline

--- a/packages/article-main-standard/src/styles/article-meta/index.web.js
+++ b/packages/article-main-standard/src/styles/article-meta/index.web.js
@@ -1,16 +1,10 @@
 import { StyleSheet } from "react-native";
-import { spacing } from "@times-components/styleguide";
 import globalStyle from "../shared";
 import sharedStyles from "./shared";
 
 const styles = StyleSheet.create({
   ...globalStyle,
-  ...sharedStyles,
-  articleMetaElement: {
-    ...sharedStyles.articleMetaElement,
-    paddingBottom: spacing(1),
-    paddingTop: spacing(1)
-  }
+  ...sharedStyles
 });
 
 export default styles;

--- a/packages/article-main-standard/src/styles/article-meta/responsive.web.js
+++ b/packages/article-main-standard/src/styles/article-meta/responsive.web.js
@@ -3,14 +3,8 @@ import styled from "styled-components";
 import { breakpoints, colours, spacing } from "@times-components/styleguide";
 
 export const MetaTextElement = styled(Text)`
-  border-top: 1px solid ${colours.functional.keyline};
-
-  @media (min-width: ${breakpoints.medium}px) {
-    padding-top: ${spacing(1)};
-    padding-bottom: ${spacing(1)};
-  }
-
   @media (min-width: ${breakpoints.wide}px) {
+    border-top: 1px solid ${colours.functional.keyline};
     line-height: 18px;
     padding-bottom: ${spacing(5)};
   }
@@ -21,12 +15,13 @@ export const Meta = styled(View)`
   margin-right: ${spacing(2)};
 
   @media (min-width: ${breakpoints.medium}px) {
-    margin-left: 0;
-    margin-right: 0;
+    margin-left: ${spacing(0)};
+    margin-right: ${spacing(0)};
   }
 
   @media (min-width: ${breakpoints.wide}px) {
-    padding-top: 0px;
-    margin-bottom: 0;
+    padding-top: ${spacing(0)};
+    margin-bottom: ${spacing(0)};
+    padding-bottom: ${spacing(0)};
   }
 `;

--- a/packages/article-main-standard/src/styles/article-meta/shared.js
+++ b/packages/article-main-standard/src/styles/article-meta/shared.js
@@ -8,10 +8,15 @@ const sharedStyles = {
     marginBottom: spacing(4),
     marginLeft: spacing(2),
     marginRight: spacing(2),
+    paddingBottom: spacing(2),
     paddingLeft: 0,
     paddingRight: 0
   },
   articleMetaElement: {
+    paddingTop: spacing(2)
+  },
+  articleMetaElementWithBorder: {
+    paddingTop: spacing(2),
     borderTopColor: colours.functional.keyline,
     borderTopWidth: 1
   },


### PR DESCRIPTION
JIRA task : https://nidigitalsolutions.jira.com/browse/REPLAT-6900

**1. Web - mobile and tablet breakpoints remove the keyline between byline and pub info.**

- Tablet breakpoint:
<img width="914" alt="Screenshot 2019-06-28 at 12 47 00" src="https://user-images.githubusercontent.com/10476819/60336394-e78f6280-99a8-11e9-8d71-30c3b9d8c479.png">

- Mobile breakpoint:
<img width="564" alt="Screenshot 2019-06-28 at 12 47 22" src="https://user-images.githubusercontent.com/10476819/60336410-f8d86f00-99a8-11e9-8142-d8abf3a666b4.png">

**2. Android/IOS - the keyline should be removed and padding is correct spacing between elements (10px)**

IOS:
<img width="338" alt="Screenshot 2019-06-28 at 13 23 02" src="https://user-images.githubusercontent.com/10476819/60336788-f591b300-99a9-11e9-8122-470cd4aebea3.png">


Android:
<img width="328" alt="Screenshot 2019-06-28 at 12 30 16" src="https://user-images.githubusercontent.com/10476819/60336570-62f11400-99a9-11e9-9d84-e5a0e2455777.png">


