### PR TITLE
Fix: Lead asset pixel bug

### DIFF
--- a/packages/image/__tests__/android/__snapshots__/image-with-style.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image-with-style.android.test.js.snap
@@ -24,7 +24,6 @@ exports[`1. default image 1`] = `
         Object {
           "height": "100%",
           "position": "absolute",
-          "resizeMode": "contain",
           "width": "100%",
         }
       }
@@ -34,7 +33,6 @@ exports[`1. default image 1`] = `
         Object {
           "height": "100%",
           "position": "absolute",
-          "resizeMode": "contain",
           "width": "100%",
         }
       }

--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -549,6 +549,7 @@ exports[`12. uses lowressize image as placeholder if passed 1`] = `
       <Image
         fadeDuration={0}
         fadeImageIn={false}
+        resizeMode="contain"
         source={
           Object {
             "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",

--- a/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
@@ -102,7 +102,6 @@ exports[`1. landscape default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -112,7 +111,6 @@ exports[`1. landscape default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -218,7 +216,6 @@ exports[`1. landscape default modal 1`] = `
             Object {
               "height": "100%",
               "position": "absolute",
-              "resizeMode": "contain",
               "width": "100%",
             }
           }
@@ -358,7 +355,6 @@ exports[`2. portrait default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -368,7 +364,6 @@ exports[`2. portrait default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -474,7 +469,6 @@ exports[`2. portrait default modal 1`] = `
             Object {
               "height": "100%",
               "position": "absolute",
-              "resizeMode": "contain",
               "width": "100%",
             }
           }
@@ -614,7 +608,6 @@ exports[`3. tablet landscape default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -624,7 +617,6 @@ exports[`3. tablet landscape default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -655,7 +647,6 @@ exports[`3. tablet landscape default modal 1`] = `
                     Object {
                       "height": "100%",
                       "position": "absolute",
-                      "resizeMode": "contain",
                       "width": "100%",
                     }
                   }
@@ -735,7 +726,6 @@ exports[`3. tablet landscape default modal 1`] = `
             Object {
               "height": "100%",
               "position": "absolute",
-              "resizeMode": "contain",
               "width": "100%",
             }
           }
@@ -766,7 +756,6 @@ exports[`3. tablet landscape default modal 1`] = `
               Object {
                 "height": "100%",
                 "position": "absolute",
-                "resizeMode": "contain",
                 "width": "100%",
               }
             }
@@ -880,7 +869,6 @@ exports[`4. tablet portrait default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -890,7 +878,6 @@ exports[`4. tablet portrait default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -921,7 +908,6 @@ exports[`4. tablet portrait default modal 1`] = `
                     Object {
                       "height": "100%",
                       "position": "absolute",
-                      "resizeMode": "contain",
                       "width": "100%",
                     }
                   }
@@ -1001,7 +987,6 @@ exports[`4. tablet portrait default modal 1`] = `
             Object {
               "height": "100%",
               "position": "absolute",
-              "resizeMode": "contain",
               "width": "100%",
             }
           }
@@ -1032,7 +1017,6 @@ exports[`4. tablet portrait default modal 1`] = `
               Object {
                 "height": "100%",
                 "position": "absolute",
-                "resizeMode": "contain",
                 "width": "100%",
               }
             }

--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -83,6 +83,7 @@ exports[`1. modal image 1`] = `
                   fadeDuration={0}
                   fadeImageIn={false}
                   onImagePress={null}
+                  resizeMode="contain"
                   show={false}
                   source={
                     Object {
@@ -145,6 +146,7 @@ exports[`1. modal image 1`] = `
             fadeDuration={0}
             fadeImageIn={false}
             onImagePress={null}
+            resizeMode="contain"
             show={false}
             source={
               Object {
@@ -363,6 +365,7 @@ exports[`3. modal image with custom highressize 1`] = `
                   fadeDuration={0}
                   fadeImageIn={false}
                   onImagePress={null}
+                  resizeMode="contain"
                   show={false}
                   source={
                     Object {
@@ -425,6 +428,7 @@ exports[`3. modal image with custom highressize 1`] = `
             fadeDuration={0}
             fadeImageIn={false}
             onImagePress={null}
+            resizeMode="contain"
             show={false}
             source={
               Object {

--- a/packages/image/__tests__/ios/__snapshots__/image-with-style.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image-with-style.ios.test.js.snap
@@ -24,7 +24,6 @@ exports[`1. default image 1`] = `
         Object {
           "height": "100%",
           "position": "absolute",
-          "resizeMode": "contain",
           "width": "100%",
         }
       }
@@ -34,7 +33,6 @@ exports[`1. default image 1`] = `
         Object {
           "height": "100%",
           "position": "absolute",
-          "resizeMode": "contain",
           "width": "100%",
         }
       }

--- a/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
@@ -549,6 +549,7 @@ exports[`12. uses lowressize image as placeholder if passed 1`] = `
       <Image
         fadeDuration={0}
         fadeImageIn={false}
+        resizeMode="contain"
         source={
           Object {
             "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",

--- a/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
@@ -103,7 +103,6 @@ exports[`1. landscape default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -113,7 +112,6 @@ exports[`1. landscape default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -228,7 +226,6 @@ exports[`1. landscape default modal 1`] = `
             Object {
               "height": "100%",
               "position": "absolute",
-              "resizeMode": "contain",
               "width": "100%",
             }
           }
@@ -369,7 +366,6 @@ exports[`2. portrait default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -379,7 +375,6 @@ exports[`2. portrait default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -494,7 +489,6 @@ exports[`2. portrait default modal 1`] = `
             Object {
               "height": "100%",
               "position": "absolute",
-              "resizeMode": "contain",
               "width": "100%",
             }
           }
@@ -635,7 +629,6 @@ exports[`3. tablet landscape default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -645,7 +638,6 @@ exports[`3. tablet landscape default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -676,7 +668,6 @@ exports[`3. tablet landscape default modal 1`] = `
                     Object {
                       "height": "100%",
                       "position": "absolute",
-                      "resizeMode": "contain",
                       "width": "100%",
                     }
                   }
@@ -765,7 +756,6 @@ exports[`3. tablet landscape default modal 1`] = `
             Object {
               "height": "100%",
               "position": "absolute",
-              "resizeMode": "contain",
               "width": "100%",
             }
           }
@@ -796,7 +786,6 @@ exports[`3. tablet landscape default modal 1`] = `
               Object {
                 "height": "100%",
                 "position": "absolute",
-                "resizeMode": "contain",
                 "width": "100%",
               }
             }
@@ -911,7 +900,6 @@ exports[`4. tablet portrait default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -921,7 +909,6 @@ exports[`4. tablet portrait default modal 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -952,7 +939,6 @@ exports[`4. tablet portrait default modal 1`] = `
                     Object {
                       "height": "100%",
                       "position": "absolute",
-                      "resizeMode": "contain",
                       "width": "100%",
                     }
                   }
@@ -1041,7 +1027,6 @@ exports[`4. tablet portrait default modal 1`] = `
             Object {
               "height": "100%",
               "position": "absolute",
-              "resizeMode": "contain",
               "width": "100%",
             }
           }
@@ -1072,7 +1057,6 @@ exports[`4. tablet portrait default modal 1`] = `
               Object {
                 "height": "100%",
                 "position": "absolute",
-                "resizeMode": "contain",
                 "width": "100%",
               }
             }

--- a/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
@@ -83,6 +83,7 @@ exports[`1. modal image 1`] = `
                   fadeDuration={0}
                   fadeImageIn={false}
                   onImagePress={null}
+                  resizeMode="contain"
                   show={false}
                   source={
                     Object {
@@ -159,6 +160,7 @@ exports[`1. modal image 1`] = `
             fadeDuration={0}
             fadeImageIn={false}
             onImagePress={null}
+            resizeMode="contain"
             show={false}
             source={
               Object {
@@ -391,6 +393,7 @@ exports[`3. modal image with custom highressize 1`] = `
                   fadeDuration={0}
                   fadeImageIn={false}
                   onImagePress={null}
+                  resizeMode="contain"
                   show={false}
                   source={
                     Object {
@@ -467,6 +470,7 @@ exports[`3. modal image with custom highressize 1`] = `
             fadeDuration={0}
             fadeImageIn={false}
             onImagePress={null}
+            resizeMode="contain"
             show={false}
             source={
               Object {

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -137,6 +137,7 @@ class TimesImage extends Component {
                 <Image
                   {...defaultImageProps}
                   fadeDuration={0}
+                  resizeMode="contain"
                   source={{ uri: lowResUri }}
                   style={styles.image}
                 />

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -43,7 +43,6 @@ const styles = {
   image: {
     height: "100%",
     position: "absolute",
-    resizeMode: "contain",
     width: "100%"
   },
   imageContainer: {

--- a/packages/section/__tests__/android/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/android/__snapshots__/section.test.js.snap
@@ -57,7 +57,6 @@ exports[`Sunday Times magazine section 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -179,7 +178,6 @@ exports[`Times magazine section 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }

--- a/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
@@ -57,7 +57,6 @@ exports[`Sunday Times magazine section 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }
@@ -179,7 +178,6 @@ exports[`Times magazine section 1`] = `
                   Object {
                     "height": "100%",
                     "position": "absolute",
-                    "resizeMode": "contain",
                     "width": "100%",
                   }
                 }


### PR DESCRIPTION
- Fixes issue with 1px white line above lead asset on in depth articles. https://nidigitalsolutions.jira.com/browse/REPLAT-6628
- move `resizeMode="contain"` from style to the `image` component.

## iOS app

<img width="446" alt="Screenshot 2019-07-05 at 12 25 11" src="https://user-images.githubusercontent.com/1736782/60720600-2c744580-9f23-11e9-96b3-38a8ebaccad4.png">
