### PR TITLE
feat: REPLAT-5483 implement wide huge breakpoints on  lead 1 and 1 slice

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2578,7 +2578,7 @@ exports[`33. lead one and one - huge 1`] = `
         }
       }
     >
-      <TileC />
+      <TileAQ />
     </View>
   </View>
 </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2546,9 +2546,11 @@ exports[`33. lead one and one - huge 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "flex": 1,
         "flexDirection": "row",
         "marginHorizontal": 10,
+        "width": "87.6%",
       }
     }
   >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2550,7 +2550,7 @@ exports[`33. lead one and one - huge 1`] = `
         "flex": 1,
         "flexDirection": "row",
         "marginHorizontal": 10,
-        "width": "87.6%",
+        "width": "86%",
       }
     }
   >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -67,6 +67,7 @@ exports[`3. lead one and one - medium 1`] = `
   <View>
     <View>
       <TileU
+        breakpoint="medium"
         tileName="lead"
       />
     </View>
@@ -534,6 +535,7 @@ exports[`18. lead one and one - wide 1`] = `
   <View>
     <View>
       <TileU
+        breakpoint="wide"
         tileName="lead"
       />
     </View>
@@ -1021,12 +1023,13 @@ exports[`33. lead one and one - huge 1`] = `
   <View>
     <View>
       <TileU
+        breakpoint="huge"
         tileName="lead"
       />
     </View>
     <View />
     <View>
-      <TileC
+      <TileAQ
         tileName="support"
       />
     </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -1133,6 +1133,7 @@ exports[`22. tile u 1`] = `
     style={
       Object {
         "paddingBottom": 5,
+        "paddingRight": 20,
         "width": "40%",
       }
     }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2578,7 +2578,7 @@ exports[`33. lead one and one - huge 1`] = `
         }
       }
     >
-      <TileC />
+      <TileAQ />
     </View>
   </View>
 </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2546,9 +2546,11 @@ exports[`33. lead one and one - huge 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "flex": 1,
         "flexDirection": "row",
         "marginHorizontal": 10,
+        "width": "87.6%",
       }
     }
   >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2550,7 +2550,7 @@ exports[`33. lead one and one - huge 1`] = `
         "flex": 1,
         "flexDirection": "row",
         "marginHorizontal": 10,
-        "width": "87.6%",
+        "width": "86%",
       }
     }
   >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -67,6 +67,7 @@ exports[`3. lead one and one - medium 1`] = `
   <View>
     <View>
       <TileU
+        breakpoint="medium"
         tileName="lead"
       />
     </View>
@@ -534,6 +535,7 @@ exports[`18. lead one and one - wide 1`] = `
   <View>
     <View>
       <TileU
+        breakpoint="wide"
         tileName="lead"
       />
     </View>
@@ -1021,12 +1023,13 @@ exports[`33. lead one and one - huge 1`] = `
   <View>
     <View>
       <TileU
+        breakpoint="huge"
         tileName="lead"
       />
     </View>
     <View />
     <View>
-      <TileC
+      <TileAQ
         tileName="support"
       />
     </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -1133,6 +1133,7 @@ exports[`22. tile u 1`] = `
     style={
       Object {
         "paddingBottom": 5,
+        "paddingRight": 20,
         "width": "40%",
       }
     }

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -1017,6 +1017,7 @@ exports[`3. lead one and one 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileU
+        breakpoint="wide"
         tileName="lead"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -232,6 +232,7 @@ exports[`3. lead one and one 1`] = `
   <div>
     <div>
       <TileU
+        breakpoint="wide"
         tileName="lead"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -308,6 +308,7 @@ exports[`3. lead one and one - medium 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileU
+        breakpoint="wide"
         tileName="lead"
       />
     </div>
@@ -2124,6 +2125,7 @@ exports[`18. lead one and one - wide 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileU
+        breakpoint="wide"
         tileName="lead"
       />
     </div>
@@ -3940,6 +3942,7 @@ exports[`33. lead one and one - huge 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileU
+        breakpoint="wide"
         tileName="lead"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -55,6 +55,7 @@ exports[`3. lead one and one - medium 1`] = `
   <div>
     <div>
       <TileU
+        breakpoint="wide"
         tileName="lead"
       />
     </div>
@@ -505,6 +506,7 @@ exports[`18. lead one and one - wide 1`] = `
   <div>
     <div>
       <TileU
+        breakpoint="wide"
         tileName="lead"
       />
     </div>
@@ -955,6 +957,7 @@ exports[`33. lead one and one - huge 1`] = `
   <div>
     <div>
       <TileU
+        breakpoint="wide"
         tileName="lead"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -1723,6 +1723,7 @@ exports[`22. tile u 1`] = `
 
 .IS2 {
   padding-bottom: 5px;
+  padding-right: 20px;
   width: 40%;
 }
 

--- a/packages/edition-slices/edition-slices.showcase.js
+++ b/packages/edition-slices/edition-slices.showcase.js
@@ -98,7 +98,7 @@ const sliceStories = [
   },
   {
     mock: mockLeadOneAndOneSlice(),
-    name: "Lead One And One (Mobile: A,B, Tablet: U,C)",
+    name: "Lead One And One (Mobile: A,B, Tablet: U,C, Wide: U,C, Huge:U,AQ)",
     Slice: LeadOneAndOneSlice
   },
   {

--- a/packages/edition-slices/src/slices/leadoneandone/index.js
+++ b/packages/edition-slices/src/slices/leadoneandone/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { LeadOneAndOneSlice } from "@times-components/slice-layout";
-import { TileA, TileB, TileC, TileU } from "../../tiles";
+import { TileA, TileB, TileC, TileU, TileAQ } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
 class LeadOneAndOne extends Component {
@@ -9,6 +9,7 @@ class LeadOneAndOne extends Component {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);
     this.renderMedium = this.renderMedium.bind(this);
+    this.renderHuge = this.renderHuge.bind(this);
   }
 
   renderSmall(breakpoint) {
@@ -33,8 +34,36 @@ class LeadOneAndOne extends Component {
     return (
       <LeadOneAndOneSlice
         breakpoint={breakpoint}
-        lead={<TileU onPress={onPress} tile={lead} tileName="lead" />}
+        lead={
+          <TileU
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={lead}
+            tileName="lead"
+          />
+        }
         support={<TileC onPress={onPress} tile={support} tileName="support" />}
+      />
+    );
+  }
+
+  renderHuge(breakpoint) {
+    const {
+      onPress,
+      slice: { lead, support }
+    } = this.props;
+    return (
+      <LeadOneAndOneSlice
+        breakpoint={breakpoint}
+        lead={
+          <TileU
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={lead}
+            tileName="lead"
+          />
+        }
+        support={<TileAQ onPress={onPress} tile={support} tileName="support" />}
       />
     );
   }
@@ -42,8 +71,10 @@ class LeadOneAndOne extends Component {
   render() {
     return (
       <ResponsiveSlice
-        renderMedium={this.renderMedium}
         renderSmall={this.renderSmall}
+        renderMedium={this.renderMedium}
+        renderWide={this.renderMedium}
+        renderHuge={this.renderHuge}
       />
     );
   }

--- a/packages/edition-slices/src/tiles/tile-u/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/require-default-props */
 import React from "react";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
@@ -11,7 +12,7 @@ import {
 } from "../shared";
 import styleFactory from "./styles";
 
-const TileU = ({ onPress, tile, breakpoint }) => {
+const TileU = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
   const styles = styleFactory(breakpoint);
   const crop = getTileImage(tile, "crop32");
 
@@ -55,10 +56,6 @@ TileU.propTypes = {
   breakpoint: PropTypes.string,
   onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired
-};
-
-TileU.defaultProps = {
-  breakpoint: editionBreakpoints.small
 };
 
 export default withTileTracking(TileU);

--- a/packages/edition-slices/src/tiles/tile-u/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/index.js
@@ -1,16 +1,28 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
+import { editionBreakpoints } from "@times-components/styleguide";
 import {
   getTileImage,
+  getTileSummary,
   TileLink,
   TileSummary,
   withTileTracking
 } from "../shared";
-import styles from "./styles";
+import styleFactory from "./styles";
 
-const TileU = ({ onPress, tile }) => {
+const TileU = ({ onPress, tile, breakpoint }) => {
+  const styles = styleFactory(breakpoint);
   const crop = getTileImage(tile, "crop32");
+
+  const teaserLength = {
+    [editionBreakpoints.wide]: 125,
+    [editionBreakpoints.huge]: 300
+  };
+  const summary =
+    breakpoint !== editionBreakpoints.medium
+      ? getTileSummary(tile, teaserLength[breakpoint])
+      : null;
 
   return (
     <TileLink
@@ -22,6 +34,7 @@ const TileU = ({ onPress, tile }) => {
       <TileSummary
         headlineStyle={styles.headline}
         style={styles.summaryContainer}
+        summary={summary}
         tile={tile}
         withStar
       />
@@ -39,8 +52,13 @@ const TileU = ({ onPress, tile }) => {
 };
 
 TileU.propTypes = {
+  breakpoint: PropTypes.string,
   onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired
+};
+
+TileU.defaultProps = {
+  breakpoint: editionBreakpoints.small
 };
 
 export default withTileTracking(TileU);

--- a/packages/edition-slices/src/tiles/tile-u/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/styles/index.js
@@ -1,15 +1,20 @@
-import { fonts, spacing } from "@times-components/styleguide";
+import {
+  fontFactory,
+  spacing,
+  editionBreakpoints
+} from "@times-components/styleguide";
 
-const styles = {
+const styles = fontSize => ({
   container: {
     flex: 1,
     flexDirection: "row",
     padding: spacing(2)
   },
   headline: {
-    fontFamily: fonts.headline,
-    fontSize: 35,
-    lineHeight: 35,
+    ...fontFactory({
+      font: "headline",
+      fontSize
+    }),
     paddingVertical: spacing(1)
   },
   imageContainer: {
@@ -17,8 +22,12 @@ const styles = {
   },
   summaryContainer: {
     paddingBottom: spacing(1),
+    paddingRight: spacing(4),
     width: "40%"
   }
-};
+});
 
-export default styles;
+export default breakpoint =>
+  editionBreakpoints.huge === breakpoint
+    ? styles("articleHeadline")
+    : styles("tileLeadHeadline");

--- a/packages/provider-queries/src/section-fragment.js
+++ b/packages/provider-queries/src/section-fragment.js
@@ -210,7 +210,11 @@ export default gql`
             listingAsset {
               ...listingAsset169and32
             }
+            summary125: summary(maxCharCount: 125)
+            summary300: summary(maxCharCount: 300)
           }
+          teaser125: teaser(maxCharCount: 125)
+          teaser300: teaser(maxCharCount: 300)
         }
         support {
           headline
@@ -840,7 +844,11 @@ export default gql`
             listingAsset {
               ...listingAsset169and32
             }
+            summary125: summary(maxCharCount: 125)
+            summary300: summary(maxCharCount: 300)
           }
+          teaser125: teaser(maxCharCount: 125)
+          teaser300: teaser(maxCharCount: 300)
         }
         support {
           headline

--- a/packages/slice-layout/src/templates/leadoneandone/index.js
+++ b/packages/slice-layout/src/templates/leadoneandone/index.js
@@ -3,9 +3,11 @@ import { View } from "react-native";
 import { editionBreakpoints } from "@times-components/styleguide";
 import { defaultProps, propTypes } from "./proptypes";
 import HorizontalLayout from "../horizontallayout";
-import styles from "./styles";
+import styleFactory from "./styles";
 
 const leadOneAndOneSlice = ({ breakpoint, lead, support }) => {
+  const styles = styleFactory(breakpoint);
+
   if (breakpoint === editionBreakpoints.small) {
     return (
       <View>

--- a/packages/slice-layout/src/templates/leadoneandone/styles.js
+++ b/packages/slice-layout/src/templates/leadoneandone/styles.js
@@ -26,7 +26,7 @@ const hugeBreakpointStyles = {
   ...styles,
   container: {
     ...styles.container,
-    width: "87.6%",
+    width: "86%",
     alignSelf: "center"
   }
 };

--- a/packages/slice-layout/src/templates/leadoneandone/styles.js
+++ b/packages/slice-layout/src/templates/leadoneandone/styles.js
@@ -1,4 +1,4 @@
-import { spacing, colours } from "@times-components/styleguide";
+import { spacing, colours, editionBreakpoints } from "@times-components/styleguide";
 
 const styles = {
   container: {
@@ -18,4 +18,15 @@ const styles = {
   }
 };
 
-export default styles;
+const hugeBreakpointStyles = {
+  ...styles,
+  container : {
+    ...styles.container,
+    width: "87.6%",
+    alignSelf: "center",
+  }
+}
+
+export default breakpoint => breakpoint === editionBreakpoints.huge
+  ? hugeBreakpointStyles
+  : styles

--- a/packages/slice-layout/src/templates/leadoneandone/styles.js
+++ b/packages/slice-layout/src/templates/leadoneandone/styles.js
@@ -1,4 +1,8 @@
-import { spacing, colours, editionBreakpoints } from "@times-components/styleguide";
+import {
+  spacing,
+  colours,
+  editionBreakpoints
+} from "@times-components/styleguide";
 
 const styles = {
   container: {
@@ -20,13 +24,12 @@ const styles = {
 
 const hugeBreakpointStyles = {
   ...styles,
-  container : {
+  container: {
     ...styles.container,
     width: "87.6%",
-    alignSelf: "center",
+    alignSelf: "center"
   }
-}
+};
 
-export default breakpoint => breakpoint === editionBreakpoints.huge
-  ? hugeBreakpointStyles
-  : styles
+export default breakpoint =>
+  breakpoint === editionBreakpoints.huge ? hugeBreakpointStyles : styles;


### PR DESCRIPTION
Jira: https://nidigitalsolutions.jira.com/browse/REPLAT-5483

- Wide breakpoint: 125 char teaser text on lead tile, headline font size on support tile remains 22 
- Huge breakpoint: 300 char teaser text on lead tile, 125 teaser text on support tile, increased headline font size on lead tile, content width - max 1180

Storybook - wide breakpoint:
![Screenshot_1562245855](https://user-images.githubusercontent.com/16742525/60675052-3135ec80-9e84-11e9-878c-32a4ad5cf73a.png)


Storybook - huge breakpoint:
![Screenshot_1562341429](https://user-images.githubusercontent.com/16742525/60734132-9b6b9180-9f57-11e9-8f73-3fd21e6d3e9a.png)
![Screenshot_1562341405](https://user-images.githubusercontent.com/16742525/60734138-9dcdeb80-9f57-11e9-9229-b4233e0218de.png)


App - wide breakpoint:
![Screenshot_1562342141](https://user-images.githubusercontent.com/16742525/60734150-a58d9000-9f57-11e9-9482-944826a6bf62.png)


App - huge breakpoint:
![Screenshot_1562341210](https://user-images.githubusercontent.com/16742525/60734163-ae7e6180-9f57-11e9-97cc-20aae30e0193.png)
![Screenshot_1562341060](https://user-images.githubusercontent.com/16742525/60734166-b0e0bb80-9f57-11e9-9a2c-c89e42e6f64d.png)
