### PR TITLE
Fix: Sponsored ads

### DIFF
--- a/packages/article-extras/__tests__/web/__snapshots__/article-extras.web.test.js.snap
+++ b/packages/article-extras/__tests__/web/__snapshots__/article-extras.web.test.js.snap
@@ -14,6 +14,9 @@ Array [
       isVisible={true}
     />
   </aside>,
+  <div
+    id="sponsored-article"
+  />,
   <ArticleComments
     articleId="dummy-article-id"
     isEnabled={true}

--- a/packages/article-extras/src/article-extras.web.js
+++ b/packages/article-extras/src/article-extras.web.js
@@ -53,6 +53,7 @@ const ArticleExtras = ({
         slice={relatedArticleSlice}
       />
     </aside>
+    <aside id="ad-article-sponsored"></aside>
     <ArticleComments
       articleId={articleId}
       isEnabled={commentsEnabled}

--- a/packages/article-extras/src/article-extras.web.js
+++ b/packages/article-extras/src/article-extras.web.js
@@ -53,7 +53,8 @@ const ArticleExtras = ({
         slice={relatedArticleSlice}
       />
     </aside>
-    <aside id="ad-article-sponsored"></aside>
+    {/* Nativo inserts Sponsored Articles in this div */}
+    <div id="sponsored-article" />
     <ArticleComments
       articleId={articleId}
       isEnabled={commentsEnabled}


### PR DESCRIPTION
- In order to make injecting Sponsored Articles easier for Nativo, commercial have asked for a wrapping div with id `sponsored-article`. 