### PR TITLE
fix: respect null expiry for flags

### DIFF
--- a/packages/article-flag/__tests__/shared.get-active-flags.js
+++ b/packages/article-flag/__tests__/shared.get-active-flags.js
@@ -36,6 +36,17 @@ export default () => {
       }
     },
     {
+      name: "returns flags when expiry time is null",
+      test: () => {
+        const flags = [
+          { expiryTime: null, type: "UPDATED" },
+          { expiryTime: null, type: "EXCLUSIVE" }
+        ];
+
+        expect(getActiveFlags(flags)).toEqual(flags);
+      }
+    },
+    {
       name: "returns no flags when no flags are provided",
       test: () => {
         expect(getActiveFlags([])).toEqual([]);

--- a/packages/article-flag/src/get-active-flags.js
+++ b/packages/article-flag/src/get-active-flags.js
@@ -3,7 +3,10 @@ const getActiveArticleFlags = flags => {
   return flags
     .map(
       flag =>
-        new Date().getTime() < new Date(flag.expiryTime).getTime() ? flag : null
+        flag.expiryTime === null ||
+        new Date().getTime() < new Date(flag.expiryTime).getTime()
+          ? flag
+          : null
     )
     .filter(flag => flag !== null);
 };


### PR DESCRIPTION
This fixes issue of flags not showing up when the expiry time is null