### PR TITLE
feat: (REPLAT-6797) add viewport tracking for unruly ads

### DIFF
--- a/android-app/build.gradle
+++ b/android-app/build.gradle
@@ -41,7 +41,7 @@ task removePreviousReactArchives(type: Delete) {
 task generateReactArchives {
     subprojects { subproject ->
         apply plugin: 'maven'
-        def reactProjects = ["react-native-svg", "react-native-webview"]
+        def reactProjects = ["react-native-svg", "react-native-webview", "react-native-device-info"]
 
         if (reactProjects.contains(subproject.name)) {
             task generateReactArchive(type: Upload) {

--- a/android-app/package.json
+++ b/android-app/package.json
@@ -16,6 +16,7 @@
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-native": "0.59.10",
+    "react-native-device-info": "2.3.2",
     "react-native-svg": "9.4.0",
     "react-native-webview": "5.10.0",
     "url-polyfill": "1.1.0"

--- a/android-app/settings.gradle
+++ b/android-app/settings.gradle
@@ -5,3 +5,6 @@ project(':react-native-svg').projectDir = new File(settingsDir, '../node_modules
 
 include ':react-native-webview'
 project(':react-native-webview').projectDir = new File(settingsDir, '../node_modules/react-native-webview/android')
+
+include ':react-native-device-info'
+project(':react-native-device-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')

--- a/android-app/xnative/build.gradle
+++ b/android-app/xnative/build.gradle
@@ -81,4 +81,7 @@ dependencies {
     api("react-repo:react-native-webview:${packageInfo.dependencies.'react-native-webview'}") {	
         exclude group: "com.facebook.react"	
     }
+    api("react-repo:react-native-device-info:${packageInfo.dependencies.'react-native-device-info'}") {
+        exclude group: "com.facebook.react"
+    }
 }

--- a/android-app/xnative/src/main/java/uk/co/thetimes/xnative/XNative.java
+++ b/android-app/xnative/src/main/java/uk/co/thetimes/xnative/XNative.java
@@ -1,6 +1,7 @@
 package uk.co.thetimes.xnative;
 
 import com.facebook.common.internal.ImmutableList;
+import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import com.facebook.react.ReactPackage;
 import com.horcrux.svg.SvgPackage;
 import com.reactnativecommunity.webview.RNCWebViewPackage;
@@ -12,7 +13,8 @@ public class XNative {
         return ImmutableList.of(
                 new ComponentsPackage(),
                 new SvgPackage(),
-                new RNCWebViewPackage()
+                new RNCWebViewPackage(),
+                new RNDeviceInfo()
         );
     }
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -153,7 +153,8 @@ repositories {
 }
 
 dependencies {
-    implementation "com.facebook.react:react-native:0.58.6"  // From node_modules
+    implementation "com.facebook.react:react-native:0.59.10"  // From node_modules
+    implementation project(':react-native-device-info')
     implementation project(':react-native-svg')
     implementation project(':react-native-webview')
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"

--- a/android/app/src/main/java/com/storybooknative/MainApplication.java
+++ b/android/app/src/main/java/com/storybooknative/MainApplication.java
@@ -3,6 +3,7 @@ package com.storybooknative;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -26,6 +27,7 @@ public class MainApplication extends Application implements ReactApplication {
         protected List<ReactPackage> getPackages() {
             return Arrays.asList(
                     new MainReactPackage(),
+                    new RNDeviceInfo(),
                     new ComponentsPackage(),
                     new StorybookStubPackage(),
                     new SvgPackage(),

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'storybooknative'
+include ':react-native-device-info'
+project(':react-native-device-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')
 include ':app'
 
 include ':react-native-svg'

--- a/ios/storybooknative.xcodeproj/project.pbxproj
+++ b/ios/storybooknative.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -53,6 +52,8 @@
 		ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */; };
 		ED297163215061F000B7C4FE /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED297162215061F000B7C4FE /* JavaScriptCore.framework */; };
 		ED2971652150620600B7C4FE /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED2971642150620600B7C4FE /* JavaScriptCore.framework */; };
+		3D0575E577194F35849EE897 /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EC6289F8CE6E40B1B979D65A /* libRNDeviceInfo.a */; };
+		57E6E257CC8344DB9A9B00A6 /* libRNDeviceInfo-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E723E09BA1714A40A35454A5 /* libRNDeviceInfo-tvOS.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -381,6 +382,9 @@
 		C6749B6A76504FECB637F739 /* libRNCWebView.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNCWebView.a; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+		9C275CFA50814814A313DE35 /* RNDeviceInfo.xcodeproj */ = {isa = PBXFileReference; name = "RNDeviceInfo.xcodeproj"; path = "../node_modules/react-native-device-info/ios/RNDeviceInfo.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		EC6289F8CE6E40B1B979D65A /* libRNDeviceInfo.a */ = {isa = PBXFileReference; name = "libRNDeviceInfo.a"; path = "libRNDeviceInfo.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		E723E09BA1714A40A35454A5 /* libRNDeviceInfo-tvOS.a */ = {isa = PBXFileReference; name = "libRNDeviceInfo-tvOS.a"; path = "libRNDeviceInfo-tvOS.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -410,6 +414,7 @@
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				8BB02F10EF4B411F89A4D887 /* libRNCWebView.a in Frameworks */,
+				3D0575E577194F35849EE897 /* libRNDeviceInfo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -426,6 +431,7 @@
 				2D02E4C61E0B4AEC006451C7 /* libRCTSettings-tvOS.a in Frameworks */,
 				2D02E4C71E0B4AEC006451C7 /* libRCTText-tvOS.a in Frameworks */,
 				2D02E4C81E0B4AEC006451C7 /* libRCTWebSocket-tvOS.a in Frameworks */,
+				57E6E257CC8344DB9A9B00A6 /* libRNDeviceInfo-tvOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -635,6 +641,7 @@
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
 				646608590E26457C903D7348 /* RNCWebView.xcodeproj */,
+				9C275CFA50814814A313DE35 /* RNDeviceInfo.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1278,12 +1285,15 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-webview/ios",
+					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 				);
 				INFOPLIST_FILE = storybooknativeTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1304,12 +1314,15 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-webview/ios",
+					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 				);
 				INFOPLIST_FILE = storybooknativeTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1331,6 +1344,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-webview/ios",
+					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 				);
 				INFOPLIST_FILE = storybooknative/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1353,6 +1367,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-webview/ios",
+					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 				);
 				INFOPLIST_FILE = storybooknative/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1382,11 +1397,14 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-webview/ios",
+					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 				);
 				INFOPLIST_FILE = "storybooknative-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1416,11 +1434,14 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-webview/ios",
+					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 				);
 				INFOPLIST_FILE = "storybooknative-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1449,11 +1470,14 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-webview/ios",
+					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 				);
 				INFOPLIST_FILE = "storybooknative-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1482,11 +1506,14 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-webview/ios",
+					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 				);
 				INFOPLIST_FILE = "storybooknative-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A collection of presentational components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {
-    "node": ">=8.10.0 <12",
+    "node": ">=8.10.0 <13",
     "yarn": "1.16.0"
   },
   "bin": {
@@ -160,6 +160,7 @@
     "@babel/runtime-corejs2": "7.4.4",
     "react-art": "16.6.3",
     "react-native": "0.59.10",
+    "react-native-device-info": "2.3.2",
     "react-native-showcase-loader": "1.1.0"
   }
 }

--- a/packages/ad/__tests__/android/__snapshots__/ad-with-style.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad-with-style.android.test.js.snap
@@ -3,59 +3,27 @@
 exports[`1. multiple ad slots 1`] = `
 Array [
   <View
-    className="IS5"
+    className="IS3"
   >
     <View
-      className="IS4"
+      className="IS2"
+      inViewport={false}
     >
       <View
-        className="IS2"
-      >
-        <RNCWebView
-          allowFileAccess={false}
-          allowsFullscreenVideo={false}
-          androidHardwareAccelerationDisabled={false}
-          cacheEnabled={true}
-          className="IS1"
-          javaScriptEnabled={true}
-          messagingEnabled={true}
-          overScrollMode="always"
-          saveFormDataDisabled={false}
-          scalesPageToFit={true}
-          thirdPartyCookiesEnabled={true}
-        />
-      </View>
-      <View
-        className="IS3"
+        className="IS1"
         inViewport={false}
       />
     </View>
   </View>,
   <View
-    className="IS5"
+    className="IS3"
   >
     <View
-      className="IS4"
+      className="IS2"
+      inViewport={false}
     >
       <View
-        className="IS2"
-      >
-        <RNCWebView
-          allowFileAccess={false}
-          allowsFullscreenVideo={false}
-          androidHardwareAccelerationDisabled={false}
-          cacheEnabled={true}
-          className="IS1"
-          javaScriptEnabled={true}
-          messagingEnabled={true}
-          overScrollMode="always"
-          saveFormDataDisabled={false}
-          scalesPageToFit={true}
-          thirdPartyCookiesEnabled={true}
-        />
-      </View>
-      <View
-        className="IS3"
+        className="IS1"
         inViewport={false}
       />
     </View>

--- a/packages/ad/__tests__/android/__snapshots__/ad-with-style.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad-with-style.android.test.js.snap
@@ -3,10 +3,10 @@
 exports[`1. multiple ad slots 1`] = `
 Array [
   <View
-    className="IS4"
+    className="IS5"
   >
     <View
-      className="IS3"
+      className="IS4"
     >
       <View
         className="IS2"
@@ -25,13 +25,17 @@ Array [
           thirdPartyCookiesEnabled={true}
         />
       </View>
+      <View
+        className="IS3"
+        inViewport={false}
+      />
     </View>
   </View>,
   <View
-    className="IS4"
+    className="IS5"
   >
     <View
-      className="IS3"
+      className="IS4"
     >
       <View
         className="IS2"
@@ -50,6 +54,10 @@ Array [
           thirdPartyCookiesEnabled={true}
         />
       </View>
+      <View
+        className="IS3"
+        inViewport={false}
+      />
     </View>
   </View>,
 ]

--- a/packages/ad/__tests__/dom-context.native.js
+++ b/packages/ad/__tests__/dom-context.native.js
@@ -51,6 +51,45 @@ export default () => {
     expect(onRenderComplete).toHaveBeenCalledTimes(1);
   });
 
+  it("calls inViewport when it receives a unrulyLoaded event from the webview and we are loaded", () => {
+    const inViewport = jest.fn();
+    const component = new DOMContextNative(DOMContextNative.defaultProps);
+    component.state = {
+      loaded: true
+    };
+    component.isVisible = true;
+    component.inViewport = inViewport;
+
+    component.handleMessageEvent(makeMessageEvent("unrulyLoaded"));
+    expect(inViewport).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesnt call inViewport when it receives a unrulyLoaded event from the webview and we are not loaded", () => {
+    const inViewport = jest.fn();
+    const component = new DOMContextNative(DOMContextNative.defaultProps);
+    component.state = {
+      loaded: false
+    };
+    component.isVisible = true;
+    component.inViewport = inViewport;
+
+    component.handleMessageEvent(makeMessageEvent("unrulyLoaded"));
+    expect(inViewport).toHaveBeenCalledTimes(0);
+  });
+
+  it("doesnt call inViewport when it receives a unrulyLoaded event from the webview and we are not visible", () => {
+    const inViewport = jest.fn();
+    const component = new DOMContextNative(DOMContextNative.defaultProps);
+    component.state = {
+      loaded: true
+    };
+    component.isVisible = false;
+    component.inViewport = inViewport;
+
+    component.handleMessageEvent(makeMessageEvent("unrulyLoaded"));
+    expect(inViewport).toHaveBeenCalledTimes(0);
+  });
+
   it("calls onRenderError when it receives a onRenderError event from the webview", () => {
     const onRenderError = jest.fn();
     const component = new DOMContextNative({

--- a/packages/ad/__tests__/ios/__snapshots__/ad-with-style.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad-with-style.ios.test.js.snap
@@ -3,10 +3,10 @@
 exports[`1. multiple ad slots 1`] = `
 Array [
   <View
-    className="IS4"
+    className="IS5"
   >
     <View
-      className="IS3"
+      className="IS4"
     >
       <View
         className="IS2"
@@ -18,13 +18,17 @@ Array [
           useSharedProcessPool={true}
         />
       </View>
+      <View
+        className="IS3"
+        inViewport={false}
+      />
     </View>
   </View>,
   <View
-    className="IS4"
+    className="IS5"
   >
     <View
-      className="IS3"
+      className="IS4"
     >
       <View
         className="IS2"
@@ -36,6 +40,10 @@ Array [
           useSharedProcessPool={true}
         />
       </View>
+      <View
+        className="IS3"
+        inViewport={false}
+      />
     </View>
   </View>,
 ]

--- a/packages/ad/__tests__/ios/__snapshots__/ad-with-style.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad-with-style.ios.test.js.snap
@@ -3,45 +3,27 @@
 exports[`1. multiple ad slots 1`] = `
 Array [
   <View
-    className="IS5"
+    className="IS3"
   >
     <View
-      className="IS4"
+      className="IS2"
+      inViewport={false}
     >
       <View
-        className="IS2"
-      >
-        <RNCWKWebView
-          cacheEnabled={true}
-          className="IS1"
-          messagingEnabled={true}
-          useSharedProcessPool={true}
-        />
-      </View>
-      <View
-        className="IS3"
+        className="IS1"
         inViewport={false}
       />
     </View>
   </View>,
   <View
-    className="IS5"
+    className="IS3"
   >
     <View
-      className="IS4"
+      className="IS2"
+      inViewport={false}
     >
       <View
-        className="IS2"
-      >
-        <RNCWKWebView
-          cacheEnabled={true}
-          className="IS1"
-          messagingEnabled={true}
-          useSharedProcessPool={true}
-        />
-      </View>
-      <View
-        className="IS3"
+        className="IS1"
         inViewport={false}
       />
     </View>

--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -62,6 +62,7 @@
     "@times-components/styleguide": "3.28.39",
     "@times-components/utils": "4.11.26",
     "@times-components/watermark": "2.6.36",
+    "@skele/components": "1.0.0-alpha.40",
     "prop-types": "15.7.2",
     "react-broadcast": "0.5.2",
     "react-native-webview": "5.10.0"

--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -63,6 +63,7 @@
     "@times-components/utils": "4.11.26",
     "@times-components/watermark": "2.6.36",
     "@skele/components": "1.0.0-alpha.40",
+    "react-native-device-info": "2.3.2",
     "prop-types": "15.7.2",
     "react-broadcast": "0.5.2",
     "react-native-webview": "5.10.0"

--- a/packages/ad/src/dom-context.js
+++ b/packages/ad/src/dom-context.js
@@ -95,26 +95,6 @@ class DOMContext extends PureComponent {
       `);
   }
 
-  outViewport() {
-    this.webView.injectJavascript(`
-      if (typeof unrulyViewportStatus === "function") {
-        unrulyViewportStatus({
-          visible: false
-        })
-      }
-    `);
-  }
-
-  inViewport() {
-    this.webView.injectJavascript(`
-      if (typeof unrulyViewportStatus === "function") {
-        unrulyViewportStatus({
-          visible: true
-        })
-      };
-    `);
-  }
-
   render() {
     const { baseUrl, data, init, width, height } = this.props;
     // NOTE: if this generated code is not working, and you don't know why

--- a/packages/ad/src/dom-context.js
+++ b/packages/ad/src/dom-context.js
@@ -6,6 +6,7 @@ import DeviceInfo from "react-native-device-info";
 import webviewEventCallbackSetup from "./utils/webview-event-callback-setup";
 import logger from "./utils/logger";
 import { propTypes, defaultProps } from "./dom-context-prop-types";
+import { calculateViewportVisible } from "./styles/index";
 
 const ViewportAwareView = Viewport.Aware(View);
 
@@ -73,27 +74,31 @@ class DOMContext extends PureComponent {
     }
   };
 
-  outViewport() {
-    this.webView.injectJavaScript(`
-        if (typeof unrulyViewportStatus === "function") {
-          unrulyViewportStatus(${JSON.stringify({
-            ...this.deviceInfo,
-            visible: false
-          })})
-        }
-      `);
-  }
+  outViewport = () => {
+    if (this.webView) {
+      this.webView.injectJavaScript(`
+          if (typeof unrulyViewportStatus === "function") {
+            unrulyViewportStatus(${JSON.stringify({
+              ...this.deviceInfo,
+              visible: false
+            })})
+          }
+        `);
+    }
+  };
 
-  inViewport() {
-    this.webView.injectJavaScript(`
-        if (typeof unrulyViewportStatus === "function") {
-          unrulyViewportStatus(${JSON.stringify({
-            ...this.deviceInfo,
-            visible: true
-          })})
-        };
-      `);
-  }
+  inViewport = () => {
+    if (this.webView) {
+      this.webView.injectJavaScript(`
+          if (typeof unrulyViewportStatus === "function") {
+            unrulyViewportStatus(${JSON.stringify({
+              ...this.deviceInfo,
+              visible: true
+            })})
+          };
+        `);
+    }
+  };
 
   render() {
     const { baseUrl, data, init, width, height } = this.props;
@@ -178,14 +183,9 @@ class DOMContext extends PureComponent {
           style={{ position: "absolute" }}
         />
         <ViewportAwareView
-          onViewportEnter={() => this.inViewport()}
-          onViewportLeave={() => this.outViewport()}
-          style={{
-            width: 10,
-            height: height / 10,
-            top: height / 2 - height / 20,
-            position: "absolute"
-          }}
+          onViewportEnter={this.inViewport}
+          onViewportLeave={this.outViewport}
+          style={calculateViewportVisible(height)}
         />
       </View>
     );

--- a/packages/ad/src/dom-context.js
+++ b/packages/ad/src/dom-context.js
@@ -95,6 +95,26 @@ class DOMContext extends PureComponent {
       `);
   }
 
+  outViewport() {
+    this.webView.injectJavascript(`
+      if (typeof unrulyViewportStatus === "function") {
+        unrulyViewportStatus({
+          visible: false
+        })
+      }
+    `);
+  }
+
+  inViewport() {
+    this.webView.injectJavascript(`
+      if (typeof unrulyViewportStatus === "function") {
+        unrulyViewportStatus({
+          visible: true
+        })
+      };
+    `);
+  }
+
   render() {
     const { baseUrl, data, init, width, height } = this.props;
     // NOTE: if this generated code is not working, and you don't know why

--- a/packages/ad/src/styles/index.js
+++ b/packages/ad/src/styles/index.js
@@ -31,10 +31,10 @@ export const calculateViewBox = ({ height, width }) => {
 };
 
 export const calculateViewportVisible = height => {
-  const middle = height / 2; // (50%)
-  const middleOffset = height / 20; // (5%)
+  const middle = height / 2;
+  const middleOffset = 5;
   const minWidth = 10; // must be some width to render
-  const minHeight = height / 10; // (10%)
+  const minHeight = 10; // must be some height to render
   /*
   It should look like this:
   ---------AD----------

--- a/packages/ad/src/styles/index.js
+++ b/packages/ad/src/styles/index.js
@@ -1,6 +1,8 @@
 import { StyleSheet } from "react-native";
 import styleguide from "@times-components/styleguide";
 
+const { colours, fontFactory, spacing } = styleguide();
+
 export const calculateViewBox = ({ height, width }) => {
   if (height >= 90 && width >= 728) {
     return {
@@ -28,7 +30,27 @@ export const calculateViewBox = ({ height, width }) => {
   };
 };
 
-const { colours, fontFactory, spacing } = styleguide();
+export const calculateViewportVisible = height => {
+  const middle = height / 2; // (50%)
+  const middleOffset = height / 20; // (5%)
+  const minWidth = 10; // must be some width to render
+  const minHeight = height / 10; // (10%)
+  /*
+  It should look like this:
+  ---------AD----------
+  ---------AD----------
+  =======MARKER========
+  ---------AD----------
+  ---------AD----------
+  */
+  return {
+    width: minWidth,
+    height: minHeight,
+    top: middle - middleOffset,
+    position: "absolute"
+  };
+};
+
 const styles = StyleSheet.create({
   children: {
     flex: 1

--- a/packages/article-skeleton/package.json
+++ b/packages/article-skeleton/package.json
@@ -99,6 +99,7 @@
     "@times-components/user-state": "0.0.18",
     "@times-components/utils": "4.11.26",
     "@times-components/video": "4.7.64",
+    "@skele/components": "1.0.0-alpha.40",
     "lodash.get": "4.4.2",
     "lodash.pick": "4.4.0",
     "mockdate": "2.0.2",

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -13,6 +13,7 @@ import {
   tabletWidthMax,
   colours
 } from "@times-components/styleguide";
+import { Viewport } from "@skele/components";
 import ArticleRowFlow from "./article-body/article-body-row";
 import {
   articleSkeletonPropTypes,
@@ -327,40 +328,42 @@ class ArticleSkeleton extends Component {
     return (
       <AdComposer adConfig={adConfig}>
         <View style={styles.articleContainer}>
-          <FlatList
-            data={content || []}
-            initialListSize={listViewSize}
-            removeClippedSubviews
-            interactiveConfig={interactiveConfig}
-            keyExtractor={item =>
-              item.index ? `${item.type}.${item.index}` : item.type
-            }
-            ListHeaderComponent={
-              <Gutter>
-                <Header width={Math.min(maxWidth, width)} />
-              </Gutter>
-            }
-            nestedScrollEnabled
-            onViewableItemsChanged={
-              onViewed ? this.onViewableItemsChanged : null
-            }
-            pageSize={listViewPageSize}
-            renderItem={({ item }) => (
-              <Gutter>
-                {renderRow(
-                  item,
-                  onCommentsPress,
-                  onCommentGuidelinesPress,
-                  onRelatedArticlePress,
-                  onTopicPress,
-                  analyticsStream
-                )}
-              </Gutter>
-            )}
-            scrollRenderAheadDistance={listViewScrollRenderAheadDistance}
-            testID="flat-list-article"
-            viewabilityConfig={viewabilityConfig}
-          />
+          <Viewport.Tracker>
+            <FlatList
+              data={content || []}
+              initialListSize={listViewSize}
+              removeClippedSubviews
+              interactiveConfig={interactiveConfig}
+              keyExtractor={item =>
+                item.index ? `${item.type}.${item.index}` : item.type
+              }
+              ListHeaderComponent={
+                <Gutter>
+                  <Header width={Math.min(maxWidth, width)} />
+                </Gutter>
+              }
+              nestedScrollEnabled
+              onViewableItemsChanged={
+                onViewed ? this.onViewableItemsChanged : null
+              }
+              pageSize={listViewPageSize}
+              renderItem={({ item }) => (
+                <Gutter>
+                  {renderRow(
+                    item,
+                    onCommentsPress,
+                    onCommentGuidelinesPress,
+                    onRelatedArticlePress,
+                    onTopicPress,
+                    analyticsStream
+                  )}
+                </Gutter>
+              )}
+              scrollRenderAheadDistance={listViewScrollRenderAheadDistance}
+              testID="flat-list-article"
+              viewabilityConfig={viewabilityConfig}
+            />
+          </Viewport.Tracker>
         </View>
       </AdComposer>
     );

--- a/packages/jest-configurator/__tests__/__snapshots__/jest-configurator.test.js.snap
+++ b/packages/jest-configurator/__tests__/__snapshots__/jest-configurator.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Jest Configurator Tests All platforms should include times-components in transform ignore patterns 1`] = `
 Array [
-  "node_modules/(?!(react-native|react-native-svg|react-native-webview|react-native-iphone-x-helper|@times-components|@storybook/react-native|react-native-swipe-gestures)/)",
+  "node_modules/(?!(react-native|react-native-svg|react-native-webview|react-native-iphone-x-helper|@times-components|@storybook/react-native|react-native-swipe-gestures|react-native-device-info)/)",
 ]
 `;

--- a/packages/jest-configurator/setup-jest.js
+++ b/packages/jest-configurator/setup-jest.js
@@ -7,3 +7,14 @@ Enzyme.configure({ adapter: new Adapter() });
 
 if (typeof window !== "undefined")
   window.HTMLCanvasElement.prototype.getContext = () => {};
+
+jest.mock("react-native-device-info", () => {
+  return {
+    getApplicationName: jest.fn(),
+    getBuildNumber: jest.fn(),
+    getBundleId: jest.fn(),
+    getDeviceId: jest.fn(),
+    getReadableVersion: jest.fn(),
+    getVersion: jest.fn()
+  };
+});

--- a/packages/jest-configurator/src/jest-configurator.js
+++ b/packages/jest-configurator/src/jest-configurator.js
@@ -93,7 +93,7 @@ export default (platform, cwd, options = {}) => {
       "^.+\\.js$": path.resolve(__dirname, "source-loader.js")
     },
     transformIgnorePatterns: [
-      "node_modules/(?!(react-native|react-native-svg|react-native-webview|react-native-iphone-x-helper|@times-components|@storybook/react-native|react-native-swipe-gestures)/)"
+      "node_modules/(?!(react-native|react-native-svg|react-native-webview|react-native-iphone-x-helper|@times-components|@storybook/react-native|react-native-swipe-gestures|react-native-device-info)/)"
     ]
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17490,6 +17490,11 @@ react-native-color-picker@^0.4.0:
     prop-types "^15.5.10"
     tinycolor2 "^1.4.1"
 
+react-native-device-info@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-2.3.2.tgz#db2b8f135aaf2515583e367ab791dcc7d2f0d14c"
+  integrity sha512-ccpPuUbwhw5uYdVwN1UJp6ykMZz6U/u82HNM3oJ7O6MP8RIMlMDkHbqR4O0sDtUSuRMGiqqRzFtmOLFYeQ0ODw==
+
 react-native-modal-datetime-picker@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-6.1.0.tgz#246563ed582e68a886134ba1e2a3226504590819"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2770,6 +2770,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@skele/components@1.0.0-alpha.40":
+  version "1.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@skele/components/-/components-1.0.0-alpha.40.tgz#1548f77ec5bdc6c6ea2ad8ffcb47809581e64289"
+  integrity sha512-8mhYslxz71l+8maHegrNqQrl+a6oRFSl+OmAC4Gny1vQ8znCyGG8gR+SWFeDnNALpOi/EZvPC65qTylkoq6xZg==
+
 "@storybook/addon-actions@4.1.18":
   version "4.1.18"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-4.1.18.tgz#f8eae3fef92b9f3f4d166d066e98b47377784a7b"


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
This ads viewport tracking for unruly so that they can know when they are in view before starting or stopping a video ad.

I am not sure of a good way to test this? Any suggestions?

Also currently waiting for an approved list of device data to pass to them without violating user data confidentiality.
