### PR TITLE
fix: prevent a jump in firefox when scrolling to the sticky element

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -603,6 +603,9 @@ exports[`full article with style 1`] = `
         </div>
       </div>
     </div>
+    <div
+      className="IS7"
+    />
     <div>
       <div
         className="c11"
@@ -616,9 +619,6 @@ exports[`full article with style 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS7"
-    />
     <div
       className="c14 responsiveweb__BodyContainer-sc-1exejum-2 c14 css-view-1dbjc4n"
     >
@@ -1321,6 +1321,9 @@ exports[`full article with style in the culture magazine 1`] = `
         </div>
       </div>
     </div>
+    <div
+      className="IS7"
+    />
     <div>
       <div
         className="c11"
@@ -1334,9 +1337,6 @@ exports[`full article with style in the culture magazine 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS7"
-    />
     <div
       className="c14 responsiveweb__BodyContainer-sc-1exejum-2 c14 css-view-1dbjc4n"
     >
@@ -2039,6 +2039,9 @@ exports[`full article with style in the style magazine 1`] = `
         </div>
       </div>
     </div>
+    <div
+      className="IS7"
+    />
     <div>
       <div
         className="c11"
@@ -2052,9 +2055,6 @@ exports[`full article with style in the style magazine 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS7"
-    />
     <div
       className="c14 responsiveweb__BodyContainer-sc-1exejum-2 c14 css-view-1dbjc4n"
     >
@@ -2757,6 +2757,9 @@ exports[`full article with style in the sunday times magazine 1`] = `
         </div>
       </div>
     </div>
+    <div
+      className="IS7"
+    />
     <div>
       <div
         className="c11"
@@ -2770,9 +2773,6 @@ exports[`full article with style in the sunday times magazine 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS7"
-    />
     <div
       className="c14 responsiveweb__BodyContainer-sc-1exejum-2 c14 css-view-1dbjc4n"
     >

--- a/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -151,6 +151,9 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       </div>
     </div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -169,9 +172,6 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <p>
         Some content
@@ -388,6 +388,9 @@ exports[`4. an article with ads 1`] = `
       </div>
     </div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -406,9 +409,6 @@ exports[`4. an article with ads 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <Ad
         contextUrl="https://url.io"

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -615,6 +615,9 @@ exports[`full article with style 1`] = `
         </figcaption>
       </figure>
     </div>
+    <div
+      className="IS5"
+    />
     <div>
       <div
         className="c12"
@@ -628,9 +631,6 @@ exports[`full article with style 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS5"
-    />
     <div
       className="c15 responsiveweb__BodyContainer-sc-1exejum-2 c15 css-view-1dbjc4n"
     >
@@ -1340,6 +1340,9 @@ exports[`full article with style in the culture magazine 1`] = `
         </figcaption>
       </figure>
     </div>
+    <div
+      className="IS7"
+    />
     <div>
       <div
         className="c12"
@@ -1353,9 +1356,6 @@ exports[`full article with style in the culture magazine 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS7"
-    />
     <div
       className="c15 responsiveweb__BodyContainer-sc-1exejum-2 c15 css-view-1dbjc4n"
     >
@@ -2065,6 +2065,9 @@ exports[`full article with style in the style magazine 1`] = `
         </figcaption>
       </figure>
     </div>
+    <div
+      className="IS7"
+    />
     <div>
       <div
         className="c12"
@@ -2078,9 +2081,6 @@ exports[`full article with style in the style magazine 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS7"
-    />
     <div
       className="c15 responsiveweb__BodyContainer-sc-1exejum-2 c15 css-view-1dbjc4n"
     >
@@ -2790,6 +2790,9 @@ exports[`full article with style in the sunday times magazine 1`] = `
         </figcaption>
       </figure>
     </div>
+    <div
+      className="IS7"
+    />
     <div>
       <div
         className="c12"
@@ -2803,9 +2806,6 @@ exports[`full article with style in the sunday times magazine 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS7"
-    />
     <div
       className="c15 responsiveweb__BodyContainer-sc-1exejum-2 c15 css-view-1dbjc4n"
     >

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -146,6 +146,9 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       </figure>
     </div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -164,9 +167,6 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <p>
         Some content
@@ -378,6 +378,9 @@ exports[`4. an article with ads 1`] = `
       </figure>
     </div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -396,9 +399,6 @@ exports[`4. an article with ads 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <Ad
         contextUrl="https://url.io"
@@ -633,6 +633,9 @@ exports[`7. an article with no author 1`] = `
       </figure>
     </div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -651,9 +654,6 @@ exports[`7. an article with no author 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <p>
         Some content

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -560,6 +560,9 @@ exports[`full article with style 1`] = `
     <ArticleLeadAsset
       className="c10 IS2"
     />
+    <div
+      className="IS3"
+    />
     <div>
       <div
         className="c11"
@@ -573,9 +576,6 @@ exports[`full article with style 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS3"
-    />
     <div
       className="c14 responsiveweb__BodyContainer-sc-1exejum-2 c14 css-view-1dbjc4n"
     >
@@ -1230,6 +1230,9 @@ exports[`full article with style in the culture magazine 1`] = `
     <ArticleLeadAsset
       className="c10 IS4"
     />
+    <div
+      className="IS5"
+    />
     <div>
       <div
         className="c11"
@@ -1243,9 +1246,6 @@ exports[`full article with style in the culture magazine 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS5"
-    />
     <div
       className="c14 responsiveweb__BodyContainer-sc-1exejum-2 c14 css-view-1dbjc4n"
     >
@@ -1900,6 +1900,9 @@ exports[`full article with style in the style magazine 1`] = `
     <ArticleLeadAsset
       className="c10 IS4"
     />
+    <div
+      className="IS5"
+    />
     <div>
       <div
         className="c11"
@@ -1913,9 +1916,6 @@ exports[`full article with style in the style magazine 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS5"
-    />
     <div
       className="c14 responsiveweb__BodyContainer-sc-1exejum-2 c14 css-view-1dbjc4n"
     >
@@ -2570,6 +2570,9 @@ exports[`full article with style in the sunday times magazine 1`] = `
     <ArticleLeadAsset
       className="c10 IS4"
     />
+    <div
+      className="IS5"
+    />
     <div>
       <div
         className="c11"
@@ -2583,9 +2586,6 @@ exports[`full article with style in the sunday times magazine 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS5"
-    />
     <div
       className="c14 responsiveweb__BodyContainer-sc-1exejum-2 c14 css-view-1dbjc4n"
     >

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -141,6 +141,9 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       </figure>
     </div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -159,9 +162,6 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <p>
         Some content
@@ -368,6 +368,9 @@ exports[`4. an article with ads 1`] = `
       </figure>
     </div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -386,9 +389,6 @@ exports[`4. an article with ads 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <Ad
         contextUrl="https://url.io"

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -556,6 +556,9 @@ exports[`full article with style 1`] = `
         </div>
       </div>
     </div>
+    <div
+      className="IS2"
+    />
     <div>
       <div
         className="c11"
@@ -569,9 +572,6 @@ exports[`full article with style 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS2"
-    />
     <div
       className="c14 responsiveweb__BodyContainer-sc-1exejum-2 c14 css-view-1dbjc4n"
     >

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -132,6 +132,9 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
       </div>
     </div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -150,9 +153,6 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <p>
         Some content
@@ -350,6 +350,9 @@ exports[`4. an article with ads 1`] = `
       </div>
     </div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -368,9 +371,6 @@ exports[`4. an article with ads 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <Ad
         contextUrl="https://url.io"

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -586,6 +586,9 @@ exports[`full article with style 1`] = `
     <ArticleLeadAsset
       className="c9"
     />
+    <div
+      className="IS3"
+    />
     <div>
       <div
         className="c10"
@@ -599,9 +602,6 @@ exports[`full article with style 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS3"
-    />
     <div
       className="c13 responsiveweb__BodyContainer-sc-1exejum-2 c13 css-view-1dbjc4n"
     >

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -620,6 +620,9 @@ exports[`6. should show topics when logged in or shared 1`] = `
       </figure>
     </div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -638,9 +641,6 @@ exports[`6. should show topics when logged in or shared 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <p>
         Some content

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
@@ -136,6 +136,9 @@ exports[`1. a primary image 1`] = `
   <div
     className="c1 responsiveweb__MainContainer-sc-1exejum-0 c1 css-view-1dbjc4n"
   >
+    <div
+      className="IS2"
+    />
     <div>
       <div
         className="c2"
@@ -149,9 +152,6 @@ exports[`1. a primary image 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS2"
-    />
     <div
       className="c5 responsiveweb__BodyContainer-sc-1exejum-2 c5 css-view-1dbjc4n"
     >
@@ -283,6 +283,9 @@ exports[`2. a fullwidth image 1`] = `
   <div
     className="c1 responsiveweb__MainContainer-sc-1exejum-0 c1 css-view-1dbjc4n"
   >
+    <div
+      className="IS2"
+    />
     <div>
       <div
         className="c2"
@@ -296,9 +299,6 @@ exports[`2. a fullwidth image 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS2"
-    />
     <div
       className="c5 responsiveweb__BodyContainer-sc-1exejum-2 c5 css-view-1dbjc4n"
     >
@@ -454,6 +454,9 @@ exports[`3. a secondary image 1`] = `
   <div
     className="c1 responsiveweb__MainContainer-sc-1exejum-0 c1 css-view-1dbjc4n"
   >
+    <div
+      className="IS2"
+    />
     <div>
       <div
         className="c2"
@@ -467,9 +470,6 @@ exports[`3. a secondary image 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS2"
-    />
     <div
       className="c5 responsiveweb__BodyContainer-sc-1exejum-2 c5 css-view-1dbjc4n"
     >
@@ -630,6 +630,9 @@ exports[`4. an inline image 1`] = `
   <div
     className="c1 responsiveweb__MainContainer-sc-1exejum-0 c1 css-view-1dbjc4n"
   >
+    <div
+      className="IS2"
+    />
     <div>
       <div
         className="c2"
@@ -643,9 +646,6 @@ exports[`4. an inline image 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS2"
-    />
     <div
       className="c5 responsiveweb__BodyContainer-sc-1exejum-2 c5 css-view-1dbjc4n"
     >

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
@@ -12,6 +12,9 @@ exports[`1. a primary image 1`] = `
   </div>
   <div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -30,9 +33,6 @@ exports[`1. a primary image 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <div
         id="0"
@@ -84,6 +84,9 @@ exports[`2. a fullwidth image 1`] = `
   </div>
   <div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -102,9 +105,6 @@ exports[`2. a fullwidth image 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <div
         id="0"
@@ -154,6 +154,9 @@ exports[`3. a secondary image 1`] = `
   </div>
   <div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -172,9 +175,6 @@ exports[`3. a secondary image 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <div
         id="0"
@@ -226,6 +226,9 @@ exports[`4. an inline image 1`] = `
   </div>
   <div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -244,9 +247,6 @@ exports[`4. an inline image 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <div
         id="0"

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -341,6 +341,9 @@ exports[`full article with style 1`] = `
   <div
     className="c1 responsiveweb__MainContainer-sc-1exejum-0 c1 css-view-1dbjc4n"
   >
+    <div
+      className="IS2"
+    />
     <div>
       <div
         className="c2"
@@ -354,9 +357,6 @@ exports[`full article with style 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="IS2"
-    />
     <div
       className="c5 responsiveweb__BodyContainer-sc-1exejum-2 c5 css-view-1dbjc4n"
     >

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -12,6 +12,9 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
   </div>
   <div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -30,9 +33,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <p>
         <span>
@@ -364,6 +364,9 @@ exports[`2. an article with no content 1`] = `
   </div>
   <div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -382,9 +385,6 @@ exports[`2. an article with no content 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <ArticleExtras
         articleHeadline="Some Headline"
@@ -464,6 +464,9 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
   </div>
   <div>
     <div
+      data-tc-sticky-placeholder={true}
+    />
+    <div
       data-tc-sticky-container={true}
     >
       <div>
@@ -482,9 +485,6 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
         </div>
       </div>
     </div>
-    <div
-      data-tc-sticky-placeholder={true}
-    />
     <div>
       <p>
         <span>

--- a/packages/article-skeleton/__tests__/web/__snapshots__/sticky-save-share-bar.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/sticky-save-share-bar.web.test.js.snap
@@ -4,6 +4,7 @@ exports[`StickySaveAndShareBar renders 1`] = `
 <StickySaveAndShareBar>
   <WithStickyContext(Sticky)>
     <Sticky>
+      <div />
       <div>
         <responsiveweb__OuterSaveShareContainer>
           <StyledComponent
@@ -27,7 +28,6 @@ exports[`StickySaveAndShareBar renders 1`] = `
           </StyledComponent>
         </responsiveweb__OuterSaveShareContainer>
       </div>
-      <div />
     </Sticky>
   </WithStickyContext(Sticky)>
 </StickySaveAndShareBar>

--- a/packages/sticky/__tests__/web/__snapshots__/sticky.test.js.snap
+++ b/packages/sticky/__tests__/web/__snapshots__/sticky.test.js.snap
@@ -194,6 +194,10 @@ exports[`Sticky shouldBeSticky is checked when deciding whether to become sticky
         style="width: 600px; margin: 0px auto;"
       >
         <div
+          data-tc-sticky-placeholder="true"
+          style="display: none;"
+        />
+        <div
           data-tc-sticky-container="true"
         >
           <div
@@ -205,10 +209,6 @@ exports[`Sticky shouldBeSticky is checked when deciding whether to become sticky
             />
           </div>
         </div>
-        <div
-          data-tc-sticky-placeholder="true"
-          style="display: none;"
-        />
       </div>
     </div>
   </div>

--- a/packages/sticky/src/sticky.js
+++ b/packages/sticky/src/sticky.js
@@ -91,7 +91,7 @@ class UnwrappedSticky extends Component {
     if (node) {
       this.component = node.firstElementChild;
       this.sizer = this.component.firstElementChild;
-      this.placeholder = this.container.nextSibling;
+      this.placeholder = this.container.previousSibling;
 
       this.updateSticky();
     } else {
@@ -144,12 +144,12 @@ class UnwrappedSticky extends Component {
     const { Component, style, children, className } = this.props;
     return (
       <>
+        <div style={{ display: "none" }} data-tc-sticky-placeholder />
         <div data-tc-sticky-container ref={this.createContainerRef}>
           <Component className={className} style={style}>
             <div data-tc-sticky-sizer>{children}</div>
           </Component>
         </div>
-        <div style={{ display: "none" }} data-tc-sticky-placeholder />
       </>
     );
   }


### PR DESCRIPTION
Firefox seems to be jumping when reaching the sticky element for the first time. This PR fixes that. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
