### PR TITLE
feat: implement wide and huge tablet Second1Column

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -252,12 +252,14 @@ exports[`10. secondary one and columnist - medium 1`] = `
   <View>
     <View>
       <TileAA
+        breakpoint="medium"
         tileName="secondary"
       />
     </View>
     <View />
     <View>
       <TileAB
+        breakpoint="medium"
         tileName="columnist"
       />
     </View>
@@ -715,12 +717,14 @@ exports[`25. secondary one and columnist - wide 1`] = `
   <View>
     <View>
       <TileAA
+        breakpoint="wide"
         tileName="secondary"
       />
     </View>
     <View />
     <View>
       <TileAB
+        breakpoint="wide"
         tileName="columnist"
       />
     </View>
@@ -1193,12 +1197,14 @@ exports[`40. secondary one and columnist - huge 1`] = `
   <View>
     <View>
       <TileAA
+        breakpoint="huge"
         tileName="secondary"
       />
     </View>
     <View />
     <View>
       <TileAB
+        breakpoint="huge"
         tileName="columnist"
       />
     </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -252,12 +252,14 @@ exports[`10. secondary one and columnist - medium 1`] = `
   <View>
     <View>
       <TileAA
+        breakpoint="medium"
         tileName="secondary"
       />
     </View>
     <View />
     <View>
       <TileAB
+        breakpoint="medium"
         tileName="columnist"
       />
     </View>
@@ -715,12 +717,14 @@ exports[`25. secondary one and columnist - wide 1`] = `
   <View>
     <View>
       <TileAA
+        breakpoint="wide"
         tileName="secondary"
       />
     </View>
     <View />
     <View>
       <TileAB
+        breakpoint="wide"
         tileName="columnist"
       />
     </View>
@@ -1193,12 +1197,14 @@ exports[`40. secondary one and columnist - huge 1`] = `
   <View>
     <View>
       <TileAA
+        breakpoint="huge"
         tileName="secondary"
       />
     </View>
     <View />
     <View>
       <TileAB
+        breakpoint="huge"
         tileName="columnist"
       />
     </View>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -1522,6 +1522,7 @@ exports[`8. secondary one and columnist 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileAA
+        breakpoint="wide"
         tileName="secondary"
       />
     </div>
@@ -1532,6 +1533,7 @@ exports[`8. secondary one and columnist 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAB
+        breakpoint="wide"
         tileName="columnist"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -344,12 +344,14 @@ exports[`8. secondary one and columnist 1`] = `
   <div>
     <div>
       <TileAA
+        breakpoint="wide"
         tileName="secondary"
       />
     </div>
     <div />
     <div>
       <TileAB
+        breakpoint="wide"
         tileName="columnist"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1109,6 +1109,7 @@ exports[`10. secondary one and columnist - medium 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileAA
+        breakpoint="wide"
         tileName="secondary"
       />
     </div>
@@ -1119,6 +1120,7 @@ exports[`10. secondary one and columnist - medium 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAB
+        breakpoint="wide"
         tileName="columnist"
       />
     </div>
@@ -2916,6 +2918,7 @@ exports[`25. secondary one and columnist - wide 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileAA
+        breakpoint="wide"
         tileName="secondary"
       />
     </div>
@@ -2926,6 +2929,7 @@ exports[`25. secondary one and columnist - wide 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAB
+        breakpoint="wide"
         tileName="columnist"
       />
     </div>
@@ -4723,6 +4727,7 @@ exports[`40. secondary one and columnist - huge 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileAA
+        breakpoint="wide"
         tileName="secondary"
       />
     </div>
@@ -4733,6 +4738,7 @@ exports[`40. secondary one and columnist - huge 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAB
+        breakpoint="wide"
         tileName="columnist"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -238,12 +238,14 @@ exports[`10. secondary one and columnist - medium 1`] = `
   <div>
     <div>
       <TileAA
+        breakpoint="wide"
         tileName="secondary"
       />
     </div>
     <div />
     <div>
       <TileAB
+        breakpoint="wide"
         tileName="columnist"
       />
     </div>
@@ -679,12 +681,14 @@ exports[`25. secondary one and columnist - wide 1`] = `
   <div>
     <div>
       <TileAA
+        breakpoint="wide"
         tileName="secondary"
       />
     </div>
     <div />
     <div>
       <TileAB
+        breakpoint="wide"
         tileName="columnist"
       />
     </div>
@@ -1120,12 +1124,14 @@ exports[`40. secondary one and columnist - huge 1`] = `
   <div>
     <div>
       <TileAA
+        breakpoint="wide"
         tileName="secondary"
       />
     </div>
     <div />
     <div>
       <TileAB
+        breakpoint="wide"
         tileName="columnist"
       />
     </div>

--- a/packages/edition-slices/src/slices/secondaryoneandcolumnist/index.js
+++ b/packages/edition-slices/src/slices/secondaryoneandcolumnist/index.js
@@ -38,10 +38,20 @@ class SecondaryOneAndColumnist extends Component {
       <SecondaryOneAndColumnistSlice
         breakpoint={breakpoint}
         columnist={
-          <TileAB onPress={onPress} tile={columnist} tileName="columnist" />
+          <TileAB
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={columnist}
+            tileName="columnist"
+          />
         }
         secondary={
-          <TileAA onPress={onPress} tile={secondary} tileName="secondary" />
+          <TileAA
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={secondary}
+            tileName="secondary"
+          />
         }
       />
     );

--- a/packages/edition-slices/src/tiles/tile-aa/index.js
+++ b/packages/edition-slices/src/tiles/tile-aa/index.js
@@ -1,15 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
+import { editionBreakpoints } from "@times-components/styleguide";
 import {
   getTileImage,
   TileLink,
   TileSummary,
   withTileTracking
 } from "../shared";
-import styles from "./styles";
+import styleFactory from "./styles";
 
-const TileT = ({ onPress, tile }) => {
+const TileAA = ({ onPress, tile, breakpoint }) => {
+  const styles = styleFactory(breakpoint);
   const crop = getTileImage(tile, "crop169");
 
   return (
@@ -32,9 +34,14 @@ const TileT = ({ onPress, tile }) => {
   );
 };
 
-TileT.propTypes = {
+TileAA.propTypes = {
+  breakpoint: PropTypes.string,
   onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired
 };
 
-export default withTileTracking(TileT);
+TileAA.defaultProps = {
+  breakpoint: editionBreakpoints.small
+};
+
+export default withTileTracking(TileAA);

--- a/packages/edition-slices/src/tiles/tile-aa/index.js
+++ b/packages/edition-slices/src/tiles/tile-aa/index.js
@@ -10,7 +10,7 @@ import {
 } from "../shared";
 import styleFactory from "./styles";
 
-const TileAA = ({ onPress, tile, breakpoint }) => {
+const TileAA = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
   const styles = styleFactory(breakpoint);
   const crop = getTileImage(tile, "crop169");
 
@@ -35,13 +35,9 @@ const TileAA = ({ onPress, tile, breakpoint }) => {
 };
 
 TileAA.propTypes = {
-  breakpoint: PropTypes.string,
+  breakpoint: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired
-};
-
-TileAA.defaultProps = {
-  breakpoint: editionBreakpoints.small
 };
 
 export default withTileTracking(TileAA);

--- a/packages/edition-slices/src/tiles/tile-aa/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-aa/styles/index.js
@@ -1,13 +1,24 @@
-import { fonts, spacing } from "@times-components/styleguide";
+import {
+  fonts,
+  spacing,
+  editionBreakpoints
+} from "@times-components/styleguide";
 
-const styles = {
+const headlineFontSizeResolver = {
+  [editionBreakpoints.huge]: 35,
+  [editionBreakpoints.wide]: 35,
+  [editionBreakpoints.small]: 30,
+  [editionBreakpoints.medium]: 30
+};
+
+export default breakpoint => ({
   container: {
     paddingHorizontal: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,
-    fontSize: 30,
-    lineHeight: 30
+    fontSize: headlineFontSizeResolver[breakpoint],
+    lineHeight: headlineFontSizeResolver[breakpoint]
   },
   imageContainer: {
     paddingBottom: spacing(1)
@@ -15,6 +26,4 @@ const styles = {
   summaryContainer: {
     paddingVertical: spacing(1)
   }
-};
-
-export default styles;
+});

--- a/packages/edition-slices/src/tiles/tile-ab/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/index.js
@@ -11,7 +11,7 @@ import {
 } from "../shared";
 import styleFactory from "./styles";
 
-const TileAB = ({ onPress, tile, breakpoint }) => {
+const TileAB = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
   const styles = styleFactory(breakpoint);
   const crop = getTileImage(tile, "crop23");
 
@@ -38,13 +38,9 @@ const TileAB = ({ onPress, tile, breakpoint }) => {
 };
 
 TileAB.propTypes = {
-  breakpoint: PropTypes.string,
+  breakpoint: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired
-};
-
-TileAB.defaultProps = {
-  breakpoint: editionBreakpoints.small
 };
 
 export default withTileTracking(TileAB);

--- a/packages/edition-slices/src/tiles/tile-ab/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
+import { editionBreakpoints } from "@times-components/styleguide";
 import {
   getTileImage,
   getTileSummary,
@@ -8,9 +9,10 @@ import {
   TileSummary,
   withTileTracking
 } from "../shared";
-import styles from "./styles";
+import styleFactory from "./styles";
 
-const TileH = ({ onPress, tile }) => {
+const TileAB = ({ onPress, tile, breakpoint }) => {
+  const styles = styleFactory(breakpoint);
   const crop = getTileImage(tile, "crop23");
 
   return (
@@ -35,9 +37,14 @@ const TileH = ({ onPress, tile }) => {
   );
 };
 
-TileH.propTypes = {
+TileAB.propTypes = {
+  breakpoint: PropTypes.string,
   onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired
 };
 
-export default withTileTracking(TileH);
+TileAB.defaultProps = {
+  breakpoint: editionBreakpoints.small
+};
+
+export default withTileTracking(TileAB);

--- a/packages/edition-slices/src/tiles/tile-ab/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/styles/index.js
@@ -1,14 +1,25 @@
-import { fonts, spacing } from "@times-components/styleguide";
+import {
+  fonts,
+  spacing,
+  editionBreakpoints
+} from "@times-components/styleguide";
 
-const styles = {
+const headlineFontSizeResolver = {
+  [editionBreakpoints.huge]: 45,
+  [editionBreakpoints.wide]: 45,
+  [editionBreakpoints.small]: 30,
+  [editionBreakpoints.medium]: 30
+};
+
+export default breakpoint => ({
   container: {
     flexDirection: "row",
     paddingHorizontal: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,
-    fontSize: 30,
-    lineHeight: 30,
+    fontSize: headlineFontSizeResolver[breakpoint],
+    lineHeight: headlineFontSizeResolver[breakpoint],
     marginBottom: spacing(1)
   },
   image: {
@@ -25,6 +36,4 @@ const styles = {
     paddingVertical: spacing(2),
     width: "50%"
   }
-};
-
-export default styles;
+});


### PR DESCRIPTION
Jira: https://nidigitalsolutions.jira.com/browse/REPLAT-5492

Implement wide and huge tablet breakpoint for Secondary 1 and Columnist edition slice.

Wide/Huge:
![image](https://user-images.githubusercontent.com/7889661/60587765-f063a800-9d9d-11e9-8247-d10e1682f7e0.png)

Portrait tablet for ref:
![image](https://user-images.githubusercontent.com/7889661/60587830-15581b00-9d9e-11e9-8283-e2ff232e8ef5.png)

