### PR TITLE
feat: leading articles slice for wide huge tablet

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -602,18 +602,21 @@ exports[`21. leaders slice - wide 1`] = `
     <View>
       <View>
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </View>
       <View />
       <View>
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </View>
       <View />
       <View>
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </View>
@@ -1085,18 +1088,21 @@ exports[`36. leaders slice - huge 1`] = `
     <View>
       <View>
         <TileAG
+          breakpoint="huge"
           tileName="leader2"
         />
       </View>
       <View />
       <View>
         <TileAG
+          breakpoint="huge"
           tileName="leader1"
         />
       </View>
       <View />
       <View>
         <TileAG
+          breakpoint="huge"
           tileName="leader3"
         />
       </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -602,18 +602,21 @@ exports[`21. leaders slice - wide 1`] = `
     <View>
       <View>
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </View>
       <View />
       <View>
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </View>
       <View />
       <View>
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </View>
@@ -1085,18 +1088,21 @@ exports[`36. leaders slice - huge 1`] = `
     <View>
       <View>
         <TileAG
+          breakpoint="huge"
           tileName="leader2"
         />
       </View>
       <View />
       <View>
         <TileAG
+          breakpoint="huge"
           tileName="leader1"
         />
       </View>
       <View />
       <View>
         <TileAG
+          breakpoint="huge"
           tileName="leader3"
         />
       </View>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -751,6 +751,7 @@ exports[`2. leaders 1`] = `
         className="css-view-1dbjc4n IS5"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </div>
@@ -761,6 +762,7 @@ exports[`2. leaders 1`] = `
         className="css-view-1dbjc4n IS7"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </div>
@@ -771,6 +773,7 @@ exports[`2. leaders 1`] = `
         className="css-view-1dbjc4n IS9"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </div>
@@ -918,6 +921,7 @@ exports[`2. leaders 2`] = `
         className="css-view-1dbjc4n IS5"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </div>
@@ -928,6 +932,7 @@ exports[`2. leaders 2`] = `
         className="css-view-1dbjc4n IS7"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </div>
@@ -938,6 +943,7 @@ exports[`2. leaders 2`] = `
         className="css-view-1dbjc4n IS9"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </div>
@@ -2689,6 +2695,7 @@ exports[`14. leaders 1`] = `
         className="css-view-1dbjc4n IS5"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </div>
@@ -2699,6 +2706,7 @@ exports[`14. leaders 1`] = `
         className="css-view-1dbjc4n IS7"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </div>
@@ -2709,6 +2717,7 @@ exports[`14. leaders 1`] = `
         className="css-view-1dbjc4n IS9"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -164,18 +164,21 @@ exports[`2. leaders 1`] = `
     <div>
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </div>
       <div />
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </div>
       <div />
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </div>
@@ -201,18 +204,21 @@ exports[`2. leaders 2`] = `
     <div>
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </div>
       <div />
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </div>
       <div />
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </div>
@@ -582,18 +588,21 @@ exports[`14. leaders 1`] = `
     <div>
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </div>
       <div />
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </div>
       <div />
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -609,6 +609,7 @@ exports[`6. leaders slice - medium 1`] = `
         className="css-view-1dbjc4n IS5"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </div>
@@ -619,6 +620,7 @@ exports[`6. leaders slice - medium 1`] = `
         className="css-view-1dbjc4n IS7"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </div>
@@ -629,6 +631,7 @@ exports[`6. leaders slice - medium 1`] = `
         className="css-view-1dbjc4n IS9"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </div>
@@ -2421,6 +2424,7 @@ exports[`21. leaders slice - wide 1`] = `
         className="css-view-1dbjc4n IS5"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </div>
@@ -2431,6 +2435,7 @@ exports[`21. leaders slice - wide 1`] = `
         className="css-view-1dbjc4n IS7"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </div>
@@ -2441,6 +2446,7 @@ exports[`21. leaders slice - wide 1`] = `
         className="css-view-1dbjc4n IS9"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </div>
@@ -4233,6 +4239,7 @@ exports[`36. leaders slice - huge 1`] = `
         className="css-view-1dbjc4n IS5"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </div>
@@ -4243,6 +4250,7 @@ exports[`36. leaders slice - huge 1`] = `
         className="css-view-1dbjc4n IS7"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </div>
@@ -4253,6 +4261,7 @@ exports[`36. leaders slice - huge 1`] = `
         className="css-view-1dbjc4n IS9"
       >
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -120,18 +120,21 @@ exports[`6. leaders slice - medium 1`] = `
     <div>
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </div>
       <div />
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </div>
       <div />
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </div>
@@ -566,18 +569,21 @@ exports[`21. leaders slice - wide 1`] = `
     <div>
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </div>
       <div />
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </div>
       <div />
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </div>
@@ -1012,18 +1018,21 @@ exports[`36. leaders slice - huge 1`] = `
     <div>
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader2"
         />
       </div>
       <div />
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader1"
         />
       </div>
       <div />
       <div>
         <TileAG
+          breakpoint="wide"
           tileName="leader3"
         />
       </div>

--- a/packages/edition-slices/src/slices/leaders/index.js
+++ b/packages/edition-slices/src/slices/leaders/index.js
@@ -53,9 +53,30 @@ class LeadersSlice extends Component {
     return (
       <Leaders
         breakpoint={breakpoint}
-        leader1={<TileAG onPress={onPress} tile={leader1} tileName="leader1" />}
-        leader2={<TileAG onPress={onPress} tile={leader2} tileName="leader2" />}
-        leader3={<TileAG onPress={onPress} tile={leader3} tileName="leader3" />}
+        leader1={
+          <TileAG
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={leader1}
+            tileName="leader1"
+          />
+        }
+        leader2={
+          <TileAG
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={leader2}
+            tileName="leader2"
+          />
+        }
+        leader3={
+          <TileAG
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={leader3}
+            tileName="leader3"
+          />
+        }
       />
     );
   }

--- a/packages/edition-slices/src/tiles/tile-ag/index.js
+++ b/packages/edition-slices/src/tiles/tile-ag/index.js
@@ -1,17 +1,20 @@
+/* eslint-disable react/require-default-props */
 import React from "react";
 import PropTypes from "prop-types";
+import { editionBreakpoints } from "@times-components/styleguide";
 import {
   getTileStrapline,
   TileLink,
   TileSummary,
   withTileTracking
 } from "../shared";
-import styles from "./styles";
+import stylesFactory from "./styles";
 
-const TileAG = ({ onPress, tile }) => {
+const TileAG = ({ onPress, tile, breakpoint = editionBreakpoints.wide }) => {
   const {
     article: { id, shortHeadline, url }
   } = tile;
+  const styles = stylesFactory(breakpoint);
   const tileWithoutLabelAndFlags = { article: { id, shortHeadline, url } };
 
   return (
@@ -32,6 +35,7 @@ const TileAG = ({ onPress, tile }) => {
 };
 
 TileAG.propTypes = {
+  breakpoint: PropTypes.string,
   onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired
 };

--- a/packages/edition-slices/src/tiles/tile-ag/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ag/styles/index.js
@@ -1,15 +1,24 @@
-import { fonts, spacing } from "@times-components/styleguide";
+import {
+  fonts,
+  spacing,
+  editionBreakpoints
+} from "@times-components/styleguide";
 import { verticalStyles } from "../../shared/styles";
 
-const styles = {
+const headlineFontSizeResolver = {
+  [editionBreakpoints.huge]: 35,
+  [editionBreakpoints.wide]: 30
+};
+
+export default breakpoint => ({
   container: {
     paddingBottom: spacing(2),
     paddingHorizontal: spacing(4)
   },
   headline: {
     fontFamily: fonts.headline,
-    fontSize: 30,
-    lineHeight: 30,
+    fontSize: headlineFontSizeResolver[breakpoint],
+    lineHeight: headlineFontSizeResolver[breakpoint],
     marginBottom: spacing(1),
     marginTop: spacing(4),
     textAlign: "center"
@@ -21,6 +30,4 @@ const styles = {
     lineHeight: 20,
     textAlign: "center"
   }
-};
-
-export default styles;
+});


### PR DESCRIPTION
Jira: https://nidigitalsolutions.jira.com/browse/REPLAT-5494
Implement Comment Leading Articles for wide and huge tablet breakpoints. Font size changed for huge breakpoint.

![image](https://user-images.githubusercontent.com/7889661/60712086-ea490500-9f1e-11e9-89cd-8a457abb8b11.png)

