### PR TITLE
fix: REPLAT-6946 video label disappears when centred layout

### DIFF
--- a/packages/fixture-generator/src/mock-slice.ts
+++ b/packages/fixture-generator/src/mock-slice.ts
@@ -111,9 +111,19 @@ function getDailyRegister(count: number): Array<DailyUniversalRegisterItem> {
 
 function mockLeadOneAndFourSlice(): LeadOneAndFourSliceWithName {
   const tiles = getTiles(5);
+
+  const leadTile = {
+    ...tiles[0],
+    article: {
+      ...tiles[0].article,
+      hasVideo: true,
+      label: "short label centered"
+    }
+  };
+
   return <LeadOneAndFourSliceWithName>{
     name: "LeadOneAndFourSlice",
-    lead: tiles[0],
+    lead: leadTile,
     support1: tiles[1],
     support2: tiles[2],
     support3: tiles[3],

--- a/packages/section/__tests__/shared-tracking.js
+++ b/packages/section/__tests__/shared-tracking.js
@@ -9,7 +9,8 @@ import Section from "../src/section";
 
 jest.mock("@times-components/icons", () => ({
   IconForwardArrow: "IconForwardArrow",
-  IconStar: "IconStar"
+  IconStar: "IconStar",
+  IconVideo: "IconVideo"
 }));
 jest.mock("react-native", () => {
   const rn = require.requireActual("react-native");

--- a/packages/video-label/__tests__/android/__snapshots__/video-label-with-style.android.test.js.snap
+++ b/packages/video-label/__tests__/android/__snapshots__/video-label-with-style.android.test.js.snap
@@ -27,7 +27,7 @@ exports[`1. video label with a title 1`] = `
     style={
       Object {
         "color": "#008347",
-        "flex": 1,
+        "flex": -1,
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 12,
         "fontWeight": "400",
@@ -70,7 +70,7 @@ exports[`2. video label without a title shows video 1`] = `
     style={
       Object {
         "color": "#008347",
-        "flex": 1,
+        "flex": -1,
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 12,
         "fontWeight": "400",
@@ -113,7 +113,7 @@ exports[`3. video label with the black default colour 1`] = `
     style={
       Object {
         "color": "black",
-        "flex": 1,
+        "flex": -1,
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 12,
         "fontWeight": "400",

--- a/packages/video-label/__tests__/ios/__snapshots__/video-label-with-style.ios.test.js.snap
+++ b/packages/video-label/__tests__/ios/__snapshots__/video-label-with-style.ios.test.js.snap
@@ -26,7 +26,7 @@ exports[`1. video label with a title 1`] = `
     style={
       Object {
         "color": "#008347",
-        "flex": 1,
+        "flex": -1,
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 12,
         "fontWeight": "400",
@@ -68,7 +68,7 @@ exports[`2. video label without a title shows video 1`] = `
     style={
       Object {
         "color": "#008347",
-        "flex": 1,
+        "flex": -1,
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 12,
         "fontWeight": "400",
@@ -110,7 +110,7 @@ exports[`3. video label with the black default colour 1`] = `
     style={
       Object {
         "color": "black",
-        "flex": 1,
+        "flex": -1,
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 12,
         "fontWeight": "400",

--- a/packages/video-label/__tests__/web/__snapshots__/video-label-with-style.web.test.js.snap
+++ b/packages/video-label/__tests__/web/__snapshots__/video-label-with-style.web.test.js.snap
@@ -40,7 +40,7 @@ exports[`1. video label with a title 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12;
   line-height: 12;
-  flex: 1;
+  flex: -1;
   font-weight: 400;
   letter-spacing: 1.2;
   margin-left: 5px;
@@ -72,7 +72,7 @@ exports[`1. video label with a title 1`] = `
       />
     </div>
     <div
-      className="css-text-901oao r-flex-13awgt0 r-fontFamily-j2s0nr r-fontSize-1enofrn r-fontWeight-16dba41 r-letterSpacing-19r33im r-lineHeight-56xrmm r-marginLeft-1f6r7vd r-paddingTop-njp1lv IS2 S2"
+      className="css-text-901oao r-flex-9c3h7m r-fontFamily-j2s0nr r-fontSize-1enofrn r-fontWeight-16dba41 r-letterSpacing-19r33im r-lineHeight-56xrmm r-marginLeft-1f6r7vd r-paddingTop-njp1lv IS2 S2"
     >
       SWIMMING
     </div>
@@ -120,7 +120,7 @@ exports[`2. video label without a title shows video 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12;
   line-height: 12;
-  flex: 1;
+  flex: -1;
   font-weight: 400;
   letter-spacing: 1.2;
   margin-left: 5px;
@@ -152,7 +152,7 @@ exports[`2. video label without a title shows video 1`] = `
       />
     </div>
     <div
-      className="css-text-901oao r-flex-13awgt0 r-fontFamily-j2s0nr r-fontSize-1enofrn r-fontWeight-16dba41 r-letterSpacing-19r33im r-lineHeight-56xrmm r-marginLeft-1f6r7vd r-paddingTop-njp1lv IS2 S2"
+      className="css-text-901oao r-flex-9c3h7m r-fontFamily-j2s0nr r-fontSize-1enofrn r-fontWeight-16dba41 r-letterSpacing-19r33im r-lineHeight-56xrmm r-marginLeft-1f6r7vd r-paddingTop-njp1lv IS2 S2"
     >
       VIDEO
     </div>
@@ -200,7 +200,7 @@ exports[`3. video label with the black default colour 1`] = `
   font-family: GillSansMTStd-Medium;
   font-size: 12;
   line-height: 12;
-  flex: 1;
+  flex: -1;
   font-weight: 400;
   letter-spacing: 1.2;
   margin-left: 5px;
@@ -232,7 +232,7 @@ exports[`3. video label with the black default colour 1`] = `
       />
     </div>
     <div
-      className="css-text-901oao r-flex-13awgt0 r-fontFamily-j2s0nr r-fontSize-1enofrn r-fontWeight-16dba41 r-letterSpacing-19r33im r-lineHeight-56xrmm r-marginLeft-1f6r7vd r-paddingTop-njp1lv IS2 S2"
+      className="css-text-901oao r-flex-9c3h7m r-fontFamily-j2s0nr r-fontSize-1enofrn r-fontWeight-16dba41 r-letterSpacing-19r33im r-lineHeight-56xrmm r-marginLeft-1f6r7vd r-paddingTop-njp1lv IS2 S2"
     >
       VIDEO
     </div>

--- a/packages/video-label/src/style/shared.js
+++ b/packages/video-label/src/style/shared.js
@@ -16,7 +16,7 @@ const styles = {
       font: "supporting",
       fontSize: "cardMetaMobile"
     }),
-    flex: 1,
+    flex: -1,
     fontWeight: "400",
     letterSpacing: 1.2,
     lineHeight: 11,


### PR DESCRIPTION
Jira story: https://nidigitalsolutions.jira.com/browse/REPLAT-6946
A regression was created where the video label was not shown in some articles or slices. This happened when we tried to get the video label text not to overlap its container (which could have been observed for label text longer than a row) .`flex:1` was added to the video label styles that gives enough space for short labels, makes the longer labels wrap properly but when the layout is centred
the label text width is lost.

Video label disappears on:
- article templates like article-in-depth, article-main-comment 
- slices where we have tile with centred layout 

As per RN documentation: 

> When flex is -1, the component is normally sized according width and height. However, if there's not enough space, the component will shrink to its minWidth and minHeight. 

Before:
![Screenshot_1562678895](https://user-images.githubusercontent.com/16742525/60969484-4bf6de00-a328-11e9-941e-ac9f2102250a.png)
![Screenshot_1562679489](https://user-images.githubusercontent.com/16742525/60969514-57e2a000-a328-11e9-87fc-50bd9a31c6dd.png)
![Screenshot_1562679965](https://user-images.githubusercontent.com/16742525/60969492-50bb9200-a328-11e9-9b00-071c779751ba.png)


After:
![Screenshot_1562678938](https://user-images.githubusercontent.com/16742525/60969510-55804600-a328-11e9-81ca-2d246c711404.png)
![Screenshot_1562679459](https://user-images.githubusercontent.com/16742525/60969488-4dc0a180-a328-11e9-85af-78349d561699.png)
![Screenshot_1562680016](https://user-images.githubusercontent.com/16742525/60969519-5a44fa00-a328-11e9-984d-225ca5e36d6f.png)


Storybook example with short and long text:
![Screenshot_1562678585](https://user-images.githubusercontent.com/16742525/60970711-3931d880-a32b-11e9-8921-bf32f334a116.png)
![Screenshot_1562680650](https://user-images.githubusercontent.com/16742525/60970717-3afb9c00-a32b-11e9-866b-f6080ede8b15.png)

IOS:
![Simulator Screen Shot - iPhone Xʀ - 2019-07-11 at 18 40 45](https://user-images.githubusercontent.com/16742525/61114048-2a1c6900-a498-11e9-87dc-579a9640c6d4.png)
![Simulator Screen Shot - iPhone Xʀ - 2019-07-11 at 18 41 18](https://user-images.githubusercontent.com/16742525/61114058-31dc0d80-a498-11e9-8c16-4c17dd42c32a.png)
![Simulator Screen Shot - iPhone Xʀ - 2019-07-12 at 11 11 58](https://user-images.githubusercontent.com/16742525/61114081-415b5680-a498-11e9-8cb0-d50f84cab210.png)


Web still works as expected:
![Screenshot 2019-07-09 at 17 27 05](https://user-images.githubusercontent.com/16742525/60973887-bd875a00-a331-11e9-8614-21f9bfeb1099.png)
![Screenshot 2019-07-09 at 17 19 41](https://user-images.githubusercontent.com/16742525/60973895-c0824a80-a331-11e9-8475-0b0d6544e4e7.png)
![Screenshot 2019-07-09 at 17 25 53](https://user-images.githubusercontent.com/16742525/60973902-c2e4a480-a331-11e9-8cec-41756e523c55.png)


