### PR TITLE
fix: REPLAT-7295 images on tiles being letterboxed

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -36,6 +36,7 @@ exports[`1. tile a 1`] = `
   </View>
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
 </Link>
@@ -107,6 +108,7 @@ exports[`3. tile c 1`] = `
   <View>
     <Image
       aspectRatio={1.7777777777777777}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -150,6 +152,7 @@ exports[`4. tile d 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <View>
@@ -192,6 +195,7 @@ exports[`5. tile e 1`] = `
 >
   <Image
     aspectRatio={0.8}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <View>
@@ -286,6 +290,7 @@ exports[`7. tile g 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -370,6 +375,7 @@ exports[`8. tile h 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />
 </Link>
@@ -381,6 +387,7 @@ exports[`9. tile i 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <View>
@@ -423,6 +430,7 @@ exports[`10. tile j 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <View>
@@ -465,6 +473,7 @@ exports[`11. tile k 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <View>
@@ -574,6 +583,7 @@ exports[`14. tile n 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
   />
   <View>
@@ -664,6 +674,7 @@ exports[`16. tile p 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -722,6 +733,7 @@ exports[`17. tile q 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
 </Link>
@@ -765,6 +777,7 @@ exports[`18. tile r 1`] = `
   </View>
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
 </Link>
@@ -853,6 +866,7 @@ exports[`21. tile t 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <View>
@@ -926,6 +940,7 @@ exports[`22. tile u 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
 </Link>
@@ -944,6 +959,7 @@ exports[`23. tile v 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <View>
@@ -1017,6 +1033,7 @@ exports[`24. tile w 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
 </Link>
@@ -1152,6 +1169,7 @@ exports[`27. tile z 1`] = `
   </View>
   <Image
     aspectRatio={0.8}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
 </Link>
@@ -1168,6 +1186,7 @@ exports[`28. tile aa 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <View>
@@ -1247,6 +1266,7 @@ exports[`29. tile ab 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />
 </Link>
@@ -1346,6 +1366,7 @@ exports[`32. tile aj 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
+    fill={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>
@@ -1376,6 +1397,7 @@ exports[`33. tile ak 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
+    fill={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>
@@ -1394,6 +1416,7 @@ exports[`34. tile al 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <View>
@@ -1441,6 +1464,7 @@ exports[`35. tile am 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <View>
@@ -1486,6 +1510,7 @@ exports[`36. tile an 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -1536,6 +1561,7 @@ exports[`37. tile ap 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -1580,6 +1606,7 @@ exports[`38. tile ad 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <View>
@@ -1622,6 +1649,7 @@ exports[`39. tile ac 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <View>
@@ -1666,6 +1694,7 @@ exports[`40. tile aq 1`] = `
   <View>
     <Image
       aspectRatio={1.7777777777777777}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -1715,6 +1744,7 @@ exports[`41. tile ar 1`] = `
   <View>
     <Image
       aspectRatio={1.7777777777777777}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -1773,6 +1803,7 @@ exports[`42. tile as 1`] = `
   <View>
     <Image
       aspectRatio={1.5}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
     />
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -36,6 +36,7 @@ exports[`1. tile a 1`] = `
   </View>
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
 </Link>
@@ -107,6 +108,7 @@ exports[`3. tile c 1`] = `
   <View>
     <Image
       aspectRatio={1.7777777777777777}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -150,6 +152,7 @@ exports[`4. tile d 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <View>
@@ -192,6 +195,7 @@ exports[`5. tile e 1`] = `
 >
   <Image
     aspectRatio={0.8}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <View>
@@ -286,6 +290,7 @@ exports[`7. tile g 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -370,6 +375,7 @@ exports[`8. tile h 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />
 </Link>
@@ -381,6 +387,7 @@ exports[`9. tile i 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <View>
@@ -423,6 +430,7 @@ exports[`10. tile j 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <View>
@@ -465,6 +473,7 @@ exports[`11. tile k 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <View>
@@ -574,6 +583,7 @@ exports[`14. tile n 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
   />
   <View>
@@ -664,6 +674,7 @@ exports[`16. tile p 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -722,6 +733,7 @@ exports[`17. tile q 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
 </Link>
@@ -765,6 +777,7 @@ exports[`18. tile r 1`] = `
   </View>
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
 </Link>
@@ -853,6 +866,7 @@ exports[`21. tile t 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <View>
@@ -926,6 +940,7 @@ exports[`22. tile u 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
 </Link>
@@ -944,6 +959,7 @@ exports[`23. tile v 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <View>
@@ -1017,6 +1033,7 @@ exports[`24. tile w 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
 </Link>
@@ -1152,6 +1169,7 @@ exports[`27. tile z 1`] = `
   </View>
   <Image
     aspectRatio={0.8}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
 </Link>
@@ -1168,6 +1186,7 @@ exports[`28. tile aa 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <View>
@@ -1247,6 +1266,7 @@ exports[`29. tile ab 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />
 </Link>
@@ -1346,6 +1366,7 @@ exports[`32. tile aj 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
+    fill={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>
@@ -1376,6 +1397,7 @@ exports[`33. tile ak 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
+    fill={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>
@@ -1394,6 +1416,7 @@ exports[`34. tile al 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <View>
@@ -1441,6 +1464,7 @@ exports[`35. tile am 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <View>
@@ -1486,6 +1510,7 @@ exports[`36. tile an 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -1536,6 +1561,7 @@ exports[`37. tile ap 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -1580,6 +1606,7 @@ exports[`38. tile ad 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <View>
@@ -1622,6 +1649,7 @@ exports[`39. tile ac 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <View>
@@ -1666,6 +1694,7 @@ exports[`40. tile aq 1`] = `
   <View>
     <Image
       aspectRatio={1.7777777777777777}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -1715,6 +1744,7 @@ exports[`41. tile ar 1`] = `
   <View>
     <Image
       aspectRatio={1.7777777777777777}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -1773,6 +1803,7 @@ exports[`42. tile as 1`] = `
   <View>
     <Image
       aspectRatio={1.5}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
     />
   </View>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -70,6 +70,7 @@ exports[`1. tile a 1`] = `
   <Image
     aspectRatio={1.7777777777777777}
     className="IS3"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
 </Link>
@@ -228,6 +229,7 @@ exports[`3. tile c 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </div>
@@ -307,6 +309,7 @@ exports[`4. tile d 1`] = `
   <Image
     aspectRatio={1.5}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div
@@ -385,6 +388,7 @@ exports[`5. tile e 1`] = `
   <Image
     aspectRatio={0.8}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <div
@@ -567,6 +571,7 @@ exports[`7. tile g 1`] = `
   <Image
     aspectRatio={1}
     className="IS1"
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -723,6 +728,7 @@ exports[`8. tile h 1`] = `
   <Image
     aspectRatio={0.6666666666666666}
     className="IS3"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />
 </Link>
@@ -770,6 +776,7 @@ exports[`9. tile i 1`] = `
   <Image
     aspectRatio={1.7777777777777777}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div
@@ -846,6 +853,7 @@ exports[`10. tile j 1`] = `
   <Image
     aspectRatio={1.5}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div
@@ -921,6 +929,7 @@ exports[`11. tile k 1`] = `
   <Image
     aspectRatio={1.5}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div
@@ -1127,6 +1136,7 @@ exports[`14. tile n 1`] = `
   <Image
     aspectRatio={1}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
   />
   <div
@@ -1314,6 +1324,7 @@ exports[`16. tile p 1`] = `
   <Image
     aspectRatio={1}
     className="IS1"
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -1392,6 +1403,7 @@ exports[`17. tile q 1`] = `
   <Image
     aspectRatio={1.5}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
 </Link>
@@ -1458,6 +1470,7 @@ exports[`18. tile r 1`] = `
   </div>
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
 </Link>
@@ -1691,6 +1704,7 @@ exports[`21. tile t 1`] = `
   <Image
     aspectRatio={1.7777777777777777}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div
@@ -1816,6 +1830,7 @@ exports[`22. tile u 1`] = `
   <Image
     aspectRatio={1.5}
     className="IS3"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
 </Link>
@@ -1859,6 +1874,7 @@ exports[`23. tile v 1`] = `
   <Image
     aspectRatio={1.7777777777777777}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div
@@ -1985,6 +2001,7 @@ exports[`24. tile w 1`] = `
   <Image
     aspectRatio={1.5}
     className="IS3"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
 </Link>
@@ -2241,6 +2258,7 @@ exports[`27. tile z 1`] = `
   </div>
   <Image
     aspectRatio={0.8}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
 </Link>
@@ -2285,6 +2303,7 @@ exports[`28. tile aa 1`] = `
   <Image
     aspectRatio={1.7777777777777777}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div
@@ -2434,6 +2453,7 @@ exports[`29. tile ab 1`] = `
   <Image
     aspectRatio={0.6666666666666666}
     className="IS3"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />
 </Link>
@@ -2634,6 +2654,7 @@ exports[`32. tile aj 1`] = `
     aspectRatio={1.5}
     className="IS3"
     disablePlaceholder={true}
+    fill={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>
@@ -2695,6 +2716,7 @@ exports[`33. tile ak 1`] = `
     aspectRatio={1.5}
     className="IS3"
     disablePlaceholder={true}
+    fill={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>
@@ -2747,6 +2769,7 @@ exports[`34. tile al 1`] = `
   <Image
     aspectRatio={1.5}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div
@@ -2841,6 +2864,7 @@ exports[`35. tile am 1`] = `
   <Image
     aspectRatio={1.7777777777777777}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div
@@ -2940,6 +2964,7 @@ exports[`36. tile an 1`] = `
   <Image
     aspectRatio={1}
     className="IS1"
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -3033,6 +3058,7 @@ exports[`37. tile ap 1`] = `
   <Image
     aspectRatio={1}
     className="IS1"
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -3111,6 +3137,7 @@ exports[`38. tile ad 1`] = `
   <Image
     aspectRatio={1.5}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div
@@ -3208,6 +3235,7 @@ exports[`39. tile ac 1`] = `
   <Image
     aspectRatio={1.7777777777777777}
     className="IS1"
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div
@@ -3298,6 +3326,7 @@ exports[`40. tile aq 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </div>
@@ -3413,6 +3442,7 @@ exports[`41. tile ar 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </div>
@@ -3522,6 +3552,7 @@ exports[`42. tile as 1`] = `
   >
     <Image
       aspectRatio={1.5}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
     />
   </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -36,6 +36,7 @@ exports[`1. tile a 1`] = `
   </div>
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
 </Link>
@@ -105,6 +106,7 @@ exports[`3. tile c 1`] = `
   <div>
     <Image
       aspectRatio={1.7777777777777777}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </div>
@@ -148,6 +150,7 @@ exports[`4. tile d 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div>
@@ -190,6 +193,7 @@ exports[`5. tile e 1`] = `
 >
   <Image
     aspectRatio={0.8}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <div>
@@ -284,6 +288,7 @@ exports[`7. tile g 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -368,6 +373,7 @@ exports[`8. tile h 1`] = `
   </div>
   <Image
     aspectRatio={0.6666666666666666}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />
 </Link>
@@ -379,6 +385,7 @@ exports[`9. tile i 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div>
@@ -421,6 +428,7 @@ exports[`10. tile j 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div>
@@ -463,6 +471,7 @@ exports[`11. tile k 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div>
@@ -572,6 +581,7 @@ exports[`14. tile n 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
   />
   <div>
@@ -662,6 +672,7 @@ exports[`16. tile p 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -720,6 +731,7 @@ exports[`17. tile q 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
 </Link>
@@ -763,6 +775,7 @@ exports[`18. tile r 1`] = `
   </div>
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
 </Link>
@@ -851,6 +864,7 @@ exports[`21. tile t 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div>
@@ -924,6 +938,7 @@ exports[`22. tile u 1`] = `
   </div>
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
 </Link>
@@ -942,6 +957,7 @@ exports[`23. tile v 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div>
@@ -1015,6 +1031,7 @@ exports[`24. tile w 1`] = `
   </div>
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
 </Link>
@@ -1150,6 +1167,7 @@ exports[`27. tile z 1`] = `
   </div>
   <Image
     aspectRatio={0.8}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
 </Link>
@@ -1166,6 +1184,7 @@ exports[`28. tile aa 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div>
@@ -1245,6 +1264,7 @@ exports[`29. tile ab 1`] = `
   </div>
   <Image
     aspectRatio={0.6666666666666666}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />
 </Link>
@@ -1344,6 +1364,7 @@ exports[`32. tile aj 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
+    fill={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>
@@ -1374,6 +1395,7 @@ exports[`33. tile ak 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
+    fill={true}
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
   />
 </Link>
@@ -1392,6 +1414,7 @@ exports[`34. tile al 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div>
@@ -1439,6 +1462,7 @@ exports[`35. tile am 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div>
@@ -1484,6 +1508,7 @@ exports[`36. tile an 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -1534,6 +1559,7 @@ exports[`37. tile ap 1`] = `
 >
   <Image
     aspectRatio={1}
+    fill={true}
     resizeMode="cover"
     rounded={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
@@ -1578,6 +1604,7 @@ exports[`38. tile ad 1`] = `
 >
   <Image
     aspectRatio={1.5}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div>
@@ -1620,6 +1647,7 @@ exports[`39. tile ac 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
+    fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div>
@@ -1664,6 +1692,7 @@ exports[`40. tile aq 1`] = `
   <div>
     <Image
       aspectRatio={1.7777777777777777}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </div>
@@ -1713,6 +1742,7 @@ exports[`41. tile ar 1`] = `
   <div>
     <Image
       aspectRatio={1.7777777777777777}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </div>
@@ -1769,6 +1799,7 @@ exports[`42. tile as 1`] = `
   <div>
     <Image
       aspectRatio={1.5}
+      fill={true}
       uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
     />
   </div>

--- a/packages/edition-slices/src/tiles/tile-a/index.js
+++ b/packages/edition-slices/src/tiles/tile-a/index.js
@@ -32,6 +32,7 @@ const TileA = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-aa/index.js
+++ b/packages/edition-slices/src/tiles/tile-aa/index.js
@@ -24,6 +24,7 @@ const TileAA = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <TileSummary
         headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-ab/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/index.js
@@ -38,6 +38,7 @@ const TileAB = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-ac/index.js
+++ b/packages/edition-slices/src/tiles/tile-ac/index.js
@@ -30,6 +30,7 @@ const TileAC = ({ onPress, tile, breakpoint }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={imageContainer}
         uri={crop.url}
+        fill
       />
       <TileSummary
         headlineStyle={headline}

--- a/packages/edition-slices/src/tiles/tile-ad/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/index.js
@@ -26,6 +26,7 @@ const TileAD = ({ onPress, tile, breakpoint }) => {
           relativeVerticalOffset={crop.relativeVerticalOffset}
           style={imageContainer}
           uri={crop.url}
+          fill
         />
       )}
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-ah/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/index.js
@@ -29,6 +29,7 @@ const TileAH = ({ onPress, tile, breakpoint }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
         rounded
         resizeMode="cover"
       />

--- a/packages/edition-slices/src/tiles/tile-ai/index.js
+++ b/packages/edition-slices/src/tiles/tile-ai/index.js
@@ -22,6 +22,7 @@ const TileAI = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <TileStar articleId={tile.article.id} style={styles.starButton} />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-aj/index.js
+++ b/packages/edition-slices/src/tiles/tile-aj/index.js
@@ -32,6 +32,7 @@ const TileAJ = ({ id, image, onPress, title, url }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={imageContainer}
         uri={crop.url}
+        fill
       />
     </Link>
   );

--- a/packages/edition-slices/src/tiles/tile-ak/index.js
+++ b/packages/edition-slices/src/tiles/tile-ak/index.js
@@ -32,6 +32,7 @@ const TileAK = ({ id, image, onPress, title, url, breakpoint }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={imageContainer}
         uri={crop.url}
+        fill
       />
     </Link>
   );

--- a/packages/edition-slices/src/tiles/tile-al/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/index.js
@@ -29,6 +29,7 @@ const TileAL = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <WithoutWhiteSpace
         render={whiteSpaceHeight => (

--- a/packages/edition-slices/src/tiles/tile-am/index.js
+++ b/packages/edition-slices/src/tiles/tile-am/index.js
@@ -24,6 +24,7 @@ const TileAM = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <WithoutWhiteSpace
         render={whiteSpaceHeight => (

--- a/packages/edition-slices/src/tiles/tile-an/index.js
+++ b/packages/edition-slices/src/tiles/tile-an/index.js
@@ -23,6 +23,7 @@ const TileAN = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
         rounded
         resizeMode="cover"
       />

--- a/packages/edition-slices/src/tiles/tile-ap/index.js
+++ b/packages/edition-slices/src/tiles/tile-ap/index.js
@@ -22,6 +22,7 @@ const TileAP = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
         rounded
         resizeMode="cover"
       />

--- a/packages/edition-slices/src/tiles/tile-aq/index.js
+++ b/packages/edition-slices/src/tiles/tile-aq/index.js
@@ -21,6 +21,7 @@ const TileAQ = ({ onPress, tile }) => {
         <Image
           aspectRatio={16 / 9}
           uri={crop.url}
+          fill
           relativeWidth={crop.relativeWidth}
           relativeHeight={crop.relativeHeight}
           relativeHorizontalOffset={crop.relativeHorizontalOffset}

--- a/packages/edition-slices/src/tiles/tile-ar/index.js
+++ b/packages/edition-slices/src/tiles/tile-ar/index.js
@@ -26,6 +26,7 @@ const TileAR = ({ onPress, tile }) => {
         <Image
           aspectRatio={16 / 9}
           uri={crop.url}
+          fill
           relativeWidth={crop.relativeWidth}
           relativeHeight={crop.relativeHeight}
           relativeHorizontalOffset={crop.relativeHorizontalOffset}

--- a/packages/edition-slices/src/tiles/tile-as/index.js
+++ b/packages/edition-slices/src/tiles/tile-as/index.js
@@ -25,6 +25,7 @@ const TileAS = ({ onPress, tile }) => {
         <Image
           aspectRatio={3 / 2}
           uri={crop.url}
+          fill
           relativeWidth={crop.relativeWidth}
           relativeHeight={crop.relativeHeight}
           relativeHorizontalOffset={crop.relativeHorizontalOffset}

--- a/packages/edition-slices/src/tiles/tile-c/index.js
+++ b/packages/edition-slices/src/tiles/tile-c/index.js
@@ -19,6 +19,7 @@ const TileC = ({ onPress, tile }) => {
         <Image
           aspectRatio={16 / 9}
           uri={crop.url}
+          fill
           relativeWidth={crop.relativeWidth}
           relativeHeight={crop.relativeHeight}
           relativeHorizontalOffset={crop.relativeHorizontalOffset}

--- a/packages/edition-slices/src/tiles/tile-d/index.js
+++ b/packages/edition-slices/src/tiles/tile-d/index.js
@@ -24,6 +24,7 @@ const TileD = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <TileSummary
         headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-e/index.js
+++ b/packages/edition-slices/src/tiles/tile-e/index.js
@@ -24,6 +24,7 @@ const TileE = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <TileSummary
         headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-g/index.js
+++ b/packages/edition-slices/src/tiles/tile-g/index.js
@@ -25,6 +25,7 @@ const TileG = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
         rounded
         resizeMode="cover"
       />

--- a/packages/edition-slices/src/tiles/tile-h/index.js
+++ b/packages/edition-slices/src/tiles/tile-h/index.js
@@ -30,6 +30,7 @@ const TileH = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-i/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/index.js
@@ -22,6 +22,7 @@ const TileI = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <TileSummary
         headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-j/index.js
+++ b/packages/edition-slices/src/tiles/tile-j/index.js
@@ -22,6 +22,7 @@ const TileJ = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <TileSummary
         headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-k/index.js
+++ b/packages/edition-slices/src/tiles/tile-k/index.js
@@ -24,6 +24,7 @@ const TileK = ({ onPress, tile, breakpoint }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <TileSummary
         headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-n/index.js
+++ b/packages/edition-slices/src/tiles/tile-n/index.js
@@ -30,6 +30,7 @@ const TileN = ({ isDarkStar, onPress, tile, breakpoint }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <TileSummary
         flagColour={styles.flagColour}

--- a/packages/edition-slices/src/tiles/tile-p/index.js
+++ b/packages/edition-slices/src/tiles/tile-p/index.js
@@ -28,6 +28,7 @@ const TileP = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
         rounded
         resizeMode="cover"
       />

--- a/packages/edition-slices/src/tiles/tile-q/index.js
+++ b/packages/edition-slices/src/tiles/tile-q/index.js
@@ -22,6 +22,7 @@ const TileQ = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <TileStar articleId={tile.article.id} style={styles.starButton} />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-r/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/index.js
@@ -20,6 +20,7 @@ const TileR = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
       <Image
         aspectRatio={16 / 9}
         uri={crop.url}
+        fill
         relativeWidth={crop.relativeWidth}
         relativeHeight={crop.relativeHeight}
         relativeHorizontalOffset={crop.relativeHorizontalOffset}

--- a/packages/edition-slices/src/tiles/tile-t/index.js
+++ b/packages/edition-slices/src/tiles/tile-t/index.js
@@ -21,6 +21,7 @@ const TileT = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <TileSummary
         headlineStyle={styles.headline}

--- a/packages/edition-slices/src/tiles/tile-u/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/index.js
@@ -48,6 +48,7 @@ const TileU = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-v/index.js
+++ b/packages/edition-slices/src/tiles/tile-v/index.js
@@ -22,6 +22,7 @@ const TileV = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
       <TileSummary headlineStyle={styles.headline} tile={tile} />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-w/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/index.js
@@ -44,6 +44,7 @@ const TileW = ({ onPress, tile, breakpoint }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
+        fill
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-z/index.js
+++ b/packages/edition-slices/src/tiles/tile-z/index.js
@@ -27,6 +27,7 @@ const TileZ = ({ onPress, tile }) => {
         relativeHorizontalOffset={crop.relativeHorizontalOffset}
         relativeVerticalOffset={crop.relativeVerticalOffset}
         uri={crop.url}
+        fill
       />
     </TileLink>
   );


### PR DESCRIPTION
![Screenshot_1565185184](https://user-images.githubusercontent.com/615608/62627395-3c67b680-b921-11e9-92ad-bdf4192036ff.png)
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
