### PR TITLE
fix: paragraph with dropcap margin bottom fixed

### DIFF
--- a/packages/article-image/__tests__/android/__snapshots__/article-image-inline.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image-inline.android.test.js.snap
@@ -58,7 +58,6 @@ exports[`1. inline image (landscape) with caption and credits 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 13,
               "lineHeight": 20,
-              "marginTop": -5,
             }
           }
         >
@@ -143,7 +142,6 @@ exports[`2. inline image (portrait) with caption and credits 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 13,
               "lineHeight": 20,
-              "marginTop": -5,
             }
           }
         >

--- a/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
@@ -41,7 +41,6 @@ exports[`1. mobile primary image with caption and credits 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 13,
               "lineHeight": 20,
-              "marginTop": -5,
             }
           }
         >
@@ -109,7 +108,6 @@ exports[`2. tablet primary image with caption and credits 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 13,
               "lineHeight": 20,
-              "marginTop": -5,
             }
           }
         >
@@ -350,7 +348,6 @@ exports[`5. secondary image with caption and credits 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 13,
               "lineHeight": 20,
-              "marginTop": -5,
             }
           }
         >

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -71,7 +71,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             <View
               style={
                 Object {
-                  "height": 0,
+                  "height": 20,
                   "marginBottom": -10,
                 }
               }
@@ -646,7 +646,7 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
             <View
               style={
                 Object {
-                  "height": 0,
+                  "height": 20,
                   "marginBottom": -10,
                 }
               }
@@ -682,7 +682,7 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
             <View
               style={
                 Object {
-                  "height": 0,
+                  "height": 20,
                   "marginBottom": -10,
                 }
               }

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -72,6 +72,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               style={
                 Object {
                   "height": 0,
+                  "marginBottom": -10,
                 }
               }
             >
@@ -646,6 +647,7 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
               style={
                 Object {
                   "height": 0,
+                  "marginBottom": -10,
                 }
               }
             >
@@ -681,6 +683,7 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
               style={
                 Object {
                   "height": 0,
+                  "marginBottom": -10,
                 }
               }
             >

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -301,7 +301,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "fontFamily": "GillSansMTStd-Medium",
                       "fontSize": 13,
                       "lineHeight": 20,
-                      "marginTop": -5,
                     }
                   }
                 >
@@ -1030,7 +1029,6 @@ exports[`4. an article skeleton with responsive items 1`] = `
                       "fontFamily": "GillSansMTStd-Medium",
                       "fontSize": 13,
                       "lineHeight": 20,
-                      "marginTop": -5,
                     }
                   }
                 >

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -72,7 +72,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               style={
                 Object {
                   "height": 20,
-                  "marginBottom": -10,
                 }
               }
             >
@@ -647,7 +646,6 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
               style={
                 Object {
                   "height": 20,
-                  "marginBottom": -10,
                 }
               }
             >
@@ -683,7 +681,6 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
               style={
                 Object {
                   "height": 20,
-                  "marginBottom": -10,
                 }
               }
             >

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -72,6 +72,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               style={
                 Object {
                   "height": 0,
+                  "marginBottom": -10,
                 }
               }
             >
@@ -644,6 +645,7 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
               style={
                 Object {
                   "height": 0,
+                  "marginBottom": -10,
                 }
               }
             >
@@ -679,6 +681,7 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
               style={
                 Object {
                   "height": 0,
+                  "marginBottom": -10,
                 }
               }
             >

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -71,7 +71,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             <View
               style={
                 Object {
-                  "height": 0,
+                  "height": 20,
                   "marginBottom": -10,
                 }
               }
@@ -644,7 +644,7 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
             <View
               style={
                 Object {
-                  "height": 0,
+                  "height": 20,
                   "marginBottom": -10,
                 }
               }
@@ -680,7 +680,7 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
             <View
               style={
                 Object {
-                  "height": 0,
+                  "height": 20,
                   "marginBottom": -10,
                 }
               }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -72,7 +72,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               style={
                 Object {
                   "height": 20,
-                  "marginBottom": -10,
                 }
               }
             >
@@ -645,7 +644,6 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
               style={
                 Object {
                   "height": 20,
-                  "marginBottom": -10,
                 }
               }
             >
@@ -681,7 +679,6 @@ exports[`3. an article with a nested markup in first paragraph displays a drop c
               style={
                 Object {
                   "height": 20,
-                  "marginBottom": -10,
                 }
               }
             >

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -18,7 +18,12 @@ import styleguide, {
 } from "@times-components/styleguide";
 import { screenWidth } from "@times-components/utils";
 import Video from "@times-components/video";
-import { Layout, Text, MarkupFactory } from "@times-components/text-flow";
+import {
+  Layout,
+  Text,
+  MarkupFactory,
+  Markup
+} from "@times-components/text-flow";
 import DropCap from "@times-components/article-paragraph/src/drop-cap";
 import ArticleLink from "./article-link";
 import InsetCaption from "./inset-caption";
@@ -165,14 +170,27 @@ export default ({
         font: "supporting",
         fontSize: "caption"
       });
-      const captionText = new Text.Text({
-        font: cFontFamily,
-        lineHeight: cLineHeight * fontScale,
-        markup: [new Body(caption)],
-        size: cFontSize * fontScale,
-        width: width * 0.35
-      });
-      const captionHeight = captionText.measuredHeight;
+      let height = 0;
+      if (caption) {
+        const captionText = new Text.Text({
+          font: cFontFamily,
+          lineHeight: cLineHeight * fontScale,
+          markup: [new Body(caption)],
+          size: cFontSize * fontScale,
+          width: width * 0.35
+        });
+        height += captionText.measuredHeight;
+      }
+      if (credits && credits[0] !== "<") {
+        const creditsText = new Text.Text({
+          font: cFontFamily,
+          lineHeight: cLineHeight * fontScale,
+          markup: [new Body(credits)],
+          size: cFontSize * fontScale,
+          width: width * 0.35
+        });
+        height += creditsText.measuredHeight;
+      }
       const inline = new Layout.InlineBlock({
         getComponent() {
           return (
@@ -192,7 +210,7 @@ export default ({
             </View>
           );
         },
-        height: width * 0.35 * aspectRatio + captionHeight,
+        height: width * 0.35 * aspectRatio + height,
         layoutDone: false,
         prevHeight: 0,
         width: width * 0.35
@@ -332,11 +350,35 @@ export default ({
       const quote = new Text.Text({
         font: qFontFamily,
         lineHeight: qLineHeight * fontScale,
-        markup: [new Body(content)],
+        markup: [
+          new Body('"'),
+          new Markup.Newline(),
+          new Body(content),
+          new Markup.Newline()
+        ],
         size: qFontSize * fontScale,
         width: width * 0.35
       });
-      const height = quote.measuredHeight;
+      const {
+        fontFamily: cFontFamily,
+        fontSize: cFontSize,
+        lineHeight: cLineHeight
+      } = fontFactory({
+        font: "supporting",
+        fontSize: "caption"
+      });
+      let captionHeight = 0;
+      if (name) {
+        const caption = new Text.Text({
+          font: cFontFamily,
+          lineHeight: cLineHeight * fontScale,
+          markup: [new Markup.Newline(), new Body(name), new Markup.Newline()],
+          size: cFontSize * fontScale,
+          width: width * 0.35
+        });
+        captionHeight = caption.measuredHeight;
+      }
+      const height = quote.measuredHeight + (captionHeight + spacing(1));
       return {
         element: new Layout.InlineBlock({
           getComponent() {
@@ -364,7 +406,7 @@ export default ({
               </Context.Consumer>
             );
           },
-          height: height + lineHeight * 1.3 * fontScale,
+          height,
           width: width * 0.35
         }),
         shouldRenderChildren: false

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -98,7 +98,12 @@ const renderText = (block, inlined = false) => {
     ));
   }
   return block.getComponent(style => (
-    <View style={{ height: block.measuredHeight }}>
+    <View
+      style={[
+        { height: block.measuredHeight },
+        styles.inlineParagraphContainer
+      ]}
+    >
       {block.block.children.map(line =>
         line.idealSpans.map(span => {
           if (span.href) {

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -98,7 +98,7 @@ const renderText = (block, inlined = false) => {
     ));
   }
   return block.getComponent(style => (
-    <View style={[{ height: block.measuredHeight }]}>
+    <View style={{ height: block.measuredHeight }}>
       {block.block.children.map(line =>
         line.idealSpans.map(span => {
           if (span.href) {

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -257,6 +257,7 @@ class ArticleSkeleton extends Component {
     const { fontScale } = Dimensions.get("window");
 
     const textFlow = new Layout.TextFlow({
+      padding: 20,
       flow: rows.map(rowData =>
         ArticleRowFlow({
           content: rowData,

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -34,7 +34,7 @@ const viewabilityConfig = {
 };
 
 const convertStyles = ({ font, size }) => ({
-  fontFamily: font.replace(/-Bold|Italic/gi, ""),
+  fontFamily: font.replace(/-Bold|-Italic/gi, ""),
   fontSize: size,
   fontStyle: font.includes("Italic") ? "italic" : "normal",
   fontWeight: font.includes("Bold") ? "bold" : "normal"

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -98,12 +98,7 @@ const renderText = (block, inlined = false) => {
     ));
   }
   return block.getComponent(style => (
-    <View
-      style={[
-        { height: block.measuredHeight },
-        styles.inlineParagraphContainer
-      ]}
-    >
+    <View style={[{ height: block.measuredHeight }]}>
       {block.block.children.map(line =>
         line.idealSpans.map(span => {
           if (span.href) {

--- a/packages/article-skeleton/src/styles/shared.js
+++ b/packages/article-skeleton/src/styles/shared.js
@@ -14,9 +14,6 @@ const globalStyle = {
     backgroundColor: "#ffffff",
     maxWidth: "100%",
     width: maxWidth
-  },
-  inlineParagraphContainer: {
-    marginBottom: spacing(-2)
   }
 };
 

--- a/packages/article-skeleton/src/styles/shared.js
+++ b/packages/article-skeleton/src/styles/shared.js
@@ -14,6 +14,9 @@ const globalStyle = {
     backgroundColor: "#ffffff",
     maxWidth: "100%",
     width: maxWidth
+  },
+  inlineParagraphContainer: {
+    marginBottom: spacing(-2)
   }
 };
 

--- a/packages/caption/__tests__/android/__snapshots__/caption-with-style.android.test.js.snap
+++ b/packages/caption/__tests__/android/__snapshots__/caption-with-style.android.test.js.snap
@@ -17,7 +17,6 @@ exports[`1. caption with container and text styles 1`] = `
           "fontFamily": "GillSansMTStd-Medium",
           "fontSize": 13,
           "lineHeight": 20,
-          "marginTop": -5,
         }
       }
     >
@@ -59,7 +58,6 @@ exports[`2. caption with container, caption, and credit styles 1`] = `
           "fontFamily": "GillSansMTStd-Medium",
           "fontSize": 10,
           "lineHeight": 20,
-          "marginTop": -5,
         }
       }
     >
@@ -101,7 +99,6 @@ exports[`3. caption with only container styles 1`] = `
           "fontFamily": "GillSansMTStd-Medium",
           "fontSize": 13,
           "lineHeight": 20,
-          "marginTop": -5,
         }
       }
     >

--- a/packages/caption/src/styles/index.android.js
+++ b/packages/caption/src/styles/index.android.js
@@ -15,8 +15,7 @@ const styles = StyleSheet.create({
   },
   text: {
     ...sharedStyles.text,
-    lineHeight: spacing(4),
-    marginTop: -spacing(1)
+    lineHeight: spacing(4)
   }
 });
 

--- a/packages/text-flow/__tests__/android/__snapshots__/text.test.js.snap
+++ b/packages/text-flow/__tests__/android/__snapshots__/text.test.js.snap
@@ -54,7 +54,7 @@ Array [
         "y": 0,
       },
     ],
-    "width": 1.9308355807606137,
+    "width": 1.9728082370106137,
     "x": 0,
     "y": 0,
   },
@@ -64,13 +64,6 @@ Array [
     "width": 0,
     "x": 0,
     "y": 30,
-  },
-  Object {
-    "height": 0,
-    "spans": Array [],
-    "width": 0,
-    "x": 0,
-    "y": 60,
   },
 ]
 `;
@@ -130,31 +123,16 @@ Array [
       },
     ],
     "height": 0,
-    "width": 1.9308355807606137,
+    "width": 1.9728082370106137,
     "x": 0,
     "y": 0,
-  },
-  Object {
-    "children": Array [
-      Object {
-        "children": "",
-        "height": 0,
-        "width": 0,
-        "x": 0,
-        "y": 30,
-      },
-    ],
-    "height": 0,
-    "width": 0,
-    "x": 0,
-    "y": 30,
   },
   Object {
     "children": Array [],
     "height": 0,
     "width": 0,
     "x": 0,
-    "y": 60,
+    "y": 30,
   },
 ]
 `;

--- a/packages/text-flow/src/Layout/TextFlow.js
+++ b/packages/text-flow/src/Layout/TextFlow.js
@@ -11,6 +11,8 @@ export default class TextFlow extends Container {
 
   height = 20;
 
+  padding = 20;
+
   flow = [];
 
   // TODO: operate only on args and block, not children
@@ -86,11 +88,14 @@ export default class TextFlow extends Container {
               });
             }
           }
-          vPosition += next.measuredHeight;
-          child.addChild(next);
+          pulledLines += this.padding / next.lineHeight
+          next.block.measuredHeight += this.padding
+          next.measuredHeight += this.padding
+          vPosition += next.measuredHeight
+          child.addChild(next)
           grabbed += 1;
           next = this.flow[grabbed];
-          if (pulledLines >= elNumLines || !next) {
+          if (pulledLines >= elLines.length || !next) {
             break;
           }
         }

--- a/packages/text-flow/src/Layout/TextFlow.js
+++ b/packages/text-flow/src/Layout/TextFlow.js
@@ -68,7 +68,7 @@ export default class TextFlow extends Container {
             // Support merging of inlines one day
             break;
           }
-          next.lineWidths = elLines.slice(pulledLines);
+          next.lineWidths = elLines.slice(Math.floor(pulledLines));
           next.width = this.width;
           next.layout();
           if (
@@ -95,8 +95,8 @@ export default class TextFlow extends Container {
           child.addChild(next)
           grabbed += 1;
           next = this.flow[grabbed];
-          if (pulledLines >= elLines.length || !next) {
-            break;
+          if (vPosition > (child.y + child.height) || !next) {
+            break
           }
         }
         i = grabbed;

--- a/packages/text-flow/src/Text/Text.js
+++ b/packages/text-flow/src/Text/Text.js
@@ -1,5 +1,4 @@
 /* eslint-disable prefer-destructuring,no-continue,no-underscore-dangle */
-import FontLoader from "./FontLoader";
 import Word from "./Word";
 import Character from "./Character";
 import Line from "./Line";
@@ -14,13 +13,13 @@ import Box from "./Box";
 export default class Text extends Container {
   markup = [];
 
-  lineHeight = null;
+  lineHeight = 30;
 
   characters = [];
 
   width = 100;
 
-  height = 20;
+  height = 30;
 
   _measuredHeight = 0;
 
@@ -136,7 +135,6 @@ export default class Text extends Container {
     }
 
     this.wordLayout();
-    this.lineLayout();
   }
 
   get idealSpans() {
@@ -316,19 +314,6 @@ export default class Text extends Container {
           flagged: 1,
           penalty: -infinity,
           width: 0
-        }),
-        new Box({
-          word: new Word()
-        }),
-        new Glue({
-          shrink: 0,
-          stretch: infinity,
-          width: 0
-        }),
-        new Penalty({
-          flagged: 1,
-          penalty: -infinity,
-          width: 0
         })
       ]);
 
@@ -375,83 +360,6 @@ export default class Text extends Container {
       }
     }
     this._block.measuredHeight = vPosition;
-  }
-
-  lineLayout() {
-    // loop over lines
-    // place into text
-    let measuredHeight = 0;
-    let line;
-    const a = Align;
-    const fnt = FontLoader.getFont(this.font);
-
-    const len = this.lines.length;
-    for (let i = 0; i < len; i += 1) {
-      line = this.lines[i];
-
-      // correct measuredWidth if last line character contains tracking
-      if (line.lastWord() !== undefined && line.lastWord().lastCharacter()) {
-        line.measuredWidth -= line
-          .lastWord()
-          .lastCharacter()
-          .trackingOffset();
-      }
-
-      measuredHeight += line.measuredHeight;
-      if (this.align === a.TOP_CENTER) {
-        // move to center
-        line.x = (this.width - line.measuredWidth) / 2;
-      } else if (this.align === a.TOP_RIGHT) {
-        // move to right
-        line.x = this.width - line.measuredWidth;
-      } else if (this.align === a.MIDDLE_CENTER) {
-        // move to center
-        line.x = (this.width - line.measuredWidth) / 2;
-      } else if (this.align === a.MIDDLE_RIGHT) {
-        // move to right
-        line.x = this.width - line.measuredWidth;
-      } else if (this.align === a.BOTTOM_CENTER) {
-        // move to center
-        line.x = (this.width - line.measuredWidth) / 2;
-      } else if (this.align === a.BOTTOM_RIGHT) {
-        // move to right
-        line.x = this.width - line.measuredWidth;
-      }
-    }
-
-    // TOP ALIGNED
-    if (
-      this.align === a.TOP_LEFT ||
-      this.align === a.TOP_CENTER ||
-      this.align === a.TOP_RIGHT
-    ) {
-      this._block.y =
-        this.lines[0].measuredHeight * fnt.ascent / fnt.units +
-        this.lines[0].measuredHeight * fnt.top / fnt.units;
-
-      // MIDDLE ALIGNED
-    } else if (
-      this.align === a.MIDDLE_LEFT ||
-      this.align === a.MIDDLE_CENTER ||
-      this.align === a.MIDDLE_RIGHT
-    ) {
-      this._block.y =
-        this.lines[0].measuredHeight +
-        (this.height - measuredHeight) / 2 +
-        this.lines[0].measuredHeight * fnt.middle / fnt.units;
-
-      // BOTTOM ALIGNED
-    } else if (
-      this.align === a.BOTTOM_LEFT ||
-      this.align === a.BOTTOM_CENTER ||
-      this.align === a.BOTTOM_RIGHT
-    ) {
-      this._block.y =
-        this.height -
-        this.lines[this.lines.length - 1].y +
-        this.lines[0].measuredHeight * fnt.bottom / fnt.units;
-    }
-
     this.measuredHeight = this._block.measuredHeight;
     this.measuredWidth = this._block.measuredWidth;
   }


### PR DESCRIPTION
[Jira](https://nidigitalsolutions.jira.com/browse/REPLAT-6707).

What was done:
Spacing below paragraph with drop cap updated.

What's affected: 
iOS and Android app

Before:
![para-spacing-before](https://user-images.githubusercontent.com/8720661/61292523-13e51480-a7da-11e9-87e5-f376056d096c.png)


After:
![para-spacing-after](https://user-images.githubusercontent.com/8720661/61292527-15aed800-a7da-11e9-83de-e147fbe02eaf.png)
