### PR TITLE
fix: (REPLAT-6982) update slices width for huge breakpoint

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1437,6 +1437,7 @@ exports[`20. lead two no pic and two - wide 1`] = `
     <View
       style={
         Object {
+          "paddingTop": 10,
           "width": "16%",
         }
       }
@@ -1906,6 +1907,7 @@ exports[`26. secondary two and two - wide 1`] = `
       Object {
         "flex": 1,
         "flexDirection": "row",
+        "marginHorizontal": 10,
       }
     }
   >
@@ -2294,40 +2296,50 @@ exports[`31. comment lead and cartoon - huge 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "flex": 1,
-        "flexDirection": "row",
-        "paddingRight": 20,
-        "paddingTop": 10,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "width": "33.3%",
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingRight": 20,
+          "paddingTop": 10,
         }
       }
     >
-      <TileAH />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "width": "33.3%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "66.7%",
+      >
+        <TileAH />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAI />
+      />
+      <View
+        style={
+          Object {
+            "width": "66.7%",
+          }
+        }
+      >
+        <TileAI />
+      </View>
     </View>
   </View>
 </View>
@@ -2354,176 +2366,184 @@ exports[`32. daily universal register - huge 1`] = `
     <View
       style={
         Object {
-          "alignItems": "center",
           "alignSelf": "center",
-          "backgroundColor": "#F0F0F0",
           "flex": 1,
-          "width": "86%",
+          "width": 1180,
         }
       }
     >
-      <Image
-        style={
-          Object {
-            "height": 73,
-            "marginVertical": 10,
-            "width": 285,
-          }
-        }
-      />
-      <Text
-        style={
-          Object {
-            "color": "#850029",
-            "fontFamily": "TimesDigitalW04",
-            "fontSize": 16,
-            "marginBottom": 25,
-          }
-        }
-      >
-        Daily Universal Register
-      </Text>
       <View
         style={
           Object {
-            "flexDirection": "row",
-            "paddingHorizontal": "8%",
-            "width": "100%",
+            "alignItems": "center",
+            "backgroundColor": "#F0F0F0",
+            "flex": 1,
           }
         }
       >
+        <Image
+          style={
+            Object {
+              "height": 73,
+              "marginVertical": 10,
+              "width": 285,
+            }
+          }
+        />
+        <Text
+          style={
+            Object {
+              "color": "#850029",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 16,
+              "marginBottom": 25,
+            }
+          }
+        >
+          Daily Universal Register
+        </Text>
         <View
           style={
             Object {
-              "alignItems": "center",
-              "flex": 1,
-              "flexDirection": "column",
-              "paddingHorizontal": 25,
+              "flexDirection": "row",
+              "paddingHorizontal": "8%",
+              "width": "100%",
             }
           }
         >
           <View
             style={
               Object {
-                "borderBottomColor": "#DBDBDB",
-                "borderBottomWidth": 1,
-                "borderColor": "#DBDBDB",
-                "borderStyle": "solid",
-                "marginHorizontal": 10,
-                "marginVertical": 25,
-                "width": "100%",
+                "alignItems": "center",
+                "flex": 1,
+                "flexDirection": "column",
+                "paddingHorizontal": 25,
               }
             }
-          />
-          <View>
-            <TileS />
+          >
+            <View
+              style={
+                Object {
+                  "borderBottomColor": "#DBDBDB",
+                  "borderBottomWidth": 1,
+                  "borderColor": "#DBDBDB",
+                  "borderStyle": "solid",
+                  "marginHorizontal": 10,
+                  "marginVertical": 25,
+                  "width": "100%",
+                }
+              }
+            />
+            <View>
+              <TileS />
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flex": 1,
+                "flexDirection": "column",
+                "paddingHorizontal": 25,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "borderBottomColor": "#DBDBDB",
+                  "borderBottomWidth": 1,
+                  "borderColor": "#DBDBDB",
+                  "borderStyle": "solid",
+                  "marginHorizontal": 10,
+                  "marginVertical": 25,
+                  "width": "100%",
+                }
+              }
+            />
+            <View>
+              <TileS />
+            </View>
           </View>
         </View>
         <View
           style={
             Object {
-              "alignItems": "center",
-              "flex": 1,
-              "flexDirection": "column",
-              "paddingHorizontal": 25,
+              "flexDirection": "row",
+              "paddingHorizontal": "8%",
+              "width": "100%",
             }
           }
         >
           <View
             style={
               Object {
-                "borderBottomColor": "#DBDBDB",
-                "borderBottomWidth": 1,
-                "borderColor": "#DBDBDB",
-                "borderStyle": "solid",
-                "marginHorizontal": 10,
-                "marginVertical": 25,
-                "width": "100%",
+                "alignItems": "center",
+                "flex": 1,
+                "flexDirection": "column",
+                "paddingHorizontal": 25,
               }
             }
-          />
-          <View>
-            <TileS />
+          >
+            <View
+              style={
+                Object {
+                  "borderBottomColor": "#DBDBDB",
+                  "borderBottomWidth": 1,
+                  "borderColor": "#DBDBDB",
+                  "borderStyle": "solid",
+                  "marginHorizontal": 10,
+                  "marginVertical": 25,
+                  "width": "100%",
+                }
+              }
+            />
+            <Image
+              style={
+                Object {
+                  "height": 45,
+                  "width": 60,
+                }
+              }
+            />
+            <View>
+              <TileS />
+            </View>
           </View>
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "flexDirection": "row",
-            "paddingHorizontal": "8%",
-            "width": "100%",
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "alignItems": "center",
-              "flex": 1,
-              "flexDirection": "column",
-              "paddingHorizontal": 25,
-            }
-          }
-        >
           <View
             style={
               Object {
-                "borderBottomColor": "#DBDBDB",
-                "borderBottomWidth": 1,
-                "borderColor": "#DBDBDB",
-                "borderStyle": "solid",
-                "marginHorizontal": 10,
-                "marginVertical": 25,
-                "width": "100%",
+                "alignItems": "center",
+                "flex": 1,
+                "flexDirection": "column",
+                "paddingHorizontal": 25,
               }
             }
-          />
-          <Image
-            style={
-              Object {
-                "height": 45,
-                "width": 60,
+          >
+            <View
+              style={
+                Object {
+                  "borderBottomColor": "#DBDBDB",
+                  "borderBottomWidth": 1,
+                  "borderColor": "#DBDBDB",
+                  "borderStyle": "solid",
+                  "marginHorizontal": 10,
+                  "marginVertical": 25,
+                  "width": "100%",
+                }
               }
-            }
-          />
-          <View>
-            <TileS />
-          </View>
-        </View>
-        <View
-          style={
-            Object {
-              "alignItems": "center",
-              "flex": 1,
-              "flexDirection": "column",
-              "paddingHorizontal": 25,
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "borderBottomColor": "#DBDBDB",
-                "borderBottomWidth": 1,
-                "borderColor": "#DBDBDB",
-                "borderStyle": "solid",
-                "marginHorizontal": 10,
-                "marginVertical": 25,
-                "width": "100%",
+            />
+            <Image
+              style={
+                Object {
+                  "height": 45,
+                  "width": 60,
+                }
               }
-            }
-          />
-          <Image
-            style={
-              Object {
-                "height": 45,
-                "width": 60,
-              }
-            }
-          />
-          <View>
-            <TileS />
+            />
+            <View>
+              <TileS />
+            </View>
           </View>
         </View>
       </View>
@@ -2548,39 +2568,47 @@ exports[`33. lead one and one - huge 1`] = `
       Object {
         "alignSelf": "center",
         "flex": 1,
-        "flexDirection": "row",
-        "marginHorizontal": 10,
-        "width": "86%",
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "width": "83.33%",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginHorizontal": 10,
         }
       }
     >
-      <TileU />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "width": "83.33%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "16.67%",
+      >
+        <TileU />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAQ />
+      />
+      <View
+        style={
+          Object {
+            "width": "16.67%",
+          }
+        }
+      >
+        <TileAQ />
+      </View>
     </View>
   </View>
 </View>
@@ -2597,7 +2625,17 @@ exports[`34. lead one full width - huge 1`] = `
     }
   }
 >
-  <TileR />
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
+      }
+    }
+  >
+    <TileR />
+  </View>
 </View>
 `;
 
@@ -2615,69 +2653,80 @@ exports[`35. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "flexDirection": "row",
-        "justifyContent": "center",
-        "paddingHorizontal": 10,
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "width": "36%",
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "paddingHorizontal": 10,
         }
       }
     >
-      <TileX />
       <View
         style={
           Object {
-            "borderBottomWidth": 1,
+            "width": "42%",
+          }
+        }
+      >
+        <TileX />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
+          }
+        />
+        <TileY />
+      </View>
+      <View
+        style={
+          Object {
             "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
             "borderStyle": "solid",
-            "marginHorizontal": 10,
+            "marginVertical": 10,
           }
         }
       />
-      <TileY />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "paddingTop": 10,
+            "width": "16%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "14%",
+      >
+        <TileAL />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAL />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "width": "42%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "36%",
-        }
-      }
-    >
-      <TileZ />
+      >
+        <TileZ />
+      </View>
     </View>
   </View>
 </View>
@@ -2743,61 +2792,71 @@ exports[`36. leaders slice - huge 1`] = `
     <View
       style={
         Object {
+          "alignSelf": "center",
           "flex": 1,
-          "flexDirection": "row",
-          "paddingBottom": 5,
+          "width": 1180,
         }
       }
     >
       <View
         style={
           Object {
-            "paddingHorizontal": 10,
-            "width": "33%",
+            "flex": 1,
+            "flexDirection": "row",
+            "paddingBottom": 5,
           }
         }
       >
-        <TileAG />
-      </View>
-      <View
-        style={
-          Object {
-            "borderColor": "#DBDBDB",
-            "borderRightWidth": 1,
-            "borderStyle": "solid",
-            "marginVertical": 10,
+        <View
+          style={
+            Object {
+              "paddingHorizontal": 10,
+              "width": "33%",
+            }
           }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingHorizontal": 10,
-            "width": "33%",
+        >
+          <TileAG />
+        </View>
+        <View
+          style={
+            Object {
+              "borderColor": "#DBDBDB",
+              "borderRightWidth": 1,
+              "borderStyle": "solid",
+              "marginVertical": 10,
+            }
           }
-        }
-      >
-        <TileAG />
-      </View>
-      <View
-        style={
-          Object {
-            "borderColor": "#DBDBDB",
-            "borderRightWidth": 1,
-            "borderStyle": "solid",
-            "marginVertical": 10,
+        />
+        <View
+          style={
+            Object {
+              "paddingHorizontal": 10,
+              "width": "33%",
+            }
           }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingHorizontal": 10,
-            "width": "33%",
+        >
+          <TileAG />
+        </View>
+        <View
+          style={
+            Object {
+              "borderColor": "#DBDBDB",
+              "borderRightWidth": 1,
+              "borderStyle": "solid",
+              "marginVertical": 10,
+            }
           }
-        }
-      >
-        <TileAG />
+        />
+        <View
+          style={
+            Object {
+              "paddingHorizontal": 10,
+              "width": "33%",
+            }
+          }
+        >
+          <TileAG />
+        </View>
       </View>
     </View>
   </View>
@@ -2825,8 +2884,9 @@ exports[`37. secondary one and four - huge 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": "#272D34",
-          "paddingHorizontal": 10,
+          "alignSelf": "center",
+          "flex": 1,
+          "width": 1180,
         }
       }
     >
@@ -2834,109 +2894,118 @@ exports[`37. secondary one and four - huge 1`] = `
         style={
           Object {
             "backgroundColor": "#272D34",
-            "flexDirection": "row",
-            "margin": 10,
-            "marginBottom": 10,
-          }
-        }
-      >
-        <TheTimesLogo />
-      </View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#4D4D4D",
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flexDirection": "row",
+            "paddingHorizontal": 10,
           }
         }
       >
         <View
           style={
             Object {
-              "width": "50%",
+              "backgroundColor": "#272D34",
+              "flexDirection": "row",
+              "margin": 10,
+              "marginBottom": 10,
             }
           }
         >
-          <View>
-            <TileN />
-          </View>
+          <TheTimesLogo />
         </View>
         <View
           style={
             Object {
-              "borderColor": "#4D4D4D",
-              "borderRightWidth": 1,
+              "borderBottomColor": "#4D4D4D",
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
               "borderStyle": "solid",
-              "marginVertical": 10,
+              "marginHorizontal": 10,
             }
           }
         />
         <View
           style={
             Object {
-              "width": "25%",
+              "flexDirection": "row",
             }
           }
         >
-          <View>
-            <TileO />
+          <View
+            style={
+              Object {
+                "width": "50%",
+              }
+            }
+          >
+            <View>
+              <TileN />
+            </View>
           </View>
           <View
             style={
               Object {
-                "borderBottomWidth": 1,
                 "borderColor": "#4D4D4D",
+                "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "marginHorizontal": 10,
+                "marginVertical": 10,
               }
             }
           />
-          <View>
-            <TileO />
-          </View>
-        </View>
-        <View
-          style={
-            Object {
-              "borderColor": "#4D4D4D",
-              "borderRightWidth": 1,
-              "borderStyle": "solid",
-              "marginVertical": 10,
+          <View
+            style={
+              Object {
+                "width": "25%",
+              }
             }
-          }
-        />
-        <View
-          style={
-            Object {
-              "width": "25%",
-            }
-          }
-        >
-          <View>
-            <TileO />
+          >
+            <View>
+              <TileO />
+            </View>
+            <View
+              style={
+                Object {
+                  "borderBottomWidth": 1,
+                  "borderColor": "#4D4D4D",
+                  "borderStyle": "solid",
+                  "marginHorizontal": 10,
+                }
+              }
+            />
+            <View>
+              <TileO />
+            </View>
           </View>
           <View
             style={
               Object {
-                "borderBottomWidth": 1,
                 "borderColor": "#4D4D4D",
+                "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "marginHorizontal": 10,
+                "marginVertical": 10,
               }
             }
           />
-          <View>
-            <TileO />
+          <View
+            style={
+              Object {
+                "width": "25%",
+              }
+            }
+          >
+            <View>
+              <TileO />
+            </View>
+            <View
+              style={
+                Object {
+                  "borderBottomWidth": 1,
+                  "borderColor": "#4D4D4D",
+                  "borderStyle": "solid",
+                  "marginHorizontal": 10,
+                }
+              }
+            />
+            <View>
+              <TileO />
+            </View>
           </View>
         </View>
       </View>
@@ -2956,7 +3025,17 @@ exports[`38. secondary one - huge 1`] = `
     }
   }
 >
-  <TileW />
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
+      }
+    }
+  >
+    <TileW />
+  </View>
 </View>
 `;
 
@@ -2974,80 +3053,90 @@ exports[`39. secondary four - huge 1`] = `
   <View
     style={
       Object {
-        "flexDirection": "row",
-        "marginHorizontal": 10,
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "flex": 1,
-          "width": "25%",
+          "flexDirection": "row",
+          "marginHorizontal": 10,
         }
       }
     >
-      <TileC />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "width": "25%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "width": "25%",
+      >
+        <TileC />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileC />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "width": "25%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "width": "25%",
+      >
+        <TileC />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileC />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "width": "25%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "width": "25%",
+      >
+        <TileC />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileC />
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "width": "25%",
+          }
+        }
+      >
+        <TileC />
+      </View>
     </View>
   </View>
 </View>
@@ -3067,41 +3156,51 @@ exports[`40. secondary one and columnist - huge 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "flex": 1,
-        "flexDirection": "row",
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "paddingLeft": 10,
-          "paddingTop": 10,
-          "width": "33%",
+          "flex": 1,
+          "flexDirection": "row",
         }
       }
     >
-      <TileAA />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingTop": 10,
+            "width": "33%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingRight": 10,
-          "width": "67%",
+      >
+        <TileAA />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAB />
+      />
+      <View
+        style={
+          Object {
+            "paddingRight": 10,
+            "width": "67%",
+          }
+        }
+      >
+        <TileAB />
+      </View>
     </View>
   </View>
 </View>
@@ -3122,78 +3221,86 @@ exports[`41. secondary two and two - huge 1`] = `
     style={
       Object {
         "alignSelf": "center",
-        "flexDirection": "row",
-        "width": "86%",
+        "flex": 1,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "width": "33.4%",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginHorizontal": 10,
         }
       }
     >
-      <TileAM />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "width": "33.4%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingHorizontal": 10,
-          "width": "16.6%",
+      >
+        <TileAM />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAN />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "width": "16.6%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "33.4%",
+      >
+        <TileAN />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAM />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "width": "33.4%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingHorizontal": 10,
-          "width": "16.6%",
+      >
+        <TileAM />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAN />
+      />
+      <View
+        style={
+          Object {
+            "width": "16.6%",
+          }
+        }
+      >
+        <TileAN />
+      </View>
     </View>
   </View>
 </View>
@@ -3213,73 +3320,83 @@ exports[`42. lead one and four slice - huge 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "flex": 1,
-        "flexDirection": "row",
-        "paddingHorizontal": 10,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "padding": 10,
-          "width": "50%",
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingHorizontal": 10,
         }
       }
     >
-      <TileAC />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "50%",
-        }
-      }
-    >
-      <TileAD />
       <View
         style={
           Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
+            "padding": 10,
+            "width": "50%",
           }
         }
-      />
-      <TileAD />
+      >
+        <TileAC />
+      </View>
       <View
         style={
           Object {
-            "borderBottomWidth": 1,
             "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
             "borderStyle": "solid",
-            "marginHorizontal": 10,
+            "marginVertical": 10,
           }
         }
       />
-      <TileAD />
       <View
         style={
           Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
+            "width": "50%",
           }
         }
-      />
-      <TileAD />
+      >
+        <TileAD />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
+          }
+        />
+        <TileAD />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
+          }
+        />
+        <TileAD />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
+          }
+        />
+        <TileAD />
+      </View>
     </View>
   </View>
 </View>
@@ -3299,58 +3416,68 @@ exports[`43. standard slice - huge 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "flex": 1,
-        "flexDirection": "row",
-        "paddingHorizontal": 50,
+        "width": 1180,
       }
     }
   >
-    <View>
-      <TileK />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
-          }
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingHorizontal": 50,
         }
-      />
-      <TileK />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
+      }
+    >
+      <View>
+        <TileK />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
           }
-        }
-      />
-      <TileK />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
+        />
+        <TileK />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
           }
-        }
-      />
-      <TileK />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
+        />
+        <TileK />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
           }
-        }
-      />
-      <TileK />
+        />
+        <TileK />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
+          }
+        />
+        <TileK />
+      </View>
     </View>
   </View>
 </View>
@@ -3371,79 +3498,88 @@ exports[`44. secondary two no pic and two - huge 1`] = `
     style={
       Object {
         "alignSelf": "center",
-        "flexDirection": "row",
-        "marginHorizontal": 10,
-        "width": "86%",
+        "flex": 1,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "width": "33.4%",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginHorizontal": 10,
         }
       }
     >
-      <TileAE />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "width": "33.4%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingHorizontal": 10,
-          "width": "16.6%",
+      >
+        <TileAE />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAP />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "paddingHorizontal": 5,
+            "width": "16.6%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "33.4%",
+      >
+        <TileAP />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAE />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "width": "33.4%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingHorizontal": 10,
-          "width": "16.6%",
+      >
+        <TileAE />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAP />
+      />
+      <View
+        style={
+          Object {
+            "paddingHorizontal": 5,
+            "width": "16.6%",
+          }
+        }
+      >
+        <TileAP />
+      </View>
     </View>
   </View>
 </View>
@@ -3463,39 +3599,49 @@ exports[`45. puzzle - huge 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "flex": 1,
-        "flexDirection": "row",
-        "paddingHorizontal": 15,
-        "paddingTop": 10,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "width": "33%",
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingHorizontal": 15,
+          "paddingTop": 10,
         }
       }
     >
-      <TileAK />
-    </View>
-    <View
-      style={
-        Object {
-          "width": "33%",
+      <View
+        style={
+          Object {
+            "width": "33%",
+          }
         }
-      }
-    >
-      <TileAK />
-    </View>
-    <View
-      style={
-        Object {
-          "width": "33%",
+      >
+        <TileAK />
+      </View>
+      <View
+        style={
+          Object {
+            "width": "33%",
+          }
         }
-      }
-    >
-      <TileAK />
+      >
+        <TileAK />
+      </View>
+      <View
+        style={
+          Object {
+            "width": "33%",
+          }
+        }
+      >
+        <TileAK />
+      </View>
     </View>
   </View>
 </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -941,16 +941,18 @@ exports[`31. comment lead and cartoon - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileAH
-        breakpoint="huge"
-        tileName="lead"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAI
-        tileName="cartoon"
-      />
+      <View>
+        <TileAH
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAI
+          tileName="cartoon"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -960,58 +962,60 @@ exports[`32. daily universal register - huge 1`] = `
 <View>
   <View>
     <View>
-      <Image
-        resizeMode="contain"
-        source={
-          Object {
-            "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+      <View>
+        <Image
+          resizeMode="contain"
+          source={
+            Object {
+              "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+            }
           }
-        }
-      />
-      <Text>
-        Daily Universal Register
-      </Text>
-      <View>
+        />
+        <Text>
+          Daily Universal Register
+        </Text>
         <View>
-          <View />
           <View>
-            <TileS />
+            <View />
+            <View>
+              <TileS />
+            </View>
+          </View>
+          <View>
+            <View />
+            <View>
+              <TileS />
+            </View>
           </View>
         </View>
         <View>
-          <View />
           <View>
-            <TileS />
-          </View>
-        </View>
-      </View>
-      <View>
-        <View>
-          <View />
-          <Image
-            resizeMode="contain"
-            source={
-              Object {
-                "testUri": "../../../packages/edition-slices/assets/leaves.png",
+            <View />
+            <Image
+              resizeMode="contain"
+              source={
+                Object {
+                  "testUri": "../../../packages/edition-slices/assets/leaves.png",
+                }
               }
-            }
-          />
-          <View>
-            <TileS />
+            />
+            <View>
+              <TileS />
+            </View>
           </View>
-        </View>
-        <View>
-          <View />
-          <Image
-            resizeMode="contain"
-            source={
-              Object {
-                "testUri": "../../../packages/edition-slices/assets/cake.png",
-              }
-            }
-          />
           <View>
-            <TileS />
+            <View />
+            <Image
+              resizeMode="contain"
+              source={
+                Object {
+                  "testUri": "../../../packages/edition-slices/assets/cake.png",
+                }
+              }
+            />
+            <View>
+              <TileS />
+            </View>
           </View>
         </View>
       </View>
@@ -1024,16 +1028,18 @@ exports[`33. lead one and one - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileU
-        breakpoint="huge"
-        tileName="lead"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAQ
-        tileName="support"
-      />
+      <View>
+        <TileU
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAQ
+          tileName="support"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1041,10 +1047,12 @@ exports[`33. lead one and one - huge 1`] = `
 
 exports[`34. lead one full width - huge 1`] = `
 <View>
-  <TileR
-    breakpoint="huge"
-    tileName="lead"
-  />
+  <View>
+    <TileR
+      breakpoint="huge"
+      tileName="lead"
+    />
+  </View>
 </View>
 `;
 
@@ -1052,25 +1060,27 @@ exports[`35. lead two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileX
-        tileName="lead1"
-      />
+      <View>
+        <TileX
+          tileName="lead1"
+        />
+        <View />
+        <TileY
+          tileName="lead2"
+        />
+      </View>
       <View />
-      <TileY
-        tileName="lead2"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAL
-        tileName="support1"
-      />
-    </View>
-    <View />
-    <View>
-      <TileZ
-        tileName="support2"
-      />
+      <View>
+        <TileAL
+          tileName="support1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileZ
+          tileName="support2"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1096,24 +1106,26 @@ exports[`36. leaders slice - huge 1`] = `
   <View>
     <View>
       <View>
-        <TileAG
-          breakpoint="huge"
-          tileName="leader2"
-        />
-      </View>
-      <View />
-      <View>
-        <TileAG
-          breakpoint="huge"
-          tileName="leader1"
-        />
-      </View>
-      <View />
-      <View>
-        <TileAG
-          breakpoint="huge"
-          tileName="leader3"
-        />
+        <View>
+          <TileAG
+            breakpoint="huge"
+            tileName="leader2"
+          />
+        </View>
+        <View />
+        <View>
+          <TileAG
+            breakpoint="huge"
+            tileName="leader1"
+          />
+        </View>
+        <View />
+        <View>
+          <TileAG
+            breakpoint="huge"
+            tileName="leader3"
+          />
+        </View>
       </View>
     </View>
   </View>
@@ -1125,47 +1137,49 @@ exports[`37. secondary one and four - huge 1`] = `
   <View>
     <View>
       <View>
-        <TheTimesLogo
-          height={40}
-          width={42}
-        />
-      </View>
-      <View />
-      <View>
         <View>
-          <View>
-            <TileN
-              breakpoint="huge"
-              tileName="secondary"
-            />
-          </View>
+          <TheTimesLogo
+            height={40}
+            width={42}
+          />
         </View>
         <View />
         <View>
           <View>
-            <TileO
-              tileName="support1"
-            />
+            <View>
+              <TileN
+                breakpoint="huge"
+                tileName="secondary"
+              />
+            </View>
           </View>
           <View />
           <View>
-            <TileO
-              tileName="support3"
-            />
-          </View>
-        </View>
-        <View />
-        <View>
-          <View>
-            <TileO
-              tileName="support2"
-            />
+            <View>
+              <TileO
+                tileName="support1"
+              />
+            </View>
+            <View />
+            <View>
+              <TileO
+                tileName="support3"
+              />
+            </View>
           </View>
           <View />
           <View>
-            <TileO
-              tileName="support4"
-            />
+            <View>
+              <TileO
+                tileName="support2"
+              />
+            </View>
+            <View />
+            <View>
+              <TileO
+                tileName="support4"
+              />
+            </View>
           </View>
         </View>
       </View>
@@ -1176,10 +1190,12 @@ exports[`37. secondary one and four - huge 1`] = `
 
 exports[`38. secondary one - huge 1`] = `
 <View>
-  <TileW
-    breakpoint="huge"
-    tileName="secondary"
-  />
+  <View>
+    <TileW
+      breakpoint="huge"
+      tileName="secondary"
+    />
+  </View>
 </View>
 `;
 
@@ -1187,27 +1203,29 @@ exports[`39. secondary four - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileC
-        tileName="secondary1"
-      />
-    </View>
-    <View />
-    <View>
-      <TileC
-        tileName="secondary2"
-      />
-    </View>
-    <View />
-    <View>
-      <TileC
-        tileName="secondary3"
-      />
-    </View>
-    <View />
-    <View>
-      <TileC
-        tileName="secondary4"
-      />
+      <View>
+        <TileC
+          tileName="secondary1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileC
+          tileName="secondary2"
+        />
+      </View>
+      <View />
+      <View>
+        <TileC
+          tileName="secondary3"
+        />
+      </View>
+      <View />
+      <View>
+        <TileC
+          tileName="secondary4"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1217,17 +1235,19 @@ exports[`40. secondary one and columnist - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileAA
-        breakpoint="huge"
-        tileName="secondary"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAB
-        breakpoint="huge"
-        tileName="columnist"
-      />
+      <View>
+        <TileAA
+          breakpoint="huge"
+          tileName="secondary"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAB
+          breakpoint="huge"
+          tileName="columnist"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1237,27 +1257,29 @@ exports[`41. secondary two and two - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileAM
-        tileName="secondary1"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAN
-        tileName="support1"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAM
-        tileName="secondary2"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAN
-        tileName="support2"
-      />
+      <View>
+        <TileAM
+          tileName="secondary1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAN
+          tileName="support1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAM
+          tileName="secondary2"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAN
+          tileName="support2"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1267,32 +1289,34 @@ exports[`42. lead one and four slice - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileAC
-        breakpoint="huge"
-        tileName="lead"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAD
-        breakpoint="huge"
-        tileName="support1"
-      />
+      <View>
+        <TileAC
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </View>
       <View />
-      <TileAD
-        breakpoint="huge"
-        tileName="support2"
-      />
-      <View />
-      <TileAD
-        breakpoint="huge"
-        tileName="support3"
-      />
-      <View />
-      <TileAD
-        breakpoint="huge"
-        tileName="support4"
-      />
+      <View>
+        <TileAD
+          breakpoint="huge"
+          tileName="support1"
+        />
+        <View />
+        <TileAD
+          breakpoint="huge"
+          tileName="support2"
+        />
+        <View />
+        <TileAD
+          breakpoint="huge"
+          tileName="support3"
+        />
+        <View />
+        <TileAD
+          breakpoint="huge"
+          tileName="support4"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1302,25 +1326,27 @@ exports[`43. standard slice - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileK
-        breakpoint="huge"
-      />
-      <View />
-      <TileK
-        breakpoint="huge"
-      />
-      <View />
-      <TileK
-        breakpoint="huge"
-      />
-      <View />
-      <TileK
-        breakpoint="huge"
-      />
-      <View />
-      <TileK
-        breakpoint="huge"
-      />
+      <View>
+        <TileK
+          breakpoint="huge"
+        />
+        <View />
+        <TileK
+          breakpoint="huge"
+        />
+        <View />
+        <TileK
+          breakpoint="huge"
+        />
+        <View />
+        <TileK
+          breakpoint="huge"
+        />
+        <View />
+        <TileK
+          breakpoint="huge"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1330,27 +1356,29 @@ exports[`44. secondary two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileAE
-        tileName="secondary1"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAP
-        tileName="support1"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAE
-        tileName="secondary2"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAP
-        tileName="support2"
-      />
+      <View>
+        <TileAE
+          tileName="secondary1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAP
+          tileName="support1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAE
+          tileName="secondary2"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAP
+          tileName="support2"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1360,67 +1388,69 @@ exports[`45. puzzle - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileAK
-        breakpoint="huge"
-        id="0"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+      <View>
+        <TileAK
+          breakpoint="huge"
+          id="0"
+          image={
+            Object {
+              "crop11": null,
+              "crop169": null,
+              "crop23": null,
+              "crop32": Object {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+              },
+              "crop45": null,
+              "crops": Array [],
+              "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            }
           }
-        }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </View>
-    <View>
-      <TileAK
-        breakpoint="huge"
-        id="1"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          title="Times Concise medium No 7881"
+          url="/crossword/123"
+        />
+      </View>
+      <View>
+        <TileAK
+          breakpoint="huge"
+          id="1"
+          image={
+            Object {
+              "crop11": null,
+              "crop169": null,
+              "crop23": null,
+              "crop32": Object {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+              },
+              "crop45": null,
+              "crops": Array [],
+              "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            }
           }
-        }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </View>
-    <View>
-      <TileAK
-        breakpoint="huge"
-        id="2"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          title="Times Concise medium No 7881"
+          url="/crossword/123"
+        />
+      </View>
+      <View>
+        <TileAK
+          breakpoint="huge"
+          id="2"
+          image={
+            Object {
+              "crop11": null,
+              "crop169": null,
+              "crop23": null,
+              "crop32": Object {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+              },
+              "crop45": null,
+              "crops": Array [],
+              "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            }
           }
-        }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
+          title="Times Concise medium No 7881"
+          url="/crossword/123"
+        />
+      </View>
     </View>
   </View>
 </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1437,6 +1437,7 @@ exports[`20. lead two no pic and two - wide 1`] = `
     <View
       style={
         Object {
+          "paddingTop": 10,
           "width": "16%",
         }
       }
@@ -1906,6 +1907,7 @@ exports[`26. secondary two and two - wide 1`] = `
       Object {
         "flex": 1,
         "flexDirection": "row",
+        "marginHorizontal": 10,
       }
     }
   >
@@ -2294,40 +2296,50 @@ exports[`31. comment lead and cartoon - huge 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "flex": 1,
-        "flexDirection": "row",
-        "paddingRight": 20,
-        "paddingTop": 10,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "width": "33.3%",
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingRight": 20,
+          "paddingTop": 10,
         }
       }
     >
-      <TileAH />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "width": "33.3%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "66.7%",
+      >
+        <TileAH />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAI />
+      />
+      <View
+        style={
+          Object {
+            "width": "66.7%",
+          }
+        }
+      >
+        <TileAI />
+      </View>
     </View>
   </View>
 </View>
@@ -2354,176 +2366,184 @@ exports[`32. daily universal register - huge 1`] = `
     <View
       style={
         Object {
-          "alignItems": "center",
           "alignSelf": "center",
-          "backgroundColor": "#F0F0F0",
           "flex": 1,
-          "width": "86%",
+          "width": 1180,
         }
       }
     >
-      <Image
-        style={
-          Object {
-            "height": 73,
-            "marginVertical": 10,
-            "width": 285,
-          }
-        }
-      />
-      <Text
-        style={
-          Object {
-            "color": "#850029",
-            "fontFamily": "TimesDigitalW04",
-            "fontSize": 16,
-            "marginBottom": 25,
-          }
-        }
-      >
-        Daily Universal Register
-      </Text>
       <View
         style={
           Object {
-            "flexDirection": "row",
-            "paddingHorizontal": "8%",
-            "width": "100%",
+            "alignItems": "center",
+            "backgroundColor": "#F0F0F0",
+            "flex": 1,
           }
         }
       >
+        <Image
+          style={
+            Object {
+              "height": 73,
+              "marginVertical": 10,
+              "width": 285,
+            }
+          }
+        />
+        <Text
+          style={
+            Object {
+              "color": "#850029",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 16,
+              "marginBottom": 25,
+            }
+          }
+        >
+          Daily Universal Register
+        </Text>
         <View
           style={
             Object {
-              "alignItems": "center",
-              "flex": 1,
-              "flexDirection": "column",
-              "paddingHorizontal": 25,
+              "flexDirection": "row",
+              "paddingHorizontal": "8%",
+              "width": "100%",
             }
           }
         >
           <View
             style={
               Object {
-                "borderBottomColor": "#DBDBDB",
-                "borderBottomWidth": 1,
-                "borderColor": "#DBDBDB",
-                "borderStyle": "solid",
-                "marginHorizontal": 10,
-                "marginVertical": 25,
-                "width": "100%",
+                "alignItems": "center",
+                "flex": 1,
+                "flexDirection": "column",
+                "paddingHorizontal": 25,
               }
             }
-          />
-          <View>
-            <TileS />
+          >
+            <View
+              style={
+                Object {
+                  "borderBottomColor": "#DBDBDB",
+                  "borderBottomWidth": 1,
+                  "borderColor": "#DBDBDB",
+                  "borderStyle": "solid",
+                  "marginHorizontal": 10,
+                  "marginVertical": 25,
+                  "width": "100%",
+                }
+              }
+            />
+            <View>
+              <TileS />
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flex": 1,
+                "flexDirection": "column",
+                "paddingHorizontal": 25,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "borderBottomColor": "#DBDBDB",
+                  "borderBottomWidth": 1,
+                  "borderColor": "#DBDBDB",
+                  "borderStyle": "solid",
+                  "marginHorizontal": 10,
+                  "marginVertical": 25,
+                  "width": "100%",
+                }
+              }
+            />
+            <View>
+              <TileS />
+            </View>
           </View>
         </View>
         <View
           style={
             Object {
-              "alignItems": "center",
-              "flex": 1,
-              "flexDirection": "column",
-              "paddingHorizontal": 25,
+              "flexDirection": "row",
+              "paddingHorizontal": "8%",
+              "width": "100%",
             }
           }
         >
           <View
             style={
               Object {
-                "borderBottomColor": "#DBDBDB",
-                "borderBottomWidth": 1,
-                "borderColor": "#DBDBDB",
-                "borderStyle": "solid",
-                "marginHorizontal": 10,
-                "marginVertical": 25,
-                "width": "100%",
+                "alignItems": "center",
+                "flex": 1,
+                "flexDirection": "column",
+                "paddingHorizontal": 25,
               }
             }
-          />
-          <View>
-            <TileS />
+          >
+            <View
+              style={
+                Object {
+                  "borderBottomColor": "#DBDBDB",
+                  "borderBottomWidth": 1,
+                  "borderColor": "#DBDBDB",
+                  "borderStyle": "solid",
+                  "marginHorizontal": 10,
+                  "marginVertical": 25,
+                  "width": "100%",
+                }
+              }
+            />
+            <Image
+              style={
+                Object {
+                  "height": 45,
+                  "width": 60,
+                }
+              }
+            />
+            <View>
+              <TileS />
+            </View>
           </View>
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "flexDirection": "row",
-            "paddingHorizontal": "8%",
-            "width": "100%",
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "alignItems": "center",
-              "flex": 1,
-              "flexDirection": "column",
-              "paddingHorizontal": 25,
-            }
-          }
-        >
           <View
             style={
               Object {
-                "borderBottomColor": "#DBDBDB",
-                "borderBottomWidth": 1,
-                "borderColor": "#DBDBDB",
-                "borderStyle": "solid",
-                "marginHorizontal": 10,
-                "marginVertical": 25,
-                "width": "100%",
+                "alignItems": "center",
+                "flex": 1,
+                "flexDirection": "column",
+                "paddingHorizontal": 25,
               }
             }
-          />
-          <Image
-            style={
-              Object {
-                "height": 45,
-                "width": 60,
+          >
+            <View
+              style={
+                Object {
+                  "borderBottomColor": "#DBDBDB",
+                  "borderBottomWidth": 1,
+                  "borderColor": "#DBDBDB",
+                  "borderStyle": "solid",
+                  "marginHorizontal": 10,
+                  "marginVertical": 25,
+                  "width": "100%",
+                }
               }
-            }
-          />
-          <View>
-            <TileS />
-          </View>
-        </View>
-        <View
-          style={
-            Object {
-              "alignItems": "center",
-              "flex": 1,
-              "flexDirection": "column",
-              "paddingHorizontal": 25,
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "borderBottomColor": "#DBDBDB",
-                "borderBottomWidth": 1,
-                "borderColor": "#DBDBDB",
-                "borderStyle": "solid",
-                "marginHorizontal": 10,
-                "marginVertical": 25,
-                "width": "100%",
+            />
+            <Image
+              style={
+                Object {
+                  "height": 45,
+                  "width": 60,
+                }
               }
-            }
-          />
-          <Image
-            style={
-              Object {
-                "height": 45,
-                "width": 60,
-              }
-            }
-          />
-          <View>
-            <TileS />
+            />
+            <View>
+              <TileS />
+            </View>
           </View>
         </View>
       </View>
@@ -2548,39 +2568,47 @@ exports[`33. lead one and one - huge 1`] = `
       Object {
         "alignSelf": "center",
         "flex": 1,
-        "flexDirection": "row",
-        "marginHorizontal": 10,
-        "width": "86%",
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "width": "83.33%",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginHorizontal": 10,
         }
       }
     >
-      <TileU />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "width": "83.33%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "16.67%",
+      >
+        <TileU />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAQ />
+      />
+      <View
+        style={
+          Object {
+            "width": "16.67%",
+          }
+        }
+      >
+        <TileAQ />
+      </View>
     </View>
   </View>
 </View>
@@ -2597,7 +2625,17 @@ exports[`34. lead one full width - huge 1`] = `
     }
   }
 >
-  <TileR />
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
+      }
+    }
+  >
+    <TileR />
+  </View>
 </View>
 `;
 
@@ -2615,69 +2653,80 @@ exports[`35. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "flexDirection": "row",
-        "justifyContent": "center",
-        "paddingHorizontal": 10,
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "width": "36%",
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "paddingHorizontal": 10,
         }
       }
     >
-      <TileX />
       <View
         style={
           Object {
-            "borderBottomWidth": 1,
+            "width": "42%",
+          }
+        }
+      >
+        <TileX />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
+          }
+        />
+        <TileY />
+      </View>
+      <View
+        style={
+          Object {
             "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
             "borderStyle": "solid",
-            "marginHorizontal": 10,
+            "marginVertical": 10,
           }
         }
       />
-      <TileY />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "paddingTop": 10,
+            "width": "16%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "14%",
+      >
+        <TileAL />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAL />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "width": "42%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "36%",
-        }
-      }
-    >
-      <TileZ />
+      >
+        <TileZ />
+      </View>
     </View>
   </View>
 </View>
@@ -2743,61 +2792,71 @@ exports[`36. leaders slice - huge 1`] = `
     <View
       style={
         Object {
+          "alignSelf": "center",
           "flex": 1,
-          "flexDirection": "row",
-          "paddingBottom": 5,
+          "width": 1180,
         }
       }
     >
       <View
         style={
           Object {
-            "paddingHorizontal": 10,
-            "width": "33%",
+            "flex": 1,
+            "flexDirection": "row",
+            "paddingBottom": 5,
           }
         }
       >
-        <TileAG />
-      </View>
-      <View
-        style={
-          Object {
-            "borderColor": "#DBDBDB",
-            "borderRightWidth": 1,
-            "borderStyle": "solid",
-            "marginVertical": 10,
+        <View
+          style={
+            Object {
+              "paddingHorizontal": 10,
+              "width": "33%",
+            }
           }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingHorizontal": 10,
-            "width": "33%",
+        >
+          <TileAG />
+        </View>
+        <View
+          style={
+            Object {
+              "borderColor": "#DBDBDB",
+              "borderRightWidth": 1,
+              "borderStyle": "solid",
+              "marginVertical": 10,
+            }
           }
-        }
-      >
-        <TileAG />
-      </View>
-      <View
-        style={
-          Object {
-            "borderColor": "#DBDBDB",
-            "borderRightWidth": 1,
-            "borderStyle": "solid",
-            "marginVertical": 10,
+        />
+        <View
+          style={
+            Object {
+              "paddingHorizontal": 10,
+              "width": "33%",
+            }
           }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingHorizontal": 10,
-            "width": "33%",
+        >
+          <TileAG />
+        </View>
+        <View
+          style={
+            Object {
+              "borderColor": "#DBDBDB",
+              "borderRightWidth": 1,
+              "borderStyle": "solid",
+              "marginVertical": 10,
+            }
           }
-        }
-      >
-        <TileAG />
+        />
+        <View
+          style={
+            Object {
+              "paddingHorizontal": 10,
+              "width": "33%",
+            }
+          }
+        >
+          <TileAG />
+        </View>
       </View>
     </View>
   </View>
@@ -2825,8 +2884,9 @@ exports[`37. secondary one and four - huge 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": "#272D34",
-          "paddingHorizontal": 10,
+          "alignSelf": "center",
+          "flex": 1,
+          "width": 1180,
         }
       }
     >
@@ -2834,109 +2894,118 @@ exports[`37. secondary one and four - huge 1`] = `
         style={
           Object {
             "backgroundColor": "#272D34",
-            "flexDirection": "row",
-            "margin": 10,
-            "marginBottom": 10,
-          }
-        }
-      >
-        <TheTimesLogo />
-      </View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#4D4D4D",
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flexDirection": "row",
+            "paddingHorizontal": 10,
           }
         }
       >
         <View
           style={
             Object {
-              "width": "50%",
+              "backgroundColor": "#272D34",
+              "flexDirection": "row",
+              "margin": 10,
+              "marginBottom": 10,
             }
           }
         >
-          <View>
-            <TileN />
-          </View>
+          <TheTimesLogo />
         </View>
         <View
           style={
             Object {
-              "borderColor": "#4D4D4D",
-              "borderRightWidth": 1,
+              "borderBottomColor": "#4D4D4D",
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
               "borderStyle": "solid",
-              "marginVertical": 10,
+              "marginHorizontal": 10,
             }
           }
         />
         <View
           style={
             Object {
-              "width": "25%",
+              "flexDirection": "row",
             }
           }
         >
-          <View>
-            <TileO />
+          <View
+            style={
+              Object {
+                "width": "50%",
+              }
+            }
+          >
+            <View>
+              <TileN />
+            </View>
           </View>
           <View
             style={
               Object {
-                "borderBottomWidth": 1,
                 "borderColor": "#4D4D4D",
+                "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "marginHorizontal": 10,
+                "marginVertical": 10,
               }
             }
           />
-          <View>
-            <TileO />
-          </View>
-        </View>
-        <View
-          style={
-            Object {
-              "borderColor": "#4D4D4D",
-              "borderRightWidth": 1,
-              "borderStyle": "solid",
-              "marginVertical": 10,
+          <View
+            style={
+              Object {
+                "width": "25%",
+              }
             }
-          }
-        />
-        <View
-          style={
-            Object {
-              "width": "25%",
-            }
-          }
-        >
-          <View>
-            <TileO />
+          >
+            <View>
+              <TileO />
+            </View>
+            <View
+              style={
+                Object {
+                  "borderBottomWidth": 1,
+                  "borderColor": "#4D4D4D",
+                  "borderStyle": "solid",
+                  "marginHorizontal": 10,
+                }
+              }
+            />
+            <View>
+              <TileO />
+            </View>
           </View>
           <View
             style={
               Object {
-                "borderBottomWidth": 1,
                 "borderColor": "#4D4D4D",
+                "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "marginHorizontal": 10,
+                "marginVertical": 10,
               }
             }
           />
-          <View>
-            <TileO />
+          <View
+            style={
+              Object {
+                "width": "25%",
+              }
+            }
+          >
+            <View>
+              <TileO />
+            </View>
+            <View
+              style={
+                Object {
+                  "borderBottomWidth": 1,
+                  "borderColor": "#4D4D4D",
+                  "borderStyle": "solid",
+                  "marginHorizontal": 10,
+                }
+              }
+            />
+            <View>
+              <TileO />
+            </View>
           </View>
         </View>
       </View>
@@ -2956,7 +3025,17 @@ exports[`38. secondary one - huge 1`] = `
     }
   }
 >
-  <TileW />
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
+      }
+    }
+  >
+    <TileW />
+  </View>
 </View>
 `;
 
@@ -2974,80 +3053,90 @@ exports[`39. secondary four - huge 1`] = `
   <View
     style={
       Object {
-        "flexDirection": "row",
-        "marginHorizontal": 10,
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "flex": 1,
-          "width": "25%",
+          "flexDirection": "row",
+          "marginHorizontal": 10,
         }
       }
     >
-      <TileC />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "width": "25%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "width": "25%",
+      >
+        <TileC />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileC />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "width": "25%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "width": "25%",
+      >
+        <TileC />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileC />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "width": "25%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "width": "25%",
+      >
+        <TileC />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileC />
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "width": "25%",
+          }
+        }
+      >
+        <TileC />
+      </View>
     </View>
   </View>
 </View>
@@ -3067,41 +3156,51 @@ exports[`40. secondary one and columnist - huge 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "flex": 1,
-        "flexDirection": "row",
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "paddingLeft": 10,
-          "paddingTop": 10,
-          "width": "33%",
+          "flex": 1,
+          "flexDirection": "row",
         }
       }
     >
-      <TileAA />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingTop": 10,
+            "width": "33%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingRight": 10,
-          "width": "67%",
+      >
+        <TileAA />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAB />
+      />
+      <View
+        style={
+          Object {
+            "paddingRight": 10,
+            "width": "67%",
+          }
+        }
+      >
+        <TileAB />
+      </View>
     </View>
   </View>
 </View>
@@ -3122,78 +3221,86 @@ exports[`41. secondary two and two - huge 1`] = `
     style={
       Object {
         "alignSelf": "center",
-        "flexDirection": "row",
-        "width": "86%",
+        "flex": 1,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "width": "33.4%",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginHorizontal": 10,
         }
       }
     >
-      <TileAM />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "width": "33.4%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingHorizontal": 10,
-          "width": "16.6%",
+      >
+        <TileAM />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAN />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "width": "16.6%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "33.4%",
+      >
+        <TileAN />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAM />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "width": "33.4%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingHorizontal": 10,
-          "width": "16.6%",
+      >
+        <TileAM />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAN />
+      />
+      <View
+        style={
+          Object {
+            "width": "16.6%",
+          }
+        }
+      >
+        <TileAN />
+      </View>
     </View>
   </View>
 </View>
@@ -3213,73 +3320,83 @@ exports[`42. lead one and four slice - huge 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "flex": 1,
-        "flexDirection": "row",
-        "paddingHorizontal": 10,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "padding": 10,
-          "width": "50%",
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingHorizontal": 10,
         }
       }
     >
-      <TileAC />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "50%",
-        }
-      }
-    >
-      <TileAD />
       <View
         style={
           Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
+            "padding": 10,
+            "width": "50%",
           }
         }
-      />
-      <TileAD />
+      >
+        <TileAC />
+      </View>
       <View
         style={
           Object {
-            "borderBottomWidth": 1,
             "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
             "borderStyle": "solid",
-            "marginHorizontal": 10,
+            "marginVertical": 10,
           }
         }
       />
-      <TileAD />
       <View
         style={
           Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
+            "width": "50%",
           }
         }
-      />
-      <TileAD />
+      >
+        <TileAD />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
+          }
+        />
+        <TileAD />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
+          }
+        />
+        <TileAD />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
+          }
+        />
+        <TileAD />
+      </View>
     </View>
   </View>
 </View>
@@ -3299,58 +3416,68 @@ exports[`43. standard slice - huge 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "flex": 1,
-        "flexDirection": "row",
-        "paddingHorizontal": 50,
+        "width": 1180,
       }
     }
   >
-    <View>
-      <TileK />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
-          }
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingHorizontal": 50,
         }
-      />
-      <TileK />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
+      }
+    >
+      <View>
+        <TileK />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
           }
-        }
-      />
-      <TileK />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
+        />
+        <TileK />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
           }
-        }
-      />
-      <TileK />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-            "marginHorizontal": 10,
+        />
+        <TileK />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
           }
-        }
-      />
-      <TileK />
+        />
+        <TileK />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+              "marginHorizontal": 10,
+            }
+          }
+        />
+        <TileK />
+      </View>
     </View>
   </View>
 </View>
@@ -3371,79 +3498,88 @@ exports[`44. secondary two no pic and two - huge 1`] = `
     style={
       Object {
         "alignSelf": "center",
-        "flexDirection": "row",
-        "marginHorizontal": 10,
-        "width": "86%",
+        "flex": 1,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "width": "33.4%",
+          "flex": 1,
+          "flexDirection": "row",
+          "marginHorizontal": 10,
         }
       }
     >
-      <TileAE />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      <View
+        style={
+          Object {
+            "width": "33.4%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingHorizontal": 10,
-          "width": "16.6%",
+      >
+        <TileAE />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAP />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "paddingHorizontal": 5,
+            "width": "16.6%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "33.4%",
+      >
+        <TileAP />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAE />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
+      />
+      <View
+        style={
+          Object {
+            "width": "33.4%",
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingHorizontal": 10,
-          "width": "16.6%",
+      >
+        <TileAE />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
         }
-      }
-    >
-      <TileAP />
+      />
+      <View
+        style={
+          Object {
+            "paddingHorizontal": 5,
+            "width": "16.6%",
+          }
+        }
+      >
+        <TileAP />
+      </View>
     </View>
   </View>
 </View>
@@ -3463,39 +3599,49 @@ exports[`45. puzzle - huge 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "flex": 1,
-        "flexDirection": "row",
-        "paddingHorizontal": 15,
-        "paddingTop": 10,
+        "width": 1180,
       }
     }
   >
     <View
       style={
         Object {
-          "width": "33%",
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingHorizontal": 15,
+          "paddingTop": 10,
         }
       }
     >
-      <TileAK />
-    </View>
-    <View
-      style={
-        Object {
-          "width": "33%",
+      <View
+        style={
+          Object {
+            "width": "33%",
+          }
         }
-      }
-    >
-      <TileAK />
-    </View>
-    <View
-      style={
-        Object {
-          "width": "33%",
+      >
+        <TileAK />
+      </View>
+      <View
+        style={
+          Object {
+            "width": "33%",
+          }
         }
-      }
-    >
-      <TileAK />
+      >
+        <TileAK />
+      </View>
+      <View
+        style={
+          Object {
+            "width": "33%",
+          }
+        }
+      >
+        <TileAK />
+      </View>
     </View>
   </View>
 </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -941,16 +941,18 @@ exports[`31. comment lead and cartoon - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileAH
-        breakpoint="huge"
-        tileName="lead"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAI
-        tileName="cartoon"
-      />
+      <View>
+        <TileAH
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAI
+          tileName="cartoon"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -960,58 +962,60 @@ exports[`32. daily universal register - huge 1`] = `
 <View>
   <View>
     <View>
-      <Image
-        resizeMode="contain"
-        source={
-          Object {
-            "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+      <View>
+        <Image
+          resizeMode="contain"
+          source={
+            Object {
+              "testUri": "../../../packages/edition-slices/assets/daily-universal-register.png",
+            }
           }
-        }
-      />
-      <Text>
-        Daily Universal Register
-      </Text>
-      <View>
+        />
+        <Text>
+          Daily Universal Register
+        </Text>
         <View>
-          <View />
           <View>
-            <TileS />
+            <View />
+            <View>
+              <TileS />
+            </View>
+          </View>
+          <View>
+            <View />
+            <View>
+              <TileS />
+            </View>
           </View>
         </View>
         <View>
-          <View />
           <View>
-            <TileS />
-          </View>
-        </View>
-      </View>
-      <View>
-        <View>
-          <View />
-          <Image
-            resizeMode="contain"
-            source={
-              Object {
-                "testUri": "../../../packages/edition-slices/assets/leaves.png",
+            <View />
+            <Image
+              resizeMode="contain"
+              source={
+                Object {
+                  "testUri": "../../../packages/edition-slices/assets/leaves.png",
+                }
               }
-            }
-          />
-          <View>
-            <TileS />
+            />
+            <View>
+              <TileS />
+            </View>
           </View>
-        </View>
-        <View>
-          <View />
-          <Image
-            resizeMode="contain"
-            source={
-              Object {
-                "testUri": "../../../packages/edition-slices/assets/cake.png",
-              }
-            }
-          />
           <View>
-            <TileS />
+            <View />
+            <Image
+              resizeMode="contain"
+              source={
+                Object {
+                  "testUri": "../../../packages/edition-slices/assets/cake.png",
+                }
+              }
+            />
+            <View>
+              <TileS />
+            </View>
           </View>
         </View>
       </View>
@@ -1024,16 +1028,18 @@ exports[`33. lead one and one - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileU
-        breakpoint="huge"
-        tileName="lead"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAQ
-        tileName="support"
-      />
+      <View>
+        <TileU
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAQ
+          tileName="support"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1041,10 +1047,12 @@ exports[`33. lead one and one - huge 1`] = `
 
 exports[`34. lead one full width - huge 1`] = `
 <View>
-  <TileR
-    breakpoint="huge"
-    tileName="lead"
-  />
+  <View>
+    <TileR
+      breakpoint="huge"
+      tileName="lead"
+    />
+  </View>
 </View>
 `;
 
@@ -1052,25 +1060,27 @@ exports[`35. lead two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileX
-        tileName="lead1"
-      />
+      <View>
+        <TileX
+          tileName="lead1"
+        />
+        <View />
+        <TileY
+          tileName="lead2"
+        />
+      </View>
       <View />
-      <TileY
-        tileName="lead2"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAL
-        tileName="support1"
-      />
-    </View>
-    <View />
-    <View>
-      <TileZ
-        tileName="support2"
-      />
+      <View>
+        <TileAL
+          tileName="support1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileZ
+          tileName="support2"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1096,24 +1106,26 @@ exports[`36. leaders slice - huge 1`] = `
   <View>
     <View>
       <View>
-        <TileAG
-          breakpoint="huge"
-          tileName="leader2"
-        />
-      </View>
-      <View />
-      <View>
-        <TileAG
-          breakpoint="huge"
-          tileName="leader1"
-        />
-      </View>
-      <View />
-      <View>
-        <TileAG
-          breakpoint="huge"
-          tileName="leader3"
-        />
+        <View>
+          <TileAG
+            breakpoint="huge"
+            tileName="leader2"
+          />
+        </View>
+        <View />
+        <View>
+          <TileAG
+            breakpoint="huge"
+            tileName="leader1"
+          />
+        </View>
+        <View />
+        <View>
+          <TileAG
+            breakpoint="huge"
+            tileName="leader3"
+          />
+        </View>
       </View>
     </View>
   </View>
@@ -1125,47 +1137,49 @@ exports[`37. secondary one and four - huge 1`] = `
   <View>
     <View>
       <View>
-        <TheTimesLogo
-          height={40}
-          width={42}
-        />
-      </View>
-      <View />
-      <View>
         <View>
-          <View>
-            <TileN
-              breakpoint="huge"
-              tileName="secondary"
-            />
-          </View>
+          <TheTimesLogo
+            height={40}
+            width={42}
+          />
         </View>
         <View />
         <View>
           <View>
-            <TileO
-              tileName="support1"
-            />
+            <View>
+              <TileN
+                breakpoint="huge"
+                tileName="secondary"
+              />
+            </View>
           </View>
           <View />
           <View>
-            <TileO
-              tileName="support3"
-            />
-          </View>
-        </View>
-        <View />
-        <View>
-          <View>
-            <TileO
-              tileName="support2"
-            />
+            <View>
+              <TileO
+                tileName="support1"
+              />
+            </View>
+            <View />
+            <View>
+              <TileO
+                tileName="support3"
+              />
+            </View>
           </View>
           <View />
           <View>
-            <TileO
-              tileName="support4"
-            />
+            <View>
+              <TileO
+                tileName="support2"
+              />
+            </View>
+            <View />
+            <View>
+              <TileO
+                tileName="support4"
+              />
+            </View>
           </View>
         </View>
       </View>
@@ -1176,10 +1190,12 @@ exports[`37. secondary one and four - huge 1`] = `
 
 exports[`38. secondary one - huge 1`] = `
 <View>
-  <TileW
-    breakpoint="huge"
-    tileName="secondary"
-  />
+  <View>
+    <TileW
+      breakpoint="huge"
+      tileName="secondary"
+    />
+  </View>
 </View>
 `;
 
@@ -1187,27 +1203,29 @@ exports[`39. secondary four - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileC
-        tileName="secondary1"
-      />
-    </View>
-    <View />
-    <View>
-      <TileC
-        tileName="secondary2"
-      />
-    </View>
-    <View />
-    <View>
-      <TileC
-        tileName="secondary3"
-      />
-    </View>
-    <View />
-    <View>
-      <TileC
-        tileName="secondary4"
-      />
+      <View>
+        <TileC
+          tileName="secondary1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileC
+          tileName="secondary2"
+        />
+      </View>
+      <View />
+      <View>
+        <TileC
+          tileName="secondary3"
+        />
+      </View>
+      <View />
+      <View>
+        <TileC
+          tileName="secondary4"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1217,17 +1235,19 @@ exports[`40. secondary one and columnist - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileAA
-        breakpoint="huge"
-        tileName="secondary"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAB
-        breakpoint="huge"
-        tileName="columnist"
-      />
+      <View>
+        <TileAA
+          breakpoint="huge"
+          tileName="secondary"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAB
+          breakpoint="huge"
+          tileName="columnist"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1237,27 +1257,29 @@ exports[`41. secondary two and two - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileAM
-        tileName="secondary1"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAN
-        tileName="support1"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAM
-        tileName="secondary2"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAN
-        tileName="support2"
-      />
+      <View>
+        <TileAM
+          tileName="secondary1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAN
+          tileName="support1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAM
+          tileName="secondary2"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAN
+          tileName="support2"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1267,32 +1289,34 @@ exports[`42. lead one and four slice - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileAC
-        breakpoint="huge"
-        tileName="lead"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAD
-        breakpoint="huge"
-        tileName="support1"
-      />
+      <View>
+        <TileAC
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </View>
       <View />
-      <TileAD
-        breakpoint="huge"
-        tileName="support2"
-      />
-      <View />
-      <TileAD
-        breakpoint="huge"
-        tileName="support3"
-      />
-      <View />
-      <TileAD
-        breakpoint="huge"
-        tileName="support4"
-      />
+      <View>
+        <TileAD
+          breakpoint="huge"
+          tileName="support1"
+        />
+        <View />
+        <TileAD
+          breakpoint="huge"
+          tileName="support2"
+        />
+        <View />
+        <TileAD
+          breakpoint="huge"
+          tileName="support3"
+        />
+        <View />
+        <TileAD
+          breakpoint="huge"
+          tileName="support4"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1302,25 +1326,27 @@ exports[`43. standard slice - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileK
-        breakpoint="huge"
-      />
-      <View />
-      <TileK
-        breakpoint="huge"
-      />
-      <View />
-      <TileK
-        breakpoint="huge"
-      />
-      <View />
-      <TileK
-        breakpoint="huge"
-      />
-      <View />
-      <TileK
-        breakpoint="huge"
-      />
+      <View>
+        <TileK
+          breakpoint="huge"
+        />
+        <View />
+        <TileK
+          breakpoint="huge"
+        />
+        <View />
+        <TileK
+          breakpoint="huge"
+        />
+        <View />
+        <TileK
+          breakpoint="huge"
+        />
+        <View />
+        <TileK
+          breakpoint="huge"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1330,27 +1356,29 @@ exports[`44. secondary two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileAE
-        tileName="secondary1"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAP
-        tileName="support1"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAE
-        tileName="secondary2"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAP
-        tileName="support2"
-      />
+      <View>
+        <TileAE
+          tileName="secondary1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAP
+          tileName="support1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAE
+          tileName="secondary2"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAP
+          tileName="support2"
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -1360,67 +1388,69 @@ exports[`45. puzzle - huge 1`] = `
 <View>
   <View>
     <View>
-      <TileAK
-        breakpoint="huge"
-        id="0"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+      <View>
+        <TileAK
+          breakpoint="huge"
+          id="0"
+          image={
+            Object {
+              "crop11": null,
+              "crop169": null,
+              "crop23": null,
+              "crop32": Object {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+              },
+              "crop45": null,
+              "crops": Array [],
+              "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            }
           }
-        }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </View>
-    <View>
-      <TileAK
-        breakpoint="huge"
-        id="1"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          title="Times Concise medium No 7881"
+          url="/crossword/123"
+        />
+      </View>
+      <View>
+        <TileAK
+          breakpoint="huge"
+          id="1"
+          image={
+            Object {
+              "crop11": null,
+              "crop169": null,
+              "crop23": null,
+              "crop32": Object {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+              },
+              "crop45": null,
+              "crops": Array [],
+              "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            }
           }
-        }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </View>
-    <View>
-      <TileAK
-        breakpoint="huge"
-        id="2"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          title="Times Concise medium No 7881"
+          url="/crossword/123"
+        />
+      </View>
+      <View>
+        <TileAK
+          breakpoint="huge"
+          id="2"
+          image={
+            Object {
+              "crop11": null,
+              "crop169": null,
+              "crop23": null,
+              "crop32": Object {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+              },
+              "crop45": null,
+              "crops": Array [],
+              "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            }
           }
-        }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
+          title="Times Concise medium No 7881"
+          url="/crossword/123"
+        />
+      </View>
     </View>
   </View>
 </View>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -1352,6 +1352,7 @@ exports[`6. lead two no pic and two 1`] = `
 }
 
 .IS4 {
+  padding-top: 10px;
   width: 16%;
 }
 
@@ -2002,6 +2003,8 @@ exports[`11. secondary two and two 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  margin-right: 10px;
+  margin-left: 10px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -384,6 +384,7 @@ exports[`5. lead two no pic and two - medium 1`] = `
 }
 
 .IS4 {
+  padding-top: 10px;
   width: 16%;
 }
 
@@ -1204,6 +1205,8 @@ exports[`11. secondary two and two - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  margin-right: 10px;
+  margin-left: 10px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -2202,6 +2205,7 @@ exports[`20. lead two no pic and two - wide 1`] = `
 }
 
 .IS4 {
+  padding-top: 10px;
   width: 16%;
 }
 
@@ -3022,6 +3026,8 @@ exports[`26. secondary two and two - wide 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  margin-right: 10px;
+  margin-left: 10px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -4020,6 +4026,7 @@ exports[`35. lead two no pic and two - huge 1`] = `
 }
 
 .IS4 {
+  padding-top: 10px;
   width: 16%;
 }
 
@@ -4840,6 +4847,8 @@ exports[`41. secondary two and two - huge 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  margin-right: 10px;
+  margin-left: 10px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;

--- a/packages/edition-slices/src/slices/dailyregisterleadfour/styles.js
+++ b/packages/edition-slices/src/slices/dailyregisterleadfour/styles.js
@@ -77,10 +77,8 @@ const hugeBreakpointStyle = {
   },
   container: {
     alignItems: "center",
-    alignSelf: "center",
     backgroundColor: colours.functional.border,
-    flex: 1,
-    width: "86%"
+    flex: 1
   },
   rowItems: {
     flexDirection: "row",

--- a/packages/edition-slices/src/slices/shared/content-wrapper.js
+++ b/packages/edition-slices/src/slices/shared/content-wrapper.js
@@ -1,18 +1,15 @@
+/**
+ * ContentWrapper restricts the content area of each slice. It is used together with the Gutter component,
+ * which sets the gutter space around the content. This component is currently used only for huge breakpoints.
+ */
+
 import React from "react";
 import PropTypes from "prop-types";
 import { View } from "react-native";
-import { sliceContentMaxWidth } from "@times-components/styleguide";
+import styles from "./styles";
 
 const ContentWrapper = ({ children }) => (
-  <View
-    style={{
-      flex: 1,
-      alignSelf: "center",
-      width: sliceContentMaxWidth
-    }}
-  >
-    {children}
-  </View>
+  <View style={styles.contentWrapperStyles}>{children}</View>
 );
 
 ContentWrapper.propTypes = {

--- a/packages/edition-slices/src/slices/shared/content-wrapper.js
+++ b/packages/edition-slices/src/slices/shared/content-wrapper.js
@@ -5,15 +5,15 @@ import { sliceContentMaxWidth } from "@times-components/styleguide";
 
 const ContentWrapper = ({ children }) => (
   <View
-  style={{
-    flex:1,
-    alignSelf: "center",
-    width: sliceContentMaxWidth
-  }}
+    style={{
+      flex: 1,
+      alignSelf: "center",
+      width: sliceContentMaxWidth
+    }}
   >
     {children}
   </View>
-)
+);
 
 ContentWrapper.propTypes = {
   children: PropTypes.node.isRequired

--- a/packages/edition-slices/src/slices/shared/content-wrapper.js
+++ b/packages/edition-slices/src/slices/shared/content-wrapper.js
@@ -1,0 +1,22 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { View } from "react-native";
+import { sliceContentMaxWidth } from "@times-components/styleguide";
+
+const ContentWrapper = ({ children }) => (
+  <View
+  style={{
+    flex:1,
+    alignSelf: "center",
+    width: sliceContentMaxWidth
+  }}
+  >
+    {children}
+  </View>
+)
+
+ContentWrapper.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+export default ContentWrapper;

--- a/packages/edition-slices/src/slices/shared/index.js
+++ b/packages/edition-slices/src/slices/shared/index.js
@@ -1,4 +1,5 @@
 import Gutter from "./gutter";
+import ContentWrapper from './content-wrapper';
 import ResponsiveSlice from "./responsive-slice";
 
-export { Gutter, ResponsiveSlice };
+export { Gutter, ContentWrapper, ResponsiveSlice };

--- a/packages/edition-slices/src/slices/shared/index.js
+++ b/packages/edition-slices/src/slices/shared/index.js
@@ -1,5 +1,5 @@
 import Gutter from "./gutter";
-import ContentWrapper from './content-wrapper';
+import ContentWrapper from "./content-wrapper";
 import ResponsiveSlice from "./responsive-slice";
 
 export { Gutter, ContentWrapper, ResponsiveSlice };

--- a/packages/edition-slices/src/slices/shared/responsive-slice.js
+++ b/packages/edition-slices/src/slices/shared/responsive-slice.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { ResponsiveContext } from "@times-components/responsive";
 import { editionBreakpoints } from "@times-components/styleguide";
 import Gutter from "./gutter";
-import ContentWrapper from './content-wrapper'
+import ContentWrapper from "./content-wrapper";
 
 const ResponsiveSlice = ({
   renderSmall,
@@ -11,36 +11,36 @@ const ResponsiveSlice = ({
   renderWide,
   renderHuge
 }) => (
-    <ResponsiveContext.Consumer>
-      {({ editionBreakpoint }) => {
-        switch (editionBreakpoint) {
-          case editionBreakpoints.small:
-            return renderSmall(editionBreakpoint);
-          case editionBreakpoints.medium:
-            return <Gutter>{renderMedium(editionBreakpoint)}</Gutter>;
-          case editionBreakpoints.wide:
-            return (
-              <Gutter>
-                {(renderWide && renderWide(editionBreakpoint)) ||
+  <ResponsiveContext.Consumer>
+    {({ editionBreakpoint }) => {
+      switch (editionBreakpoint) {
+        case editionBreakpoints.small:
+          return renderSmall(editionBreakpoint);
+        case editionBreakpoints.medium:
+          return <Gutter>{renderMedium(editionBreakpoint)}</Gutter>;
+        case editionBreakpoints.wide:
+          return (
+            <Gutter>
+              {(renderWide && renderWide(editionBreakpoint)) ||
+                (renderMedium && renderMedium(editionBreakpoint))}
+            </Gutter>
+          );
+        case editionBreakpoints.huge:
+          return (
+            <Gutter>
+              <ContentWrapper>
+                {(renderHuge && renderHuge(editionBreakpoint)) ||
+                  (renderWide && renderWide(editionBreakpoint)) ||
                   (renderMedium && renderMedium(editionBreakpoint))}
-              </Gutter>
-            );
-          case editionBreakpoints.huge:
-            return (
-              <Gutter>
-                <ContentWrapper>
-                  {(renderHuge && renderHuge(editionBreakpoint)) ||
-                    (renderWide && renderWide(editionBreakpoint)) ||
-                    (renderMedium && renderMedium(editionBreakpoint))}
-                </ContentWrapper>
-              </Gutter>
-            );
-          default:
-            return renderSmall(editionBreakpoint);
-        }
-      }}
-    </ResponsiveContext.Consumer>
-  );
+              </ContentWrapper>
+            </Gutter>
+          );
+        default:
+          return renderSmall(editionBreakpoint);
+      }
+    }}
+  </ResponsiveContext.Consumer>
+);
 
 ResponsiveSlice.propTypes = {
   renderHuge: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/shared/responsive-slice.js
+++ b/packages/edition-slices/src/slices/shared/responsive-slice.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { ResponsiveContext } from "@times-components/responsive";
 import { editionBreakpoints } from "@times-components/styleguide";
 import Gutter from "./gutter";
+import ContentWrapper from './content-wrapper'
 
 const ResponsiveSlice = ({
   renderSmall,
@@ -10,34 +11,36 @@ const ResponsiveSlice = ({
   renderWide,
   renderHuge
 }) => (
-  <ResponsiveContext.Consumer>
-    {({ editionBreakpoint }) => {
-      switch (editionBreakpoint) {
-        case editionBreakpoints.small:
-          return renderSmall(editionBreakpoint);
-        case editionBreakpoints.medium:
-          return <Gutter>{renderMedium(editionBreakpoint)}</Gutter>;
-        case editionBreakpoints.wide:
-          return (
-            <Gutter>
-              {(renderWide && renderWide(editionBreakpoint)) ||
-                (renderMedium && renderMedium(editionBreakpoint))}
-            </Gutter>
-          );
-        case editionBreakpoints.huge:
-          return (
-            <Gutter>
-              {(renderHuge && renderHuge(editionBreakpoint)) ||
-                (renderWide && renderWide(editionBreakpoint)) ||
-                (renderMedium && renderMedium(editionBreakpoint))}
-            </Gutter>
-          );
-        default:
-          return renderSmall(editionBreakpoint);
-      }
-    }}
-  </ResponsiveContext.Consumer>
-);
+    <ResponsiveContext.Consumer>
+      {({ editionBreakpoint }) => {
+        switch (editionBreakpoint) {
+          case editionBreakpoints.small:
+            return renderSmall(editionBreakpoint);
+          case editionBreakpoints.medium:
+            return <Gutter>{renderMedium(editionBreakpoint)}</Gutter>;
+          case editionBreakpoints.wide:
+            return (
+              <Gutter>
+                {(renderWide && renderWide(editionBreakpoint)) ||
+                  (renderMedium && renderMedium(editionBreakpoint))}
+              </Gutter>
+            );
+          case editionBreakpoints.huge:
+            return (
+              <Gutter>
+                <ContentWrapper>
+                  {(renderHuge && renderHuge(editionBreakpoint)) ||
+                    (renderWide && renderWide(editionBreakpoint)) ||
+                    (renderMedium && renderMedium(editionBreakpoint))}
+                </ContentWrapper>
+              </Gutter>
+            );
+          default:
+            return renderSmall(editionBreakpoint);
+        }
+      }}
+    </ResponsiveContext.Consumer>
+  );
 
 ResponsiveSlice.propTypes = {
   renderHuge: PropTypes.func.isRequired,

--- a/packages/edition-slices/src/slices/shared/styles.js
+++ b/packages/edition-slices/src/slices/shared/styles.js
@@ -1,0 +1,11 @@
+import { sliceContentMaxWidth } from "@times-components/styleguide";
+
+const styles = {
+  contentWrapperStyles: {
+    flex: 1,
+    alignSelf: "center",
+    width: sliceContentMaxWidth
+  }
+};
+
+export default styles;

--- a/packages/edition-slices/src/tiles/tile-r/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/styles/index.js
@@ -10,18 +10,11 @@ const headlineFontSizeResolver = {
   [editionBreakpoints.wide]: 45
 };
 
-const hugeScreenContainerStyle = {
-  width: "86%",
-  paddingHorizontal: spacing(0),
-  alignSelf: "center"
-};
-
 export default breakpoint => ({
   container: {
     paddingBottom: spacing(3),
     paddingHorizontal: spacing(4),
-    paddingTop: spacing(2),
-    ...(breakpoint === editionBreakpoints.huge && hugeScreenContainerStyle)
+    paddingTop: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,

--- a/packages/slice-layout/__tests__/android/__snapshots__/l2np2-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/l2np2-with-style.android.test.js.snap
@@ -165,6 +165,7 @@ exports[`3. lead two no pic and two - wide 1`] = `
   <View
     style={
       Object {
+        "paddingTop": 10,
         "width": "16%",
       }
     }
@@ -210,7 +211,7 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "width": "36%",
+        "width": "42%",
       }
     }
   >
@@ -244,7 +245,8 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "width": "14%",
+        "paddingTop": 10,
+        "width": "16%",
       }
     }
   >
@@ -265,7 +267,7 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "width": "36%",
+        "width": "42%",
       }
     }
   >

--- a/packages/slice-layout/__tests__/android/__snapshots__/sd2and2-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/sd2and2-with-style.android.test.js.snap
@@ -188,6 +188,7 @@ exports[`3. secondary two and two - wide 1`] = `
     Object {
       "flex": 1,
       "flexDirection": "row",
+      "marginHorizontal": 10,
     }
   }
 >
@@ -272,9 +273,9 @@ exports[`4. secondary two and two - huge 1`] = `
 <View
   style={
     Object {
-      "alignSelf": "center",
+      "flex": 1,
       "flexDirection": "row",
-      "width": "86%",
+      "marginHorizontal": 10,
     }
   }
 >
@@ -302,7 +303,6 @@ exports[`4. secondary two and two - huge 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
         "width": "16.6%",
       }
     }
@@ -345,7 +345,6 @@ exports[`4. secondary two and two - huge 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
         "width": "16.6%",
       }
     }

--- a/packages/slice-layout/__tests__/android/__snapshots__/sd2np2-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/sd2np2-with-style.android.test.js.snap
@@ -239,10 +239,9 @@ exports[`4. secondary two no pic and two - huge 1`] = `
 <View
   style={
     Object {
-      "alignSelf": "center",
+      "flex": 1,
       "flexDirection": "row",
       "marginHorizontal": 10,
-      "width": "86%",
     }
   }
 >
@@ -270,7 +269,7 @@ exports[`4. secondary two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
+        "paddingHorizontal": 5,
         "width": "16.6%",
       }
     }
@@ -313,7 +312,7 @@ exports[`4. secondary two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
+        "paddingHorizontal": 5,
         "width": "16.6%",
       }
     }

--- a/packages/slice-layout/__tests__/ios/__snapshots__/l2np2-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/l2np2-with-style.ios.test.js.snap
@@ -165,6 +165,7 @@ exports[`3. lead two no pic and two - wide 1`] = `
   <View
     style={
       Object {
+        "paddingTop": 10,
         "width": "16%",
       }
     }
@@ -210,7 +211,7 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "width": "36%",
+        "width": "42%",
       }
     }
   >
@@ -244,7 +245,8 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "width": "14%",
+        "paddingTop": 10,
+        "width": "16%",
       }
     }
   >
@@ -265,7 +267,7 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "width": "36%",
+        "width": "42%",
       }
     }
   >

--- a/packages/slice-layout/__tests__/ios/__snapshots__/sd2and2-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/sd2and2-with-style.ios.test.js.snap
@@ -188,6 +188,7 @@ exports[`3. secondary two and two - wide 1`] = `
     Object {
       "flex": 1,
       "flexDirection": "row",
+      "marginHorizontal": 10,
     }
   }
 >
@@ -272,9 +273,9 @@ exports[`4. secondary two and two - huge 1`] = `
 <View
   style={
     Object {
-      "alignSelf": "center",
+      "flex": 1,
       "flexDirection": "row",
-      "width": "86%",
+      "marginHorizontal": 10,
     }
   }
 >
@@ -302,7 +303,6 @@ exports[`4. secondary two and two - huge 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
         "width": "16.6%",
       }
     }
@@ -345,7 +345,6 @@ exports[`4. secondary two and two - huge 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
         "width": "16.6%",
       }
     }

--- a/packages/slice-layout/__tests__/ios/__snapshots__/sd2np2-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/sd2np2-with-style.ios.test.js.snap
@@ -239,10 +239,9 @@ exports[`4. secondary two no pic and two - huge 1`] = `
 <View
   style={
     Object {
-      "alignSelf": "center",
+      "flex": 1,
       "flexDirection": "row",
       "marginHorizontal": 10,
-      "width": "86%",
     }
   }
 >
@@ -270,7 +269,7 @@ exports[`4. secondary two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
+        "paddingHorizontal": 5,
         "width": "16.6%",
       }
     }
@@ -313,7 +312,7 @@ exports[`4. secondary two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
+        "paddingHorizontal": 5,
         "width": "16.6%",
       }
     }

--- a/packages/slice-layout/__tests__/web/__snapshots__/l2np2-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/l2np2-with-style.web.test.js.snap
@@ -273,6 +273,7 @@ exports[`3. lead two no pic and two - wide 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
+        "paddingTop": "10px",
         "width": "16%",
       }
     }
@@ -341,7 +342,7 @@ exports[`4. lead two no pic and two - huge 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "36%",
+        "width": "42%",
       }
     }
   >
@@ -396,7 +397,8 @@ exports[`4. lead two no pic and two - huge 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "14%",
+        "paddingTop": "10px",
+        "width": "16%",
       }
     }
   >
@@ -428,7 +430,7 @@ exports[`4. lead two no pic and two - huge 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "36%",
+        "width": "42%",
       }
     }
   >

--- a/packages/slice-layout/__tests__/web/__snapshots__/sd2and2-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/sd2and2-with-style.web.test.js.snap
@@ -288,6 +288,8 @@ exports[`3. secondary two and two - wide 1`] = `
       "flexDirection": "row",
       "flexGrow": 1,
       "flexShrink": 1,
+      "marginLeft": "10px",
+      "marginRight": "10px",
       "msFlexDirection": "row",
       "msFlexNegative": 1,
       "msFlexPositive": 1,
@@ -397,15 +399,23 @@ exports[`4. secondary two and two - huge 1`] = `
 <div
   style={
     Object {
-      "WebkitAlignSelf": "center",
       "WebkitBoxDirection": "normal",
+      "WebkitBoxFlex": 1,
       "WebkitBoxOrient": "horizontal",
+      "WebkitFlexBasis": "0%",
       "WebkitFlexDirection": "row",
-      "alignSelf": "center",
+      "WebkitFlexGrow": 1,
+      "WebkitFlexShrink": 1,
+      "flexBasis": "0%",
       "flexDirection": "row",
+      "flexGrow": 1,
+      "flexShrink": 1,
+      "marginLeft": "10px",
+      "marginRight": "10px",
       "msFlexDirection": "row",
-      "msFlexItemAlign": "center",
-      "width": "86%",
+      "msFlexNegative": 1,
+      "msFlexPositive": 1,
+      "msFlexPreferredSize": "0%",
     }
   }
 >
@@ -440,8 +450,6 @@ exports[`4. secondary two and two - huge 1`] = `
   <div
     style={
       Object {
-        "paddingLeft": "10px",
-        "paddingRight": "10px",
         "width": "16.6%",
       }
     }
@@ -498,8 +506,6 @@ exports[`4. secondary two and two - huge 1`] = `
   <div
     style={
       Object {
-        "paddingLeft": "10px",
-        "paddingRight": "10px",
         "width": "16.6%",
       }
     }

--- a/packages/slice-layout/__tests__/web/__snapshots__/sd2np2-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/sd2np2-with-style.web.test.js.snap
@@ -393,17 +393,23 @@ exports[`4. secondary two no pic and two - huge 1`] = `
   className="css-view-1dbjc4n"
   style={
     Object {
-      "WebkitAlignSelf": "center",
       "WebkitBoxDirection": "normal",
+      "WebkitBoxFlex": 1,
       "WebkitBoxOrient": "horizontal",
+      "WebkitFlexBasis": "0%",
       "WebkitFlexDirection": "row",
-      "alignSelf": "center",
+      "WebkitFlexGrow": 1,
+      "WebkitFlexShrink": 1,
+      "flexBasis": "0%",
       "flexDirection": "row",
+      "flexGrow": 1,
+      "flexShrink": 1,
       "marginLeft": "10px",
       "marginRight": "10px",
       "msFlexDirection": "row",
-      "msFlexItemAlign": "center",
-      "width": "86%",
+      "msFlexNegative": 1,
+      "msFlexPositive": 1,
+      "msFlexPreferredSize": "0%",
     }
   }
 >
@@ -443,8 +449,8 @@ exports[`4. secondary two no pic and two - huge 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "paddingLeft": "10px",
-        "paddingRight": "10px",
+        "paddingLeft": "5px",
+        "paddingRight": "5px",
         "width": "16.6%",
       }
     }
@@ -509,8 +515,8 @@ exports[`4. secondary two no pic and two - huge 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "paddingLeft": "10px",
-        "paddingRight": "10px",
+        "paddingLeft": "5px",
+        "paddingRight": "5px",
         "width": "16.6%",
       }
     }

--- a/packages/slice-layout/src/templates/leadoneandone/index.js
+++ b/packages/slice-layout/src/templates/leadoneandone/index.js
@@ -3,11 +3,9 @@ import { View } from "react-native";
 import { editionBreakpoints } from "@times-components/styleguide";
 import { defaultProps, propTypes } from "./proptypes";
 import HorizontalLayout from "../horizontallayout";
-import styleFactory from "./styles";
+import styles from "./styles";
 
 const leadOneAndOneSlice = ({ breakpoint, lead, support }) => {
-  const styles = styleFactory(breakpoint);
-
   if (breakpoint === editionBreakpoints.small) {
     return (
       <View>

--- a/packages/slice-layout/src/templates/leadoneandone/styles.js
+++ b/packages/slice-layout/src/templates/leadoneandone/styles.js
@@ -1,8 +1,4 @@
-import {
-  spacing,
-  colours,
-  editionBreakpoints
-} from "@times-components/styleguide";
+import { spacing, colours } from "@times-components/styleguide";
 
 const styles = {
   container: {
@@ -22,14 +18,4 @@ const styles = {
   }
 };
 
-const hugeBreakpointStyles = {
-  ...styles,
-  container: {
-    ...styles.container,
-    width: "86%",
-    alignSelf: "center"
-  }
-};
-
-export default breakpoint =>
-  breakpoint === editionBreakpoints.huge ? hugeBreakpointStyles : styles;
+export default styles;

--- a/packages/slice-layout/src/templates/leadtwonopicandtwo/styles.js
+++ b/packages/slice-layout/src/templates/leadtwonopicandtwo/styles.js
@@ -16,21 +16,13 @@ const stylesWide = {
     width: "42%"
   },
   middleTile: {
+    paddingTop: spacing(2),
     width: "16%"
   }
 };
 
-const stylesHuge = {
-  column: {
-    width: "36%"
-  },
-  middleTile: {
-    width: "14%"
-  }
-};
-
 const stylesResolver = {
-  huge: stylesHuge,
+  huge: stylesWide,
   wide: stylesWide
 };
 

--- a/packages/slice-layout/src/templates/secondarytwoandtwo/styles.js
+++ b/packages/slice-layout/src/templates/secondarytwoandtwo/styles.js
@@ -28,33 +28,19 @@ const mediumBreakpointStyles = {
 const wideBreakpointStyles = {
   container: {
     flex: 1,
-    flexDirection: "row"
-  },
-  secondaryItemContainer: {
-    width: "33.4%"
-  },
-  supportItemContainer: {
-    width: "16.6%"
-  }
-};
-
-const hugeBreakpointStyles = {
-  container: {
-    alignSelf: "center",
     flexDirection: "row",
-    width: "86%"
+    marginHorizontal: spacing(2)
   },
   secondaryItemContainer: {
     width: "33.4%"
   },
   supportItemContainer: {
-    paddingHorizontal: spacing(2),
     width: "16.6%"
   }
 };
 
 const stylesToReturn = {
-  huge: hugeBreakpointStyles,
+  huge: wideBreakpointStyles,
   medium: mediumBreakpointStyles,
   small: smallBreakpointStyles,
   wide: wideBreakpointStyles

--- a/packages/slice-layout/src/templates/secondarytwonopicandtwo/styles.js
+++ b/packages/slice-layout/src/templates/secondarytwonopicandtwo/styles.js
@@ -26,24 +26,8 @@ const wideBreakpointStyles = {
   }
 };
 
-const hugeBreakpointStyles = {
-  container: {
-    alignSelf: "center",
-    flexDirection: "row",
-    marginHorizontal: spacing(2),
-    width: "86%"
-  },
-  secondaryItemContainer: {
-    width: "33.4%"
-  },
-  supportItemContainer: {
-    paddingHorizontal: spacing(2),
-    width: "16.6%"
-  }
-};
-
 const stylesToreturn = {
-  huge: hugeBreakpointStyles,
+  huge: wideBreakpointStyles,
   medium: mediumBreakpointStyles,
   wide: wideBreakpointStyles
 };

--- a/packages/styleguide/src/breakpoints/index.js
+++ b/packages/styleguide/src/breakpoints/index.js
@@ -11,6 +11,7 @@ const editionBreakpointWidths = {
   wide: 1024
 };
 const editionMaxWidth = editionBreakpointWidths.huge;
+const sliceContentMaxWidth = 1180;
 
 const getEditionBreakpoint = width => {
   if (width < editionBreakpointWidths.medium) {
@@ -37,5 +38,6 @@ export {
   editionBreakpoints,
   editionMaxWidth,
   getEditionBreakpoint,
-  editionBreakpointWidths
+  editionBreakpointWidths,
+  sliceContentMaxWidth
 };

--- a/packages/styleguide/src/styleguide.js
+++ b/packages/styleguide/src/styleguide.js
@@ -7,7 +7,8 @@ import breakpoints, {
   editionBreakpoints,
   editionMaxWidth,
   getEditionBreakpoint,
-  editionBreakpointWidths
+  editionBreakpointWidths,
+  sliceContentMaxWidth
 } from "./breakpoints";
 import timesLineHeightsFactory from "./line-heights";
 import timesFonts from "./fonts/fonts";
@@ -44,6 +45,7 @@ export {
   editionBreakpoints,
   editionBreakpointWidths,
   editionMaxWidth,
+  sliceContentMaxWidth,
   fonts,
   fontFactory,
   fontSizes,


### PR DESCRIPTION
This PR is to implement a simple slice content wrapper used to restrict the content width to 1180px for huge breakpoints

This is by design:
![Screenshot 2019-07-15 at 16 57 25](https://user-images.githubusercontent.com/16742525/61222147-cc4f8180-a722-11e9-88fb-26be378d8375.png)


**Before:**
![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2019-07-15 at 17 07 31](https://user-images.githubusercontent.com/16742525/61222951-6532cc80-a724-11e9-95ef-8e89f60b6f96.png)


**After:**
![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2019-07-15 at 17 08 32](https://user-images.githubusercontent.com/16742525/61222972-6fed6180-a724-11e9-9a9e-ba531be767de.png)



