### PR TITLE
feat: REPLAT 5482 implement wide huge breakpoints on lead 1 full width slice

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -83,6 +83,7 @@ exports[`3. lead one and one - medium 1`] = `
 exports[`4. lead one full width - medium 1`] = `
 <View>
   <TileR
+    breakpoint="medium"
     tileName="lead"
   />
 </View>
@@ -550,6 +551,7 @@ exports[`18. lead one and one - wide 1`] = `
 exports[`19. lead one full width - wide 1`] = `
 <View>
   <TileR
+    breakpoint="wide"
     tileName="lead"
   />
 </View>
@@ -1037,6 +1039,7 @@ exports[`33. lead one and one - huge 1`] = `
 exports[`34. lead one full width - huge 1`] = `
 <View>
   <TileR
+    breakpoint="huge"
     tileName="lead"
   />
 </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -83,6 +83,7 @@ exports[`3. lead one and one - medium 1`] = `
 exports[`4. lead one full width - medium 1`] = `
 <View>
   <TileR
+    breakpoint="medium"
     tileName="lead"
   />
 </View>
@@ -550,6 +551,7 @@ exports[`18. lead one and one - wide 1`] = `
 exports[`19. lead one full width - wide 1`] = `
 <View>
   <TileR
+    breakpoint="wide"
     tileName="lead"
   />
 </View>
@@ -1037,6 +1039,7 @@ exports[`33. lead one and one - huge 1`] = `
 exports[`34. lead one full width - huge 1`] = `
 <View>
   <TileR
+    breakpoint="huge"
     tileName="lead"
   />
 </View>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -607,6 +607,7 @@ exports[`2. lead one full width 1`] = `
   className="css-view-1dbjc4n IS1"
 >
   <TileR
+    breakpoint="wide"
     tileName="lead"
   />
 </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -142,6 +142,7 @@ exports[`1. secondary one and four 2`] = `
 exports[`2. lead one full width 1`] = `
 <div>
   <TileR
+    breakpoint="wide"
     tileName="lead"
   />
 </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -342,6 +342,7 @@ exports[`4. lead one full width - medium 1`] = `
   className="css-view-1dbjc4n IS1"
 >
   <TileR
+    breakpoint="wide"
     tileName="lead"
   />
 </div>
@@ -2158,6 +2159,7 @@ exports[`19. lead one full width - wide 1`] = `
   className="css-view-1dbjc4n IS1"
 >
   <TileR
+    breakpoint="wide"
     tileName="lead"
   />
 </div>
@@ -3974,6 +3976,7 @@ exports[`34. lead one full width - huge 1`] = `
   className="css-view-1dbjc4n IS1"
 >
   <TileR
+    breakpoint="wide"
     tileName="lead"
   />
 </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -71,6 +71,7 @@ exports[`3. lead one and one - medium 1`] = `
 exports[`4. lead one full width - medium 1`] = `
 <div>
   <TileR
+    breakpoint="wide"
     tileName="lead"
   />
 </div>
@@ -521,6 +522,7 @@ exports[`18. lead one and one - wide 1`] = `
 exports[`19. lead one full width - wide 1`] = `
 <div>
   <TileR
+    breakpoint="wide"
     tileName="lead"
   />
 </div>
@@ -971,6 +973,7 @@ exports[`33. lead one and one - huge 1`] = `
 exports[`34. lead one full width - huge 1`] = `
 <div>
   <TileR
+    breakpoint="wide"
     tileName="lead"
   />
 </div>

--- a/packages/edition-slices/edition-slices.showcase.js
+++ b/packages/edition-slices/edition-slices.showcase.js
@@ -103,7 +103,7 @@ const sliceStories = [
   },
   {
     mock: mockLeadOneFullWidthSlice(),
-    name: "Lead One Full Width (Mobile: A, Tablet: R)",
+    name: "Lead One Full Width (Mobile: A, Tablet/Wide/Huge: R)",
     Slice: LeadOneFullWidthSlice
   },
   {

--- a/packages/edition-slices/src/slices/leadonefullwidth/index.js
+++ b/packages/edition-slices/src/slices/leadonefullwidth/index.js
@@ -18,19 +18,28 @@ class LeadOneFullWidthSlice extends Component {
     return <TileA onPress={onPress} tile={lead} tileName="lead" />;
   }
 
-  renderMedium() {
+  renderMedium(breakpoint) {
     const {
       slice: { lead },
       onPress
     } = this.props;
-    return <TileR onPress={onPress} tile={lead} tileName="lead" />;
+    return (
+      <TileR
+        breakpoint={breakpoint}
+        onPress={onPress}
+        tile={lead}
+        tileName="lead"
+      />
+    );
   }
 
   render() {
     return (
       <ResponsiveSlice
-        renderMedium={this.renderMedium}
         renderSmall={this.renderSmall}
+        renderMedium={this.renderMedium}
+        renderWide={this.renderMedium}
+        renderHuge={this.renderMedium}
       />
     );
   }

--- a/packages/edition-slices/src/tiles/tile-r/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/index.js
@@ -1,15 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
+import { editionBreakpoints } from "@times-components/styleguide";
 import {
   getTileImage,
   TileLink,
   TileSummary,
   withTileTracking
 } from "../shared";
-import styles from "./styles";
+import stylesFactory from "./styles";
 
-const TileR = ({ onPress, tile }) => {
+const TileR = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
+  const styles = stylesFactory(breakpoint);
   const crop = getTileImage(tile, "crop169");
 
   return (
@@ -28,6 +30,7 @@ const TileR = ({ onPress, tile }) => {
 };
 
 TileR.propTypes = {
+  breakpoint: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired
 };

--- a/packages/edition-slices/src/tiles/tile-r/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/styles/index.js
@@ -10,12 +10,6 @@ const headlineFontSizeResolver = {
   [editionBreakpoints.wide]: 45
 };
 
-const defaultContainerStyle = {
-  paddingBottom: spacing(3),
-  paddingHorizontal: spacing(4),
-  paddingTop: spacing(2)
-};
-
 const hugeScreenContainerStyle = {
   width: "87.6%",
   paddingHorizontal: spacing(0),
@@ -24,8 +18,10 @@ const hugeScreenContainerStyle = {
 
 export default breakpoint => ({
   container: {
-    ...defaultContainerStyle,
-    ...(breakpoint === editionBreakpoints.huge ? hugeScreenContainerStyle : {})
+    paddingBottom: spacing(3),
+    paddingHorizontal: spacing(4),
+    paddingTop: spacing(2),
+    ...(breakpoint === editionBreakpoints.huge && hugeScreenContainerStyle)
   },
   headline: {
     fontFamily: fonts.headline,

--- a/packages/edition-slices/src/tiles/tile-r/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/styles/index.js
@@ -11,7 +11,7 @@ const headlineFontSizeResolver = {
 };
 
 const hugeScreenContainerStyle = {
-  width: "87.6%",
+  width: "86%",
   paddingHorizontal: spacing(0),
   alignSelf: "center"
 };

--- a/packages/edition-slices/src/tiles/tile-r/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/styles/index.js
@@ -1,16 +1,35 @@
-import { fonts, spacing } from "@times-components/styleguide";
+import {
+  fonts,
+  spacing,
+  editionBreakpoints
+} from "@times-components/styleguide";
 
-const styles = {
+const headlineFontSizeResolver = {
+  [editionBreakpoints.medium]: 40,
+  [editionBreakpoints.huge]: 45,
+  [editionBreakpoints.wide]: 45
+};
+
+const defaultContainerStyle = {
+  paddingBottom: spacing(3),
+  paddingHorizontal: spacing(4),
+  paddingTop: spacing(2)
+};
+
+const hugeScreenContainerStyle = {
+  width: "87.6%",
+  paddingHorizontal: spacing(0),
+  alignSelf: "center"
+};
+
+export default breakpoint => ({
   container: {
-    paddingBottom: spacing(3),
-    paddingHorizontal: spacing(4),
-    paddingTop: spacing(2)
+    ...defaultContainerStyle,
+    ...(breakpoint === editionBreakpoints.huge ? hugeScreenContainerStyle : {})
   },
   headline: {
     fontFamily: fonts.headline,
-    fontSize: 40,
-    lineHeight: 40
+    fontSize: headlineFontSizeResolver[breakpoint],
+    lineHeight: headlineFontSizeResolver[breakpoint]
   }
-};
-
-export default styles;
+});


### PR DESCRIPTION
Jira: https://nidigitalsolutions.jira.com/browse/REPLAT-5482

- Wide breakpoint - font size increased
- Huge breakpoint - same as wide, except the max width of 1180

Storybook - wide breakpoint:
![Screenshot_1562326131](https://user-images.githubusercontent.com/16742525/60727407-7d496580-9f46-11e9-888b-e9abf79b7c27.png)

Storybook - huge breakpoint:
![Screenshot_1562335460](https://user-images.githubusercontent.com/16742525/60727814-7c650380-9f47-11e9-8de7-05a4782bfc38.png)
![Screenshot_1562335676](https://user-images.githubusercontent.com/16742525/60727821-7f5ff400-9f47-11e9-9e53-5a3682fc4166.png)
*note:  the bordered box is of 1366px and it is to depict the gutter space for huge breakpoint