### PR TITLE
chore: update react-native version to 0.59.10, remove custom JSC

### DIFF
--- a/android-app/build.gradle
+++ b/android-app/build.gradle
@@ -26,11 +26,6 @@ allprojects {
         maven {
             url "$reactRepositoryPath"
         }
-
-        maven {
-            // Local Maven repo containing AARs with JSC library built for Android
-            url "$rootDir/../node_modules/@kudo-ci/jsc-android/dist"
-        }
     }
 }
 

--- a/android-app/package.json
+++ b/android-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@times-components/android-app",
-  "version": "0.14.133",
+  "version": "0.15.0",
   "license": "BSD-3-Clause",
   "scripts": {
     "build": "./gradlew clean && ./gradlew generateReactArchives && ./gradlew assemble && ./gradlew publish",
@@ -11,11 +11,10 @@
     "start": "react-native start --config metro.config.js"
   },
   "dependencies": {
-    "@kudo-ci/jsc-android": "241213-no-jit",
     "@times-components/pages": "2.0.105",
     "prop-types": "15.7.2",
     "react": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-svg": "9.4.0",
     "react-native-webview": "5.10.0",
     "url-polyfill": "1.1.0"

--- a/android-app/package.json
+++ b/android-app/package.json
@@ -11,7 +11,6 @@
     "start": "react-native start --config metro.config.js"
   },
   "dependencies": {
-    "@kudo-ci/jsc-android": "241213-no-jit",
     "@times-components/pages": "2.0.106",
     "prop-types": "15.7.2",
     "react": "16.8.6",

--- a/android-app/xnative/build.gradle
+++ b/android-app/xnative/build.gradle
@@ -74,8 +74,6 @@ android {
 }
 
 dependencies {
-    implementation "org.webkit:android-jsc:r241213"
-    
     api "com.facebook.react:react-native:${packageInfo.dependencies.'react-native'}"
     api("react-repo:react-native-svg:${packageInfo.dependencies.'react-native-svg'}") {	
         exclude group: "com.facebook.react"	

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -13,7 +13,7 @@
     "@times-components/pages": "2.0.105",
     "prop-types": "15.7.2",
     "react": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "url-polyfill": "1.1.0"
   },
   "devDependencies": {

--- a/lib/cli/package-json.js
+++ b/lib/cli/package-json.js
@@ -53,7 +53,7 @@ module.exports = variables => ({
     prettier: "1.14.3",
     react: "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     webpack: "4.30.0",
     "webpack-cli": "3.3.1"

--- a/package.json
+++ b/package.json
@@ -162,9 +162,8 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/runtime": "7.4.4",
     "@babel/runtime-corejs2": "7.4.4",
-    "@kudo-ci/jsc-android": "241213-no-jit",
     "react-art": "16.6.3",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-showcase-loader": "1.1.0"
   }
 }

--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -53,7 +53,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -56,7 +56,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/article-comments/package.json
+++ b/packages/article-comments/package.json
@@ -59,7 +59,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-error/package.json
+++ b/packages/article-error/package.json
@@ -46,7 +46,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3"
   },
   "peerDependencies": {

--- a/packages/article-extras/package.json
+++ b/packages/article-extras/package.json
@@ -51,7 +51,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-flag/package.json
+++ b/packages/article-flag/package.json
@@ -55,7 +55,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/article-image/package.json
+++ b/packages/article-image/package.json
@@ -58,7 +58,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/article-in-depth/package.json
+++ b/packages/article-in-depth/package.json
@@ -55,7 +55,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-label/package.json
+++ b/packages/article-label/package.json
@@ -60,7 +60,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/article-lead-asset/package.json
+++ b/packages/article-lead-asset/package.json
@@ -48,7 +48,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-list/package.json
+++ b/packages/article-list/package.json
@@ -61,7 +61,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/article-magazine-comment/package.json
+++ b/packages/article-magazine-comment/package.json
@@ -55,7 +55,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-magazine-standard/package.json
+++ b/packages/article-magazine-standard/package.json
@@ -55,7 +55,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-main-comment/package.json
+++ b/packages/article-main-comment/package.json
@@ -55,7 +55,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-main-standard/package.json
+++ b/packages/article-main-standard/package.json
@@ -54,7 +54,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-paragraph/package.json
+++ b/packages/article-paragraph/package.json
@@ -64,7 +64,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-skeleton/package.json
+++ b/packages/article-skeleton/package.json
@@ -63,7 +63,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/article-summary/package.json
+++ b/packages/article-summary/package.json
@@ -54,7 +54,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/article-topics/package.json
+++ b/packages/article-topics/package.json
@@ -56,7 +56,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -53,7 +53,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -61,7 +61,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/brightcove-video/package.json
+++ b/packages/brightcove-video/package.json
@@ -60,7 +60,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -56,7 +56,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -56,7 +56,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -51,7 +51,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/date-publication/package.json
+++ b/packages/date-publication/package.json
@@ -53,7 +53,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/edition-slices/package.json
+++ b/packages/edition-slices/package.json
@@ -68,7 +68,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/error-view/package.json
+++ b/packages/error-view/package.json
@@ -55,7 +55,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/gestures/package.json
+++ b/packages/gestures/package.json
@@ -53,7 +53,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-art": "16.6.3",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/gradient/package.json
+++ b/packages/gradient/package.json
@@ -66,7 +66,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -56,7 +56,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -56,7 +56,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/interactive-wrapper/package.json
+++ b/packages/interactive-wrapper/package.json
@@ -52,7 +52,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/key-facts/package.json
+++ b/packages/key-facts/package.json
@@ -55,7 +55,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/lazy-load/package.json
+++ b/packages/lazy-load/package.json
@@ -48,7 +48,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "styled-components": "4.2.0",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -56,7 +56,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/markup/package.json
+++ b/packages/markup/package.json
@@ -57,7 +57,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/message-bar/package.json
+++ b/packages/message-bar/package.json
@@ -51,7 +51,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -40,7 +40,7 @@
     "jest": "24.8.0",
     "prettier": "1.14.3",
     "react": "16.8.6",
-    "react-native": "0.59.9"
+    "react-native": "0.59.10"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -48,7 +48,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0"
   },

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -57,7 +57,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -56,7 +56,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/pull-quote/package.json
+++ b/packages/pull-quote/package.json
@@ -56,7 +56,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/related-articles/package.json
+++ b/packages/related-articles/package.json
@@ -60,7 +60,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/responsive/package.json
+++ b/packages/responsive/package.json
@@ -50,7 +50,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/save-and-share-bar/package.json
+++ b/packages/save-and-share-bar/package.json
@@ -59,7 +59,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/save-star-web/package.json
+++ b/packages/save-star-web/package.json
@@ -57,7 +57,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -64,7 +64,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/slice-layout/package.json
+++ b/packages/slice-layout/package.json
@@ -56,7 +56,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -71,7 +71,7 @@
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
     "react-helmet-async": "1.0.2",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "styled-components": "4.2.0",
     "unfetch": "^3.0.0"

--- a/packages/star-button/package.json
+++ b/packages/star-button/package.json
@@ -50,7 +50,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/sticky/package.json
+++ b/packages/sticky/package.json
@@ -53,7 +53,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "stylelint": "9.4.0",
     "stylelint-config-recommended": "2.1.0",
     "stylelint-config-styled-components": "0.1.1",

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -54,7 +54,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/svgs/package.json
+++ b/packages/svgs/package.json
@@ -64,7 +64,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/text-flow/package.json
+++ b/packages/text-flow/package.json
@@ -49,7 +49,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"
   },

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -58,7 +58,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/user-state/package.json
+++ b/packages/user-state/package.json
@@ -51,7 +51,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -57,7 +57,7 @@
     "apollo-link-http": "1.5.14",
     "lodash.omitby": "4.6.0",
     "prop-types": "15.7.2",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "styled-components": "4.2.0",
     "unfetch": "^3.0.0"
   },

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -67,7 +67,7 @@
     "react": "16.8.6",
     "react-art": "16.6.3",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -54,7 +54,7 @@
     "prettier": "1.14.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"
   },

--- a/storybook-native/package.json
+++ b/storybook-native/package.json
@@ -31,7 +31,7 @@
     "babel-polyfill": "6.26.0",
     "prop-types": "15.7.2",
     "react": "16.8.6",
-    "react-native": "0.59.9",
+    "react-native": "0.59.10",
     "react-native-svg": "9.4.0",
     "url-polyfill": "1.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,11 +2091,6 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@kudo-ci/jsc-android@241213-no-jit":
-  version "241213.10000.0"
-  resolved "https://registry.yarnpkg.com/@kudo-ci/jsc-android/-/jsc-android-241213.10000.0.tgz#a299636bdacaf5eb6d800a4ce7892a7c1eb813bd"
-  integrity sha512-2Oy45sWvUljbhixttrlTvfuBzetRtIayNQmUhjeijwV6oCJ8KswrgEpCKeotlyxkCUuWcVKUM8I7lzISY16QMg==
-
 "@lerna/add@^3.2.0":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.4.1.tgz#d41068317e30f530df48220d256b5e79690b1877"
@@ -17747,10 +17742,10 @@ react-native-webview@5.10.0:
     escape-string-regexp "1.0.5"
     invariant "2.2.4"
 
-react-native@0.59.9:
-  version "0.59.9"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.59.9.tgz#c94ee4fa35121720c05235a2dd6cdd2784bf5177"
-  integrity sha512-/+8EgIZwFpYHyyJ7Zav7B6LHNrytwUQ+EKGT/QV7HSrgpf2Y5NZNeUYUHKiVKLYpBip1G32/LcAECQj37YRwGQ==
+react-native@0.59.10:
+  version "0.59.10"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.59.10.tgz#352f381e382f93a0403be499c9e384bf51c2591c"
+  integrity sha512-guB9YW+pBqS1dnfZ4ntzjINopiCUAbdmshU2wMWD1W32fRczLAopi/7Q2iHKP8LTCdxuYZV3fa9Mew5PSuANAw==
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@react-native-community/cli" "^1.2.1"


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
This PR updates the react-native dependency to 0.59.10 which is the last bugfix release for the 0.59 series of react-native. This means we can now use the bundled JSC again and turn the DFG JIT back on for a performance boost without the crashing on samsung phones.
