### PR TITLE
fix: issue with safari browser being launched when scroll to ad

### DIFF
--- a/packages/ad/src/dom-context.js
+++ b/packages/ad/src/dom-context.js
@@ -123,7 +123,6 @@ class DOMContext extends PureComponent {
         }}
       >
         <WebView
-          originWhitelist={["http://.*", "https://.*"]}
           onMessage={this.handleMessageEvent}
           onNavigationStateChange={this.handleNavigationStateChange}
           ref={ref => {


### PR DESCRIPTION
- fixes https://nidigitalsolutions.jira.com/browse/REPLAT-6914 which blocks beta release.
- it reverts a change made by @jmars here: https://github.com/newsuk/times-components/commit/e5272b5ee55f900cbdafb36fd63ba29f261f5a3a#diff-6bc333c08ceabd74f38d0d732289f9c2 but without the `androidHardwareAccelerationDisabled` change (https://nidigitalsolutions.jira.com/browse/REPLAT-6795)
