### PR TITLE
fix: links should not recreate a styled component on every render

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -121,7 +121,9 @@ exports[`1. a full article 1`] = `
     , The Times
   </span>
   Share
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -179,7 +181,9 @@ exports[`1. a full article 1`] = `
       </g>
     </svg>
   </a>
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -196,7 +200,9 @@ exports[`1. a full article 1`] = `
     </svg>
   </a>
   Save  
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={18}
@@ -289,12 +295,15 @@ exports[`1. a full article 1`] = `
   <nav>
     <a
       href="/topic/topic"
+      target={null}
     >
       Topic
     </a>
   </nav>
   Share
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -352,7 +361,9 @@ exports[`1. a full article 1`] = `
       </g>
     </svg>
   </a>
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -369,7 +380,9 @@ exports[`1. a full article 1`] = `
     </svg>
   </a>
   Save  
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={18}

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -136,7 +136,9 @@ exports[`1. a full article 1`] = `
     </figcaption>
   </figure>
   Share
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -194,7 +196,9 @@ exports[`1. a full article 1`] = `
       </g>
     </svg>
   </a>
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -211,7 +215,9 @@ exports[`1. a full article 1`] = `
     </svg>
   </a>
   Save  
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={18}
@@ -304,12 +310,15 @@ exports[`1. a full article 1`] = `
   <nav>
     <a
       href="/topic/topic"
+      target={null}
     >
       Topic
     </a>
   </nav>
   Share
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -367,7 +376,9 @@ exports[`1. a full article 1`] = `
       </g>
     </svg>
   </a>
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -384,7 +395,9 @@ exports[`1. a full article 1`] = `
     </svg>
   </a>
   Save  
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={18}

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -121,7 +121,9 @@ exports[`1. a full article 1`] = `
     </figcaption>
   </figure>
   Share
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -179,7 +181,9 @@ exports[`1. a full article 1`] = `
       </g>
     </svg>
   </a>
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -196,7 +200,9 @@ exports[`1. a full article 1`] = `
     </svg>
   </a>
   Save  
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={18}
@@ -289,12 +295,15 @@ exports[`1. a full article 1`] = `
   <nav>
     <a
       href="/topic/topic"
+      target={null}
     >
       Topic
     </a>
   </nav>
   Share
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -352,7 +361,9 @@ exports[`1. a full article 1`] = `
       </g>
     </svg>
   </a>
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -369,7 +380,9 @@ exports[`1. a full article 1`] = `
     </svg>
   </a>
   Save  
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={18}

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -115,7 +115,9 @@ exports[`1. a full article 1`] = `
     , The Times
   </span>
   Share
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -173,7 +175,9 @@ exports[`1. a full article 1`] = `
       </g>
     </svg>
   </a>
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -190,7 +194,9 @@ exports[`1. a full article 1`] = `
     </svg>
   </a>
   Save  
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={18}
@@ -283,12 +289,15 @@ exports[`1. a full article 1`] = `
   <nav>
     <a
       href="/topic/topic"
+      target={null}
     >
       Topic
     </a>
   </nav>
   Share
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -346,7 +355,9 @@ exports[`1. a full article 1`] = `
       </g>
     </svg>
   </a>
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -363,7 +374,9 @@ exports[`1. a full article 1`] = `
     </svg>
   </a>
   Save  
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={18}

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -107,6 +107,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
   <nav>
     <a
       href="/topic/topic"
+      target={null}
     >
       Topic
     </a>
@@ -149,7 +150,9 @@ exports[`1. a full article with an image as the lead asset 1`] = `
     </span>
   </span>
   Share
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -207,7 +210,9 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       </g>
     </svg>
   </a>
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -224,7 +229,9 @@ exports[`1. a full article with an image as the lead asset 1`] = `
     </svg>
   </a>
   Save  
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={18}
@@ -317,12 +324,15 @@ exports[`1. a full article with an image as the lead asset 1`] = `
   <nav>
     <a
       href="/topic/topic"
+      target={null}
     >
       Topic
     </a>
   </nav>
   Share
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -380,7 +390,9 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       </g>
     </svg>
   </a>
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={15}
@@ -397,7 +409,9 @@ exports[`1. a full article with an image as the lead asset 1`] = `
     </svg>
   </a>
   Save  
-  <a>
+  <a
+    target={null}
+  >
     <svg
       aria-label="[title]"
       height={18}

--- a/packages/article-skeleton/__tests__/mocks.web.js
+++ b/packages/article-skeleton/__tests__/mocks.web.js
@@ -25,7 +25,11 @@ jest.mock("@times-components/date-publication", () => "DatePublication");
 jest.mock("@times-components/image", () => "Image");
 jest.mock("@times-components/interactive-wrapper", () => "InteractiveWrapper");
 jest.mock("@times-components/key-facts", () => "KeyFacts");
-jest.mock("@times-components/link", () => "Link");
+jest.mock("@times-components/link", () => ({
+  __esModule: true,
+  default: "Link",
+  TextLink: "TextLink"
+}));
 jest.mock("@times-components/pull-quote", () => "PullQuote");
 jest.mock("@times-components/related-articles", () => "RelatedArticles");
 jest.mock("@times-components/video-label", () => "VideoLabel");

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-link.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-link.web.test.js.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Article Link should render with the dropCap link not underlined 1`] = `
-<a
-  class="linkweb__RespLink-yfb9n-0 dbQloS"
-  href="www.example.com"
+<Link
   target="target"
+  underlined={false}
+  url="www.example.com"
 >
   A
-</a>
+</Link>
 `;
 
 exports[`Article Link should render with the link underlined 1`] = `
-<a
-  class="linkweb__RespLink-yfb9n-0 eiSqrz"
-  href="www.example.com"
+<Link
   target="target"
+  underlined={true}
+  url="www.example.com"
 >
   a link
-</a>
+</Link>
 `;

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-link.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-link.web.test.js.snap
@@ -2,9 +2,8 @@
 
 exports[`Article Link should render with the dropCap link not underlined 1`] = `
 <a
-  class="linkweb-yfb9n-0 hNmDnn"
+  class="linkweb__RespLink-yfb9n-0 dbQloS"
   href="www.example.com"
-  style="text-decoration:none"
   target="target"
 >
   A
@@ -13,9 +12,8 @@ exports[`Article Link should render with the dropCap link not underlined 1`] = `
 
 exports[`Article Link should render with the link underlined 1`] = `
 <a
-  class="linkweb-yfb9n-0 hNmDnn"
+  class="linkweb__RespLink-yfb9n-0 eiSqrz"
   href="www.example.com"
-  style="text-decoration:underline"
   target="target"
 >
   a link

--- a/packages/article-skeleton/__tests__/web/article-link.web.test.js
+++ b/packages/article-skeleton/__tests__/web/article-link.web.test.js
@@ -1,13 +1,24 @@
 import React from "react";
-import { render } from "enzyme";
+import TestRenderer from "react-test-renderer";
 
 import {
   addSerializers,
   compose,
   enzymeTreeSerializer,
-  stylePrinter
+  minimaliseTransform,
+  minimalWebTransform,
+  print
 } from "@times-components/jest-serializer";
+
+import "../mocks.web";
 import ArticleLink from "../../src/article-body/article-link.web";
+
+const omitProps = new Set([
+  "article",
+  "className",
+  "responsiveLinkStyles",
+  "style"
+]);
 
 describe("Article Link", () => {
   const props = {
@@ -18,17 +29,25 @@ describe("Article Link", () => {
     children: ["A"]
   };
 
-  addSerializers(expect, enzymeTreeSerializer(), compose(stylePrinter));
+  addSerializers(
+    expect,
+    enzymeTreeSerializer(),
+    compose(
+      print,
+      minimalWebTransform,
+      minimaliseTransform((value, key) => omitProps.has(key))
+    )
+  );
 
   it("should render with the dropCap link not underlined", () => {
-    const component = render(<ArticleLink {...props} />);
-    expect(component).toMatchSnapshot();
+    const testRenderer = TestRenderer.create(<ArticleLink {...props} />);
+    expect(testRenderer).toMatchSnapshot();
   });
 
   it("should render with the link underlined", () => {
     props.children = ["a link"];
 
-    const component = render(<ArticleLink {...props} />);
-    expect(component).toMatchSnapshot();
+    const testRenderer = TestRenderer.create(<ArticleLink {...props} />);
+    expect(testRenderer).toMatchSnapshot();
   });
 });

--- a/packages/article-topics/__tests__/web/__snapshots__/article-topics-with-style.web.test.js.snap
+++ b/packages/article-topics/__tests__/web/__snapshots__/article-topics-with-style.web.test.js.snap
@@ -48,10 +48,6 @@ exports[`1. group of topics 1`] = `
   justify-content: center;
   margin-bottom: 10px;
 }
-
-.IS1 {
-  text-decoration: none;
-}
 </style>
 
 <div
@@ -61,7 +57,7 @@ exports[`1. group of topics 1`] = `
     className="css-view-1dbjc4n r-marginRight-zso239 r-marginTop-156q2ks S3"
   >
     <a
-      className="IS1"
+      className="linkweb__RespLink-yfb9n-0 ducvCA"
     >
       <div
         className="css-view-1dbjc4n r-borderColor-1kv57cf r-borderRadius-1jkafct r-borderWidth-rs99b7 r-paddingBottom-1mi0q7o r-paddingLeft-1yt7n81 r-paddingRight-ry3cjt r-paddingTop-m611by S2"
@@ -125,10 +121,6 @@ exports[`2. group of topics at large scale 1`] = `
   justify-content: center;
   margin-bottom: 10px;
 }
-
-.IS1 {
-  text-decoration: none;
-}
 </style>
 
 <div
@@ -138,7 +130,7 @@ exports[`2. group of topics at large scale 1`] = `
     className="css-view-1dbjc4n r-marginRight-zso239 r-marginTop-156q2ks S3"
   >
     <a
-      className="IS1"
+      className="linkweb__RespLink-yfb9n-0 ducvCA"
     >
       <div
         className="css-view-1dbjc4n r-borderColor-1kv57cf r-borderRadius-1jkafct r-borderWidth-rs99b7 r-paddingBottom-1mi0q7o r-paddingLeft-1yt7n81 r-paddingRight-ry3cjt r-paddingTop-m611by S2"
@@ -202,10 +194,6 @@ exports[`3. group of topics at xlarge scale 1`] = `
   justify-content: center;
   margin-bottom: 10px;
 }
-
-.IS1 {
-  text-decoration: none;
-}
 </style>
 
 <div
@@ -215,7 +203,7 @@ exports[`3. group of topics at xlarge scale 1`] = `
     className="css-view-1dbjc4n r-marginRight-zso239 r-marginTop-156q2ks S3"
   >
     <a
-      className="IS1"
+      className="linkweb__RespLink-yfb9n-0 ducvCA"
     >
       <div
         className="css-view-1dbjc4n r-borderColor-1kv57cf r-borderRadius-1jkafct r-borderWidth-rs99b7 r-paddingBottom-1mi0q7o r-paddingLeft-1yt7n81 r-paddingRight-ry3cjt r-paddingTop-m611by S2"

--- a/packages/article-topics/__tests__/web/__snapshots__/article-topics-with-style.web.test.js.snap
+++ b/packages/article-topics/__tests__/web/__snapshots__/article-topics-with-style.web.test.js.snap
@@ -57,7 +57,7 @@ exports[`1. group of topics 1`] = `
     className="css-view-1dbjc4n r-marginRight-zso239 r-marginTop-156q2ks S3"
   >
     <a
-      className="linkweb__RespLink-yfb9n-0 ducvCA"
+      className="linkweb__RespLink-yfb9n-0 cCCShB"
     >
       <div
         className="css-view-1dbjc4n r-borderColor-1kv57cf r-borderRadius-1jkafct r-borderWidth-rs99b7 r-paddingBottom-1mi0q7o r-paddingLeft-1yt7n81 r-paddingRight-ry3cjt r-paddingTop-m611by S2"
@@ -130,7 +130,7 @@ exports[`2. group of topics at large scale 1`] = `
     className="css-view-1dbjc4n r-marginRight-zso239 r-marginTop-156q2ks S3"
   >
     <a
-      className="linkweb__RespLink-yfb9n-0 ducvCA"
+      className="linkweb__RespLink-yfb9n-0 cCCShB"
     >
       <div
         className="css-view-1dbjc4n r-borderColor-1kv57cf r-borderRadius-1jkafct r-borderWidth-rs99b7 r-paddingBottom-1mi0q7o r-paddingLeft-1yt7n81 r-paddingRight-ry3cjt r-paddingTop-m611by S2"
@@ -203,7 +203,7 @@ exports[`3. group of topics at xlarge scale 1`] = `
     className="css-view-1dbjc4n r-marginRight-zso239 r-marginTop-156q2ks S3"
   >
     <a
-      className="linkweb__RespLink-yfb9n-0 ducvCA"
+      className="linkweb__RespLink-yfb9n-0 cCCShB"
     >
       <div
         className="css-view-1dbjc4n r-borderColor-1kv57cf r-borderRadius-1jkafct r-borderWidth-rs99b7 r-paddingBottom-1mi0q7o r-paddingLeft-1yt7n81 r-paddingRight-ry3cjt r-paddingTop-m611by S2"

--- a/packages/article-topics/__tests__/web/__snapshots__/article-topics.web.test.js.snap
+++ b/packages/article-topics/__tests__/web/__snapshots__/article-topics.web.test.js.snap
@@ -5,6 +5,7 @@ exports[`1. group of topics 1`] = `
   <div>
     <a
       href="/topic/football"
+      target={null}
     >
       <div>
         <div
@@ -19,6 +20,7 @@ exports[`1. group of topics 1`] = `
   <div>
     <a
       href="/topic/manchester-united"
+      target={null}
     >
       <div>
         <div
@@ -33,6 +35,7 @@ exports[`1. group of topics 1`] = `
   <div>
     <a
       href="/topic/chelsea"
+      target={null}
     >
       <div>
         <div
@@ -47,6 +50,7 @@ exports[`1. group of topics 1`] = `
   <div>
     <a
       href="/topic/arsenal"
+      target={null}
     >
       <div>
         <div
@@ -61,6 +65,7 @@ exports[`1. group of topics 1`] = `
   <div>
     <a
       href="/topic/rugby-union"
+      target={null}
     >
       <div>
         <div

--- a/packages/link/__tests__/web/__snapshots__/link.web.test.js.snap
+++ b/packages/link/__tests__/web/__snapshots__/link.web.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`1. with responsive styles 1`] = `
 .c0 {
+  -webkit-text-decoration: underline !important;
+  text-decoration: underline !important;
   color: #006699;
   font-family: "TimesDigitalW04-Regular";
   font-size: 17px;
@@ -20,24 +22,20 @@ exports[`1. with responsive styles 1`] = `
 <a
   className="c0"
   href="http://thetimes.co.uk"
-  style={
-    Object {
-      "textDecoration": "underline",
-    }
-  }
 >
   The Times
 </a>
 `;
 
 exports[`2. with a target 1`] = `
+.c0 {
+  -webkit-text-decoration: none !important;
+  text-decoration: none !important;
+}
+
 <a
+  className="c0"
   href="http://thetimes.co.uk"
-  style={
-    Object {
-      "textDecoration": "none",
-    }
-  }
   target="_blank"
 >
   The Times
@@ -45,26 +43,28 @@ exports[`2. with a target 1`] = `
 `;
 
 exports[`3. renders link 1`] = `
+.c0 {
+  -webkit-text-decoration: none !important;
+  text-decoration: none !important;
+}
+
 <a
+  className="c0"
   href="http://thetimes.co.uk"
-  style={
-    Object {
-      "textDecoration": "none",
-    }
-  }
 >
   The Times
 </a>
 `;
 
 exports[`4. renders link with target 1`] = `
+.c0 {
+  -webkit-text-decoration: none !important;
+  text-decoration: none !important;
+}
+
 <a
+  className="c0"
   href="http://thetimes.co.uk"
-  style={
-    Object {
-      "textDecoration": "none",
-    }
-  }
   target="_blank"
 >
   The Times

--- a/packages/link/__tests__/web/__snapshots__/link.web.test.js.snap
+++ b/packages/link/__tests__/web/__snapshots__/link.web.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`1. with responsive styles 1`] = `
 .c0 {
-  -webkit-text-decoration: underline !important;
-  text-decoration: underline !important;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
   color: #006699;
   font-family: "TimesDigitalW04-Regular";
   font-size: 17px;
@@ -22,6 +22,7 @@ exports[`1. with responsive styles 1`] = `
 <a
   className="c0"
   href="http://thetimes.co.uk"
+  target={null}
 >
   The Times
 </a>
@@ -29,8 +30,8 @@ exports[`1. with responsive styles 1`] = `
 
 exports[`2. with a target 1`] = `
 .c0 {
-  -webkit-text-decoration: none !important;
-  text-decoration: none !important;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 <a
@@ -44,13 +45,14 @@ exports[`2. with a target 1`] = `
 
 exports[`3. renders link 1`] = `
 .c0 {
-  -webkit-text-decoration: none !important;
-  text-decoration: none !important;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 <a
   className="c0"
   href="http://thetimes.co.uk"
+  target={null}
 >
   The Times
 </a>
@@ -58,8 +60,8 @@ exports[`3. renders link 1`] = `
 
 exports[`4. renders link with target 1`] = `
 .c0 {
-  -webkit-text-decoration: none !important;
-  text-decoration: none !important;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 <a

--- a/packages/link/link.showcase.js
+++ b/packages/link/link.showcase.js
@@ -38,6 +38,37 @@ export default {
       type: "story"
     },
     {
+      component: (_, { action }) => {
+        const responsiveLinkStyles = {
+          base: `
+            height: 100px;
+            width: 100px;
+            display: block;
+            background-color: red;
+            color: white;
+          `,
+          medium: `
+            background-color: blue;
+          `
+        };
+
+        return (
+          <Link
+            onPress={action("onPress")}
+            url="https://thetimes.co.uk"
+            target="_blank"
+            responsiveLinkStyles={responsiveLinkStyles}
+            underlined={false}
+          >
+            resize me
+          </Link>
+        );
+      },
+      name: "Responsive Link",
+      type: "story",
+      platform: "web"
+    },
+    {
       component: (_, { action }) => (
         <Link
           onPress={e => {

--- a/packages/link/src/link.web.js
+++ b/packages/link/src/link.web.js
@@ -1,63 +1,56 @@
+/* eslint-disable react/require-default-props */
 import React from "react";
 import styled from "styled-components";
 import { breakpoints } from "@times-components/styleguide";
 import PropTypes from "prop-types";
 
-const RespLink = responsiveLinkStyles =>
-  styled.a`
-    ${responsiveLinkStyles.base} @media (min-width: ${breakpoints.medium}px) {
-      ${responsiveLinkStyles.medium};
-    }
-  `;
+const respStylesSelector = selector => ({ responsiveLinkStyles }) =>
+  (responsiveLinkStyles && responsiveLinkStyles[selector]) || "";
+
+const RespLink = styled.a`
+  text-decoration: ${props =>
+    props.underlined && props.responsiveLinkStyles
+      ? "underline"
+      : "none"} !important;
+
+  ${respStylesSelector("base")};
+
+  @media (min-width: ${breakpoints.medium}px) {
+    ${respStylesSelector("medium")};
+  }
+`;
 
 const Link = ({
   children,
-  onPress,
-  responsiveLinkStyles,
-  target,
   url,
-  underlined
+  onPress = () => {},
+  target = null,
+  underlined = true,
+  responsiveLinkStyles = null
 }) => {
-  const Wrapper =
-    responsiveLinkStyles !== null ? RespLink(responsiveLinkStyles) : "a";
+  const props = Object.assign(
+    { underlined },
+    target ? { target } : {},
+    responsiveLinkStyles ? { responsiveLinkStyles } : {}
+  );
 
-  const style =
-    underlined && responsiveLinkStyles
-      ? { textDecoration: "underline" }
-      : { textDecoration: "none" };
-
-  const props = {
-    href: url,
-    onClick: onPress,
-    style
-  };
-
-  return target ? (
-    <Wrapper {...props} target={target}>
+  return (
+    <RespLink href={url} onClick={onPress} {...props}>
       {children}
-    </Wrapper>
-  ) : (
-    <Wrapper {...props}>{children}</Wrapper>
+    </RespLink>
   );
 };
 
 Link.propTypes = {
   children: PropTypes.node.isRequired,
+  url: PropTypes.string.isRequired,
   onPress: PropTypes.func,
+  target: PropTypes.string,
+  underlined: PropTypes.bool,
   responsiveLinkStyles: PropTypes.shape({
     base: PropTypes.string,
     medium: PropTypes.string
-  }),
-  target: PropTypes.string,
-  url: PropTypes.string.isRequired,
-  underlined: PropTypes.bool
-};
-
-Link.defaultProps = {
-  onPress: () => {},
-  responsiveLinkStyles: null,
-  target: null,
-  underlined: true
+  })
 };
 
 export default Link;

--- a/packages/link/src/link.web.js
+++ b/packages/link/src/link.web.js
@@ -9,9 +9,7 @@ const respStylesSelector = selector => ({ responsiveLinkStyles }) =>
 
 const RespLink = styled.a`
   text-decoration: ${props =>
-    props.underlined && props.responsiveLinkStyles
-      ? "underline"
-      : "none"} !important;
+    props.underlined && props.responsiveLinkStyles ? "underline" : "none"};
 
   ${respStylesSelector("base")};
 
@@ -28,11 +26,11 @@ const Link = ({
   underlined = true,
   responsiveLinkStyles = null
 }) => {
-  const props = Object.assign(
-    { underlined },
-    target ? { target } : {},
-    responsiveLinkStyles ? { responsiveLinkStyles } : {}
-  );
+  const props = {
+    underlined,
+    target,
+    responsiveLinkStyles
+  };
 
   return (
     <RespLink href={url} onClick={onPress} {...props}>

--- a/packages/pagination/__tests__/web/__snapshots__/pagination-with-styles.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination-with-styles.web.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`1. renders 1`] = `
 .c4 {
-  -webkit-text-decoration: none !important;
-  text-decoration: none !important;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .c5 {
@@ -158,11 +158,14 @@ exports[`1. renders 1`] = `
           >
             <linkweb__RespLink
               href="?mock-1"
+              responsiveLinkStyles={null}
+              target={null}
               underlined={true}
             >
               <a
                 className="c4"
                 href="?mock-1"
+                target={null}
               >
                 <div
                   className="css-view-1dbjc4n r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingBottom-xd6kpl r-paddingTop-m611by S3"
@@ -195,11 +198,14 @@ exports[`1. renders 1`] = `
           >
             <linkweb__RespLink
               href="?mock-3"
+              responsiveLinkStyles={null}
+              target={null}
               underlined={true}
             >
               <a
                 className="c4"
                 href="?mock-3"
+                target={null}
               >
                 <div
                   className="css-view-1dbjc4n r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingBottom-xd6kpl r-paddingTop-m611by S3"

--- a/packages/pagination/__tests__/web/__snapshots__/pagination-with-styles.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination-with-styles.web.test.js.snap
@@ -2,6 +2,11 @@
 
 exports[`1. renders 1`] = `
 .c4 {
+  -webkit-text-decoration: none !important;
+  text-decoration: none !important;
+}
+
+.c5 {
   display: none;
 }
 
@@ -56,7 +61,7 @@ exports[`1. renders 1`] = `
 }
 
 @media (min-width:768px) {
-  .c4 {
+  .c5 {
     display: inline;
   }
 }
@@ -125,14 +130,6 @@ exports[`1. renders 1`] = `
   margin-right: 10px;
   text-align: right;
 }
-
-.IS1 {
-  text-decoration: none;
-}
-
-.IS2 {
-  text-decoration: none;
-}
 </style>
 
 <pagination-containerweb__ContainerWithResults>
@@ -159,64 +156,74 @@ exports[`1. renders 1`] = `
           <div
             className="c3 responsiveweb__LinkContainer-sc-10qy9xl-0 c3 css-view-1dbjc4n"
           >
-            <a
-              className="IS1"
+            <linkweb__RespLink
               href="?mock-1"
+              underlined={true}
             >
-              <div
-                className="css-view-1dbjc4n r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingBottom-xd6kpl r-paddingTop-m611by S3"
-                data-testid="pagination-button-previous"
+              <a
+                className="c4"
+                href="?mock-1"
               >
                 <div
-                  className="css-text-901oao r-color-j7kcqb r-fontFamily-j2s0nr r-fontSize-a023e6 r-height-14g73ha r-lineHeight-fxxt2n r-marginLeft-1n0xq6e r-textAlign-fdjqy7 S2"
+                  className="css-view-1dbjc4n r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingBottom-xd6kpl r-paddingTop-m611by S3"
+                  data-testid="pagination-button-previous"
                 >
-                  <span
-                    className="css-text-901oao css-textHasAncestor-16my406"
+                  <div
+                    className="css-text-901oao r-color-j7kcqb r-fontFamily-j2s0nr r-fontSize-a023e6 r-height-14g73ha r-lineHeight-fxxt2n r-marginLeft-1n0xq6e r-textAlign-fdjqy7 S2"
                   >
-                    Previous
-                    <page-labelweb__ResponsiveLabel>
-                      <span
-                        className="c4 page-labelweb__ResponsiveLabel-sc-1gpr097-0 c4 css-text-901oao css-textHasAncestor-16my406"
-                      >
-                         page
-                      </span>
-                    </page-labelweb__ResponsiveLabel>
-                  </span>
+                    <span
+                      className="css-text-901oao css-textHasAncestor-16my406"
+                    >
+                      Previous
+                      <page-labelweb__ResponsiveLabel>
+                        <span
+                          className="c5 page-labelweb__ResponsiveLabel-sc-1gpr097-0 c5 css-text-901oao css-textHasAncestor-16my406"
+                        >
+                           page
+                        </span>
+                      </page-labelweb__ResponsiveLabel>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </a>
+              </a>
+            </linkweb__RespLink>
           </div>
         </responsiveweb__LinkContainer>
         <responsiveweb__LinkContainer>
           <div
             className="c3 responsiveweb__LinkContainer-sc-10qy9xl-0 c3 css-view-1dbjc4n"
           >
-            <a
-              className="IS2"
+            <linkweb__RespLink
               href="?mock-3"
+              underlined={true}
             >
-              <div
-                className="css-view-1dbjc4n r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingBottom-xd6kpl r-paddingTop-m611by S3"
-                data-testid="pagination-button-next"
+              <a
+                className="c4"
+                href="?mock-3"
               >
                 <div
-                  className="css-text-901oao r-color-j7kcqb r-fontFamily-j2s0nr r-fontSize-a023e6 r-height-14g73ha r-lineHeight-fxxt2n r-marginRight-zso239 r-textAlign-1ff274t S4"
+                  className="css-view-1dbjc4n r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingBottom-xd6kpl r-paddingTop-m611by S3"
+                  data-testid="pagination-button-next"
                 >
-                  <span
-                    className="css-text-901oao css-textHasAncestor-16my406"
+                  <div
+                    className="css-text-901oao r-color-j7kcqb r-fontFamily-j2s0nr r-fontSize-a023e6 r-height-14g73ha r-lineHeight-fxxt2n r-marginRight-zso239 r-textAlign-1ff274t S4"
                   >
-                    Next
-                    <page-labelweb__ResponsiveLabel>
-                      <span
-                        className="c4 page-labelweb__ResponsiveLabel-sc-1gpr097-0 c4 css-text-901oao css-textHasAncestor-16my406"
-                      >
-                         page
-                      </span>
-                    </page-labelweb__ResponsiveLabel>
-                  </span>
+                    <span
+                      className="css-text-901oao css-textHasAncestor-16my406"
+                    >
+                      Next
+                      <page-labelweb__ResponsiveLabel>
+                        <span
+                          className="c5 page-labelweb__ResponsiveLabel-sc-1gpr097-0 c5 css-text-901oao css-textHasAncestor-16my406"
+                        >
+                           page
+                        </span>
+                      </page-labelweb__ResponsiveLabel>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </a>
+              </a>
+            </linkweb__RespLink>
           </div>
         </responsiveweb__LinkContainer>
       </div>

--- a/packages/pagination/__tests__/web/__snapshots__/pagination.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination.web.test.js.snap
@@ -16,10 +16,13 @@ exports[`1. renders results, previous and next 1`] = `
           <div>
             <linkweb__RespLink
               href="?mock-4"
+              responsiveLinkStyles={null}
+              target={null}
               underlined={true}
             >
               <a
                 href="?mock-4"
+                target={null}
               >
                 <div>
                   <svg
@@ -54,10 +57,13 @@ exports[`1. renders results, previous and next 1`] = `
           <div>
             <linkweb__RespLink
               href="?mock-6"
+              responsiveLinkStyles={null}
+              target={null}
               underlined={true}
             >
               <a
                 href="?mock-6"
+                target={null}
               >
                 <div>
                   <div>
@@ -103,10 +109,13 @@ exports[`2. renders with no results 1`] = `
           <div>
             <linkweb__RespLink
               href="?mock-4"
+              responsiveLinkStyles={null}
+              target={null}
               underlined={true}
             >
               <a
                 href="?mock-4"
+                target={null}
               >
                 <div>
                   <svg
@@ -141,10 +150,13 @@ exports[`2. renders with no results 1`] = `
           <div>
             <linkweb__RespLink
               href="?mock-6"
+              responsiveLinkStyles={null}
+              target={null}
               underlined={true}
             >
               <a
                 href="?mock-6"
+                target={null}
               >
                 <div>
                   <div>
@@ -221,10 +233,13 @@ exports[`4. limits the starting result to the total count 1`] = `
           <div>
             <linkweb__RespLink
               href="?mock-3"
+              responsiveLinkStyles={null}
+              target={null}
               underlined={true}
             >
               <a
                 href="?mock-3"
+                target={null}
               >
                 <div>
                   <svg
@@ -273,10 +288,13 @@ exports[`5. renders previous and not next 1`] = `
           <div>
             <linkweb__RespLink
               href="?mock-4"
+              responsiveLinkStyles={null}
+              target={null}
               underlined={true}
             >
               <a
                 href="?mock-4"
+                target={null}
               >
                 <div>
                   <svg
@@ -328,10 +346,13 @@ exports[`6. renders next and not previous 1`] = `
           <div>
             <linkweb__RespLink
               href="?mock-2"
+              responsiveLinkStyles={null}
+              target={null}
               underlined={true}
             >
               <a
                 href="?mock-2"
+                target={null}
               >
                 <div>
                   <div>

--- a/packages/pagination/__tests__/web/__snapshots__/pagination.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination.web.test.js.snap
@@ -14,68 +14,78 @@ exports[`1. renders results, previous and next 1`] = `
       <div>
         <responsiveweb__LinkContainer>
           <div>
-            <a
+            <linkweb__RespLink
               href="?mock-4"
+              underlined={true}
             >
-              <div>
-                <svg
-                  height={12}
-                  viewBox="42 12 60 120"
-                  width={7}
-                >
-                  <g
-                    fill="#006699"
-                  >
-                    <path
-                      d="8cd5ea7b91eea38d77fd9ad20f3573cb"
-                    />
-                  </g>
-                </svg>
+              <a
+                href="?mock-4"
+              >
                 <div>
-                  <span>
-                    Previous
-                    <page-labelweb__ResponsiveLabel>
-                      <span>
-                         page
-                      </span>
-                    </page-labelweb__ResponsiveLabel>
-                  </span>
+                  <svg
+                    height={12}
+                    viewBox="42 12 60 120"
+                    width={7}
+                  >
+                    <g
+                      fill="#006699"
+                    >
+                      <path
+                        d="8cd5ea7b91eea38d77fd9ad20f3573cb"
+                      />
+                    </g>
+                  </svg>
+                  <div>
+                    <span>
+                      Previous
+                      <page-labelweb__ResponsiveLabel>
+                        <span>
+                           page
+                        </span>
+                      </page-labelweb__ResponsiveLabel>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </a>
+              </a>
+            </linkweb__RespLink>
           </div>
         </responsiveweb__LinkContainer>
         <responsiveweb__LinkContainer>
           <div>
-            <a
+            <linkweb__RespLink
               href="?mock-6"
+              underlined={true}
             >
-              <div>
+              <a
+                href="?mock-6"
+              >
                 <div>
-                  <span>
-                    Next
-                    <page-labelweb__ResponsiveLabel>
-                      <span>
-                         page
-                      </span>
-                    </page-labelweb__ResponsiveLabel>
-                  </span>
-                </div>
-                <svg
-                  height={12}
-                  viewBox="42 12 60 120"
-                  width={7}
-                >
-                  <g
-                    fill="#006699"
+                  <div>
+                    <span>
+                      Next
+                      <page-labelweb__ResponsiveLabel>
+                        <span>
+                           page
+                        </span>
+                      </page-labelweb__ResponsiveLabel>
+                    </span>
+                  </div>
+                  <svg
+                    height={12}
+                    viewBox="42 12 60 120"
+                    width={7}
                   >
-                    <path
-                      d="9a11f164df72df4cb9ea6a3266824472"
-                    />
-                  </g>
-                </svg>
-              </div>
-            </a>
+                    <g
+                      fill="#006699"
+                    >
+                      <path
+                        d="9a11f164df72df4cb9ea6a3266824472"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </a>
+            </linkweb__RespLink>
           </div>
         </responsiveweb__LinkContainer>
       </div>
@@ -91,68 +101,78 @@ exports[`2. renders with no results 1`] = `
       <div>
         <responsiveweb__LinkContainer>
           <div>
-            <a
+            <linkweb__RespLink
               href="?mock-4"
+              underlined={true}
             >
-              <div>
-                <svg
-                  height={12}
-                  viewBox="42 12 60 120"
-                  width={7}
-                >
-                  <g
-                    fill="#006699"
-                  >
-                    <path
-                      d="8cd5ea7b91eea38d77fd9ad20f3573cb"
-                    />
-                  </g>
-                </svg>
+              <a
+                href="?mock-4"
+              >
                 <div>
-                  <span>
-                    Previous
-                    <page-labelweb__ResponsiveLabel>
-                      <span>
-                         page
-                      </span>
-                    </page-labelweb__ResponsiveLabel>
-                  </span>
+                  <svg
+                    height={12}
+                    viewBox="42 12 60 120"
+                    width={7}
+                  >
+                    <g
+                      fill="#006699"
+                    >
+                      <path
+                        d="8cd5ea7b91eea38d77fd9ad20f3573cb"
+                      />
+                    </g>
+                  </svg>
+                  <div>
+                    <span>
+                      Previous
+                      <page-labelweb__ResponsiveLabel>
+                        <span>
+                           page
+                        </span>
+                      </page-labelweb__ResponsiveLabel>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </a>
+              </a>
+            </linkweb__RespLink>
           </div>
         </responsiveweb__LinkContainer>
         <responsiveweb__LinkContainer>
           <div>
-            <a
+            <linkweb__RespLink
               href="?mock-6"
+              underlined={true}
             >
-              <div>
+              <a
+                href="?mock-6"
+              >
                 <div>
-                  <span>
-                    Next
-                    <page-labelweb__ResponsiveLabel>
-                      <span>
-                         page
-                      </span>
-                    </page-labelweb__ResponsiveLabel>
-                  </span>
-                </div>
-                <svg
-                  height={12}
-                  viewBox="42 12 60 120"
-                  width={7}
-                >
-                  <g
-                    fill="#006699"
+                  <div>
+                    <span>
+                      Next
+                      <page-labelweb__ResponsiveLabel>
+                        <span>
+                           page
+                        </span>
+                      </page-labelweb__ResponsiveLabel>
+                    </span>
+                  </div>
+                  <svg
+                    height={12}
+                    viewBox="42 12 60 120"
+                    width={7}
                   >
-                    <path
-                      d="9a11f164df72df4cb9ea6a3266824472"
-                    />
-                  </g>
-                </svg>
-              </div>
-            </a>
+                    <g
+                      fill="#006699"
+                    >
+                      <path
+                        d="9a11f164df72df4cb9ea6a3266824472"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </a>
+            </linkweb__RespLink>
           </div>
         </responsiveweb__LinkContainer>
       </div>
@@ -199,35 +219,40 @@ exports[`4. limits the starting result to the total count 1`] = `
       <div>
         <responsiveweb__LinkContainer>
           <div>
-            <a
+            <linkweb__RespLink
               href="?mock-3"
+              underlined={true}
             >
-              <div>
-                <svg
-                  height={12}
-                  viewBox="42 12 60 120"
-                  width={7}
-                >
-                  <g
-                    fill="#006699"
-                  >
-                    <path
-                      d="8cd5ea7b91eea38d77fd9ad20f3573cb"
-                    />
-                  </g>
-                </svg>
+              <a
+                href="?mock-3"
+              >
                 <div>
-                  <span>
-                    Previous
-                    <page-labelweb__ResponsiveLabel>
-                      <span>
-                         page
-                      </span>
-                    </page-labelweb__ResponsiveLabel>
-                  </span>
+                  <svg
+                    height={12}
+                    viewBox="42 12 60 120"
+                    width={7}
+                  >
+                    <g
+                      fill="#006699"
+                    >
+                      <path
+                        d="8cd5ea7b91eea38d77fd9ad20f3573cb"
+                      />
+                    </g>
+                  </svg>
+                  <div>
+                    <span>
+                      Previous
+                      <page-labelweb__ResponsiveLabel>
+                        <span>
+                           page
+                        </span>
+                      </page-labelweb__ResponsiveLabel>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </a>
+              </a>
+            </linkweb__RespLink>
           </div>
         </responsiveweb__LinkContainer>
         <responsiveweb__LinkContainer>
@@ -246,35 +271,40 @@ exports[`5. renders previous and not next 1`] = `
       <div>
         <responsiveweb__LinkContainer>
           <div>
-            <a
+            <linkweb__RespLink
               href="?mock-4"
+              underlined={true}
             >
-              <div>
-                <svg
-                  height={12}
-                  viewBox="42 12 60 120"
-                  width={7}
-                >
-                  <g
-                    fill="#006699"
-                  >
-                    <path
-                      d="8cd5ea7b91eea38d77fd9ad20f3573cb"
-                    />
-                  </g>
-                </svg>
+              <a
+                href="?mock-4"
+              >
                 <div>
-                  <span>
-                    Previous
-                    <page-labelweb__ResponsiveLabel>
-                      <span>
-                         page
-                      </span>
-                    </page-labelweb__ResponsiveLabel>
-                  </span>
+                  <svg
+                    height={12}
+                    viewBox="42 12 60 120"
+                    width={7}
+                  >
+                    <g
+                      fill="#006699"
+                    >
+                      <path
+                        d="8cd5ea7b91eea38d77fd9ad20f3573cb"
+                      />
+                    </g>
+                  </svg>
+                  <div>
+                    <span>
+                      Previous
+                      <page-labelweb__ResponsiveLabel>
+                        <span>
+                           page
+                        </span>
+                      </page-labelweb__ResponsiveLabel>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </a>
+              </a>
+            </linkweb__RespLink>
           </div>
         </responsiveweb__LinkContainer>
         <responsiveweb__LinkContainer>
@@ -296,35 +326,40 @@ exports[`6. renders next and not previous 1`] = `
         </responsiveweb__LinkContainer>
         <responsiveweb__LinkContainer>
           <div>
-            <a
+            <linkweb__RespLink
               href="?mock-2"
+              underlined={true}
             >
-              <div>
+              <a
+                href="?mock-2"
+              >
                 <div>
-                  <span>
-                    Next
-                    <page-labelweb__ResponsiveLabel>
-                      <span>
-                         page
-                      </span>
-                    </page-labelweb__ResponsiveLabel>
-                  </span>
-                </div>
-                <svg
-                  height={12}
-                  viewBox="42 12 60 120"
-                  width={7}
-                >
-                  <g
-                    fill="#006699"
+                  <div>
+                    <span>
+                      Next
+                      <page-labelweb__ResponsiveLabel>
+                        <span>
+                           page
+                        </span>
+                      </page-labelweb__ResponsiveLabel>
+                    </span>
+                  </div>
+                  <svg
+                    height={12}
+                    viewBox="42 12 60 120"
+                    width={7}
                   >
-                    <path
-                      d="9a11f164df72df4cb9ea6a3266824472"
-                    />
-                  </g>
-                </svg>
-              </div>
-            </a>
+                    <g
+                      fill="#006699"
+                    >
+                      <path
+                        d="9a11f164df72df4cb9ea6a3266824472"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </a>
+            </linkweb__RespLink>
           </div>
         </responsiveweb__LinkContainer>
       </div>

--- a/packages/save-star-web/__tests__/web/__snapshots__/save-star-web.test.js.snap
+++ b/packages/save-star-web/__tests__/web/__snapshots__/save-star-web.test.js.snap
@@ -41,7 +41,9 @@ Array [
   <div>
     Saved
   </div>,
-  <a>
+  <a
+    target={null}
+  >
     <div>
       <svg
         aria-label="[title]"
@@ -69,7 +71,9 @@ Array [
   <div>
     Save  
   </div>,
-  <a>
+  <a
+    target={null}
+  >
     <div>
       <svg
         aria-label="[title]"


### PR DESCRIPTION
Currently, links re-create a styled-component on every single render, forcing both styled-components and react to do more work than necessary. I've updated the component to use `styled-components`'  prop interpalation feature instead.

In the long term, I think we should deprecate and/or remove `responsiveLinkStyles` as it doesn't seem like a useful abstraction and isn't great for performance, and is also not supported on native platforms, but I don't have a great view of how and why it is used. 

I also think we should add "cursor:pointer" as a default for all links, but didn't want to do that in this PR as it impacts more places. 

Todo: 

- [x] Remove the `!important` 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
