### PR TITLE
fix: return nothing if adblock is detected

### DIFF
--- a/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
@@ -393,3 +393,13 @@ exports[`3. nothing if there is an error in the loading of scripts 1`] = `
   </MockServerClientRender>
 </Ad>
 `;
+
+exports[`4. returns nothing if user has adblock 1`] = `
+<Ad
+  baseUrl="https://www.thetimes.co.uk/"
+  contextUrl="https://www.thetimes.co.uk"
+  isLoading={false}
+  section="news"
+  slotName="header"
+/>
+`;

--- a/packages/ad/__tests__/web/ad-with-style.web.test.js
+++ b/packages/ad/__tests__/web/ad-with-style.web.test.js
@@ -66,8 +66,6 @@ const tests = [
   {
     name: "multiple ad slots",
     test: () => {
-      window.isAdBlockDisabled = true;
-
       const wrapper = mount(
         <AdComposer adConfig={adConfig}>
           <Fragment>
@@ -90,7 +88,6 @@ const tests = [
   {
     name: "placeholder when isLoading",
     test: () => {
-      window.isAdBlockDisabled = true;
       const wrapper = mount(
         <AdComposer adConfig={adConfig}>
           <Fragment>
@@ -129,7 +126,7 @@ const tests = [
   {
     name: "returns nothing if user has AdBlock",
     test: () => {
-      window.isAdBlockDisabled = false;
+      window.hasAdBlock = true;
 
       const wrapper = mount(
         <AdComposer adConfig={adConfig}>

--- a/packages/ad/__tests__/web/ad-with-style.web.test.js
+++ b/packages/ad/__tests__/web/ad-with-style.web.test.js
@@ -66,6 +66,8 @@ const tests = [
   {
     name: "multiple ad slots",
     test: () => {
+      window.isAdBlockDisabled = true;
+
       const wrapper = mount(
         <AdComposer adConfig={adConfig}>
           <Fragment>
@@ -88,6 +90,7 @@ const tests = [
   {
     name: "placeholder when isLoading",
     test: () => {
+      window.isAdBlockDisabled = true;
       const wrapper = mount(
         <AdComposer adConfig={adConfig}>
           <Fragment>
@@ -119,6 +122,24 @@ const tests = [
         .setAdError();
 
       wrapper.update();
+
+      expect(AdComponent).toMatchSnapshot();
+    }
+  },
+  {
+    name: "returns nothing if user has AdBlock",
+    test: () => {
+      window.isAdBlockDisabled = false;
+
+      const wrapper = mount(
+        <AdComposer adConfig={adConfig}>
+          <Fragment>
+            <Ad {...props} slotName="header" />
+          </Fragment>
+        </AdComposer>
+      );
+
+      const AdComponent = wrapper.find("Ad");
 
       expect(AdComponent).toMatchSnapshot();
     }

--- a/packages/ad/src/ad.js
+++ b/packages/ad/src/ad.js
@@ -40,7 +40,7 @@ class Ad extends Component {
   componentDidMount() {
     if (this.isWeb) {
       this.setState({
-        hasAdBlock: !window.isAdBlockDisabled
+        hasAdBlock: window.hasAdBlock
       });
     }
   }

--- a/packages/ad/src/ad.js
+++ b/packages/ad/src/ad.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import React, { Component } from "react";
 import { Subscriber } from "react-broadcast";
 import { Platform, View } from "react-native";
@@ -26,11 +27,22 @@ class Ad extends Component {
 
     this.prebidConfig = prebidConfig;
 
+    this.isWeb = Platform.OS === "web";
+
     this.state = {
       config: getSlotConfig(slotName, screenWidth()),
       hasError: false,
-      isAdReady: false
+      isAdReady: false,
+      hasAdBlock: false
     };
+  }
+
+  componentDidMount() {
+    if (this.isWeb) {
+      this.setState({
+        hasAdBlock: !window.isAdBlockDisabled
+      });
+    }
   }
 
   setAdReady = () => {
@@ -54,9 +66,10 @@ class Ad extends Component {
       slotName,
       style
     } = this.props;
-    const { config, hasError, isAdReady } = this.state;
+    const { config, hasError, isAdReady, hasAdBlock } = this.state;
+    const { isWeb } = this;
 
-    if (hasError) return null;
+    if ((isWeb && hasAdBlock) || hasError) return null;
 
     this.slots = adConfig.bidderSlots.map(slot =>
       getPrebidSlotConfig(
@@ -104,8 +117,6 @@ class Ad extends Component {
               ? screenWidth()
               : config.maxSizes.width
         };
-
-    const isWeb = Platform.OS === "web";
 
     const adView = (
       <View style={[styles.container, style]}>


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
JIRA:
https://nidigitalsolutions.jira.com/browse/REPLAT-7192

I have added detection for adblock in render:
https://github.com/newsuk/cps-content-render/pull/2860
Also there was a change in the flag and the way it is added to the project in this PR:
https://github.com/newsuk/cps-content-render/pull/2862

So if the user has been detected using adBlock, the Ad component will return nothing (null).
Also I have created a snapshot test for this case.
