### PR TITLE
fix: article scroll tracking

### DIFF
--- a/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
@@ -14,38 +14,23 @@ exports[`1. multiple ad slots 1`] = `
 }
 
 .IS3 {
-  align-items: center;
-  flex: 1;
-}
-
-.IS4 {
   height: auto;
   overflow: hidden;
   width: 1;
 }
 
+.IS4 {
+  align-items: center;
+  flex: 1;
+}
+
 .IS5 {
-  align-items: center;
-  flex: 1;
-}
-
-.IS6 {
-  align-items: center;
-  flex: 1;
-}
-
-.IS7 {
   height: auto;
   overflow: hidden;
   width: 970;
 }
 
-.IS8 {
-  align-items: center;
-  flex: 1;
-}
-
-.IS9 {
+.IS6 {
   align-items: center;
   flex: 1;
 }
@@ -59,18 +44,7 @@ exports[`1. multiple ad slots 1`] = `
     section="news"
     slotName="header"
   >
-    <ServerClientRender
-      client={
-        <View
-          className="IS3"
-        >
-          <DOMContext
-            baseUrl="https://www.thetimes.co.uk/"
-            height={250}
-            width={970}
-          />
-        </View>
-      }
+    <MockServerClientRender
       server={null}
     >
       <View
@@ -90,7 +64,7 @@ exports[`1. multiple ad slots 1`] = `
           </DOMContext>
         </div>
       </View>
-    </ServerClientRender>
+    </MockServerClientRender>
   </Ad>
   <Ad
     baseUrl="https://www.thetimes.co.uk/"
@@ -99,22 +73,11 @@ exports[`1. multiple ad slots 1`] = `
     section="news"
     slotName="pixel"
   >
-    <ServerClientRender
-      client={
-        <View
-          className="IS6"
-        >
-          <DOMContext
-            baseUrl="https://www.thetimes.co.uk/"
-            height={1}
-            width={1}
-          />
-        </View>
-      }
+    <MockServerClientRender
       server={null}
     >
       <View
-        className="IS5"
+        className="IS4"
       >
         <div
           className="css-view-1dbjc4n r-alignItems-1awozwy r-flex-13awgt0"
@@ -125,12 +88,12 @@ exports[`1. multiple ad slots 1`] = `
             width={1}
           >
             <div
-              className="IS4"
+              className="IS3"
             />
           </DOMContext>
         </div>
       </View>
-    </ServerClientRender>
+    </MockServerClientRender>
   </Ad>
   <Ad
     baseUrl="https://www.thetimes.co.uk/"
@@ -139,22 +102,11 @@ exports[`1. multiple ad slots 1`] = `
     section="news"
     slotName="intervention"
   >
-    <ServerClientRender
-      client={
-        <View
-          className="IS9"
-        >
-          <DOMContext
-            baseUrl="https://www.thetimes.co.uk/"
-            height={250}
-            width={970}
-          />
-        </View>
-      }
+    <MockServerClientRender
       server={null}
     >
       <View
-        className="IS8"
+        className="IS6"
       >
         <div
           className="css-view-1dbjc4n r-alignItems-1awozwy r-flex-13awgt0"
@@ -165,12 +117,12 @@ exports[`1. multiple ad slots 1`] = `
             width={970}
           >
             <div
-              className="IS7"
+              className="IS5"
             />
           </DOMContext>
         </div>
       </View>
-    </ServerClientRender>
+    </MockServerClientRender>
   </Ad>
 </AdComposer>
 `;
@@ -231,15 +183,6 @@ exports[`2. placeholder when isloading 1`] = `
   align-items: center;
   flex: 1;
 }
-
-.IS8 {
-  flex: 1;
-}
-
-.IS9 {
-  align-items: center;
-  flex: 1;
-}
 </style>
 
 <Ad
@@ -249,18 +192,7 @@ exports[`2. placeholder when isloading 1`] = `
   section="news"
   slotName="header"
 >
-  <ServerClientRender
-    client={
-      <View
-        className="IS9"
-      >
-        <AdPlaceholder
-          className="IS8"
-          height={250}
-          width={970}
-        />
-      </View>
-    }
+  <MockServerClientRender
     server={null}
   >
     <View
@@ -317,7 +249,7 @@ exports[`2. placeholder when isloading 1`] = `
         </AdPlaceholder>
       </div>
     </View>
-  </ServerClientRender>
+  </MockServerClientRender>
 </Ad>
 `;
 
@@ -383,15 +315,6 @@ exports[`3. nothing if there is an error in the loading of scripts 1`] = `
   align-items: center;
   flex: 1;
 }
-
-.IS9 {
-  flex: 1;
-}
-
-.IS10 {
-  align-items: center;
-  flex: 1;
-}
 </style>
 
 <Ad
@@ -401,23 +324,7 @@ exports[`3. nothing if there is an error in the loading of scripts 1`] = `
   section="news"
   slotName="header"
 >
-  <ServerClientRender
-    client={
-      <View
-        className="IS10"
-      >
-        <DOMContext
-          baseUrl="https://www.thetimes.co.uk/"
-          height={0}
-          width={0}
-        />
-        <AdPlaceholder
-          className="IS9"
-          height={250}
-          width={970}
-        />
-      </View>
-    }
+  <MockServerClientRender
     server={null}
   >
     <View
@@ -483,6 +390,6 @@ exports[`3. nothing if there is an error in the loading of scripts 1`] = `
         </AdPlaceholder>
       </div>
     </View>
-  </ServerClientRender>
+  </MockServerClientRender>
 </Ad>
 `;

--- a/packages/ad/__tests__/web/ad-with-style.web.test.js
+++ b/packages/ad/__tests__/web/ad-with-style.web.test.js
@@ -20,6 +20,19 @@ import adInit from "../../src/utils/ad-init";
 import adConfig from "../../fixtures/article-ad-config.json";
 import Ad, { AdComposer } from "../../src/ad";
 
+jest.mock("@times-components/utils", () => {
+  const utils = jest.requireActual("@times-components/utils");
+
+  function MockServerClientRender({ client }) {
+    return client();
+  }
+
+  return {
+    ...utils,
+    ServerClientRender: MockServerClientRender
+  };
+});
+
 jest.mock("../../src/utils/ad-init");
 adInit.mockImplementation(() => ({
   destroySlots: () => {},

--- a/packages/ad/src/ad.js
+++ b/packages/ad/src/ad.js
@@ -1,13 +1,13 @@
 import React, { Component } from "react";
 import { Subscriber } from "react-broadcast";
-import { View, Platform } from "react-native";
+import { Platform, View } from "react-native";
 import { screenWidth, ServerClientRender } from "@times-components/utils";
-import { getSlotConfig, prebidConfig, getPrebidSlotConfig } from "./utils";
+import { getPrebidSlotConfig, getSlotConfig, prebidConfig } from "./utils";
 import adInit from "./utils/ad-init";
 import AdPlaceholder from "./ad-placeholder";
 import DOMContext from "./dom-context";
 import AdComposer from "./ad-composer";
-import { propTypes, defaultProps } from "./ad-prop-types";
+import { defaultProps, propTypes } from "./ad-prop-types";
 import styles from "./styles";
 
 class Ad extends Component {
@@ -107,36 +107,32 @@ class Ad extends Component {
 
     const isWeb = Platform.OS === "web";
 
-    const AdComponent = (
-      <DOMContext
-        baseUrl={baseUrl}
-        data={data}
-        init={adInit}
-        onRenderComplete={this.setAdReady}
-        onRenderError={this.setAdError}
-        {...sizeProps}
-      />
-    );
-
-    const AdPlaceholderComponent = (
-      <AdPlaceholder
-        height={config.maxSizes.height}
-        style={styles.children}
-        width={config.maxSizes.width}
-      />
-    );
-
-    const AdView = (
+    const adView = (
       <View style={[styles.container, style]}>
-        {isLoading ? null : AdComponent}
-        {isLoading || !isAdReady ? AdPlaceholderComponent : null}
+        {isLoading ? null : (
+          <DOMContext
+            baseUrl={baseUrl}
+            data={data}
+            init={adInit}
+            onRenderComplete={this.setAdReady}
+            onRenderError={this.setAdError}
+            {...sizeProps}
+          />
+        )}
+        {isLoading || !isAdReady ? (
+          <AdPlaceholder
+            height={config.maxSizes.height}
+            style={styles.children}
+            width={config.maxSizes.width}
+          />
+        ) : null}
       </View>
     );
 
     return isWeb ? (
-      <ServerClientRender client={AdView} server={null} />
+      <ServerClientRender client={() => adView} server={null} />
     ) : (
-      AdView
+      adView
     );
   }
 

--- a/packages/article-skeleton/src/sticky-save-and-share-bar.js
+++ b/packages/article-skeleton/src/sticky-save-and-share-bar.js
@@ -45,8 +45,8 @@ const SaveShareContainer = styled.div`
 function SaveShareContainerWrapper(props) {
   return (
     <ServerClientRender
-      client={<SaveShareContainer isClient {...props} />}
-      server={<SaveShareContainer {...props} />}
+      client={() => <SaveShareContainer isClient {...props} />}
+      server={() => <SaveShareContainer {...props} />}
     />
   );
 }

--- a/packages/user-state/src/client-user-state-consumer.js
+++ b/packages/user-state/src/client-user-state-consumer.js
@@ -21,25 +21,18 @@ import PropTypes from "prop-types";
 import Context from "@times-components/context";
 import { ServerClientRender } from "@times-components/utils";
 
-// Using React Components for the Client/Server for performance reasons
-function Client({ children, user }) {
-  const { nuk = {} } = window;
-  const clientUser = nuk.user || {};
-
-  return children({ user: { ...user, ...clientUser } });
-}
-
-function Server({ children, user }) {
-  return children({ user });
-}
-
 function ClientUserStateConsumer({ children, serverRender = true }) {
   return (
     <Context.Consumer>
       {({ user }) => (
         <ServerClientRender
-          client={<Client {...{ children, user }} />}
-          server={serverRender ? <Server {...{ children, user }} /> : null}
+          client={() => {
+            const { nuk = {} } = window;
+            const clientUser = nuk.user || {};
+
+            return children({ user: { ...user, ...clientUser } });
+          }}
+          server={serverRender ? () => children({ user }) : null}
         />
       )}
     </Context.Consumer>

--- a/packages/utils/__tests__/__snapshots__/server-client-render.test.js.snap
+++ b/packages/utils/__tests__/__snapshots__/server-client-render.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ServerClientRender renders the client path on the front end 1`] = `
+<div
+  id="react-root"
+>
+  <h1>
+    Hello World
+  </h1>
+</div>
+`;
+
+exports[`ServerClientRender renders the server path on the server 1`] = `"<h1 data-reactroot=\\"\\">Hello World</h1>"`;

--- a/packages/utils/__tests__/server-client-render.test.js
+++ b/packages/utils/__tests__/server-client-render.test.js
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-env browser */
+
+import React from "react";
+import { hydrate, render } from "react-dom";
+import { renderToString } from "react-dom/server";
+import ServerClientRender from "../src/server-client-render";
+
+describe("ServerClientRender", () => {
+  it("renders the server path on the server", () => {
+    const component = (
+      <ServerClientRender client={null} server={() => <h1>Hello World</h1>} />
+    );
+    const string = renderToString(component);
+    expect(string).toMatchSnapshot();
+  });
+
+  it("the client render function is never called on the server", () => {
+    const client = jest.fn(() => null);
+    const component = (
+      <ServerClientRender client={client} server={() => <h1>Hello World</h1>} />
+    );
+    renderToString(component);
+    expect(client).not.toHaveBeenCalled();
+  });
+
+  it("renders the client path on the front end", () => {
+    const component = (
+      <ServerClientRender client={() => <h1>Hello World</h1>} server={null} />
+    );
+    const root = document.createElement("div");
+    root.id = "react-root";
+    render(component, root);
+    expect(root).toMatchSnapshot();
+  });
+
+  describe("regression", () => {
+    it("dom references remain stable whilst two pass rendering", () => {
+      const component = (
+        <ServerClientRender
+          client={() => <div id="test" />}
+          server={() => <div id="test" />}
+        />
+      );
+      const root = document.createElement("div");
+      root.innerHTML = renderToString(component);
+      document.body.appendChild(root);
+
+      const rendered = root.querySelector("#test");
+
+      hydrate(component, root);
+
+      expect(root.querySelector("#test")).toBe(rendered);
+    });
+  });
+});

--- a/packages/utils/src/server-client-render.js
+++ b/packages/utils/src/server-client-render.js
@@ -28,13 +28,13 @@ class ServerClientRender extends Component {
     const { isClient } = this.state;
     const { client, server } = this.props;
 
-    return isClient ? client : server;
+    return isClient ? client && client() : server && server();
   }
 }
 
 ServerClientRender.propTypes = {
-  server: PropTypes.node,
-  client: PropTypes.node
+  server: PropTypes.func,
+  client: PropTypes.func
 };
 
 ServerClientRender.defaultProps = {


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/REPLAT-7031

In this PR, I've fixed article scroll tracking. I've done that by updating the two pass rendering mechanism to remove the "wrapper" Client and Server components. These were originally included to prevent React rendering both the Client and the Server "paths" whilst only one was needed. However, it turns out this breaks React's reconciling mechanism, and it leads to React unnecessarily destroying and recreating dom nodes on the second "pass" of rendering, even when this is unnecessary.

I thought for performance reasons it was necessary to continue to not render both "paths" whilst only using one, and so I have removed the "wrapper" components from `ClientUserStateConsumer`, and updated `ServerClientRender` to take render functions which it only calls whilst necessary. This is unfortunately a less elegant API, but it feels necessary. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
