### PR TITLE
spike: responsive API

### DIFF
--- a/packages/article-comments/package.json
+++ b/packages/article-comments/package.json
@@ -42,7 +42,7 @@
     "@times-components/link": "3.4.31",
     "@times-components/styleguide": "3.28.36",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.12",

--- a/packages/article-extras/package.json
+++ b/packages/article-extras/package.json
@@ -69,7 +69,7 @@
     "@times-components/styleguide": "3.28.36",
     "@times-components/user-state": "0.0.15",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article-image/package.json
+++ b/packages/article-image/package.json
@@ -75,7 +75,7 @@
     "@times-components/responsive": "0.4.54",
     "@times-components/styleguide": "3.28.36",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article-in-depth/package.json
+++ b/packages/article-in-depth/package.json
@@ -77,7 +77,7 @@
     "@times-components/utils": "4.11.23",
     "@times-components/video-label": "2.3.1",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article-list/package.json
+++ b/packages/article-list/package.json
@@ -89,7 +89,7 @@
     "@times-components/watermark": "2.6.33",
     "lodash.get": "4.4.2",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/article-magazine-comment/package.json
+++ b/packages/article-magazine-comment/package.json
@@ -78,7 +78,7 @@
     "@times-components/utils": "4.11.23",
     "@times-components/video-label": "2.3.1",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article-magazine-standard/package.json
+++ b/packages/article-magazine-standard/package.json
@@ -77,7 +77,7 @@
     "@times-components/utils": "4.11.23",
     "@times-components/video-label": "2.3.1",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article-main-comment/package.json
+++ b/packages/article-main-comment/package.json
@@ -76,7 +76,7 @@
     "@times-components/utils": "4.11.23",
     "@times-components/video-label": "2.3.1",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article-main-standard/package.json
+++ b/packages/article-main-standard/package.json
@@ -77,7 +77,7 @@
     "@times-components/utils": "4.11.23",
     "@times-components/video-label": "2.3.1",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article-paragraph/package.json
+++ b/packages/article-paragraph/package.json
@@ -43,7 +43,7 @@
     "@times-components/responsive": "0.4.54",
     "@times-components/styleguide": "3.28.36",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.12",

--- a/packages/article-skeleton/package.json
+++ b/packages/article-skeleton/package.json
@@ -105,7 +105,7 @@
     "polished": "3.4.1",
     "prop-types": "15.7.2",
     "react-helmet-async": "1.0.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -88,7 +88,7 @@
     "lodash.get": "4.4.2",
     "prop-types": "15.7.2",
     "react-helmet-async": "1.0.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -72,7 +72,7 @@
     "@times-components/responsive": "0.4.54",
     "@times-components/styleguide": "3.28.36",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -73,7 +73,7 @@
     "@times-components/utils": "4.11.23",
     "lodash.memoize": "4.1.2",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/key-facts/package.json
+++ b/packages/key-facts/package.json
@@ -74,7 +74,7 @@
     "@times-components/styleguide": "3.28.36",
     "lodash.pick": "4.4.0",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/lazy-load/package.json
+++ b/packages/lazy-load/package.json
@@ -49,7 +49,7 @@
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-native": "0.59.10",
-    "styled-components": "4.2.0",
+    "styled-components": "4.3.2",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"
   },

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@times-components/styleguide": "3.28.36",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -74,7 +74,7 @@
     "@times-components/tracking": "2.4.56",
     "prop-types": "15.7.2",
     "react-display-name": "0.2.3",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/pull-quote/package.json
+++ b/packages/pull-quote/package.json
@@ -71,7 +71,7 @@
     "@times-components/link": "3.4.31",
     "@times-components/styleguide": "3.28.36",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/save-star-web/package.json
+++ b/packages/save-star-web/package.json
@@ -41,7 +41,7 @@
     "@times-components/tracking": "2.4.56",
     "@times-components/utils": "4.11.23",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.12",

--- a/packages/slice-layout/package.json
+++ b/packages/slice-layout/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@times-components/styleguide": "3.28.36",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -72,7 +72,7 @@
     "react-helmet-async": "1.0.2",
     "react-native": "0.59.10",
     "react-native-web": "0.11.4",
-    "styled-components": "4.2.0",
+    "styled-components": "4.3.2",
     "unfetch": "^3.0.0"
   },
   "publishConfig": {

--- a/packages/sticky/package.json
+++ b/packages/sticky/package.json
@@ -38,7 +38,7 @@
     "hoist-non-react-statics": "2.5.5",
     "prop-types": "15.7.2",
     "react-display-name": "0.2.3",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.12",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -56,7 +56,7 @@
     "react-apollo": "2.5.5",
     "react-helmet-async": "1.0.2",
     "react-test-renderer": "16.6.3",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -82,7 +82,7 @@
     "lodash.get": "4.4.2",
     "prop-types": "15.7.2",
     "react-helmet-async": "1.0.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -58,7 +58,7 @@
     "lodash.omitby": "4.6.0",
     "prop-types": "15.7.2",
     "react-native": "0.59.10",
-    "styled-components": "4.2.0",
+    "styled-components": "4.3.2",
     "unfetch": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -81,7 +81,7 @@
     "@times-components/styleguide": "3.28.36",
     "@times-components/svgs": "2.7.16",
     "prop-types": "15.7.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.3.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1830,17 +1830,17 @@
   dependencies:
     "@emotion/memoize" "^0.6.6"
 
-"@emotion/is-prop-valid@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
-  integrity sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==
+"@emotion/is-prop-valid@^0.8.1":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.2.tgz#b9692080da79041683021fcc32f96b40c54c59dc"
+  integrity sha512-ZQIMAA2kLUWiUeMZNJDTeCwYRx1l8SQL0kHktze4COT22occKpDML1GDUXP5/sxhOMrZO8vZw773ni4H5Snrsg==
   dependencies:
-    "@emotion/memoize" "0.7.1"
+    "@emotion/memoize" "0.7.2"
 
-"@emotion/memoize@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
-  integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
+"@emotion/memoize@0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.2.tgz#7f4c71b7654068dfcccad29553520f984cc66b30"
+  integrity sha512-hnHhwQzvPCW1QjBWFyBtsETdllOM92BfrKWbUTmh9aeOlcVOiXvlPsK4104xH8NsaKfg86PTFsWkueQeUfMA/w==
 
 "@emotion/memoize@^0.6.6":
   version "0.6.6"
@@ -12399,6 +12399,11 @@ is-valid-path@0.1.1:
   dependencies:
     is-invalid-path "^0.1.0"
 
+is-what@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.2.4.tgz#da528659017bdd4b07892dfe4fd60da6ac500e98"
+  integrity sha512-0awkPsfVd85bYStP99EqLxKvhc5SiE70hSZCPxJN2SYZ5d+IkX+r1Ri0qnPWPnuRVFrqrEnI3JgFN3yrGtjXaw==
+
 is-whitespace-character@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
@@ -14162,6 +14167,13 @@ meow@^5.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
     yargs-parser "^10.0.0"
+
+merge-anything@^2.2.4:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/merge-anything/-/merge-anything-2.4.0.tgz#86959caf02bb8969d1ae5e1b652862bc5fe54e44"
+  integrity sha512-MhJcPOEcDUIbwU0LnEfx5S9s9dfQ/KPu4g2UA5T5G1LRKS0XmpDvJ9+UUfTkfhge+nA1gStE4tJAvx6lXLs+rg==
+  dependencies:
+    is-what "^3.2.4"
 
 merge-deep@^3.0.2:
   version "3.0.2"
@@ -19911,17 +19923,19 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
 
-styled-components@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.2.0.tgz#811fbbec4d64c7189f6c7482b9eb6fefa7fefef7"
-  integrity sha512-L/LzkL3ZbBhqIVHdR7DbYujy4tqvTNRfc+4JWDCYyhTatI+8CRRQUmdaR0+ARl03DWsfKLhjewll5uNLrqrl4A==
+styled-components@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.3.2.tgz#4ca81918c812d3006f60ac5fdec7d6b64a9509cc"
+  integrity sha512-NppHzIFavZ3TsIU3R1omtddJ0Bv1+j50AKh3ZWyXHuFvJq1I8qkQ5mZ7uQgD89Y8zJNx2qRo6RqAH1BmoVafHw==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
-    "@emotion/is-prop-valid" "^0.7.3"
+    "@babel/traverse" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.8.1"
     "@emotion/unitless" "^0.7.0"
     babel-plugin-styled-components ">= 1"
     css-to-react-native "^2.2.2"
     memoize-one "^5.0.0"
+    merge-anything "^2.2.4"
     prop-types "^15.5.4"
     react-is "^16.6.0"
     stylis "^3.5.0"


### PR DESCRIPTION
This is very messy as I changed my mind about how to do it a number of times, but I think something like this is a good alternative for our media query issue mentioned on Slack today. 

The only important changes are inside the Responsive package. 

The API is defined here https://github.com/newsuk/times-components/blob/spike/responsive-api/packages/responsive/src/hooks.js (ignore the name of this file)

There is an example here https://github.com/newsuk/times-components/blob/spike/responsive-api/packages/responsive/responsive.showcase.js

The API is very `styled-components`-y.

```js
const MyComponent = Responsive.View`
    background-color: blue;

    ${Responsive.minWidth.huge`
        background-color: red;
    `};
`;
```