### PR TITLE
fix: (REPLAT-6787) article video label alignment

### DIFF
--- a/packages/video-label/__tests__/android/__snapshots__/video-label-with-style.android.test.js.snap
+++ b/packages/video-label/__tests__/android/__snapshots__/video-label-with-style.android.test.js.snap
@@ -13,8 +13,9 @@ exports[`1. video label with a title 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "marginBottom": 3,
-        "paddingBottom": 0,
+        "paddingBottom": 2,
       }
     }
   >
@@ -56,8 +57,9 @@ exports[`2. video label without a title shows video 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "marginBottom": 3,
-        "paddingBottom": 0,
+        "paddingBottom": 2,
       }
     }
   >
@@ -99,8 +101,9 @@ exports[`3. video label with the black default colour 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "marginBottom": 3,
-        "paddingBottom": 0,
+        "paddingBottom": 2,
       }
     }
   >

--- a/packages/video-label/__tests__/ios/__snapshots__/video-label-with-style.ios.test.js.snap
+++ b/packages/video-label/__tests__/ios/__snapshots__/video-label-with-style.ios.test.js.snap
@@ -13,6 +13,7 @@ exports[`1. video label with a title 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "paddingBottom": 5,
       }
     }
@@ -55,6 +56,7 @@ exports[`2. video label without a title shows video 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "paddingBottom": 5,
       }
     }
@@ -97,6 +99,7 @@ exports[`3. video label with the black default colour 1`] = `
   <View
     style={
       Object {
+        "alignSelf": "center",
         "paddingBottom": 5,
       }
     }

--- a/packages/video-label/__tests__/web/__snapshots__/video-label-with-style.web.test.js.snap
+++ b/packages/video-label/__tests__/web/__snapshots__/video-label-with-style.web.test.js.snap
@@ -3,7 +3,7 @@
 exports[`1. video label with a title 1`] = `
 <style>
 .S1 {
-  padding-bottom: 3px;
+  padding-bottom: 2px;
 }
 
 .S2 {
@@ -29,7 +29,8 @@ exports[`1. video label with a title 1`] = `
 }
 
 .IS1 {
-  padding-bottom: 3;
+  padding-bottom: 2;
+  align-self: center;
 }
 
 .IS2 {
@@ -64,7 +65,7 @@ exports[`1. video label with a title 1`] = `
     className="css-view-1dbjc4n r-alignItems-1habvwh r-flexDirection-18u37iz r-marginBottom-10sqg0u r-marginTop-19i43ro S3"
   >
     <div
-      className="css-view-1dbjc4n r-paddingBottom-3hmvjm S1"
+      className="css-view-1dbjc4n r-alignSelf-1kihuf0 r-paddingBottom-l4nmg1 S1"
     >
       <IconVideo
         fillColour="#008347"
@@ -83,7 +84,7 @@ exports[`1. video label with a title 1`] = `
 exports[`2. video label without a title shows video 1`] = `
 <style>
 .S1 {
-  padding-bottom: 3px;
+  padding-bottom: 2px;
 }
 
 .S2 {
@@ -109,7 +110,8 @@ exports[`2. video label without a title shows video 1`] = `
 }
 
 .IS1 {
-  padding-bottom: 3;
+  padding-bottom: 2;
+  align-self: center;
 }
 
 .IS2 {
@@ -144,7 +146,7 @@ exports[`2. video label without a title shows video 1`] = `
     className="css-view-1dbjc4n r-alignItems-1habvwh r-flexDirection-18u37iz r-marginBottom-10sqg0u r-marginTop-19i43ro S3"
   >
     <div
-      className="css-view-1dbjc4n r-paddingBottom-3hmvjm S1"
+      className="css-view-1dbjc4n r-alignSelf-1kihuf0 r-paddingBottom-l4nmg1 S1"
     >
       <IconVideo
         fillColour="#008347"
@@ -163,7 +165,7 @@ exports[`2. video label without a title shows video 1`] = `
 exports[`3. video label with the black default colour 1`] = `
 <style>
 .S1 {
-  padding-bottom: 3px;
+  padding-bottom: 2px;
 }
 
 .S2 {
@@ -189,7 +191,8 @@ exports[`3. video label with the black default colour 1`] = `
 }
 
 .IS1 {
-  padding-bottom: 3;
+  padding-bottom: 2;
+  align-self: center;
 }
 
 .IS2 {
@@ -224,7 +227,7 @@ exports[`3. video label with the black default colour 1`] = `
     className="css-view-1dbjc4n r-alignItems-1habvwh r-flexDirection-18u37iz r-marginBottom-10sqg0u r-marginTop-19i43ro S3"
   >
     <div
-      className="css-view-1dbjc4n r-paddingBottom-3hmvjm S1"
+      className="css-view-1dbjc4n r-alignSelf-1kihuf0 r-paddingBottom-l4nmg1 S1"
     >
       <IconVideo
         fillColour="black"

--- a/packages/video-label/src/style/index.android.js
+++ b/packages/video-label/src/style/index.android.js
@@ -6,7 +6,7 @@ const styles = StyleSheet.create({
   iconContainer: {
     ...sharedStyles.iconContainer,
     marginBottom: 3,
-    paddingBottom: 0
+    paddingBottom: 2
   },
   title: {
     ...sharedStyles.title,

--- a/packages/video-label/src/style/index.web.js
+++ b/packages/video-label/src/style/index.web.js
@@ -9,7 +9,7 @@ const styles = StyleSheet.create({
   },
   iconContainer: {
     ...sharedStyles.iconContainer,
-    paddingBottom: 3
+    paddingBottom: 2
   },
   title: {
     ...sharedStyles.title,

--- a/packages/video-label/src/style/shared.js
+++ b/packages/video-label/src/style/shared.js
@@ -10,7 +10,7 @@ const styles = {
   },
   iconContainer: {
     paddingBottom: spacing(1),
-    alignSelf: 'center'
+    alignSelf: "center"
   },
   title: {
     ...fontFactory({

--- a/packages/video-label/src/style/shared.js
+++ b/packages/video-label/src/style/shared.js
@@ -9,7 +9,8 @@ const styles = {
     marginTop: -1
   },
   iconContainer: {
-    paddingBottom: spacing(1)
+    paddingBottom: spacing(1),
+    alignSelf: 'center'
   },
   title: {
     ...fontFactory({


### PR DESCRIPTION
Story: https://nidigitalsolutions.jira.com/secure/RapidBoard.jspa?rapidView=1116&modal=detail&selectedIssue=REPLAT-6787

Video icon and label text should be vertically aligned but currently they are not. This is observed mainly in Chrome on Windows, but actually it is an issue for all browsers despite the OS. 

Currently on all browsers once we put the items' borders:
<img width="598" alt="Screenshot 2019-07-16 at 14 09 07 copy" src="https://user-images.githubusercontent.com/16742525/61369232-5b31da80-a898-11e9-9cfc-a87fccfc6aaa.png">


The incorrect alignment is better noticed on Windows browsers because the used font `GillSansMTStd-Medium` behaves differently on Windows vs Mac/Linux and all the mobile simulators

*[Some fonts on apple devices has more padding than Windows font](https://stackoverflow.com/questions/25209060/some-fonts-on-apple-devices-has-more-padding-than-windows-font)

GillSansMTStd-Medium on macOS Mojave/Chrome 75
<img width="527" alt="Screenshot 2019-07-16 at 17 40 31 copy" src="https://user-images.githubusercontent.com/16742525/61368961-ac8d9a00-a897-11e9-8a29-74f613fa1d55.png">

GillSansMTStd-Medium on Windows 10/Chrome 75
![Capture-Example copy](https://user-images.githubusercontent.com/16742525/61369063-eced1800-a897-11e9-9726-64fcc8ff71d6.png)

The current PR suggests vertically aligning the video icon in the centre and adjusting its padding size so it looks acceptable on both Mac/Win. This is the easiest/faster approach but not 100% accurate.
Other solutions include fixing the vertical alignment font metrics or detecting and applying custom CSS for each OS but all of them will need further investigation.

Attaching screenshots with the current code change:
Before:
**Windows/Chrome**
![Capture2-Chrome](https://user-images.githubusercontent.com/16742525/61369474-ddba9a00-a898-11e9-9932-658571d0e6de.png)

After:
**Windows/Chrome 75**
![Capture-Chrome-Solution](https://user-images.githubusercontent.com/16742525/61370032-2161d380-a89a-11e9-99ae-d59a41612fcd.png)


**Mac/Chrome 75**
<img width="1440" alt="Screenshot 2019-07-17 at 13 47 21" src="https://user-images.githubusercontent.com/16742525/61370071-350d3a00-a89a-11e9-84bd-b4a04f0b1af3.png">



