### PR TITLE
fix: REPLAT-6627 article flag mobile styling fixes

### DIFF
--- a/packages/article-flag/__tests__/android/__snapshots__/article-flag-with-style.android.test.js.snap
+++ b/packages/article-flag/__tests__/android/__snapshots__/article-flag-with-style.android.test.js.snap
@@ -6,7 +6,7 @@ exports[`1. red article flag 1`] = `
     Object {
       "alignItems": "center",
       "flexDirection": "row",
-      "marginTop": -5,
+      "marginTop": -3,
     }
   }
 >
@@ -28,9 +28,9 @@ exports[`1. red article flag 1`] = `
         "fontSize": 14,
         "fontWeight": "400",
         "letterSpacing": 0.6,
-        "lineHeight": 12,
+        "lineHeight": 14,
         "marginLeft": 5,
-        "marginTop": 5,
+        "marginTop": 3,
       }
     }
   >
@@ -61,7 +61,7 @@ exports[`2. multiple article flags 1`] = `
         Object {
           "alignItems": "center",
           "flexDirection": "row",
-          "marginTop": -5,
+          "marginTop": -3,
         }
       }
     >
@@ -83,9 +83,9 @@ exports[`2. multiple article flags 1`] = `
             "fontSize": 14,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 12,
+            "lineHeight": 14,
             "marginLeft": 5,
-            "marginTop": 5,
+            "marginTop": 3,
           }
         }
       >
@@ -105,7 +105,7 @@ exports[`2. multiple article flags 1`] = `
         Object {
           "alignItems": "center",
           "flexDirection": "row",
-          "marginTop": -5,
+          "marginTop": -3,
         }
       }
     >
@@ -127,9 +127,9 @@ exports[`2. multiple article flags 1`] = `
             "fontSize": 14,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 12,
+            "lineHeight": 14,
             "marginLeft": 5,
-            "marginTop": 5,
+            "marginTop": 3,
           }
         }
       >
@@ -149,7 +149,7 @@ exports[`2. multiple article flags 1`] = `
         Object {
           "alignItems": "center",
           "flexDirection": "row",
-          "marginTop": -5,
+          "marginTop": -3,
         }
       }
     >
@@ -171,9 +171,9 @@ exports[`2. multiple article flags 1`] = `
             "fontSize": 14,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 12,
+            "lineHeight": 14,
             "marginLeft": 5,
-            "marginTop": 5,
+            "marginTop": 3,
           }
         }
       >
@@ -193,7 +193,7 @@ exports[`2. multiple article flags 1`] = `
         Object {
           "alignItems": "center",
           "flexDirection": "row",
-          "marginTop": -5,
+          "marginTop": -3,
         }
       }
     >
@@ -215,9 +215,9 @@ exports[`2. multiple article flags 1`] = `
             "fontSize": 14,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 12,
+            "lineHeight": 14,
             "marginLeft": 5,
-            "marginTop": 5,
+            "marginTop": 3,
           }
         }
       >

--- a/packages/article-flag/__tests__/ios/__snapshots__/article-flag-with-style.ios.test.js.snap
+++ b/packages/article-flag/__tests__/ios/__snapshots__/article-flag-with-style.ios.test.js.snap
@@ -6,7 +6,7 @@ exports[`1. red article flag 1`] = `
     Object {
       "alignItems": "center",
       "flexDirection": "row",
-      "marginTop": -5,
+      "marginTop": -3,
     }
   }
 >
@@ -28,9 +28,9 @@ exports[`1. red article flag 1`] = `
         "fontSize": 14,
         "fontWeight": "400",
         "letterSpacing": 0.6,
-        "lineHeight": 12,
+        "lineHeight": 14,
         "marginLeft": 5,
-        "marginTop": 5,
+        "marginTop": 3,
       }
     }
   >
@@ -61,7 +61,7 @@ exports[`2. multiple article flags 1`] = `
         Object {
           "alignItems": "center",
           "flexDirection": "row",
-          "marginTop": -5,
+          "marginTop": -3,
         }
       }
     >
@@ -83,9 +83,9 @@ exports[`2. multiple article flags 1`] = `
             "fontSize": 14,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 12,
+            "lineHeight": 14,
             "marginLeft": 5,
-            "marginTop": 5,
+            "marginTop": 3,
           }
         }
       >
@@ -105,7 +105,7 @@ exports[`2. multiple article flags 1`] = `
         Object {
           "alignItems": "center",
           "flexDirection": "row",
-          "marginTop": -5,
+          "marginTop": -3,
         }
       }
     >
@@ -127,9 +127,9 @@ exports[`2. multiple article flags 1`] = `
             "fontSize": 14,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 12,
+            "lineHeight": 14,
             "marginLeft": 5,
-            "marginTop": 5,
+            "marginTop": 3,
           }
         }
       >
@@ -149,7 +149,7 @@ exports[`2. multiple article flags 1`] = `
         Object {
           "alignItems": "center",
           "flexDirection": "row",
-          "marginTop": -5,
+          "marginTop": -3,
         }
       }
     >
@@ -171,9 +171,9 @@ exports[`2. multiple article flags 1`] = `
             "fontSize": 14,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 12,
+            "lineHeight": 14,
             "marginLeft": 5,
-            "marginTop": 5,
+            "marginTop": 3,
           }
         }
       >
@@ -193,7 +193,7 @@ exports[`2. multiple article flags 1`] = `
         Object {
           "alignItems": "center",
           "flexDirection": "row",
-          "marginTop": -5,
+          "marginTop": -3,
         }
       }
     >
@@ -215,9 +215,9 @@ exports[`2. multiple article flags 1`] = `
             "fontSize": 14,
             "fontWeight": "400",
             "letterSpacing": 0.6,
-            "lineHeight": 12,
+            "lineHeight": 14,
             "marginLeft": 5,
-            "marginTop": 5,
+            "marginTop": 3,
           }
         }
       >

--- a/packages/article-flag/src/style/index.js
+++ b/packages/article-flag/src/style/index.js
@@ -6,11 +6,12 @@ const styles = {
   title: {
     ...sharedStyles.title,
     fontSize: fontSizes.meta,
-    marginTop: 5
+    lineHeight: fontSizes.meta,
+    marginTop: 3
   },
   view: {
     ...sharedStyles.view,
-    marginTop: -5
+    marginTop: -3
   }
 };
 


### PR DESCRIPTION
[REPLAT-6627](https://nidigitalsolutions.jira.com/browse/REPLAT-6627)

Flag was cut off on mobile android, because the line height was less than the font size.

Line height value updated.
Margin updated to center the circle.

Before:
![Screenshot at Jul 10 15-07-26](https://user-images.githubusercontent.com/8720661/60970836-76966600-a32b-11e9-8fa3-3af2b82b70ed.png)

After:
![Screenshot at Jul 10 15-09-19 after](https://user-images.githubusercontent.com/8720661/60970844-7c8c4700-a32b-11e9-9e8e-79bce604ff83.png)
