### PR TITLE
fix: (REPLAT-7336) save star alignment

### DIFF
--- a/packages/article-flag/__tests__/android/__snapshots__/article-flag-with-style.android.test.js.snap
+++ b/packages/article-flag/__tests__/android/__snapshots__/article-flag-with-style.android.test.js.snap
@@ -45,7 +45,7 @@ exports[`2. multiple article flags 1`] = `
     Object {
       "flexDirection": "row",
       "flexWrap": "wrap",
-      "marginBottom": 10,
+      "marginTop": 10,
     }
   }
 >

--- a/packages/article-flag/__tests__/ios/__snapshots__/article-flag-with-style.ios.test.js.snap
+++ b/packages/article-flag/__tests__/ios/__snapshots__/article-flag-with-style.ios.test.js.snap
@@ -45,7 +45,7 @@ exports[`2. multiple article flags 1`] = `
     Object {
       "flexDirection": "row",
       "flexWrap": "wrap",
-      "marginBottom": 10,
+      "marginTop": 10,
     }
   }
 >

--- a/packages/article-flag/__tests__/web/__snapshots__/article-flag-with-style.web.test.js.snap
+++ b/packages/article-flag/__tests__/web/__snapshots__/article-flag-with-style.web.test.js.snap
@@ -202,7 +202,7 @@ exports[`2. multiple article flags 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  margin-bottom: 10px;
+  margin-top: 10px;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
   -webkit-box-lines: multiple;

--- a/packages/article-flag/src/style/shared.js
+++ b/packages/article-flag/src/style/shared.js
@@ -13,7 +13,7 @@ const styles = {
   flags: {
     flexDirection: "row",
     flexWrap: "wrap",
-    marginBottom: spacing(2)
+    marginTop: spacing(2)
   },
   title: {
     ...fontFactory({

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
@@ -38,7 +38,6 @@ exports[`1. article summary component with a single paragraph 1`] = `
         "fontFamily": "TimesDigitalW04",
         "fontSize": 14,
         "lineHeight": 20,
-        "marginBottom": 10,
       }
     }
   >
@@ -126,7 +125,6 @@ exports[`2. article summary content component with the given style 1`] = `
       "fontFamily": "TimesDigitalW04",
       "fontSize": 14,
       "lineHeight": 20,
-      "marginBottom": 10,
     }
   }
 >

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
@@ -38,7 +38,6 @@ exports[`1. article summary component with a single paragraph 1`] = `
         "fontFamily": "TimesDigitalW04",
         "fontSize": 14,
         "lineHeight": 20,
-        "marginBottom": 10,
       }
     }
   >
@@ -126,7 +125,6 @@ exports[`2. article summary content component with the given style 1`] = `
       "fontFamily": "TimesDigitalW04",
       "fontSize": 14,
       "lineHeight": 20,
-      "marginBottom": 10,
     }
   }
 >

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
@@ -24,7 +24,6 @@ exports[`1. article summary component with a single paragraph 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 
 .S4 {
@@ -55,7 +54,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S3"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -140,12 +139,11 @@ exports[`2. article summary content component with the given style 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 </style>
 
 <div
-  className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S1"
+  className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S1"
 >
   <span
     className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -141,7 +141,7 @@ exports[`2. article summary with opinion byline 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -174,7 +174,7 @@ exports[`3. article summary component with multiple paragraphs 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -233,7 +233,7 @@ exports[`4. article summary component with content including line breaks 1`] = `
   className="css-view-1dbjc4n"
 >
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -290,7 +290,7 @@ exports[`5. article summary component containing links 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -372,7 +372,7 @@ exports[`7. article summary component with empty content at the end trimmed 1`] 
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -443,7 +443,7 @@ exports[`8. article summary component with no byline 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -476,7 +476,7 @@ exports[`9. article summary component with no label 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -537,7 +537,7 @@ exports[`10. article summary component with no headline 1`] = `
     />
   </div>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -578,7 +578,7 @@ exports[`11. article summary component with no date publication 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -639,7 +639,7 @@ exports[`12. article summary component with a video label 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -714,7 +714,7 @@ exports[`13. article summary component with a strapline 1`] = `
     Test Strapline
   </h4>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/article-summary/src/styles/shared.js
+++ b/packages/article-summary/src/styles/shared.js
@@ -36,7 +36,6 @@ const sharedStyles = {
   text: {
     color: colours.functional.secondary,
     flexWrap: "wrap",
-    marginBottom: spacing(2),
     ...fontFactory({
       font: "body",
       fontSize: "teaser"

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -711,7 +711,7 @@ exports[`10. secondary one and columnist - medium 1`] = `
       Object {
         "flex": 1,
         "flexDirection": "row",
-        "paddingHorizontal": 20,
+        "marginHorizontal": 20,
       }
     }
   >
@@ -730,7 +730,7 @@ exports[`10. secondary one and columnist - medium 1`] = `
           "borderColor": "#DBDBDB",
           "borderRightWidth": 1,
           "borderStyle": "solid",
-          "marginVertical": 10,
+          "marginVertical": 15,
         }
       }
     />
@@ -1892,7 +1892,7 @@ exports[`25. secondary one and columnist - wide 1`] = `
       Object {
         "flex": 1,
         "flexDirection": "row",
-        "paddingHorizontal": 20,
+        "marginHorizontal": 20,
       }
     }
   >
@@ -1911,7 +1911,7 @@ exports[`25. secondary one and columnist - wide 1`] = `
           "borderColor": "#DBDBDB",
           "borderRightWidth": 1,
           "borderStyle": "solid",
-          "marginVertical": 10,
+          "marginVertical": 15,
         }
       }
     />
@@ -3219,7 +3219,7 @@ exports[`40. secondary one and columnist - huge 1`] = `
         Object {
           "flex": 1,
           "flexDirection": "row",
-          "paddingHorizontal": 20,
+          "marginHorizontal": 20,
         }
       }
     >
@@ -3238,7 +3238,7 @@ exports[`40. secondary one and columnist - huge 1`] = `
             "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "marginVertical": 10,
+            "marginVertical": 15,
           }
         }
       />

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -508,7 +508,13 @@ exports[`7. secondary one and four - medium 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
           <View
@@ -521,7 +527,13 @@ exports[`7. secondary one and four - medium 1`] = `
               }
             }
           />
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
         </View>
@@ -542,7 +554,13 @@ exports[`7. secondary one and four - medium 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
           <View
@@ -555,7 +573,13 @@ exports[`7. secondary one and four - medium 1`] = `
               }
             }
           />
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
         </View>
@@ -1429,7 +1453,6 @@ exports[`20. lead two no pic and two - wide 1`] = `
     <View
       style={
         Object {
-          "paddingTop": 10,
           "width": "16%",
         }
       }
@@ -1664,7 +1687,13 @@ exports[`22. secondary one and four - wide 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
           <View
@@ -1677,7 +1706,13 @@ exports[`22. secondary one and four - wide 1`] = `
               }
             }
           />
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
         </View>
@@ -1698,7 +1733,13 @@ exports[`22. secondary one and four - wide 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
           <View
@@ -1711,7 +1752,13 @@ exports[`22. secondary one and four - wide 1`] = `
               }
             }
           />
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
         </View>
@@ -2683,7 +2730,6 @@ exports[`35. lead two no pic and two - huge 1`] = `
       <View
         style={
           Object {
-            "paddingTop": 10,
             "width": "16%",
           }
         }
@@ -2938,7 +2984,13 @@ exports[`37. secondary one and four - huge 1`] = `
               }
             }
           >
-            <View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
               <TileO />
             </View>
             <View
@@ -2951,7 +3003,13 @@ exports[`37. secondary one and four - huge 1`] = `
                 }
               }
             />
-            <View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
               <TileO />
             </View>
           </View>
@@ -2972,7 +3030,13 @@ exports[`37. secondary one and four - huge 1`] = `
               }
             }
           >
-            <View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
               <TileO />
             </View>
             <View
@@ -2985,7 +3049,13 @@ exports[`37. secondary one and four - huge 1`] = `
                 }
               }
             />
-            <View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
               <TileO />
             </View>
           </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -310,12 +310,14 @@ exports[`11. secondary two and two - medium 1`] = `
     <View>
       <View>
         <TileG
+          breakpoint="medium"
           tileName="support1"
         />
       </View>
       <View />
       <View>
         <TileG
+          breakpoint="medium"
           tileName="support2"
         />
       </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -880,7 +880,7 @@ exports[`18. tile r 1`] = `
   <View
     style={
       Object {
-        "paddingBottom": 10,
+        "flex": 1,
       }
     }
   >
@@ -1303,19 +1303,11 @@ exports[`25. tile x 1`] = `
     style={
       Object {
         "flex": 1,
-        "marginHorizontal": 10,
       }
     }
   >
     <View>
-      <View
-        style={
-          Object {
-            "marginHorizontal": 10,
-            "marginVertical": 5,
-          }
-        }
-      >
+      <View>
         <View
           style={
             Object {
@@ -1361,13 +1353,7 @@ exports[`25. tile x 1`] = `
 
 exports[`26. tile y 1`] = `
 <Link>
-  <View
-    style={
-      Object {
-        "marginBottom": 10,
-      }
-    }
-  >
+  <View>
     <View
       style={
         Object {
@@ -1399,7 +1385,6 @@ exports[`26. tile y 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
         }
       }
     >
@@ -1416,7 +1401,13 @@ exports[`26. tile y 1`] = `
 
 exports[`27. tile z 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -1451,9 +1442,7 @@ exports[`28. tile ab 1`] = `
   <Image
     style={
       Object {
-        "flexDirection": "column",
-        "justifyContent": "flex-end",
-        "width": "50%",
+        "flex": 1,
       }
     }
   />
@@ -1462,7 +1451,6 @@ exports[`28. tile ab 1`] = `
       Object {
         "flex": 1,
         "paddingLeft": 20,
-        "width": "50%",
       }
     }
   >
@@ -1699,6 +1687,7 @@ exports[`33. tile al 1`] = `
   <Image
     style={
       Object {
+        "marginBottom": 10,
         "width": "100%",
       }
     }
@@ -2195,6 +2184,7 @@ exports[`42. tile ah 1`] = `
     style={
       Object {
         "alignItems": "center",
+        "flex": 1,
         "paddingTop": 5,
       }
     }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -5,8 +5,7 @@ exports[`1. tile a 1`] = `
   <View
     style={
       Object {
-        "marginHorizontal": 10,
-        "marginTop": 10,
+        "margin": 10,
       }
     }
   >
@@ -47,57 +46,58 @@ exports[`1. tile a 1`] = `
 
 exports[`2. tile b 1`] = `
 <Link>
-  <View
-    style={
-      Object {
-        "flex": 1,
+  <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
       }
-    }
-  >
-    <View>
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          <ArticleLabel />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 25,
-              "fontWeight": "400",
-              "lineHeight": 25,
-              "marginBottom": 5,
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 25,
+                "fontWeight": "400",
+                "lineHeight": 25,
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          This is tile headline
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#696969",
-              "flexWrap": "wrap",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 14,
-              "lineHeight": 20,
-              "marginBottom": 10,
-            }
-          }
-        >
-          <Text>
-            
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-            ...
+          >
+            This is tile headline
           </Text>
-        </Text>
-        <ArticleFlags />
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+              }
+            }
+          >
+            <Text>
+              
+              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+              ...
+            </Text>
+          </Text>
+          <ArticleFlags />
+        </View>
       </View>
     </View>
   </View>
@@ -116,7 +116,13 @@ exports[`3. tile c 1`] = `
   >
     <Image />
   </View>
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -151,7 +157,6 @@ exports[`4. tile d 1`] = `
   <Image
     style={
       Object {
-        "paddingRight": 10,
         "width": "50%",
       }
     }
@@ -160,8 +165,7 @@ exports[`4. tile d 1`] = `
     style={
       Object {
         "paddingBottom": 5,
-        "paddingRight": 10,
-        "paddingTop": 5,
+        "paddingLeft": 10,
         "width": "50%",
       }
     }
@@ -199,7 +203,6 @@ exports[`5. tile e 1`] = `
   <Image
     style={
       Object {
-        "paddingRight": 10,
         "width": "50%",
       }
     }
@@ -208,8 +211,7 @@ exports[`5. tile e 1`] = `
     style={
       Object {
         "paddingBottom": 5,
-        "paddingRight": 10,
-        "paddingTop": 10,
+        "paddingLeft": 10,
         "width": "50%",
       }
     }
@@ -289,7 +291,6 @@ exports[`6. tile f 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
         }
       }
     >
@@ -317,10 +318,8 @@ exports[`7. tile g 1`] = `
   <View
     style={
       Object {
-        "justifyContent": "center",
-        "paddingBottom": 0,
+        "flex": 1,
         "paddingLeft": 10,
-        "paddingTop": 5,
         "width": "70%",
       }
     }
@@ -328,28 +327,36 @@ exports[`7. tile g 1`] = `
     <View
       style={
         Object {
-          "marginBottom": 5,
+          "flex": 1,
+          "justifyContent": "center",
         }
       }
     >
-      <ArticleLabel />
+      <View
+        style={
+          Object {
+            "marginBottom": 5,
+          }
+        }
+      >
+        <ArticleLabel />
+      </View>
+      <Text
+        style={
+          Object {
+            "color": "#333333",
+            "fontFamily": "TimesModern-Bold",
+            "fontSize": 22,
+            "fontWeight": "400",
+            "lineHeight": 22,
+            "marginBottom": 5,
+          }
+        }
+      >
+        This is tile headline
+      </Text>
+      <ArticleFlags />
     </View>
-    <Text
-      style={
-        Object {
-          "color": "#333333",
-          "fontFamily": "TimesModern-Bold",
-          "fontSize": 22,
-          "fontWeight": "400",
-          "lineHeight": 22,
-          "marginBottom": 5,
-          "paddingBottom": 5,
-        }
-      }
-    >
-      This is tile headline
-    </Text>
-    <ArticleFlags />
   </View>
 </Link>
 `;
@@ -360,7 +367,6 @@ exports[`8. tile h 1`] = `
     style={
       Object {
         "paddingRight": 10,
-        "paddingVertical": 10,
         "width": "50%",
       }
     }
@@ -396,7 +402,6 @@ exports[`8. tile h 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
         }
       }
     >
@@ -441,7 +446,6 @@ exports[`8. tile h 1`] = `
       Object {
         "flexDirection": "column",
         "justifyContent": "flex-end",
-        "paddingTop": 10,
         "width": "50%",
       }
     }
@@ -510,7 +514,7 @@ exports[`10. tile j 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
+        "paddingLeft": 10,
         "width": "60%",
       }
     }
@@ -590,7 +594,13 @@ exports[`11. tile k 1`] = `
 
 exports[`12. tile l 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -621,7 +631,13 @@ exports[`12. tile l 1`] = `
 
 exports[`13. tile m 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <Text
       style={
         Object {
@@ -670,7 +686,7 @@ exports[`14. tile n 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
+        "paddingLeft": 10,
         "width": "50%",
       }
     }
@@ -718,7 +734,13 @@ exports[`14. tile n 1`] = `
 
 exports[`15. tile o 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -857,7 +879,13 @@ exports[`17. tile q 1`] = `
 
 exports[`18. tile r 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "paddingBottom": 10,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -1075,8 +1103,8 @@ exports[`21. tile t 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
-        "paddingVertical": 5,
+        "paddingBottom": 5,
+        "paddingLeft": 10,
         "width": "50%",
       }
     }
@@ -1120,32 +1148,40 @@ exports[`22. tile u 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 30,
+                "fontWeight": "400",
+                "lineHeight": 30,
+                "marginBottom": 10,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "lineHeight": 30,
-              "marginBottom": 10,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1169,7 +1205,13 @@ exports[`23. tile v 1`] = `
       }
     }
   />
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -1187,8 +1229,7 @@ exports[`23. tile v 1`] = `
           "fontSize": 30,
           "fontWeight": "400",
           "lineHeight": 30,
-          "marginBottom": 5,
-          "paddingBottom": 5,
+          "marginBottom": 10,
         }
       }
     >
@@ -1211,32 +1252,40 @@ exports[`24. tile w 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 35,
+                "fontWeight": "400",
+                "lineHeight": 35,
+                "marginBottom": 5,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 35,
-              "fontWeight": "400",
-              "lineHeight": 35,
-              "marginBottom": 5,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1256,6 +1305,7 @@ exports[`25. tile x 1`] = `
     style={
       Object {
         "flex": 1,
+        "marginHorizontal": 10,
       }
     }
   >
@@ -1313,7 +1363,13 @@ exports[`25. tile x 1`] = `
 
 exports[`26. tile y 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -1412,60 +1468,68 @@ exports[`28. tile ab 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 30,
+                "fontWeight": "400",
+                "lineHeight": 30,
+                "marginBottom": 5,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
+          <Text>
+            <Text
+              style={
+                Object {
+                  "color": "#333333",
+                  "flexDirection": "row",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 13,
+                  "lineHeight": 19,
+                }
+              }
+            >
+              Richard Lloyd Parry
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#333333",
+                  "flexDirection": "row",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 13,
+                  "lineHeight": 19,
+                }
+              }
+            >
+              , Hanoi
+            </Text>
+          </Text>
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "lineHeight": 30,
-              "marginBottom": 5,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
-        <Text>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "flexDirection": "row",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 19,
-              }
-            }
-          >
-            Richard Lloyd Parry
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "flexDirection": "row",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 19,
-              }
-            }
-          >
-            , Hanoi
-          </Text>
-        </Text>
       </View>
     </View>
   </View>
@@ -1481,32 +1545,40 @@ exports[`29. tile ae 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 30,
+                "fontWeight": "400",
+                "lineHeight": 30,
+                "marginBottom": 10,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "lineHeight": 30,
-              "marginBottom": 10,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1515,7 +1587,13 @@ exports[`29. tile ae 1`] = `
 
 exports[`30. tile ag 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <Text
       style={
         Object {
@@ -1631,7 +1709,6 @@ exports[`33. tile al 1`] = `
   <Image
     style={
       Object {
-        "paddingVertical": 10,
         "width": "100%",
       }
     }
@@ -1640,35 +1717,48 @@ exports[`33. tile al 1`] = `
     style={
       Object {
         "flex": 1,
+        "fontFamily": "TimesDigitalW04-Regular",
+        "fontSize": 14,
+        "lineHeight": undefined,
+        "paddingTop": 10,
+        "width": "100%",
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 22,
+                "fontWeight": "400",
+                "lineHeight": 27,
+                "marginBottom": 0,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 22,
-              "fontWeight": "400",
-              "lineHeight": 27,
-              "marginBottom": 0,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1692,33 +1782,41 @@ exports[`34. tile am 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 35,
+                "fontWeight": "400",
+                "lineHeight": 35,
+                "marginBottom": 5,
+                "paddingBottom": 5,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 35,
-              "fontWeight": "400",
-              "lineHeight": 35,
-              "marginBottom": 5,
-              "paddingBottom": 5,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1737,8 +1835,8 @@ exports[`35. tile an 1`] = `
   <View
     style={
       Object {
+        "flex": 1,
         "justifyContent": "center",
-        "paddingHorizontal": 10,
         "paddingTop": 10,
       }
     }
@@ -1774,7 +1872,6 @@ exports[`35. tile an 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
         }
       }
     >
@@ -1801,8 +1898,8 @@ exports[`36. tile ap 1`] = `
   <View
     style={
       Object {
+        "flex": 1,
         "justifyContent": "center",
-        "paddingHorizontal": 10,
         "paddingTop": 5,
       }
     }
@@ -1848,7 +1945,7 @@ exports[`37. tile ad 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
+        "paddingLeft": 10,
         "width": "70%",
       }
     }
@@ -1897,7 +1994,7 @@ exports[`38. tile ac 1`] = `
         "backgroundColor": "#F0F0F0",
         "flex": 1,
         "justifyContent": "center",
-        "paddingHorizontal": 40,
+        "paddingHorizontal": 20,
         "paddingVertical": 15,
       }
     }
@@ -1950,32 +2047,40 @@ exports[`39. tile aq 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 22,
+                "fontWeight": "400",
+                "lineHeight": 22,
+                "marginBottom": 5,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 22,
-              "fontWeight": "400",
-              "lineHeight": 22,
-              "marginBottom": 5,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -2001,50 +2106,57 @@ exports[`40. tile ar 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          <ArticleLabel />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 20,
-              "fontWeight": "400",
-              "lineHeight": 20,
-              "marginBottom": 5,
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 20,
+                "fontWeight": "400",
+                "lineHeight": 20,
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          This is tile headline
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#696969",
-              "flexWrap": "wrap",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 14,
-              "lineHeight": 20,
-              "marginBottom": 10,
-            }
-          }
-        >
-          <Text>
-            
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-            ...
+          >
+            This is tile headline
           </Text>
-        </Text>
-        <ArticleFlags />
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+              }
+            }
+          >
+            <Text>
+              
+              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+              ...
+            </Text>
+          </Text>
+          <ArticleFlags />
+        </View>
       </View>
     </View>
   </View>
@@ -2063,7 +2175,13 @@ exports[`41. tile as 1`] = `
   >
     <Image />
   </View>
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -2095,7 +2213,6 @@ exports[`41. tile as 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
         }
       }
     >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -46,58 +46,56 @@ exports[`1. tile a 1`] = `
 
 exports[`2. tile b 1`] = `
 <Link>
-  <View>
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
+  <View
+    style={
+      Object {
+        "flex": 1,
       }
-    >
+    }
+  >
+    <View>
       <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 5,
-              }
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
             }
-          >
-            <ArticleLabel />
-          </View>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 25,
-                "fontWeight": "400",
-                "lineHeight": 25,
-                "marginBottom": 5,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "flexWrap": "wrap",
-                "fontFamily": "TimesDigitalW04",
-                "fontSize": 14,
-                "lineHeight": 20,
-              }
-            }
-          >
-            <Text>
-              
-              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-              ...
-            </Text>
-          </Text>
-          <ArticleFlags />
+          }
+        >
+          <ArticleLabel />
         </View>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 25,
+              "fontWeight": "400",
+              "lineHeight": 25,
+              "marginBottom": 5,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+            }
+          }
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1545,40 +1543,32 @@ exports[`29. tile ae 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
+    <View>
       <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 5,
-              }
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
             }
-          >
-            <ArticleLabel />
-          </View>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 30,
-                "fontWeight": "400",
-                "lineHeight": 30,
-                "marginBottom": 10,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags />
+          }
+        >
+          <ArticleLabel />
         </View>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "400",
+              "lineHeight": 30,
+              "marginBottom": 10,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1717,48 +1707,35 @@ exports[`33. tile al 1`] = `
     style={
       Object {
         "flex": 1,
-        "fontFamily": "TimesDigitalW04-Regular",
-        "fontSize": 14,
-        "lineHeight": undefined,
-        "paddingTop": 10,
-        "width": "100%",
       }
     }
   >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
+    <View>
       <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 5,
-              }
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
             }
-          >
-            <ArticleLabel />
-          </View>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 22,
-                "fontWeight": "400",
-                "lineHeight": 27,
-                "marginBottom": 0,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags />
+          }
+        >
+          <ArticleLabel />
         </View>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "400",
+              "lineHeight": 27,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1782,41 +1759,33 @@ exports[`34. tile am 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
+    <View>
       <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 5,
-              }
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
             }
-          >
-            <ArticleLabel />
-          </View>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 35,
-                "fontWeight": "400",
-                "lineHeight": 35,
-                "marginBottom": 5,
-                "paddingBottom": 5,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags />
+          }
+        >
+          <ArticleLabel />
         </View>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 35,
+              "fontWeight": "400",
+              "lineHeight": 35,
+              "marginBottom": 5,
+              "paddingBottom": 5,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -2047,40 +2016,32 @@ exports[`39. tile aq 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
+    <View>
       <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 5,
-              }
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
             }
-          >
-            <ArticleLabel />
-          </View>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 22,
-                "fontWeight": "400",
-                "lineHeight": 22,
-                "marginBottom": 5,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags />
+          }
+        >
+          <ArticleLabel />
         </View>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "400",
+              "lineHeight": 22,
+              "marginBottom": 5,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -2106,57 +2067,49 @@ exports[`40. tile ar 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
+    <View>
       <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 5,
-              }
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
             }
-          >
-            <ArticleLabel />
-          </View>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 20,
-                "fontWeight": "400",
-                "lineHeight": 20,
-                "marginBottom": 5,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "flexWrap": "wrap",
-                "fontFamily": "TimesDigitalW04",
-                "fontSize": 14,
-                "lineHeight": 20,
-              }
-            }
-          >
-            <Text>
-              
-              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-              ...
-            </Text>
-          </Text>
-          <ArticleFlags />
+          }
+        >
+          <ArticleLabel />
         </View>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 20,
+              "fontWeight": "400",
+              "lineHeight": 20,
+              "marginBottom": 5,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+            }
+          }
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags />
       </View>
     </View>
   </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -51,39 +51,37 @@ exports[`2. tile b 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <Text
-            numberOfLines={2}
-          >
-            <Text>
-              
-              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-              ...
-            </Text>
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -1053,28 +1051,10 @@ exports[`25. tile x 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
         <Text
@@ -1266,30 +1246,28 @@ exports[`29. tile ae 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -1390,9 +1368,7 @@ exports[`33. tile al 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "flexDirection": "column",
-      "paddingHorizontal": 10,
-      "paddingVertical": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1406,30 +1382,28 @@ exports[`33. tile al 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -1455,30 +1429,28 @@ exports[`34. tile am 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -1690,30 +1662,28 @@ exports[`39. tile aq 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -1742,39 +1712,37 @@ exports[`40. tile ar 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <Text
-            numberOfLines={2}
-          >
-            <Text>
-              
-              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-              ...
-            </Text>
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -737,9 +737,8 @@ exports[`18. tile r 1`] = `
 <Link
   linkStyle={
     Object {
-      "paddingBottom": 15,
-      "paddingHorizontal": 30,
-      "paddingTop": 15,
+      "flex": 1,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1089,8 +1088,7 @@ exports[`26. tile y 1`] = `
 <Link
   linkStyle={
     Object {
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1134,7 +1132,7 @@ exports[`27. tile z 1`] = `
 <Link
   linkStyle={
     Object {
-      "margin": 10,
+      "padding": 10,
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -2,11 +2,6 @@
 
 exports[`1. tile a 1`] = `
 <Link
-  linkStyle={
-    Object {
-      "marginTop": 5,
-    }
-  }
   url="/article/123"
 >
   <View>
@@ -47,8 +42,7 @@ exports[`2. tile b 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -57,37 +51,39 @@ exports[`2. tile b 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+          >
+            <Text>
+              
+              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+              ...
+            </Text>
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <Text
-          numberOfLines={2}
-        >
-          <Text>
-            
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-            ...
-          </Text>
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -99,8 +95,7 @@ exports[`3. tile c 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -230,8 +225,7 @@ exports[`6. tile f 1`] = `
 <Link
   linkStyle={
     Object {
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -297,28 +291,30 @@ exports[`7. tile g 1`] = `
   />
   <View>
     <View>
-      <ArticleLabel
-        color="#005B8D"
-        isVideo={false}
-        title="label"
+      <View>
+        <ArticleLabel
+          color="#005B8D"
+          isVideo={false}
+          title="label"
+        />
+      </View>
+      <Text
+        accessibilityRole="header"
+        aria-level="3"
+      >
+        This is tile headline
+      </Text>
+      <ArticleFlags
+        flags={
+          Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ]
+        }
       />
     </View>
-    <Text
-      accessibilityRole="header"
-      aria-level="3"
-    >
-      This is tile headline
-    </Text>
-    <ArticleFlags
-      flags={
-        Array [
-          Object {
-            "expiryTime": "2030-03-14T12:00:00.000Z",
-            "type": "EXCLUSIVE",
-          },
-        ]
-      }
-    />
   </View>
 </Link>
 `;
@@ -328,7 +324,7 @@ exports[`8. tile h 1`] = `
   linkStyle={
     Object {
       "flexDirection": "row",
-      "paddingHorizontal": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -509,8 +505,7 @@ exports[`12. tile l 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -547,6 +542,7 @@ exports[`13. tile m 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "paddingBottom": 10,
     }
   }
@@ -626,6 +622,7 @@ exports[`15. tile o 1`] = `
   linkStyle={
     Object {
       "backgroundColor": "#272D34",
+      "flex": 1,
       "paddingHorizontal": 12,
       "paddingVertical": 10,
     }
@@ -725,7 +722,6 @@ exports[`17. tile q 1`] = `
 <Link
   linkStyle={
     Object {
-      "alignItems": "center",
       "paddingVertical": 10,
     }
   }
@@ -913,28 +909,30 @@ exports[`22. tile u 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -1006,28 +1004,30 @@ exports[`24. tile w 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -1044,8 +1044,7 @@ exports[`25. tile x 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1054,10 +1053,28 @@ exports[`25. tile x 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
         <Text
@@ -1179,6 +1196,7 @@ exports[`28. tile ab 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "flexDirection": "row",
       "paddingHorizontal": 10,
       "paddingVertical": 10,
@@ -1195,36 +1213,38 @@ exports[`28. tile ab 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
+          <Text>
+            <Text>
+              Richard Lloyd Parry
+            </Text>
+            <Text>
+              , Hanoi
+            </Text>
+          </Text>
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-        <Text>
-          <Text>
-            Richard Lloyd Parry
-          </Text>
-          <Text>
-            , Hanoi
-          </Text>
-        </Text>
       </View>
     </View>
   </View>
@@ -1236,7 +1256,7 @@ exports[`29. tile ae 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
+      "padding": 10,
       "paddingTop": 15,
     }
   }
@@ -1246,28 +1266,30 @@ exports[`29. tile ae 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -1278,6 +1300,7 @@ exports[`30. tile ag 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "paddingBottom": 10,
       "paddingHorizontal": 20,
     }
@@ -1369,6 +1392,7 @@ exports[`33. tile al 1`] = `
       "flex": 1,
       "flexDirection": "column",
       "paddingHorizontal": 10,
+      "paddingVertical": 10,
     }
   }
   url="/article/123"
@@ -1382,28 +1406,30 @@ exports[`33. tile al 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -1415,8 +1441,7 @@ exports[`34. tile am 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1430,28 +1455,30 @@ exports[`34. tile am 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -1462,6 +1489,7 @@ exports[`35. tile an 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "padding": 10,
     }
   }
@@ -1513,6 +1541,7 @@ exports[`36. tile ap 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "padding": 10,
     }
   }
@@ -1645,8 +1674,7 @@ exports[`39. tile aq 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1662,28 +1690,30 @@ exports[`39. tile aq 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -1712,37 +1742,39 @@ exports[`40. tile ar 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+          >
+            <Text>
+              
+              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+              ...
+            </Text>
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <Text
-          numberOfLines={2}
-        >
-          <Text>
-            
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-            ...
-          </Text>
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -711,7 +711,7 @@ exports[`10. secondary one and columnist - medium 1`] = `
       Object {
         "flex": 1,
         "flexDirection": "row",
-        "paddingHorizontal": 20,
+        "marginHorizontal": 20,
       }
     }
   >
@@ -730,7 +730,7 @@ exports[`10. secondary one and columnist - medium 1`] = `
           "borderColor": "#DBDBDB",
           "borderRightWidth": 1,
           "borderStyle": "solid",
-          "marginVertical": 10,
+          "marginVertical": 15,
         }
       }
     />
@@ -1892,7 +1892,7 @@ exports[`25. secondary one and columnist - wide 1`] = `
       Object {
         "flex": 1,
         "flexDirection": "row",
-        "paddingHorizontal": 20,
+        "marginHorizontal": 20,
       }
     }
   >
@@ -1911,7 +1911,7 @@ exports[`25. secondary one and columnist - wide 1`] = `
           "borderColor": "#DBDBDB",
           "borderRightWidth": 1,
           "borderStyle": "solid",
-          "marginVertical": 10,
+          "marginVertical": 15,
         }
       }
     />
@@ -3219,7 +3219,7 @@ exports[`40. secondary one and columnist - huge 1`] = `
         Object {
           "flex": 1,
           "flexDirection": "row",
-          "paddingHorizontal": 20,
+          "marginHorizontal": 20,
         }
       }
     >
@@ -3238,7 +3238,7 @@ exports[`40. secondary one and columnist - huge 1`] = `
             "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "marginVertical": 10,
+            "marginVertical": 15,
           }
         }
       />

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -508,7 +508,13 @@ exports[`7. secondary one and four - medium 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
           <View
@@ -521,7 +527,13 @@ exports[`7. secondary one and four - medium 1`] = `
               }
             }
           />
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
         </View>
@@ -542,7 +554,13 @@ exports[`7. secondary one and four - medium 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
           <View
@@ -555,7 +573,13 @@ exports[`7. secondary one and four - medium 1`] = `
               }
             }
           />
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
         </View>
@@ -1429,7 +1453,6 @@ exports[`20. lead two no pic and two - wide 1`] = `
     <View
       style={
         Object {
-          "paddingTop": 10,
           "width": "16%",
         }
       }
@@ -1664,7 +1687,13 @@ exports[`22. secondary one and four - wide 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
           <View
@@ -1677,7 +1706,13 @@ exports[`22. secondary one and four - wide 1`] = `
               }
             }
           />
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
         </View>
@@ -1698,7 +1733,13 @@ exports[`22. secondary one and four - wide 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
           <View
@@ -1711,7 +1752,13 @@ exports[`22. secondary one and four - wide 1`] = `
               }
             }
           />
-          <View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
             <TileO />
           </View>
         </View>
@@ -2683,7 +2730,6 @@ exports[`35. lead two no pic and two - huge 1`] = `
       <View
         style={
           Object {
-            "paddingTop": 10,
             "width": "16%",
           }
         }
@@ -2938,7 +2984,13 @@ exports[`37. secondary one and four - huge 1`] = `
               }
             }
           >
-            <View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
               <TileO />
             </View>
             <View
@@ -2951,7 +3003,13 @@ exports[`37. secondary one and four - huge 1`] = `
                 }
               }
             />
-            <View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
               <TileO />
             </View>
           </View>
@@ -2972,7 +3030,13 @@ exports[`37. secondary one and four - huge 1`] = `
               }
             }
           >
-            <View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
               <TileO />
             </View>
             <View
@@ -2985,7 +3049,13 @@ exports[`37. secondary one and four - huge 1`] = `
                 }
               }
             />
-            <View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
               <TileO />
             </View>
           </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -310,12 +310,14 @@ exports[`11. secondary two and two - medium 1`] = `
     <View>
       <View>
         <TileG
+          breakpoint="medium"
           tileName="support1"
         />
       </View>
       <View />
       <View>
         <TileG
+          breakpoint="medium"
           tileName="support2"
         />
       </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -880,7 +880,7 @@ exports[`18. tile r 1`] = `
   <View
     style={
       Object {
-        "paddingBottom": 10,
+        "flex": 1,
       }
     }
   >
@@ -1303,19 +1303,11 @@ exports[`25. tile x 1`] = `
     style={
       Object {
         "flex": 1,
-        "marginHorizontal": 10,
       }
     }
   >
     <View>
-      <View
-        style={
-          Object {
-            "marginHorizontal": 10,
-            "marginVertical": 5,
-          }
-        }
-      >
+      <View>
         <View
           style={
             Object {
@@ -1361,13 +1353,7 @@ exports[`25. tile x 1`] = `
 
 exports[`26. tile y 1`] = `
 <Link>
-  <View
-    style={
-      Object {
-        "marginBottom": 10,
-      }
-    }
-  >
+  <View>
     <View
       style={
         Object {
@@ -1399,7 +1385,6 @@ exports[`26. tile y 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
         }
       }
     >
@@ -1416,7 +1401,13 @@ exports[`26. tile y 1`] = `
 
 exports[`27. tile z 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -1451,9 +1442,7 @@ exports[`28. tile ab 1`] = `
   <Image
     style={
       Object {
-        "flexDirection": "column",
-        "justifyContent": "flex-end",
-        "width": "50%",
+        "flex": 1,
       }
     }
   />
@@ -1462,7 +1451,6 @@ exports[`28. tile ab 1`] = `
       Object {
         "flex": 1,
         "paddingLeft": 20,
-        "width": "50%",
       }
     }
   >
@@ -1699,6 +1687,7 @@ exports[`33. tile al 1`] = `
   <Image
     style={
       Object {
+        "marginBottom": 10,
         "width": "100%",
       }
     }
@@ -2195,6 +2184,7 @@ exports[`42. tile ah 1`] = `
     style={
       Object {
         "alignItems": "center",
+        "flex": 1,
         "paddingTop": 5,
       }
     }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -46,58 +46,56 @@ exports[`1. tile a 1`] = `
 
 exports[`2. tile b 1`] = `
 <Link>
-  <View>
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
+  <View
+    style={
+      Object {
+        "flex": 1,
       }
-    >
+    }
+  >
+    <View>
       <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 0,
-              }
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
             }
-          >
-            <ArticleLabel />
-          </View>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 25,
-                "fontWeight": "900",
-                "lineHeight": 25,
-                "marginBottom": 5,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "flexWrap": "wrap",
-                "fontFamily": "TimesDigitalW04",
-                "fontSize": 14,
-                "lineHeight": 20,
-              }
-            }
-          >
-            <Text>
-              
-              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-              ...
-            </Text>
-          </Text>
-          <ArticleFlags />
+          }
+        >
+          <ArticleLabel />
         </View>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 25,
+              "fontWeight": "900",
+              "lineHeight": 25,
+              "marginBottom": 5,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+            }
+          }
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1545,40 +1543,32 @@ exports[`29. tile ae 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
+    <View>
       <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 0,
-              }
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
             }
-          >
-            <ArticleLabel />
-          </View>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 30,
-                "fontWeight": "900",
-                "lineHeight": 30,
-                "marginBottom": 10,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags />
+          }
+        >
+          <ArticleLabel />
         </View>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "900",
+              "lineHeight": 30,
+              "marginBottom": 10,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1717,48 +1707,35 @@ exports[`33. tile al 1`] = `
     style={
       Object {
         "flex": 1,
-        "fontFamily": "TimesDigitalW04-Regular",
-        "fontSize": 14,
-        "lineHeight": undefined,
-        "paddingTop": 10,
-        "width": "100%",
       }
     }
   >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
+    <View>
       <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 0,
-              }
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
             }
-          >
-            <ArticleLabel />
-          </View>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 22,
-                "fontWeight": "900",
-                "lineHeight": 27,
-                "marginBottom": 0,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags />
+          }
+        >
+          <ArticleLabel />
         </View>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "900",
+              "lineHeight": 27,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1782,41 +1759,33 @@ exports[`34. tile am 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
+    <View>
       <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 0,
-              }
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
             }
-          >
-            <ArticleLabel />
-          </View>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 35,
-                "fontWeight": "900",
-                "lineHeight": 35,
-                "marginBottom": 5,
-                "paddingBottom": 5,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags />
+          }
+        >
+          <ArticleLabel />
         </View>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 35,
+              "fontWeight": "900",
+              "lineHeight": 35,
+              "marginBottom": 5,
+              "paddingBottom": 5,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -2047,40 +2016,32 @@ exports[`39. tile aq 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
+    <View>
       <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 0,
-              }
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
             }
-          >
-            <ArticleLabel />
-          </View>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 22,
-                "fontWeight": "900",
-                "lineHeight": 22,
-                "marginBottom": 5,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags />
+          }
+        >
+          <ArticleLabel />
         </View>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "900",
+              "lineHeight": 22,
+              "marginBottom": 5,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -2106,57 +2067,49 @@ exports[`40. tile ar 1`] = `
       }
     }
   >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
+    <View>
       <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 0,
-              }
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
             }
-          >
-            <ArticleLabel />
-          </View>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 20,
-                "fontWeight": "900",
-                "lineHeight": 20,
-                "marginBottom": 5,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "flexWrap": "wrap",
-                "fontFamily": "TimesDigitalW04",
-                "fontSize": 14,
-                "lineHeight": 20,
-              }
-            }
-          >
-            <Text>
-              
-              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-              ...
-            </Text>
-          </Text>
-          <ArticleFlags />
+          }
+        >
+          <ArticleLabel />
         </View>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 20,
+              "fontWeight": "900",
+              "lineHeight": 20,
+              "marginBottom": 5,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+            }
+          }
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags />
       </View>
     </View>
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -5,8 +5,7 @@ exports[`1. tile a 1`] = `
   <View
     style={
       Object {
-        "marginHorizontal": 10,
-        "marginTop": 10,
+        "margin": 10,
       }
     }
   >
@@ -47,57 +46,58 @@ exports[`1. tile a 1`] = `
 
 exports[`2. tile b 1`] = `
 <Link>
-  <View
-    style={
-      Object {
-        "flex": 1,
+  <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
       }
-    }
-  >
-    <View>
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 0,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 0,
+              }
             }
-          }
-        >
-          <ArticleLabel />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 25,
-              "fontWeight": "900",
-              "lineHeight": 25,
-              "marginBottom": 5,
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 25,
+                "fontWeight": "900",
+                "lineHeight": 25,
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          This is tile headline
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#696969",
-              "flexWrap": "wrap",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 14,
-              "lineHeight": 20,
-              "marginBottom": 10,
-            }
-          }
-        >
-          <Text>
-            
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-            ...
+          >
+            This is tile headline
           </Text>
-        </Text>
-        <ArticleFlags />
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+              }
+            }
+          >
+            <Text>
+              
+              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+              ...
+            </Text>
+          </Text>
+          <ArticleFlags />
+        </View>
       </View>
     </View>
   </View>
@@ -116,7 +116,13 @@ exports[`3. tile c 1`] = `
   >
     <Image />
   </View>
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -151,7 +157,6 @@ exports[`4. tile d 1`] = `
   <Image
     style={
       Object {
-        "paddingRight": 10,
         "width": "50%",
       }
     }
@@ -160,8 +165,7 @@ exports[`4. tile d 1`] = `
     style={
       Object {
         "paddingBottom": 5,
-        "paddingRight": 10,
-        "paddingTop": 5,
+        "paddingLeft": 10,
         "width": "50%",
       }
     }
@@ -199,7 +203,6 @@ exports[`5. tile e 1`] = `
   <Image
     style={
       Object {
-        "paddingRight": 10,
         "width": "50%",
       }
     }
@@ -208,8 +211,7 @@ exports[`5. tile e 1`] = `
     style={
       Object {
         "paddingBottom": 5,
-        "paddingRight": 10,
-        "paddingTop": 10,
+        "paddingLeft": 10,
         "width": "50%",
       }
     }
@@ -289,7 +291,6 @@ exports[`6. tile f 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
         }
       }
     >
@@ -317,10 +318,8 @@ exports[`7. tile g 1`] = `
   <View
     style={
       Object {
-        "justifyContent": "center",
-        "paddingBottom": 0,
+        "flex": 1,
         "paddingLeft": 10,
-        "paddingTop": 5,
         "width": "70%",
       }
     }
@@ -328,28 +327,36 @@ exports[`7. tile g 1`] = `
     <View
       style={
         Object {
-          "marginBottom": 0,
+          "flex": 1,
+          "justifyContent": "center",
         }
       }
     >
-      <ArticleLabel />
+      <View
+        style={
+          Object {
+            "marginBottom": 0,
+          }
+        }
+      >
+        <ArticleLabel />
+      </View>
+      <Text
+        style={
+          Object {
+            "color": "#333333",
+            "fontFamily": "TimesModern-Bold",
+            "fontSize": 22,
+            "fontWeight": "900",
+            "lineHeight": 22,
+            "marginBottom": 5,
+          }
+        }
+      >
+        This is tile headline
+      </Text>
+      <ArticleFlags />
     </View>
-    <Text
-      style={
-        Object {
-          "color": "#333333",
-          "fontFamily": "TimesModern-Bold",
-          "fontSize": 22,
-          "fontWeight": "900",
-          "lineHeight": 22,
-          "marginBottom": 5,
-          "paddingBottom": 5,
-        }
-      }
-    >
-      This is tile headline
-    </Text>
-    <ArticleFlags />
   </View>
 </Link>
 `;
@@ -360,7 +367,6 @@ exports[`8. tile h 1`] = `
     style={
       Object {
         "paddingRight": 10,
-        "paddingVertical": 10,
         "width": "50%",
       }
     }
@@ -396,7 +402,6 @@ exports[`8. tile h 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
         }
       }
     >
@@ -441,7 +446,6 @@ exports[`8. tile h 1`] = `
       Object {
         "flexDirection": "column",
         "justifyContent": "flex-end",
-        "paddingTop": 10,
         "width": "50%",
       }
     }
@@ -510,7 +514,7 @@ exports[`10. tile j 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
+        "paddingLeft": 10,
         "width": "60%",
       }
     }
@@ -590,7 +594,13 @@ exports[`11. tile k 1`] = `
 
 exports[`12. tile l 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -621,7 +631,13 @@ exports[`12. tile l 1`] = `
 
 exports[`13. tile m 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <Text
       style={
         Object {
@@ -670,7 +686,7 @@ exports[`14. tile n 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
+        "paddingLeft": 10,
         "width": "50%",
       }
     }
@@ -718,7 +734,13 @@ exports[`14. tile n 1`] = `
 
 exports[`15. tile o 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -857,7 +879,13 @@ exports[`17. tile q 1`] = `
 
 exports[`18. tile r 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "paddingBottom": 10,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -1075,8 +1103,8 @@ exports[`21. tile t 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
-        "paddingVertical": 5,
+        "paddingBottom": 5,
+        "paddingLeft": 10,
         "width": "50%",
       }
     }
@@ -1120,32 +1148,40 @@ exports[`22. tile u 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 0,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 0,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 30,
+                "fontWeight": "900",
+                "lineHeight": 30,
+                "marginBottom": 10,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "900",
-              "lineHeight": 30,
-              "marginBottom": 10,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1169,7 +1205,13 @@ exports[`23. tile v 1`] = `
       }
     }
   />
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -1187,8 +1229,7 @@ exports[`23. tile v 1`] = `
           "fontSize": 30,
           "fontWeight": "900",
           "lineHeight": 30,
-          "marginBottom": 5,
-          "paddingBottom": 5,
+          "marginBottom": 10,
         }
       }
     >
@@ -1211,32 +1252,40 @@ exports[`24. tile w 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 0,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 0,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 35,
+                "fontWeight": "900",
+                "lineHeight": 35,
+                "marginBottom": 5,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 35,
-              "fontWeight": "900",
-              "lineHeight": 35,
-              "marginBottom": 5,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1256,6 +1305,7 @@ exports[`25. tile x 1`] = `
     style={
       Object {
         "flex": 1,
+        "marginHorizontal": 10,
       }
     }
   >
@@ -1313,7 +1363,13 @@ exports[`25. tile x 1`] = `
 
 exports[`26. tile y 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -1412,60 +1468,68 @@ exports[`28. tile ab 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 0,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 0,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 30,
+                "fontWeight": "900",
+                "lineHeight": 30,
+                "marginBottom": 5,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
+          <Text>
+            <Text
+              style={
+                Object {
+                  "color": "#333333",
+                  "flexDirection": "row",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 13,
+                  "lineHeight": 15,
+                }
+              }
+            >
+              Richard Lloyd Parry
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#333333",
+                  "flexDirection": "row",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 13,
+                  "lineHeight": 15,
+                }
+              }
+            >
+              , Hanoi
+            </Text>
+          </Text>
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "900",
-              "lineHeight": 30,
-              "marginBottom": 5,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
-        <Text>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "flexDirection": "row",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 15,
-              }
-            }
-          >
-            Richard Lloyd Parry
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "flexDirection": "row",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 15,
-              }
-            }
-          >
-            , Hanoi
-          </Text>
-        </Text>
       </View>
     </View>
   </View>
@@ -1481,32 +1545,40 @@ exports[`29. tile ae 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 0,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 0,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 30,
+                "fontWeight": "900",
+                "lineHeight": 30,
+                "marginBottom": 10,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "900",
-              "lineHeight": 30,
-              "marginBottom": 10,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1515,7 +1587,13 @@ exports[`29. tile ae 1`] = `
 
 exports[`30. tile ag 1`] = `
 <Link>
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <Text
       style={
         Object {
@@ -1631,7 +1709,6 @@ exports[`33. tile al 1`] = `
   <Image
     style={
       Object {
-        "paddingVertical": 10,
         "width": "100%",
       }
     }
@@ -1640,35 +1717,48 @@ exports[`33. tile al 1`] = `
     style={
       Object {
         "flex": 1,
+        "fontFamily": "TimesDigitalW04-Regular",
+        "fontSize": 14,
+        "lineHeight": undefined,
+        "paddingTop": 10,
+        "width": "100%",
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 0,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 0,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 22,
+                "fontWeight": "900",
+                "lineHeight": 27,
+                "marginBottom": 0,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 22,
-              "fontWeight": "900",
-              "lineHeight": 27,
-              "marginBottom": 0,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1692,33 +1782,41 @@ exports[`34. tile am 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 0,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 0,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 35,
+                "fontWeight": "900",
+                "lineHeight": 35,
+                "marginBottom": 5,
+                "paddingBottom": 5,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 35,
-              "fontWeight": "900",
-              "lineHeight": 35,
-              "marginBottom": 5,
-              "paddingBottom": 5,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -1737,8 +1835,8 @@ exports[`35. tile an 1`] = `
   <View
     style={
       Object {
+        "flex": 1,
         "justifyContent": "center",
-        "paddingHorizontal": 10,
         "paddingTop": 10,
       }
     }
@@ -1774,7 +1872,6 @@ exports[`35. tile an 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
         }
       }
     >
@@ -1801,8 +1898,8 @@ exports[`36. tile ap 1`] = `
   <View
     style={
       Object {
+        "flex": 1,
         "justifyContent": "center",
-        "paddingHorizontal": 10,
         "paddingTop": 5,
       }
     }
@@ -1848,7 +1945,7 @@ exports[`37. tile ad 1`] = `
   <View
     style={
       Object {
-        "paddingHorizontal": 10,
+        "paddingLeft": 10,
         "width": "70%",
       }
     }
@@ -1897,7 +1994,7 @@ exports[`38. tile ac 1`] = `
         "backgroundColor": "#F0F0F0",
         "flex": 1,
         "justifyContent": "center",
-        "paddingHorizontal": 40,
+        "paddingHorizontal": 20,
         "paddingVertical": 15,
       }
     }
@@ -1950,32 +2047,40 @@ exports[`39. tile aq 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 0,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 0,
+              }
             }
-          }
-        >
-          <ArticleLabel />
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 22,
+                "fontWeight": "900",
+                "lineHeight": 22,
+                "marginBottom": 5,
+              }
+            }
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags />
         </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 22,
-              "fontWeight": "900",
-              "lineHeight": 22,
-              "marginBottom": 5,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags />
       </View>
     </View>
   </View>
@@ -2001,50 +2106,57 @@ exports[`40. tile ar 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 0,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 0,
+              }
             }
-          }
-        >
-          <ArticleLabel />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 20,
-              "fontWeight": "900",
-              "lineHeight": 20,
-              "marginBottom": 5,
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 20,
+                "fontWeight": "900",
+                "lineHeight": 20,
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          This is tile headline
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#696969",
-              "flexWrap": "wrap",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 14,
-              "lineHeight": 20,
-              "marginBottom": 10,
-            }
-          }
-        >
-          <Text>
-            
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-            ...
+          >
+            This is tile headline
           </Text>
-        </Text>
-        <ArticleFlags />
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+              }
+            }
+          >
+            <Text>
+              
+              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+              ...
+            </Text>
+          </Text>
+          <ArticleFlags />
+        </View>
       </View>
     </View>
   </View>
@@ -2063,7 +2175,13 @@ exports[`41. tile as 1`] = `
   >
     <Image />
   </View>
-  <View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -2095,7 +2213,6 @@ exports[`41. tile as 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
         }
       }
     >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -51,39 +51,37 @@ exports[`2. tile b 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <Text
-            numberOfLines={2}
-          >
-            <Text>
-              
-              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-              ...
-            </Text>
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -1053,28 +1051,10 @@ exports[`25. tile x 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
         <Text
@@ -1266,30 +1246,28 @@ exports[`29. tile ae 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -1390,9 +1368,7 @@ exports[`33. tile al 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "flexDirection": "column",
-      "paddingHorizontal": 10,
-      "paddingVertical": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1406,30 +1382,28 @@ exports[`33. tile al 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -1455,30 +1429,28 @@ exports[`34. tile am 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -1690,30 +1662,28 @@ exports[`39. tile aq 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -1742,39 +1712,37 @@ exports[`40. tile ar 1`] = `
     <View>
       <View>
         <View>
-          <View>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-          >
-            This is tile headline
-          </Text>
-          <Text
-            numberOfLines={2}
-          >
-            <Text>
-              
-              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-              ...
-            </Text>
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -737,9 +737,8 @@ exports[`18. tile r 1`] = `
 <Link
   linkStyle={
     Object {
-      "paddingBottom": 15,
-      "paddingHorizontal": 30,
-      "paddingTop": 15,
+      "flex": 1,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1089,8 +1088,7 @@ exports[`26. tile y 1`] = `
 <Link
   linkStyle={
     Object {
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1134,7 +1132,7 @@ exports[`27. tile z 1`] = `
 <Link
   linkStyle={
     Object {
-      "margin": 10,
+      "padding": 10,
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -2,11 +2,6 @@
 
 exports[`1. tile a 1`] = `
 <Link
-  linkStyle={
-    Object {
-      "marginTop": 5,
-    }
-  }
   url="/article/123"
 >
   <View>
@@ -47,8 +42,7 @@ exports[`2. tile b 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -57,37 +51,39 @@ exports[`2. tile b 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+          >
+            <Text>
+              
+              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+              ...
+            </Text>
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <Text
-          numberOfLines={2}
-        >
-          <Text>
-            
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-            ...
-          </Text>
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -99,8 +95,7 @@ exports[`3. tile c 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -230,8 +225,7 @@ exports[`6. tile f 1`] = `
 <Link
   linkStyle={
     Object {
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -297,28 +291,30 @@ exports[`7. tile g 1`] = `
   />
   <View>
     <View>
-      <ArticleLabel
-        color="#005B8D"
-        isVideo={false}
-        title="label"
+      <View>
+        <ArticleLabel
+          color="#005B8D"
+          isVideo={false}
+          title="label"
+        />
+      </View>
+      <Text
+        accessibilityRole="header"
+        aria-level="3"
+      >
+        This is tile headline
+      </Text>
+      <ArticleFlags
+        flags={
+          Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ]
+        }
       />
     </View>
-    <Text
-      accessibilityRole="header"
-      aria-level="3"
-    >
-      This is tile headline
-    </Text>
-    <ArticleFlags
-      flags={
-        Array [
-          Object {
-            "expiryTime": "2030-03-14T12:00:00.000Z",
-            "type": "EXCLUSIVE",
-          },
-        ]
-      }
-    />
   </View>
 </Link>
 `;
@@ -328,7 +324,7 @@ exports[`8. tile h 1`] = `
   linkStyle={
     Object {
       "flexDirection": "row",
-      "paddingHorizontal": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -509,8 +505,7 @@ exports[`12. tile l 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -547,6 +542,7 @@ exports[`13. tile m 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "paddingBottom": 10,
     }
   }
@@ -626,6 +622,7 @@ exports[`15. tile o 1`] = `
   linkStyle={
     Object {
       "backgroundColor": "#272D34",
+      "flex": 1,
       "paddingHorizontal": 12,
       "paddingVertical": 10,
     }
@@ -725,7 +722,6 @@ exports[`17. tile q 1`] = `
 <Link
   linkStyle={
     Object {
-      "alignItems": "center",
       "paddingVertical": 10,
     }
   }
@@ -913,28 +909,30 @@ exports[`22. tile u 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -1006,28 +1004,30 @@ exports[`24. tile w 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -1044,8 +1044,7 @@ exports[`25. tile x 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1054,10 +1053,28 @@ exports[`25. tile x 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
         <Text
@@ -1179,6 +1196,7 @@ exports[`28. tile ab 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "flexDirection": "row",
       "paddingHorizontal": 10,
       "paddingVertical": 10,
@@ -1195,36 +1213,38 @@ exports[`28. tile ab 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
+          <Text>
+            <Text>
+              Richard Lloyd Parry
+            </Text>
+            <Text>
+              , Hanoi
+            </Text>
+          </Text>
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-        <Text>
-          <Text>
-            Richard Lloyd Parry
-          </Text>
-          <Text>
-            , Hanoi
-          </Text>
-        </Text>
       </View>
     </View>
   </View>
@@ -1236,7 +1256,7 @@ exports[`29. tile ae 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
+      "padding": 10,
       "paddingTop": 15,
     }
   }
@@ -1246,28 +1266,30 @@ exports[`29. tile ae 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -1278,6 +1300,7 @@ exports[`30. tile ag 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "paddingBottom": 10,
       "paddingHorizontal": 20,
     }
@@ -1369,6 +1392,7 @@ exports[`33. tile al 1`] = `
       "flex": 1,
       "flexDirection": "column",
       "paddingHorizontal": 10,
+      "paddingVertical": 10,
     }
   }
   url="/article/123"
@@ -1382,28 +1406,30 @@ exports[`33. tile al 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -1415,8 +1441,7 @@ exports[`34. tile am 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1430,28 +1455,30 @@ exports[`34. tile am 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -1462,6 +1489,7 @@ exports[`35. tile an 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "padding": 10,
     }
   }
@@ -1513,6 +1541,7 @@ exports[`36. tile ap 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "padding": 10,
     }
   }
@@ -1645,8 +1674,7 @@ exports[`39. tile aq 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingTop": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1662,28 +1690,30 @@ exports[`39. tile aq 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -1712,37 +1742,39 @@ exports[`40. tile ar 1`] = `
     <View>
       <View>
         <View>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <View>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </View>
+          <Text
+            accessibilityRole="header"
+            aria-level="3"
+          >
+            This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+          >
+            <Text>
+              
+              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+              ...
+            </Text>
+          </Text>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-        >
-          This is tile headline
-        </Text>
-        <Text
-          numberOfLines={2}
-        >
-          <Text>
-            
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-            ...
-          </Text>
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -208,6 +208,19 @@ exports[`1. secondary one and four 1`] = `
 }
 
 .IS5 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS6 {
   border-bottom-width: 1px;
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
@@ -221,11 +234,24 @@ exports[`1. secondary one and four 1`] = `
   margin-left: 10px;
 }
 
-.IS6 {
+.IS7 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS8 {
   width: 25%;
 }
 
-.IS7 {
+.IS9 {
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
   border-bottom-color: rgba(77,77,77,1.00);
@@ -239,7 +265,20 @@ exports[`1. secondary one and four 1`] = `
   margin-bottom: 10px;
 }
 
-.IS8 {
+.IS10 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS11 {
   border-bottom-width: 1px;
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
@@ -253,11 +292,24 @@ exports[`1. secondary one and four 1`] = `
   margin-left: 10px;
 }
 
-.IS9 {
+.IS12 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS13 {
   width: 25%;
 }
 
-.IS10 {
+.IS14 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -265,13 +317,13 @@ exports[`1. secondary one and four 1`] = `
   -webkit-box-direction: normal;
 }
 
-.IS11 {
+.IS15 {
   background-color: rgba(39,45,52,1.00);
   padding-right: 10px;
   padding-left: 10px;
 }
 
-.IS12 {
+.IS16 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -281,19 +333,19 @@ exports[`1. secondary one and four 1`] = `
   -ms-flex-item-align: center;
 }
 
-.IS13 {
+.IS17 {
   background-color: rgba(39,45,52,1.00);
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS13"
+  className="css-view-1dbjc4n IS17"
 >
   <div
-    className="css-view-1dbjc4n IS12"
+    className="css-view-1dbjc4n IS16"
   >
     <div
-      className="css-view-1dbjc4n IS11"
+      className="css-view-1dbjc4n IS15"
     >
       <div
         className="css-view-1dbjc4n IS1"
@@ -307,7 +359,7 @@ exports[`1. secondary one and four 1`] = `
         className="css-view-1dbjc4n IS2"
       />
       <div
-        className="css-view-1dbjc4n IS10"
+        className="css-view-1dbjc4n IS14"
       >
         <div
           className="css-view-1dbjc4n IS3"
@@ -325,20 +377,20 @@ exports[`1. secondary one and four 1`] = `
           className="css-view-1dbjc4n IS4"
         />
         <div
-          className="css-view-1dbjc4n IS6"
+          className="css-view-1dbjc4n IS8"
         >
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS5"
           >
             <TileO
               tileName="support1"
             />
           </div>
           <div
-            className="css-view-1dbjc4n IS5"
+            className="css-view-1dbjc4n IS6"
           />
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS7"
           >
             <TileO
               tileName="support3"
@@ -346,23 +398,23 @@ exports[`1. secondary one and four 1`] = `
           </div>
         </div>
         <div
-          className="css-view-1dbjc4n IS7"
+          className="css-view-1dbjc4n IS9"
         />
         <div
-          className="css-view-1dbjc4n IS9"
+          className="css-view-1dbjc4n IS13"
         >
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS10"
           >
             <TileO
               tileName="support2"
             />
           </div>
           <div
-            className="css-view-1dbjc4n IS8"
+            className="css-view-1dbjc4n IS11"
           />
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS12"
           >
             <TileO
               tileName="support4"
@@ -423,6 +475,19 @@ exports[`1. secondary one and four 2`] = `
 }
 
 .IS5 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS6 {
   border-bottom-width: 1px;
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
@@ -436,11 +501,24 @@ exports[`1. secondary one and four 2`] = `
   margin-left: 10px;
 }
 
-.IS6 {
+.IS7 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS8 {
   width: 25%;
 }
 
-.IS7 {
+.IS9 {
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
   border-bottom-color: rgba(77,77,77,1.00);
@@ -454,7 +532,20 @@ exports[`1. secondary one and four 2`] = `
   margin-bottom: 10px;
 }
 
-.IS8 {
+.IS10 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS11 {
   border-bottom-width: 1px;
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
@@ -468,11 +559,24 @@ exports[`1. secondary one and four 2`] = `
   margin-left: 10px;
 }
 
-.IS9 {
+.IS12 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS13 {
   width: 25%;
 }
 
-.IS10 {
+.IS14 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -480,13 +584,13 @@ exports[`1. secondary one and four 2`] = `
   -webkit-box-direction: normal;
 }
 
-.IS11 {
+.IS15 {
   background-color: rgba(39,45,52,1.00);
   padding-right: 10px;
   padding-left: 10px;
 }
 
-.IS12 {
+.IS16 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -496,19 +600,19 @@ exports[`1. secondary one and four 2`] = `
   -ms-flex-item-align: center;
 }
 
-.IS13 {
+.IS17 {
   background-color: rgba(39,45,52,1.00);
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS13"
+  className="css-view-1dbjc4n IS17"
 >
   <div
-    className="css-view-1dbjc4n IS12"
+    className="css-view-1dbjc4n IS16"
   >
     <div
-      className="css-view-1dbjc4n IS11"
+      className="css-view-1dbjc4n IS15"
     >
       <div
         className="css-view-1dbjc4n IS1"
@@ -522,7 +626,7 @@ exports[`1. secondary one and four 2`] = `
         className="css-view-1dbjc4n IS2"
       />
       <div
-        className="css-view-1dbjc4n IS10"
+        className="css-view-1dbjc4n IS14"
       >
         <div
           className="css-view-1dbjc4n IS3"
@@ -540,20 +644,20 @@ exports[`1. secondary one and four 2`] = `
           className="css-view-1dbjc4n IS4"
         />
         <div
-          className="css-view-1dbjc4n IS6"
+          className="css-view-1dbjc4n IS8"
         >
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS5"
           >
             <TileO
               tileName="support1"
             />
           </div>
           <div
-            className="css-view-1dbjc4n IS5"
+            className="css-view-1dbjc4n IS6"
           />
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS7"
           >
             <TileO
               tileName="support3"
@@ -561,23 +665,23 @@ exports[`1. secondary one and four 2`] = `
           </div>
         </div>
         <div
-          className="css-view-1dbjc4n IS7"
+          className="css-view-1dbjc4n IS9"
         />
         <div
-          className="css-view-1dbjc4n IS9"
+          className="css-view-1dbjc4n IS13"
         >
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS10"
           >
             <TileO
               tileName="support2"
             />
           </div>
           <div
-            className="css-view-1dbjc4n IS8"
+            className="css-view-1dbjc4n IS11"
           />
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS12"
           >
             <TileO
               tileName="support4"
@@ -1350,7 +1454,6 @@ exports[`6. lead two no pic and two 1`] = `
 }
 
 .IS4 {
-  padding-top: 10px;
   width: 16%;
 }
 
@@ -1763,6 +1866,19 @@ exports[`10. secondary one and four 1`] = `
 }
 
 .IS5 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS6 {
   border-bottom-width: 1px;
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
@@ -1776,11 +1892,24 @@ exports[`10. secondary one and four 1`] = `
   margin-left: 10px;
 }
 
-.IS6 {
+.IS7 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS8 {
   width: 25%;
 }
 
-.IS7 {
+.IS9 {
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
   border-bottom-color: rgba(77,77,77,1.00);
@@ -1794,7 +1923,20 @@ exports[`10. secondary one and four 1`] = `
   margin-bottom: 10px;
 }
 
-.IS8 {
+.IS10 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS11 {
   border-bottom-width: 1px;
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
@@ -1808,11 +1950,24 @@ exports[`10. secondary one and four 1`] = `
   margin-left: 10px;
 }
 
-.IS9 {
+.IS12 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS13 {
   width: 25%;
 }
 
-.IS10 {
+.IS14 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -1820,13 +1975,13 @@ exports[`10. secondary one and four 1`] = `
   -webkit-box-direction: normal;
 }
 
-.IS11 {
+.IS15 {
   background-color: rgba(39,45,52,1.00);
   padding-right: 10px;
   padding-left: 10px;
 }
 
-.IS12 {
+.IS16 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -1836,19 +1991,19 @@ exports[`10. secondary one and four 1`] = `
   -ms-flex-item-align: center;
 }
 
-.IS13 {
+.IS17 {
   background-color: rgba(39,45,52,1.00);
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS13"
+  className="css-view-1dbjc4n IS17"
 >
   <div
-    className="css-view-1dbjc4n IS12"
+    className="css-view-1dbjc4n IS16"
   >
     <div
-      className="css-view-1dbjc4n IS11"
+      className="css-view-1dbjc4n IS15"
     >
       <div
         className="css-view-1dbjc4n IS1"
@@ -1862,7 +2017,7 @@ exports[`10. secondary one and four 1`] = `
         className="css-view-1dbjc4n IS2"
       />
       <div
-        className="css-view-1dbjc4n IS10"
+        className="css-view-1dbjc4n IS14"
       >
         <div
           className="css-view-1dbjc4n IS3"
@@ -1880,20 +2035,20 @@ exports[`10. secondary one and four 1`] = `
           className="css-view-1dbjc4n IS4"
         />
         <div
-          className="css-view-1dbjc4n IS6"
+          className="css-view-1dbjc4n IS8"
         >
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS5"
           >
             <TileO
               tileName="support1"
             />
           </div>
           <div
-            className="css-view-1dbjc4n IS5"
+            className="css-view-1dbjc4n IS6"
           />
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS7"
           >
             <TileO
               tileName="support3"
@@ -1901,23 +2056,23 @@ exports[`10. secondary one and four 1`] = `
           </div>
         </div>
         <div
-          className="css-view-1dbjc4n IS7"
+          className="css-view-1dbjc4n IS9"
         />
         <div
-          className="css-view-1dbjc4n IS9"
+          className="css-view-1dbjc4n IS13"
         >
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS10"
           >
             <TileO
               tileName="support2"
             />
           </div>
           <div
-            className="css-view-1dbjc4n IS8"
+            className="css-view-1dbjc4n IS11"
           />
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS12"
           >
             <TileO
               tileName="support4"

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -1582,8 +1582,8 @@ exports[`8. secondary one and columnist 1`] = `
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-top: 15px;
+  margin-bottom: 15px;
 }
 
 .IS3 {
@@ -1600,8 +1600,8 @@ exports[`8. secondary one and columnist 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 20px;
-  padding-left: 20px;
+  margin-right: 20px;
+  margin-left: 20px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -386,7 +386,6 @@ exports[`5. lead two no pic and two - medium 1`] = `
 }
 
 .IS4 {
-  padding-top: 10px;
   width: 16%;
 }
 
@@ -694,6 +693,19 @@ exports[`7. secondary one and four - medium 1`] = `
 }
 
 .IS5 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS6 {
   border-bottom-width: 1px;
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
@@ -707,11 +719,24 @@ exports[`7. secondary one and four - medium 1`] = `
   margin-left: 10px;
 }
 
-.IS6 {
+.IS7 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS8 {
   width: 25%;
 }
 
-.IS7 {
+.IS9 {
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
   border-bottom-color: rgba(77,77,77,1.00);
@@ -725,7 +750,20 @@ exports[`7. secondary one and four - medium 1`] = `
   margin-bottom: 10px;
 }
 
-.IS8 {
+.IS10 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS11 {
   border-bottom-width: 1px;
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
@@ -739,11 +777,24 @@ exports[`7. secondary one and four - medium 1`] = `
   margin-left: 10px;
 }
 
-.IS9 {
+.IS12 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS13 {
   width: 25%;
 }
 
-.IS10 {
+.IS14 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -751,13 +802,13 @@ exports[`7. secondary one and four - medium 1`] = `
   -webkit-box-direction: normal;
 }
 
-.IS11 {
+.IS15 {
   background-color: rgba(39,45,52,1.00);
   padding-right: 10px;
   padding-left: 10px;
 }
 
-.IS12 {
+.IS16 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -767,19 +818,19 @@ exports[`7. secondary one and four - medium 1`] = `
   -ms-flex-item-align: center;
 }
 
-.IS13 {
+.IS17 {
   background-color: rgba(39,45,52,1.00);
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS13"
+  className="css-view-1dbjc4n IS17"
 >
   <div
-    className="css-view-1dbjc4n IS12"
+    className="css-view-1dbjc4n IS16"
   >
     <div
-      className="css-view-1dbjc4n IS11"
+      className="css-view-1dbjc4n IS15"
     >
       <div
         className="css-view-1dbjc4n IS1"
@@ -793,7 +844,7 @@ exports[`7. secondary one and four - medium 1`] = `
         className="css-view-1dbjc4n IS2"
       />
       <div
-        className="css-view-1dbjc4n IS10"
+        className="css-view-1dbjc4n IS14"
       >
         <div
           className="css-view-1dbjc4n IS3"
@@ -811,20 +862,20 @@ exports[`7. secondary one and four - medium 1`] = `
           className="css-view-1dbjc4n IS4"
         />
         <div
-          className="css-view-1dbjc4n IS6"
+          className="css-view-1dbjc4n IS8"
         >
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS5"
           >
             <TileO
               tileName="support1"
             />
           </div>
           <div
-            className="css-view-1dbjc4n IS5"
+            className="css-view-1dbjc4n IS6"
           />
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS7"
           >
             <TileO
               tileName="support3"
@@ -832,23 +883,23 @@ exports[`7. secondary one and four - medium 1`] = `
           </div>
         </div>
         <div
-          className="css-view-1dbjc4n IS7"
+          className="css-view-1dbjc4n IS9"
         />
         <div
-          className="css-view-1dbjc4n IS9"
+          className="css-view-1dbjc4n IS13"
         >
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS10"
           >
             <TileO
               tileName="support2"
             />
           </div>
           <div
-            className="css-view-1dbjc4n IS8"
+            className="css-view-1dbjc4n IS11"
           />
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS12"
           >
             <TileO
               tileName="support4"
@@ -2206,7 +2257,6 @@ exports[`20. lead two no pic and two - wide 1`] = `
 }
 
 .IS4 {
-  padding-top: 10px;
   width: 16%;
 }
 
@@ -2514,6 +2564,19 @@ exports[`22. secondary one and four - wide 1`] = `
 }
 
 .IS5 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS6 {
   border-bottom-width: 1px;
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
@@ -2527,11 +2590,24 @@ exports[`22. secondary one and four - wide 1`] = `
   margin-left: 10px;
 }
 
-.IS6 {
+.IS7 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS8 {
   width: 25%;
 }
 
-.IS7 {
+.IS9 {
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
   border-bottom-color: rgba(77,77,77,1.00);
@@ -2545,7 +2621,20 @@ exports[`22. secondary one and four - wide 1`] = `
   margin-bottom: 10px;
 }
 
-.IS8 {
+.IS10 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS11 {
   border-bottom-width: 1px;
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
@@ -2559,11 +2648,24 @@ exports[`22. secondary one and four - wide 1`] = `
   margin-left: 10px;
 }
 
-.IS9 {
+.IS12 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS13 {
   width: 25%;
 }
 
-.IS10 {
+.IS14 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -2571,13 +2673,13 @@ exports[`22. secondary one and four - wide 1`] = `
   -webkit-box-direction: normal;
 }
 
-.IS11 {
+.IS15 {
   background-color: rgba(39,45,52,1.00);
   padding-right: 10px;
   padding-left: 10px;
 }
 
-.IS12 {
+.IS16 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -2587,19 +2689,19 @@ exports[`22. secondary one and four - wide 1`] = `
   -ms-flex-item-align: center;
 }
 
-.IS13 {
+.IS17 {
   background-color: rgba(39,45,52,1.00);
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS13"
+  className="css-view-1dbjc4n IS17"
 >
   <div
-    className="css-view-1dbjc4n IS12"
+    className="css-view-1dbjc4n IS16"
   >
     <div
-      className="css-view-1dbjc4n IS11"
+      className="css-view-1dbjc4n IS15"
     >
       <div
         className="css-view-1dbjc4n IS1"
@@ -2613,7 +2715,7 @@ exports[`22. secondary one and four - wide 1`] = `
         className="css-view-1dbjc4n IS2"
       />
       <div
-        className="css-view-1dbjc4n IS10"
+        className="css-view-1dbjc4n IS14"
       >
         <div
           className="css-view-1dbjc4n IS3"
@@ -2631,20 +2733,20 @@ exports[`22. secondary one and four - wide 1`] = `
           className="css-view-1dbjc4n IS4"
         />
         <div
-          className="css-view-1dbjc4n IS6"
+          className="css-view-1dbjc4n IS8"
         >
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS5"
           >
             <TileO
               tileName="support1"
             />
           </div>
           <div
-            className="css-view-1dbjc4n IS5"
+            className="css-view-1dbjc4n IS6"
           />
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS7"
           >
             <TileO
               tileName="support3"
@@ -2652,23 +2754,23 @@ exports[`22. secondary one and four - wide 1`] = `
           </div>
         </div>
         <div
-          className="css-view-1dbjc4n IS7"
+          className="css-view-1dbjc4n IS9"
         />
         <div
-          className="css-view-1dbjc4n IS9"
+          className="css-view-1dbjc4n IS13"
         >
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS10"
           >
             <TileO
               tileName="support2"
             />
           </div>
           <div
-            className="css-view-1dbjc4n IS8"
+            className="css-view-1dbjc4n IS11"
           />
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS12"
           >
             <TileO
               tileName="support4"
@@ -4026,7 +4128,6 @@ exports[`35. lead two no pic and two - huge 1`] = `
 }
 
 .IS4 {
-  padding-top: 10px;
   width: 16%;
 }
 
@@ -4334,6 +4435,19 @@ exports[`37. secondary one and four - huge 1`] = `
 }
 
 .IS5 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS6 {
   border-bottom-width: 1px;
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
@@ -4347,11 +4461,24 @@ exports[`37. secondary one and four - huge 1`] = `
   margin-left: 10px;
 }
 
-.IS6 {
+.IS7 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS8 {
   width: 25%;
 }
 
-.IS7 {
+.IS9 {
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
   border-bottom-color: rgba(77,77,77,1.00);
@@ -4365,7 +4492,20 @@ exports[`37. secondary one and four - huge 1`] = `
   margin-bottom: 10px;
 }
 
-.IS8 {
+.IS10 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS11 {
   border-bottom-width: 1px;
   border-top-color: rgba(77,77,77,1.00);
   border-right-color: rgba(77,77,77,1.00);
@@ -4379,11 +4519,24 @@ exports[`37. secondary one and four - huge 1`] = `
   margin-left: 10px;
 }
 
-.IS9 {
+.IS12 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS13 {
   width: 25%;
 }
 
-.IS10 {
+.IS14 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -4391,13 +4544,13 @@ exports[`37. secondary one and four - huge 1`] = `
   -webkit-box-direction: normal;
 }
 
-.IS11 {
+.IS15 {
   background-color: rgba(39,45,52,1.00);
   padding-right: 10px;
   padding-left: 10px;
 }
 
-.IS12 {
+.IS16 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -4407,19 +4560,19 @@ exports[`37. secondary one and four - huge 1`] = `
   -ms-flex-item-align: center;
 }
 
-.IS13 {
+.IS17 {
   background-color: rgba(39,45,52,1.00);
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS13"
+  className="css-view-1dbjc4n IS17"
 >
   <div
-    className="css-view-1dbjc4n IS12"
+    className="css-view-1dbjc4n IS16"
   >
     <div
-      className="css-view-1dbjc4n IS11"
+      className="css-view-1dbjc4n IS15"
     >
       <div
         className="css-view-1dbjc4n IS1"
@@ -4433,7 +4586,7 @@ exports[`37. secondary one and four - huge 1`] = `
         className="css-view-1dbjc4n IS2"
       />
       <div
-        className="css-view-1dbjc4n IS10"
+        className="css-view-1dbjc4n IS14"
       >
         <div
           className="css-view-1dbjc4n IS3"
@@ -4451,20 +4604,20 @@ exports[`37. secondary one and four - huge 1`] = `
           className="css-view-1dbjc4n IS4"
         />
         <div
-          className="css-view-1dbjc4n IS6"
+          className="css-view-1dbjc4n IS8"
         >
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS5"
           >
             <TileO
               tileName="support1"
             />
           </div>
           <div
-            className="css-view-1dbjc4n IS5"
+            className="css-view-1dbjc4n IS6"
           />
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS7"
           >
             <TileO
               tileName="support3"
@@ -4472,23 +4625,23 @@ exports[`37. secondary one and four - huge 1`] = `
           </div>
         </div>
         <div
-          className="css-view-1dbjc4n IS7"
+          className="css-view-1dbjc4n IS9"
         />
         <div
-          className="css-view-1dbjc4n IS9"
+          className="css-view-1dbjc4n IS13"
         >
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS10"
           >
             <TileO
               tileName="support2"
             />
           </div>
           <div
-            className="css-view-1dbjc4n IS8"
+            className="css-view-1dbjc4n IS11"
           />
           <div
-            className="css-view-1dbjc4n"
+            className="css-view-1dbjc4n IS12"
           >
             <TileO
               tileName="support4"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1119,8 +1119,8 @@ exports[`10. secondary one and columnist - medium 1`] = `
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-top: 15px;
+  margin-bottom: 15px;
 }
 
 .IS3 {
@@ -1137,8 +1137,8 @@ exports[`10. secondary one and columnist - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 20px;
-  padding-left: 20px;
+  margin-right: 20px;
+  margin-left: 20px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -2990,8 +2990,8 @@ exports[`25. secondary one and columnist - wide 1`] = `
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-top: 15px;
+  margin-bottom: 15px;
 }
 
 .IS3 {
@@ -3008,8 +3008,8 @@ exports[`25. secondary one and columnist - wide 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 20px;
-  padding-left: 20px;
+  margin-right: 20px;
+  margin-left: 20px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -4861,8 +4861,8 @@ exports[`40. secondary one and columnist - huge 1`] = `
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-top: 15px;
+  margin-bottom: 15px;
 }
 
 .IS3 {
@@ -4879,8 +4879,8 @@ exports[`40. secondary one and columnist - huge 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 20px;
-  padding-left: 20px;
+  margin-right: 20px;
+  margin-left: 20px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -129,55 +129,51 @@ exports[`2. tile b 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n"
+    className="css-view-1dbjc4n IS3"
   >
     <div
-      className="css-view-1dbjc4n IS3"
+      className="css-view-1dbjc4n"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n"
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
         >
-          <div
-            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <div
-            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe IS2 S3"
-          >
-            <span
-              className="css-text-901oao css-textHasAncestor-16my406"
-            >
-              
-              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-              ...
-            </span>
-          </div>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe IS2 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </span>
+        </div>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </div>
     </div>
   </div>
@@ -2127,21 +2123,6 @@ exports[`25. tile x 1`] = `
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
 }
-
-.IS3 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  margin-right: 10px;
-  margin-left: 10px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
 </style>
 
 <Link
@@ -2154,42 +2135,25 @@ exports[`25. tile x 1`] = `
   url="/article/123"
 >
   <div
+<<<<<<< HEAD
     className="css-view-1dbjc4n IS4"
+=======
+    className="css-view-1dbjc4n IS2"
+>>>>>>> chore: snaps
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n"
     >
       <div
         className="css-view-1dbjc4n IS3"
       >
         <div
-          className="css-view-1dbjc4n"
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
         >
-          <div
-            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
         <h3
@@ -2539,19 +2503,6 @@ exports[`29. tile ae 1`] = `
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
 }
-
-.IS3 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
 </style>
 
 <Link
@@ -2565,44 +2516,40 @@ exports[`29. tile ae 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS2"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n"
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
         >
-          <div
-            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </div>
     </div>
   </div>
@@ -2818,10 +2765,6 @@ exports[`33. tile al 1`] = `
   margin-bottom: 0px;
 }
 
-.S3 {
-  font-size: 14px;
-}
-
 .IS1 {
   width: 100%;
 }
@@ -2838,31 +2781,13 @@ exports[`33. tile al 1`] = `
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
 }
-
-.IS3 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  font-family: TimesDigitalW04-Regular;
-  padding-top: 10px;
-  width: 100%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
 </style>
 
 <Link
   linkStyle={
     Object {
       "flex": 1,
-      "flexDirection": "column",
-      "paddingHorizontal": "10px",
-      "paddingVertical": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -2874,44 +2799,40 @@ exports[`33. tile al 1`] = `
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div
-    className="css-view-1dbjc4n r-fontSize-1b43r93 IS3 S3"
+    className="css-view-1dbjc4n IS2"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n"
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
         >
-          <div
-            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw r-marginBottom-p1pxzi S2"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw r-marginBottom-p1pxzi S2"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </div>
     </div>
   </div>
@@ -2954,19 +2875,6 @@ exports[`34. tile am 1`] = `
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
 }
-
-.IS4 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
 </style>
 
 <Link
@@ -2985,44 +2893,40 @@ exports[`34. tile am 1`] = `
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div
-    className="css-view-1dbjc4n IS4"
+    className="css-view-1dbjc4n IS3"
   >
     <div
-      className="css-view-1dbjc4n IS3"
+      className="css-view-1dbjc4n"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n"
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
         >
-          <div
-            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </div>
     </div>
   </div>
@@ -3444,19 +3348,6 @@ exports[`39. tile aq 1`] = `
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
 }
-
-.IS4 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
 </style>
 
 <Link
@@ -3478,44 +3369,40 @@ exports[`39. tile aq 1`] = `
     />
   </div>
   <div
-    className="css-view-1dbjc4n IS4"
+    className="css-view-1dbjc4n IS3"
   >
     <div
-      className="css-view-1dbjc4n IS3"
+      className="css-view-1dbjc4n"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n"
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
         >
-          <div
-            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </div>
     </div>
   </div>
@@ -3572,19 +3459,6 @@ exports[`40. tile ar 1`] = `
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
 }
-
-.IS5 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
 </style>
 
 <Link
@@ -3607,55 +3481,51 @@ exports[`40. tile ar 1`] = `
     />
   </div>
   <div
-    className="css-view-1dbjc4n IS5"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS4"
+      className="css-view-1dbjc4n"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n"
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
         >
-          <div
-            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS2 S2"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <div
-            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe IS3 S3"
-          >
-            <span
-              className="css-text-901oao css-textHasAncestor-16my406"
-            >
-              
-              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-              ...
-            </span>
-          </div>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS2 S2"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe IS3 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </span>
+        </div>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </div>
     </div>
   </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -1480,20 +1480,32 @@ exports[`18. tile r 1`] = `
   font-size: 40px;
   line-height: 40px;
 }
+
+.IS2 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
 </style>
 
 <Link
   linkStyle={
     Object {
-      "paddingBottom": "15px",
-      "paddingHorizontal": "30px",
-      "paddingTop": "15px",
+      "flex": 1,
+      "padding": "10px",
     }
   }
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n r-paddingBottom-1mi0q7o"
+    className="css-view-1dbjc4n IS2"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -2107,11 +2119,6 @@ exports[`25. tile x 1`] = `
 }
 
 .IS3 {
-  margin-right: 10px;
-  margin-left: 10px;
-}
-
-.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -2135,17 +2142,13 @@ exports[`25. tile x 1`] = `
   url="/article/123"
 >
   <div
-<<<<<<< HEAD
-    className="css-view-1dbjc4n IS4"
-=======
-    className="css-view-1dbjc4n IS2"
->>>>>>> chore: snaps
+    className="css-view-1dbjc4n IS3"
   >
     <div
       className="css-view-1dbjc4n"
     >
       <div
-        className="css-view-1dbjc4n IS3"
+        className="css-view-1dbjc4n"
       >
         <div
           className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -2208,7 +2211,6 @@ exports[`26. tile y 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -2220,14 +2222,13 @@ exports[`26. tile y 1`] = `
 <Link
   linkStyle={
     Object {
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -2246,7 +2247,7 @@ exports[`26. tile y 1`] = `
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S3"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -2280,25 +2281,29 @@ exports[`27. tile z 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 25px;
   line-height: 25px;
+  margin-bottom: 10px;
+}
+
+.IS2 {
+  margin-bottom: 10px;
 }
 </style>
 
 <Link
   linkStyle={
     Object {
-      "margin": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n"
+    className="css-view-1dbjc4n IS2"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -2311,7 +2316,7 @@ exports[`27. tile z 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
       role="heading"
     >
       This is tile headline
@@ -2356,9 +2361,7 @@ exports[`28. tile ab 1`] = `
 }
 
 .IS1 {
-  flex-direction: column;
-  justify-content: flex-end;
-  width: 50%;
+  flex: 1;
 }
 
 .IS2 {
@@ -2373,8 +2376,20 @@ exports[`28. tile ab 1`] = `
   flex-shrink: 1;
   -webkit-flex-basis: 0%;
   flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
   padding-left: 20px;
-  width: 50%;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -2400,10 +2415,10 @@ exports[`28. tile ab 1`] = `
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
@@ -2411,34 +2426,19 @@ exports[`28. tile ab 1`] = `
         <div
           className="css-view-1dbjc4n"
         >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
-          />
-        </div>
-        <h3
-          aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-        <div
-          className="css-text-901oao"
-        >
-          <span
-            className="css-text-901oao css-textHasAncestor-16my406 r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n S3"
+          <div
+            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          >
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+            role="heading"
           >
             This is tile headline
           </h3>
@@ -2767,6 +2767,7 @@ exports[`33. tile al 1`] = `
 
 .IS1 {
   width: 100%;
+  margin-bottom: 10px;
 }
 
 .IS2 {
@@ -3685,9 +3686,19 @@ exports[`42. tile ah 1`] = `
 .IS4 {
   -webkit-align-items: center;
   align-items: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
   padding-top: 5px;
   -ms-flex-align: center;
   -webkit-box-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 </style>
 

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -19,9 +19,10 @@ exports[`1. tile a 1`] = `
 }
 
 .IS2 {
-  margin-right: 10px;
-  margin-left: 10px;
   margin-top: 10px;
+  margin-right: 10px;
+  margin-bottom: 10px;
+  margin-left: 10px;
 }
 
 .IS3 {
@@ -30,11 +31,6 @@ exports[`1. tile a 1`] = `
 </style>
 
 <Link
-  linkStyle={
-    Object {
-      "marginTop": "5px",
-    }
-  }
   url="/article/123"
 >
   <div
@@ -98,7 +94,6 @@ exports[`2. tile b 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -128,58 +123,61 @@ exports[`2. tile b 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n"
   >
     <div
-      className="css-view-1dbjc4n"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          className="css-view-1dbjc4n"
         >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div
+            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          >
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe IS2 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+              ...
+            </span>
+          </div>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <div
-          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
-        >
-          <span
-            className="css-text-901oao css-textHasAncestor-16my406"
-          >
-            
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-            ...
-          </span>
-        </div>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -189,14 +187,10 @@ exports[`2. tile b 1`] = `
 exports[`3. tile c 1`] = `
 <style>
 .S1 {
-  margin-bottom: 10px;
-}
-
-.S2 {
   margin-bottom: 0px;
 }
 
-.S3 {
+.S2 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-size: 22px;
@@ -205,6 +199,7 @@ exports[`3. tile c 1`] = `
 }
 
 .IS1 {
+  margin-bottom: 10px;
   width: 100%;
 }
 
@@ -212,20 +207,32 @@ exports[`3. tile c 1`] = `
   line-height: 22px;
   padding-bottom: 5px;
 }
+
+.IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
 </style>
 
 <Link
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n r-marginBottom-15d164r IS1 S1"
+    className="css-view-1dbjc4n IS1"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -234,10 +241,10 @@ exports[`3. tile c 1`] = `
     />
   </div>
   <div
-    className="css-view-1dbjc4n"
+    className="css-view-1dbjc4n IS3"
   >
     <div
-      className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
+      className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
     >
       <ArticleLabel
         color="#005B8D"
@@ -247,7 +254,7 @@ exports[`3. tile c 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S3"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -282,7 +289,6 @@ exports[`4. tile d 1`] = `
 
 .IS1 {
   width: 50%;
-  padding-right: 10px;
 }
 
 .IS2 {
@@ -291,8 +297,7 @@ exports[`4. tile d 1`] = `
 
 .IS3 {
   padding-bottom: 5px;
-  padding-right: 10px;
-  padding-top: 5px;
+  padding-left: 10px;
   width: 50%;
 }
 </style>
@@ -361,7 +366,6 @@ exports[`5. tile e 1`] = `
 
 .IS1 {
   width: 50%;
-  padding-right: 10px;
 }
 
 .IS2 {
@@ -370,8 +374,7 @@ exports[`5. tile e 1`] = `
 
 .IS3 {
   padding-bottom: 5px;
-  padding-right: 10px;
-  padding-top: 10px;
+  padding-left: 10px;
   width: 50%;
 }
 </style>
@@ -453,7 +456,6 @@ exports[`6. tile f 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -465,8 +467,7 @@ exports[`6. tile f 1`] = `
 <Link
   linkStyle={
     Object {
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -498,7 +499,7 @@ exports[`6. tile f 1`] = `
       Three Conservative MPs resign
     </h4>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S4"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S4"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -543,18 +544,38 @@ exports[`7. tile g 1`] = `
 
 .IS2 {
   line-height: 22px;
-  padding-bottom: 5px;
 }
 
 .IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
   -webkit-justify-content: center;
   justify-content: center;
-  padding-bottom: 0px;
-  padding-left: 10px;
-  padding-top: 5px;
-  width: 70%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
   -ms-flex-pack: center;
   -webkit-box-pack: center;
+}
+
+.IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  padding-left: 10px;
+  width: 70%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 </style>
 
@@ -577,34 +598,38 @@ exports[`7. tile g 1`] = `
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
   />
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+      className="css-view-1dbjc4n IS3"
     >
-      <ArticleLabel
-        color="#005B8D"
-        isVideo={false}
-        title="label"
+      <div
+        className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+      >
+        <ArticleLabel
+          color="#005B8D"
+          isVideo={false}
+          title="label"
+        />
+      </div>
+      <h3
+        aria-level="3"
+        className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+        role="heading"
+      >
+        This is tile headline
+      </h3>
+      <ArticleFlags
+        flags={
+          Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ]
+        }
       />
     </div>
-    <h3
-      aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
-      role="heading"
-    >
-      This is tile headline
-    </h3>
-    <ArticleFlags
-      flags={
-        Array [
-          Object {
-            "expiryTime": "2030-03-14T12:00:00.000Z",
-            "type": "EXCLUSIVE",
-          },
-        ]
-      }
-    />
   </div>
 </Link>
 `;
@@ -620,7 +645,6 @@ exports[`8. tile h 1`] = `
   font-family: TimesModern-Bold;
   font-size: 22px;
   font-weight: 400;
-  margin-bottom: 10px;
 }
 
 .S3 {
@@ -632,7 +656,6 @@ exports[`8. tile h 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 
 .S4 {
@@ -644,19 +667,17 @@ exports[`8. tile h 1`] = `
 
 .IS1 {
   line-height: 22px;
+  margin-bottom: 10px;
 }
 
 .IS2 {
   padding-right: 10px;
-  padding-top: 10px;
-  padding-bottom: 10px;
   width: 50%;
 }
 
 .IS3 {
   flex-direction: column;
   justify-content: flex-end;
-  padding-top: 10px;
   width: 50%;
 }
 </style>
@@ -665,7 +686,7 @@ exports[`8. tile h 1`] = `
   linkStyle={
     Object {
       "flexDirection": "row",
-      "paddingHorizontal": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -684,13 +705,13 @@ exports[`8. tile h 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 IS1 S2"
       role="heading"
     >
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S3"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -744,7 +765,6 @@ exports[`9. tile i 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -754,6 +774,7 @@ exports[`9. tile i 1`] = `
 .IS2 {
   font-size: 35px;
   line-height: 35px;
+  margin-bottom: 10px;
   text-align: center;
 }
 
@@ -793,7 +814,7 @@ exports[`9. tile i 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -823,7 +844,6 @@ exports[`10. tile j 1`] = `
   font-family: TimesModern-Bold;
   font-size: 22px;
   font-weight: 400;
-  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -832,10 +852,10 @@ exports[`10. tile j 1`] = `
 
 .IS2 {
   line-height: 22px;
+  margin-bottom: 10px;
 }
 
 .IS3 {
-  padding-right: 10px;
   padding-left: 10px;
   width: 60%;
 }
@@ -870,7 +890,7 @@ exports[`10. tile j 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-15d164r IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -899,7 +919,6 @@ exports[`11. tile k 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -910,6 +929,7 @@ exports[`11. tile k 1`] = `
 .IS2 {
   font-size: 18px;
   line-height: 18px;
+  margin-bottom: 10px;
 }
 
 .IS3 {
@@ -946,7 +966,7 @@ exports[`11. tile k 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -976,11 +996,24 @@ exports[`12. tile l 1`] = `
   font-family: TimesModern-Bold;
   font-weight: 400;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 20px;
+  margin-bottom: 10px;
+}
+
+.IS2 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 </style>
 
@@ -988,14 +1021,13 @@ exports[`12. tile l 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n"
+    className="css-view-1dbjc4n IS2"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -1008,7 +1040,7 @@ exports[`12. tile l 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-15d164r IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe IS1 S2"
       role="heading"
     >
       This is tile headline
@@ -1055,18 +1087,32 @@ exports[`13. tile m 1`] = `
   padding-left: 40px;
   text-align: center;
 }
+
+.IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
 </style>
 
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "paddingBottom": "10px",
     }
   }
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n"
+    className="css-view-1dbjc4n IS3"
   >
     <h3
       aria-level="3"
@@ -1117,7 +1163,6 @@ exports[`14. tile n 1`] = `
 }
 
 .IS3 {
-  padding-right: 10px;
   padding-left: 10px;
   width: 50%;
 }
@@ -1198,12 +1243,26 @@ exports[`15. tile o 1`] = `
   margin-bottom: 11px;
   margin-top: 5px;
 }
+
+.IS2 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
 </style>
 
 <Link
   linkStyle={
     Object {
       "backgroundColor": "#272D34",
+      "flex": 1,
       "paddingHorizontal": 12,
       "paddingVertical": "10px",
     }
@@ -1211,7 +1270,7 @@ exports[`15. tile o 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n"
+    className="css-view-1dbjc4n IS2"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -1394,7 +1453,6 @@ exports[`17. tile q 1`] = `
 <Link
   linkStyle={
     Object {
-      "alignItems": "center",
       "paddingVertical": "10px",
     }
   }
@@ -1439,7 +1497,7 @@ exports[`18. tile r 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n"
+    className="css-view-1dbjc4n r-paddingBottom-1mi0q7o"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -1656,10 +1714,8 @@ exports[`21. tile t 1`] = `
 }
 
 .IS3 {
-  padding-right: 10px;
-  padding-left: 10px;
-  padding-top: 5px;
   padding-bottom: 5px;
+  padding-left: 10px;
   width: 50%;
 }
 </style>
@@ -1722,15 +1778,28 @@ exports[`22. tile u 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 30px;
   line-height: 30px;
+  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -1745,7 +1814,7 @@ exports[`22. tile u 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   width: 60%;
 }
 </style>
@@ -1762,46 +1831,50 @@ exports[`22. tile u 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n IS3"
   >
     <div
-      className="css-view-1dbjc4n"
+      className="css-view-1dbjc4n IS2"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          className="css-view-1dbjc4n"
         >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div
+            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          >
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
   <Image
     aspectRatio={1.5}
-    className="IS3"
+    className="IS4"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
@@ -1818,7 +1891,6 @@ exports[`23. tile v 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 5px;
 }
 
 .IS1 {
@@ -1829,7 +1901,20 @@ exports[`23. tile v 1`] = `
 .IS2 {
   font-size: 30px;
   line-height: 30px;
-  padding-bottom: 5px;
+  margin-bottom: 10px;
+}
+
+.IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 </style>
 
@@ -1850,7 +1935,7 @@ exports[`23. tile v 1`] = `
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div
-    className="css-view-1dbjc4n"
+    className="css-view-1dbjc4n IS3"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -1863,7 +1948,7 @@ exports[`23. tile v 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -1907,6 +1992,19 @@ exports[`24. tile w 1`] = `
   flex-shrink: 1;
   -webkit-flex-basis: 0%;
   flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
   padding-bottom: 5px;
   padding-right: 20px;
   width: 33.33%;
@@ -1916,7 +2014,7 @@ exports[`24. tile w 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   width: 66.66%;
 }
 </style>
@@ -1933,46 +2031,50 @@ exports[`24. tile w 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n IS3"
   >
     <div
-      className="css-view-1dbjc4n"
+      className="css-view-1dbjc4n IS2"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          className="css-view-1dbjc4n"
         >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div
+            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          >
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
   <Image
     aspectRatio={1.5}
-    className="IS3"
+    className="IS4"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
@@ -2011,8 +2113,6 @@ exports[`25. tile x 1`] = `
 .IS3 {
   margin-right: 10px;
   margin-left: 10px;
-  margin-top: 5px;
-  margin-bottom: 5px;
 }
 
 .IS4 {
@@ -2027,14 +2127,28 @@ exports[`25. tile x 1`] = `
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
 }
+
+.IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  margin-right: 10px;
+  margin-left: 10px;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
 </style>
 
 <Link
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -2043,18 +2157,39 @@ exports[`25. tile x 1`] = `
     className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n"
+      className="css-view-1dbjc4n IS2"
     >
       <div
         className="css-view-1dbjc4n IS3"
       >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          className="css-view-1dbjc4n"
         >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div
+            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          >
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
         <h3
@@ -2128,7 +2263,7 @@ exports[`26. tile y 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n"
+    className="css-view-1dbjc4n IS2"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -2286,6 +2421,7 @@ exports[`28. tile ab 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "flexDirection": "row",
       "paddingHorizontal": "10px",
       "paddingVertical": "10px",
@@ -2303,13 +2439,13 @@ exports[`28. tile ab 1`] = `
     className="css-view-1dbjc4n IS3"
   >
     <div
-      className="css-view-1dbjc4n"
+      className="css-view-1dbjc4n IS2"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          className="css-view-1dbjc4n"
         >
           <ArticleLabel
             color="#005B8D"
@@ -2340,13 +2476,32 @@ exports[`28. tile ab 1`] = `
           <span
             className="css-text-901oao css-textHasAncestor-16my406 r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n S3"
           >
-            Richard Lloyd Parry
-          </span>
-          <span
-            className="css-text-901oao css-textHasAncestor-16my406 r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n S3"
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
+          />
+          <div
+            className="css-text-901oao"
           >
-            , Hanoi
-          </span>
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406 r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n S3"
+            >
+              Richard Lloyd Parry
+            </span>
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406 r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n S3"
+            >
+              , Hanoi
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -2364,15 +2519,28 @@ exports[`29. tile ae 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 30px;
   line-height: 30px;
+  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -2390,47 +2558,51 @@ exports[`29. tile ae 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
+      "padding": "10px",
       "paddingTop": "15px",
     }
   }
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n IS3"
   >
     <div
-      className="css-view-1dbjc4n"
+      className="css-view-1dbjc4n IS2"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          className="css-view-1dbjc4n"
         >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div
+            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          >
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -2463,11 +2635,25 @@ exports[`30. tile ag 1`] = `
   font-family: TimesDigitalW04-Regular;
   text-align: center;
 }
+
+.IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
 </style>
 
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "paddingBottom": "10px",
       "paddingHorizontal": "20px",
     }
@@ -2475,7 +2661,7 @@ exports[`30. tile ag 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n"
+    className="css-view-1dbjc4n IS3"
   >
     <h3
       aria-level="3"
@@ -2632,8 +2818,11 @@ exports[`33. tile al 1`] = `
   margin-bottom: 0px;
 }
 
+.S3 {
+  font-size: 14px;
+}
+
 .IS1 {
-  padding-vertical: 10px;
   width: 100%;
 }
 
@@ -2649,6 +2838,22 @@ exports[`33. tile al 1`] = `
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
 }
+
+.IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  font-family: TimesDigitalW04-Regular;
+  padding-top: 10px;
+  width: 100%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
 </style>
 
 <Link
@@ -2657,6 +2862,7 @@ exports[`33. tile al 1`] = `
       "flex": 1,
       "flexDirection": "column",
       "paddingHorizontal": "10px",
+      "paddingVertical": "10px",
     }
   }
   url="/article/123"
@@ -2668,40 +2874,44 @@ exports[`33. tile al 1`] = `
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n r-fontSize-1b43r93 IS3 S3"
   >
     <div
-      className="css-view-1dbjc4n"
+      className="css-view-1dbjc4n IS2"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          className="css-view-1dbjc4n"
         >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div
+            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          >
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw r-marginBottom-p1pxzi S2"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw r-marginBottom-p1pxzi S2"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -2744,14 +2954,26 @@ exports[`34. tile am 1`] = `
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
 }
+
+.IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
 </style>
 
 <Link
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -2763,40 +2985,44 @@ exports[`34. tile am 1`] = `
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          className="css-view-1dbjc4n"
         >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div
+            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          >
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -2826,7 +3052,6 @@ exports[`35. tile an 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -2838,11 +3063,19 @@ exports[`35. tile an 1`] = `
 }
 
 .IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
   -webkit-justify-content: center;
   justify-content: center;
-  padding-right: 10px;
-  padding-left: 10px;
   padding-top: 10px;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
   -ms-flex-pack: center;
   -webkit-box-pack: center;
 }
@@ -2851,6 +3084,7 @@ exports[`35. tile an 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "padding": "10px",
     }
   }
@@ -2884,7 +3118,7 @@ exports[`35. tile an 1`] = `
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S3"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -2932,11 +3166,19 @@ exports[`36. tile ap 1`] = `
 }
 
 .IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
   -webkit-justify-content: center;
   justify-content: center;
-  padding-right: 10px;
-  padding-left: 10px;
   padding-top: 5px;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
   -ms-flex-pack: center;
   -webkit-box-pack: center;
 }
@@ -2945,6 +3187,7 @@ exports[`36. tile ap 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "padding": "10px",
     }
   }
@@ -3014,7 +3257,6 @@ exports[`37. tile ad 1`] = `
 }
 
 .IS3 {
-  padding-right: 10px;
   padding-left: 10px;
   width: 70%;
 }
@@ -3104,8 +3346,8 @@ exports[`38. tile ac 1`] = `
   flex-basis: 0%;
   -webkit-justify-content: center;
   justify-content: center;
-  padding-right: 40px;
-  padding-left: 40px;
+  padding-right: 20px;
+  padding-left: 20px;
   padding-top: 15px;
   padding-bottom: 15px;
   -ms-flex-align: center;
@@ -3170,14 +3412,10 @@ exports[`38. tile ac 1`] = `
 exports[`39. tile aq 1`] = `
 <style>
 .S1 {
-  margin-bottom: 10px;
-}
-
-.S2 {
   margin-bottom: 0px;
 }
 
-.S3 {
+.S2 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-size: 22px;
@@ -3186,6 +3424,7 @@ exports[`39. tile aq 1`] = `
 }
 
 .IS1 {
+  margin-bottom: 10px;
   width: 100%;
 }
 
@@ -3205,20 +3444,32 @@ exports[`39. tile aq 1`] = `
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
 }
+
+.IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
 </style>
 
 <Link
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n r-marginBottom-15d164r IS1 S1"
+    className="css-view-1dbjc4n IS1"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -3227,40 +3478,44 @@ exports[`39. tile aq 1`] = `
     />
   </div>
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
+          className="css-view-1dbjc4n"
         >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div
+            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          >
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S3"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -3270,14 +3525,10 @@ exports[`39. tile aq 1`] = `
 exports[`40. tile ar 1`] = `
 <style>
 .S1 {
-  margin-bottom: 10px;
-}
-
-.S2 {
   margin-bottom: 0px;
 }
 
-.S3 {
+.S2 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
@@ -3285,7 +3536,7 @@ exports[`40. tile ar 1`] = `
   margin-bottom: 5px;
 }
 
-.S4 {
+.S3 {
   color: rgba(105,105,105,1.00);
   -ms-flex-wrap: wrap;
   -webkit-box-lines: multiple;
@@ -3294,10 +3545,10 @@ exports[`40. tile ar 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 
 .IS1 {
+  margin-bottom: 10px;
   width: 100%;
 }
 
@@ -3310,6 +3561,19 @@ exports[`40. tile ar 1`] = `
 }
 
 .IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS5 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -3334,7 +3598,7 @@ exports[`40. tile ar 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n r-marginBottom-15d164r IS1 S1"
+    className="css-view-1dbjc4n IS1"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -3343,51 +3607,55 @@ exports[`40. tile ar 1`] = `
     />
   </div>
   <div
-    className="css-view-1dbjc4n IS4"
+    className="css-view-1dbjc4n IS5"
   >
     <div
-      className="css-view-1dbjc4n"
+      className="css-view-1dbjc4n IS4"
     >
       <div
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
+          className="css-view-1dbjc4n"
         >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div
+            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          >
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS2 S2"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe IS3 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+              ...
+            </span>
+          </div>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS2 S3"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <div
-          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S4"
-        >
-          <span
-            className="css-text-901oao css-textHasAncestor-16my406"
-          >
-            
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-            ...
-          </span>
-        </div>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -3397,21 +3665,17 @@ exports[`40. tile ar 1`] = `
 exports[`41. tile as 1`] = `
 <style>
 .S1 {
-  margin-bottom: 10px;
-}
-
-.S2 {
   margin-bottom: 0px;
 }
 
-.S3 {
+.S2 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
   margin-bottom: 5px;
 }
 
-.S4 {
+.S3 {
   color: rgba(105,105,105,1.00);
   -ms-flex-wrap: wrap;
   -webkit-box-lines: multiple;
@@ -3420,16 +3684,29 @@ exports[`41. tile as 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 
 .IS1 {
+  margin-bottom: 10px;
   width: 100%;
 }
 
 .IS2 {
   font-size: 18px;
   line-height: 18px;
+}
+
+.IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 </style>
 
@@ -3444,7 +3721,7 @@ exports[`41. tile as 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n r-marginBottom-15d164r IS1 S1"
+    className="css-view-1dbjc4n IS1"
   >
     <Image
       aspectRatio={1.5}
@@ -3453,10 +3730,10 @@ exports[`41. tile as 1`] = `
     />
   </div>
   <div
-    className="css-view-1dbjc4n"
+    className="css-view-1dbjc4n IS3"
   >
     <div
-      className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
+      className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
     >
       <ArticleLabel
         color="#005B8D"
@@ -3466,13 +3743,13 @@ exports[`41. tile as 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S3"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
       role="heading"
     >
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S4"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S3"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -2,11 +2,6 @@
 
 exports[`1. tile a 1`] = `
 <Link
-  linkStyle={
-    Object {
-      "marginTop": "5px",
-    }
-  }
   url="/article/123"
 >
   <div>
@@ -47,8 +42,7 @@ exports[`2. tile b 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -57,35 +51,37 @@ exports[`2. tile b 1`] = `
     <div>
       <div>
         <div>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <div>
+            <span>
+              
+              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+              ...
+            </span>
+          </div>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <div>
-          <span>
-            
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-            ...
-          </span>
-        </div>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -97,8 +93,7 @@ exports[`3. tile c 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -228,8 +223,7 @@ exports[`6. tile f 1`] = `
 <Link
   linkStyle={
     Object {
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -295,28 +289,30 @@ exports[`7. tile g 1`] = `
   />
   <div>
     <div>
-      <ArticleLabel
-        color="#005B8D"
-        isVideo={false}
-        title="label"
+      <div>
+        <ArticleLabel
+          color="#005B8D"
+          isVideo={false}
+          title="label"
+        />
+      </div>
+      <h3
+        aria-level="3"
+        role="heading"
+      >
+        This is tile headline
+      </h3>
+      <ArticleFlags
+        flags={
+          Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ]
+        }
       />
     </div>
-    <h3
-      aria-level="3"
-      role="heading"
-    >
-      This is tile headline
-    </h3>
-    <ArticleFlags
-      flags={
-        Array [
-          Object {
-            "expiryTime": "2030-03-14T12:00:00.000Z",
-            "type": "EXCLUSIVE",
-          },
-        ]
-      }
-    />
   </div>
 </Link>
 `;
@@ -326,7 +322,7 @@ exports[`8. tile h 1`] = `
   linkStyle={
     Object {
       "flexDirection": "row",
-      "paddingHorizontal": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -507,8 +503,7 @@ exports[`12. tile l 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -545,6 +540,7 @@ exports[`13. tile m 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "paddingBottom": "10px",
     }
   }
@@ -624,6 +620,7 @@ exports[`15. tile o 1`] = `
   linkStyle={
     Object {
       "backgroundColor": "#272D34",
+      "flex": 1,
       "paddingHorizontal": 12,
       "paddingVertical": "10px",
     }
@@ -723,7 +720,6 @@ exports[`17. tile q 1`] = `
 <Link
   linkStyle={
     Object {
-      "alignItems": "center",
       "paddingVertical": "10px",
     }
   }
@@ -911,28 +907,30 @@ exports[`22. tile u 1`] = `
     <div>
       <div>
         <div>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -1004,28 +1002,30 @@ exports[`24. tile w 1`] = `
     <div>
       <div>
         <div>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -1042,8 +1042,7 @@ exports[`25. tile x 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -1052,10 +1051,28 @@ exports[`25. tile x 1`] = `
     <div>
       <div>
         <div>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
         <h3
@@ -1177,6 +1194,7 @@ exports[`28. tile ab 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "flexDirection": "row",
       "paddingHorizontal": "10px",
       "paddingVertical": "10px",
@@ -1193,35 +1211,37 @@ exports[`28. tile ab 1`] = `
     <div>
       <div>
         <div>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
-        </div>
-        <h3
-          aria-level="3"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-        <div>
-          <span>
-            Richard Lloyd Parry
-          </span>
-          <span>
-            , Hanoi
-          </span>
+          <div>
+            <span>
+              Richard Lloyd Parry
+            </span>
+            <span>
+              , Hanoi
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -1234,7 +1254,7 @@ exports[`29. tile ae 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
+      "padding": "10px",
       "paddingTop": "15px",
     }
   }
@@ -1244,28 +1264,30 @@ exports[`29. tile ae 1`] = `
     <div>
       <div>
         <div>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -1276,6 +1298,7 @@ exports[`30. tile ag 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "paddingBottom": "10px",
       "paddingHorizontal": "20px",
     }
@@ -1367,6 +1390,7 @@ exports[`33. tile al 1`] = `
       "flex": 1,
       "flexDirection": "column",
       "paddingHorizontal": "10px",
+      "paddingVertical": "10px",
     }
   }
   url="/article/123"
@@ -1380,28 +1404,30 @@ exports[`33. tile al 1`] = `
     <div>
       <div>
         <div>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -1413,8 +1439,7 @@ exports[`34. tile am 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -1428,28 +1453,30 @@ exports[`34. tile am 1`] = `
     <div>
       <div>
         <div>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -1460,6 +1487,7 @@ exports[`35. tile an 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "padding": "10px",
     }
   }
@@ -1511,6 +1539,7 @@ exports[`36. tile ap 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "padding": "10px",
     }
   }
@@ -1643,8 +1672,7 @@ exports[`39. tile aq 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -1660,28 +1688,30 @@ exports[`39. tile aq 1`] = `
     <div>
       <div>
         <div>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>
@@ -1710,35 +1740,37 @@ exports[`40. tile ar 1`] = `
     <div>
       <div>
         <div>
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
+          <div>
+            <ArticleLabel
+              color="#005B8D"
+              isVideo={false}
+              title="label"
+            />
+          </div>
+          <h3
+            aria-level="3"
+            role="heading"
+          >
+            This is tile headline
+          </h3>
+          <div>
+            <span>
+              
+              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+              ...
+            </span>
+          </div>
+          <ArticleFlags
+            flags={
+              Array [
+                Object {
+                  "expiryTime": "2030-03-14T12:00:00.000Z",
+                  "type": "EXCLUSIVE",
+                },
+              ]
+            }
           />
         </div>
-        <h3
-          aria-level="3"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <div>
-          <span>
-            
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-            ...
-          </span>
-        </div>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
       </div>
     </div>
   </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -51,37 +51,35 @@ exports[`2. tile b 1`] = `
     <div>
       <div>
         <div>
-          <div>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <div>
-            <span>
-              
-              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-              ...
-            </span>
-          </div>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
+        <h3
+          aria-level="3"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <div>
+          <span>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </span>
+        </div>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </div>
     </div>
   </div>
@@ -1051,28 +1049,10 @@ exports[`25. tile x 1`] = `
     <div>
       <div>
         <div>
-          <div>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
         <h3
@@ -1264,30 +1244,28 @@ exports[`29. tile ae 1`] = `
     <div>
       <div>
         <div>
-          <div>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
+        <h3
+          aria-level="3"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </div>
     </div>
   </div>
@@ -1388,9 +1366,7 @@ exports[`33. tile al 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "flexDirection": "column",
-      "paddingHorizontal": "10px",
-      "paddingVertical": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -1404,30 +1380,28 @@ exports[`33. tile al 1`] = `
     <div>
       <div>
         <div>
-          <div>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
+        <h3
+          aria-level="3"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </div>
     </div>
   </div>
@@ -1453,30 +1427,28 @@ exports[`34. tile am 1`] = `
     <div>
       <div>
         <div>
-          <div>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
+        <h3
+          aria-level="3"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </div>
     </div>
   </div>
@@ -1688,30 +1660,28 @@ exports[`39. tile aq 1`] = `
     <div>
       <div>
         <div>
-          <div>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
+        <h3
+          aria-level="3"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </div>
     </div>
   </div>
@@ -1740,37 +1710,35 @@ exports[`40. tile ar 1`] = `
     <div>
       <div>
         <div>
-          <div>
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <div>
-            <span>
-              
-              Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
-              ...
-            </span>
-          </div>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
           />
         </div>
+        <h3
+          aria-level="3"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <div>
+          <span>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </span>
+        </div>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
       </div>
     </div>
   </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -735,9 +735,8 @@ exports[`18. tile r 1`] = `
 <Link
   linkStyle={
     Object {
-      "paddingBottom": "15px",
-      "paddingHorizontal": "30px",
-      "paddingTop": "15px",
+      "flex": 1,
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -1087,8 +1086,7 @@ exports[`26. tile y 1`] = `
 <Link
   linkStyle={
     Object {
-      "paddingHorizontal": "10px",
-      "paddingTop": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -1132,7 +1130,7 @@ exports[`27. tile z 1`] = `
 <Link
   linkStyle={
     Object {
-      "margin": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"

--- a/packages/edition-slices/src/slices/leaders/index.js
+++ b/packages/edition-slices/src/slices/leaders/index.js
@@ -112,15 +112,12 @@ class LeadersSlice extends Component {
 
   render() {
     return (
-      <View style={styles.container}>
-        {renderHead()}
-        <ResponsiveSlice
-          renderHuge={this.renderWide}
-          renderMedium={this.renderSmall}
-          renderSmall={this.renderSmall}
-          renderWide={this.renderWide}
-        />
-      </View>
+      <ResponsiveSlice
+        renderHuge={this.renderWide}
+        renderMedium={this.renderSmall}
+        renderSmall={this.renderSmall}
+        renderWide={this.renderWide}
+      />
     );
   }
 }

--- a/packages/edition-slices/src/slices/leaders/index.js
+++ b/packages/edition-slices/src/slices/leaders/index.js
@@ -25,7 +25,7 @@ class LeadersSlice extends Component {
   constructor(props) {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);
-    this.renderHuge = this.renderHuge.bind(this);
+    this.renderWide = this.renderWide.bind(this);
   }
 
   renderSmall(breakpoint) {
@@ -69,7 +69,7 @@ class LeadersSlice extends Component {
     );
   }
 
-  renderHuge(breakpoint) {
+  renderWide(breakpoint) {
     const {
       onPress,
       slice: { leader1, leader2, leader3 }
@@ -112,12 +112,15 @@ class LeadersSlice extends Component {
 
   render() {
     return (
-      <ResponsiveSlice
-        renderHuge={this.renderHuge}
-        renderMedium={this.renderSmall}
-        renderSmall={this.renderSmall}
-        renderWide={this.renderHuge}
-      />
+      <View style={styles.container}>
+        {renderHead()}
+        <ResponsiveSlice
+          renderHuge={this.renderWide}
+          renderMedium={this.renderSmall}
+          renderSmall={this.renderSmall}
+          renderWide={this.renderWide}
+        />
+      </View>
     );
   }
 }

--- a/packages/edition-slices/src/slices/secondarytwoandtwo/index.js
+++ b/packages/edition-slices/src/slices/secondarytwoandtwo/index.js
@@ -53,10 +53,20 @@ class SecondaryTwoAndTwo extends Component {
           <TileV onPress={onPress} tile={secondary2} tileName="secondary2" />
         }
         support1={
-          <TileG onPress={onPress} tile={support1} tileName="support1" />
+          <TileG
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={support1}
+            tileName="support1"
+          />
         }
         support2={
-          <TileG onPress={onPress} tile={support2} tileName="support2" />
+          <TileG
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={support2}
+            tileName="support2"
+          />
         }
       />
     );

--- a/packages/edition-slices/src/tiles/shared/positioned-tile-star.js
+++ b/packages/edition-slices/src/tiles/shared/positioned-tile-star.js
@@ -7,37 +7,35 @@ import TileStar from "./tile-star";
 import { isSaveSupported } from "./utils";
 
 import {
-  starDefaultPosition,
-  starCenterPosition,
-  starAfterContentPosition
+  starDefaultStyles,
+  starCenterStyles,
+  starUnderneathTextStyles
 } from "./styles";
 
 const PositionedTileStar = ({
-  articleId,
-  isAfterContentStar = false,
-  isCenteredStar = false,
-  isDarkStar = false,
-  starStyle = {}
+  centeredStar = false,
+  underneathTextStar = false,
+  ...props
 }) => {
   if (!isSaveSupported) return null;
 
-  const starPositionStyles = {
-    ...starDefaultPosition,
-    ...(isCenteredStar && starCenterPosition),
-    ...(isAfterContentStar && starAfterContentPosition)
-  };
-
   return (
-    <View style={starPositionStyles}>
-      <TileStar articleId={articleId} isDark={isDarkStar} style={starStyle} />
+    <View
+      style={[
+        starDefaultStyles,
+        centeredStar && starCenterStyles,
+        underneathTextStar && starUnderneathTextStyles
+      ]}
+    >
+      <TileStar {...props} />
     </View>
   );
 };
 
 PositionedTileStar.propTypes = {
   articleId: PropTypes.string.isRequired,
-  isAfterContentStar: PropTypes.bool,
-  isCenteredStar: PropTypes.bool,
+  underneathTextStar: PropTypes.bool,
+  centeredStar: PropTypes.bool,
   isDarkStar: PropTypes.bool,
   starStyle: PropTypes.shape({})
 };

--- a/packages/edition-slices/src/tiles/shared/positioned-tile-star.js
+++ b/packages/edition-slices/src/tiles/shared/positioned-tile-star.js
@@ -1,0 +1,45 @@
+/* eslint-disable react/require-default-props */
+import React from "react";
+import { View } from "react-native";
+import PropTypes from "prop-types";
+
+import TileStar from "./tile-star";
+import { isSaveSupported } from "./utils";
+
+import {
+  starDefaultPosition,
+  starCenterPosition,
+  starAfterContentPosition
+} from "./styles";
+
+const PositionedTileStar = ({
+  articleId,
+  isAfterContentStar = false,
+  isCenteredStar = false,
+  isDarkStar = false,
+  starStyle = {}
+}) => {
+  if (!isSaveSupported) return null;
+
+  const starPositionStyles = {
+    ...starDefaultPosition,
+    ...(isCenteredStar && starCenterPosition),
+    ...(isAfterContentStar && starAfterContentPosition)
+  };
+
+  return (
+    <View style={starPositionStyles}>
+      <TileStar articleId={articleId} isDark={isDarkStar} style={starStyle} />
+    </View>
+  );
+};
+
+PositionedTileStar.propTypes = {
+  articleId: PropTypes.string.isRequired,
+  isAfterContentStar: PropTypes.bool,
+  isCenteredStar: PropTypes.bool,
+  isDarkStar: PropTypes.bool,
+  starStyle: PropTypes.shape({})
+};
+
+export default PositionedTileStar;

--- a/packages/edition-slices/src/tiles/shared/styles/index.js
+++ b/packages/edition-slices/src/tiles/shared/styles/index.js
@@ -23,9 +23,7 @@ const verticalStyles = {
 const starDefaultStyles = {
   marginTop: "auto",
   alignItems: "flex-end",
-  paddingTop: spacing(1),
-  borderWidth: 1,
-  borderColor: "purple"
+  paddingTop: spacing(1)
 };
 
 const starCenterStyles = {

--- a/packages/edition-slices/src/tiles/shared/styles/index.js
+++ b/packages/edition-slices/src/tiles/shared/styles/index.js
@@ -11,20 +11,6 @@ const horizontalStyles = {
   }
 };
 
-const tileStar = {
-  position: "absolute",
-  right: spacing(1),
-  bottom: spacing(2)
-};
-
-const starHeadlinePaddingBottom = {
-  paddingBottom: spacing(3)
-};
-
-const starTeaserPaddingBottom = {
-  paddingBottom: spacing(5)
-};
-
 const verticalStyles = {
   container: {
     flexDirection: "column"
@@ -34,10 +20,29 @@ const verticalStyles = {
   }
 };
 
+const starDefaultPosition = {
+  marginTop: "auto",
+  alignItems: "flex-end",
+  paddingTop: spacing(1)
+};
+
+const starCenterPosition = {
+  alignItems: "center"
+};
+
+const starAfterContentPosition = {
+  marginTop: 0
+};
+
+const fullHeightSummaryContainer = {
+  flex: 1
+};
+
 export {
   horizontalStyles,
   verticalStyles,
-  tileStar,
-  starHeadlinePaddingBottom,
-  starTeaserPaddingBottom
+  starDefaultPosition,
+  starCenterPosition,
+  starAfterContentPosition,
+  fullHeightSummaryContainer
 };

--- a/packages/edition-slices/src/tiles/shared/styles/index.js
+++ b/packages/edition-slices/src/tiles/shared/styles/index.js
@@ -20,29 +20,26 @@ const verticalStyles = {
   }
 };
 
-const starDefaultPosition = {
+const starDefaultStyles = {
   marginTop: "auto",
   alignItems: "flex-end",
-  paddingTop: spacing(1)
+  paddingTop: spacing(1),
+  borderWidth: 1,
+  borderColor: "purple"
 };
 
-const starCenterPosition = {
+const starCenterStyles = {
   alignItems: "center"
 };
 
-const starAfterContentPosition = {
+const starUnderneathTextStyles = {
   marginTop: 0
-};
-
-const fullHeightSummaryContainer = {
-  flex: 1
 };
 
 export {
   horizontalStyles,
   verticalStyles,
-  starDefaultPosition,
-  starCenterPosition,
-  starAfterContentPosition,
-  fullHeightSummaryContainer
+  starDefaultStyles,
+  starCenterStyles,
+  starUnderneathTextStyles
 };

--- a/packages/edition-slices/src/tiles/shared/tile-link.js
+++ b/packages/edition-slices/src/tiles/shared/tile-link.js
@@ -1,48 +1,28 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Link from "@times-components/link";
-import TileStar from "./tile-star";
-import { tileStar } from "./styles";
-import { isSaveSupported } from "./utils";
 
 const TileLink = ({
   children,
   onPress,
   style,
-  isDarkStar,
-  withStar,
-  starStyle,
   tile: {
     article: { id, url }
   }
 }) => (
   <Link linkStyle={style} onPress={() => onPress({ id, url })} url={url}>
     {children}
-    {withStar &&
-      isSaveSupported && (
-        <TileStar
-          articleId={id}
-          isDark={isDarkStar}
-          style={[tileStar, starStyle]}
-        />
-      )}
   </Link>
 );
 
 TileLink.propTypes = {
   children: PropTypes.node.isRequired,
   onPress: PropTypes.func.isRequired,
-  starStyle: PropTypes.shape({}),
-  isDarkStar: PropTypes.bool,
-  withStar: PropTypes.bool,
   style: PropTypes.shape({}),
   tile: PropTypes.shape({}).isRequired
 };
 
 TileLink.defaultProps = {
-  isDarkStar: false,
-  withStar: true,
-  starStyle: null,
   style: {}
 };
 

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -46,8 +46,8 @@ class TileSummary extends Component {
       tile: {
         article: { id }
       },
-      isAfterContentStar,
-      isCenteredStar,
+      underneathTextStar,
+      centeredStar,
       isDarkStar,
       starStyle
     } = this.props;
@@ -56,8 +56,8 @@ class TileSummary extends Component {
       <PositionedTileStar
         articleId={id}
         isDarkStar={isDarkStar}
-        isCenteredStar={isCenteredStar}
-        isAfterContentStar={isAfterContentStar}
+        centeredStar={centeredStar}
+        underneathTextStar={underneathTextStar}
         style={starStyle}
       />
     );
@@ -136,8 +136,8 @@ TileSummary.propTypes = {
   summaryStyle: PropTypes.shape({}),
   tile: PropTypes.shape({}).isRequired,
   withStar: PropTypes.bool,
-  isAfterContentStar: PropTypes.bool,
-  isCenteredStar: PropTypes.bool,
+  underneathTextStar: PropTypes.bool,
+  centeredStar: PropTypes.bool,
   isDarkStar: PropTypes.bool,
   starStyle: PropTypes.shape({})
 };
@@ -153,8 +153,8 @@ TileSummary.defaultProps = {
   summary: null,
   summaryStyle: null,
   withStar: true,
-  isAfterContentStar: false,
-  isCenteredStar: false,
+  underneathTextStar: false,
+  centeredStar: false,
   isDarkStar: false,
   starStyle: null
 };

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -7,7 +7,6 @@ import ArticleSummary, {
 } from "@times-components/article-summary";
 import { ArticleFlags } from "@times-components/article-flag";
 import { colours } from "@times-components/styleguide";
-// import { horizontalStyles } from "./styles";
 import PositionedTileStar from "./positioned-tile-star";
 
 class TileSummary extends Component {

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -7,13 +7,8 @@ import ArticleSummary, {
 } from "@times-components/article-summary";
 import { ArticleFlags } from "@times-components/article-flag";
 import { colours } from "@times-components/styleguide";
-import TileStar from "./tile-star";
-import {
-  horizontalStyles,
-  starHeadlinePaddingBottom,
-  starTeaserPaddingBottom
-} from "./styles";
-import { isSaveSupported } from "./utils";
+// import { horizontalStyles } from "./styles";
+import PositionedTileStar from "./positioned-tile-star";
 
 class TileSummary extends Component {
   constructor(props) {
@@ -52,17 +47,19 @@ class TileSummary extends Component {
       tile: {
         article: { id }
       },
+      isAfterContentStar,
+      isCenteredStar,
       isDarkStar,
       starStyle
     } = this.props;
 
-    const tileStyle = starStyle || horizontalStyles;
-
     return (
-      <TileStar
+      <PositionedTileStar
         articleId={id}
-        isDark={isDarkStar}
-        style={tileStyle.starButton}
+        isDarkStar={isDarkStar}
+        isCenteredStar={isCenteredStar}
+        isAfterContentStar={isAfterContentStar}
+        style={starStyle}
       />
     );
   }
@@ -73,21 +70,13 @@ class TileSummary extends Component {
         headline: tileHeadline,
         article: { headline, shortHeadline }
       },
-      headlineStyle,
-      withStar,
-      summary
+      headlineStyle
     } = this.props;
-
-    const shouldAddBottomPadding = isSaveSupported && !withStar && !summary;
 
     return (
       <ArticleSummaryHeadline
         headline={tileHeadline || shortHeadline || headline}
-        style={
-          shouldAddBottomPadding
-            ? [headlineStyle, starHeadlinePaddingBottom]
-            : headlineStyle
-        }
+        style={headlineStyle}
       />
     );
   }
@@ -103,7 +92,7 @@ class TileSummary extends Component {
   render() {
     const {
       tile: {
-        article: { hasVideo, label, section, expirableFlags }
+        article: { hasVideo, label, section }
       },
       bylines,
       bylineStyle,
@@ -113,12 +102,6 @@ class TileSummary extends Component {
       withStar,
       labelColour
     } = this.props;
-
-    const shouldAddBottomPadding =
-      isSaveSupported &&
-      !withStar &&
-      expirableFlags &&
-      expirableFlags.length === 0;
 
     return (
       <ArticleSummary
@@ -135,10 +118,8 @@ class TileSummary extends Component {
           title: label
         }}
         strapline={strapline ? this.renderStrapline() : undefined}
-        saveStar={withStar && isSaveSupported && this.renderSaveStar()}
-        style={
-          shouldAddBottomPadding ? [starTeaserPaddingBottom, style] : style
-        }
+        saveStar={withStar && this.renderSaveStar()}
+        style={style}
       />
     );
   }
@@ -148,7 +129,6 @@ TileSummary.propTypes = {
   bylineStyle: PropTypes.shape({}),
   flagColour: PropTypes.shape({}),
   headlineStyle: PropTypes.shape({}),
-  isDarkStar: PropTypes.bool,
   labelColour: PropTypes.string,
   strapline: PropTypes.string,
   straplineStyle: PropTypes.shape({}),
@@ -156,21 +136,28 @@ TileSummary.propTypes = {
   summary: PropTypes.arrayOf(PropTypes.shape({})),
   summaryStyle: PropTypes.shape({}),
   tile: PropTypes.shape({}).isRequired,
-  withStar: PropTypes.bool
+  withStar: PropTypes.bool,
+  isAfterContentStar: PropTypes.bool,
+  isCenteredStar: PropTypes.bool,
+  isDarkStar: PropTypes.bool,
+  starStyle: PropTypes.shape({})
 };
 
 TileSummary.defaultProps = {
   bylineStyle: null,
   flagColour: {},
   headlineStyle: null,
-  isDarkStar: false,
   labelColour: null,
   strapline: null,
   straplineStyle: null,
   style: null,
   summary: null,
   summaryStyle: null,
-  withStar: false
+  withStar: true,
+  isAfterContentStar: false,
+  isCenteredStar: false,
+  isDarkStar: false,
+  starStyle: null
 };
 
 export default TileSummary;

--- a/packages/edition-slices/src/tiles/tile-a/index.js
+++ b/packages/edition-slices/src/tiles/tile-a/index.js
@@ -11,18 +11,13 @@ import styles from "./styles";
 
 const TileA = ({ onPress, tile }) => {
   const crop = getTileImage(tile, "crop169");
+
   return (
-    <TileLink
-      onPress={onPress}
-      tile={tile}
-      withStar={false}
-      style={styles.labelLink}
-    >
+    <TileLink onPress={onPress} tile={tile}>
       <TileSummary
         headlineStyle={styles.headline}
         style={styles.summaryContainer}
         tile={tile}
-        withStar
       />
       <Image
         aspectRatio={16 / 9}

--- a/packages/edition-slices/src/tiles/tile-a/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-a/styles/index.js
@@ -11,11 +11,7 @@ const styles = {
     width: "100%"
   },
   summaryContainer: {
-    marginHorizontal: spacing(2),
-    marginTop: spacing(2)
-  },
-  labelLink: {
-    marginTop: spacing(1)
+    margin: spacing(2)
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-ab/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/index.js
@@ -30,18 +30,21 @@ const TileAB = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
         uri={crop.url}
         fill
       />
-      <WithoutWhiteSpace
-        styles={styles.summaryContainer}
-        render={whiteSpaceHeight => (
-          <TileSummary
-            bylines={tile.article.bylines}
-            headlineStyle={styles.headline}
-            summary={getTileSummary(tile, 800)}
-            tile={tile}
-            whiteSpaceHeight={whiteSpaceHeight}
-          />
-        )}
-      />
+      <View style={styles.summaryContainer}>
+        <WithoutWhiteSpace
+          render={whiteSpaceHeight => (
+            <TileSummary
+              bylines={tile.article.bylines}
+              headlineStyle={styles.headline}
+              summary={getTileSummary(tile, 800)}
+              tile={tile}
+              whiteSpaceHeight={whiteSpaceHeight}
+              withStar={false}
+            />
+          )}
+        />
+        <PositionedTileStar articleId={tile.article.id} />
+      </View>
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-ab/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
 import { editionBreakpoints } from "@times-components/styleguide";
@@ -11,6 +12,7 @@ import {
 } from "../shared";
 import styleFactory from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
+import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileAB = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
   const styles = styleFactory(breakpoint);

--- a/packages/edition-slices/src/tiles/tile-ab/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/styles/index.js
@@ -3,6 +3,7 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
+import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const headlineFontSizeResolver = {
   [editionBreakpoints.huge]: 45,
@@ -13,6 +14,7 @@ const headlineFontSizeResolver = {
 
 export default breakpoint => ({
   container: {
+    flex: 1,
     flexDirection: "row",
     paddingHorizontal: spacing(2),
     paddingVertical:

--- a/packages/edition-slices/src/tiles/tile-ab/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/styles/index.js
@@ -3,7 +3,6 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
-import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const headlineFontSizeResolver = {
   [editionBreakpoints.huge]: 45,

--- a/packages/edition-slices/src/tiles/tile-ab/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/styles/index.js
@@ -22,19 +22,13 @@ export default breakpoint => ({
   headline: {
     fontFamily: fonts.headline,
     fontSize: headlineFontSizeResolver[breakpoint],
-    lineHeight: headlineFontSizeResolver[breakpoint],
-    marginBottom: spacing(1)
-  },
-  image: {
-    alignSelf: "flex-end"
+    lineHeight: headlineFontSizeResolver[breakpoint]
   },
   imageContainer: {
-    flexDirection: "column",
-    justifyContent: "flex-end",
-    width: "50%"
+    flex: 1
   },
   summaryContainer: {
-    paddingLeft: spacing(4),
-    width: "50%"
+    flex: 1,
+    paddingLeft: spacing(4)
   }
 });

--- a/packages/edition-slices/src/tiles/tile-ac/index.js
+++ b/packages/edition-slices/src/tiles/tile-ac/index.js
@@ -35,8 +35,8 @@ const TileAC = ({ onPress, tile, breakpoint }) => {
         headlineStyle={styles.headline}
         style={styles.summaryContainer}
         tile={tile}
-        isCenteredStar
-        isAfterContentStar
+        centeredStar
+        underneathTextStar
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-ac/index.js
+++ b/packages/edition-slices/src/tiles/tile-ac/index.js
@@ -12,13 +12,12 @@ import styleFactory from "./styles";
 
 const TileAC = ({ onPress, tile, breakpoint }) => {
   const styles = styleFactory(breakpoint);
-  const { container, headline, imageContainer, summaryContainer } = styles;
   const crop = getTileImage(tile, "crop169");
 
   return (
     <TileLink
       onPress={onPress}
-      style={container}
+      style={styles.container}
       tile={tile}
       starStyle={styles.star}
     >
@@ -28,14 +27,16 @@ const TileAC = ({ onPress, tile, breakpoint }) => {
         relativeHeight={crop.relativeHeight}
         relativeHorizontalOffset={crop.relativeHorizontalOffset}
         relativeVerticalOffset={crop.relativeVerticalOffset}
-        style={imageContainer}
+        style={styles.imageContainer}
         uri={crop.url}
         fill
       />
       <TileSummary
-        headlineStyle={headline}
-        style={summaryContainer}
+        headlineStyle={styles.headline}
+        style={styles.summaryContainer}
         tile={tile}
+        isCenteredStar
+        isAfterContentStar
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-ac/index.js
+++ b/packages/edition-slices/src/tiles/tile-ac/index.js
@@ -15,12 +15,7 @@ const TileAC = ({ onPress, tile, breakpoint }) => {
   const crop = getTileImage(tile, "crop169");
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      starStyle={styles.star}
-    >
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <Image
         aspectRatio={16 / 9}
         relativeWidth={crop.relativeWidth}

--- a/packages/edition-slices/src/tiles/tile-ac/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ac/styles/index.js
@@ -4,7 +4,6 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
-import { verticalStyles } from "../../shared/styles";
 
 const headlineFontSizeResolver = {
   [editionBreakpoints.huge]: 35,
@@ -29,13 +28,12 @@ export default breakpoint => ({
   imageContainer: {
     width: "100%"
   },
-  star: verticalStyles,
   summaryContainer: {
-    alignItems: "center",
-    backgroundColor: colours.functional.border,
     flex: 1,
+    alignItems: "center",
     justifyContent: "center",
-    paddingHorizontal: spacing(8),
+    backgroundColor: colours.functional.border,
+    paddingHorizontal: spacing(4),
     paddingVertical: spacing(3)
   }
 });

--- a/packages/edition-slices/src/tiles/tile-ad/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/index.js
@@ -12,11 +12,10 @@ import styleFactory from "./styles";
 
 const TileAD = ({ onPress, tile, breakpoint }) => {
   const styles = styleFactory(breakpoint);
-  const { container, headline, imageContainer, summaryContainer } = styles;
   const crop = getTileImage(tile, "crop32");
 
   return (
-    <TileLink onPress={onPress} style={container} tile={tile}>
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
       {breakpoint !== editionBreakpoints.medium && (
         <Image
           aspectRatio={3 / 2}
@@ -24,14 +23,14 @@ const TileAD = ({ onPress, tile, breakpoint }) => {
           relativeHeight={crop.relativeHeight}
           relativeHorizontalOffset={crop.relativeHorizontalOffset}
           relativeVerticalOffset={crop.relativeVerticalOffset}
-          style={imageContainer}
+          style={styles.imageContainer}
           uri={crop.url}
           fill
         />
       )}
       <TileSummary
-        headlineStyle={headline}
-        style={summaryContainer}
+        headlineStyle={styles.headline}
+        style={styles.summaryContainer}
         tile={tile}
       />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-ad/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/styles/index.js
@@ -27,7 +27,8 @@ const styles = breakpoint => ({
     width: "30%"
   },
   summaryContainer: {
-    width: "70%"
+    width: "70%",
+    paddingLeft: spacing(2)
   }
 });
 

--- a/packages/edition-slices/src/tiles/tile-ad/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/styles/index.js
@@ -33,12 +33,15 @@ const styles = breakpoint => ({
 });
 
 const mediumBreakpointStyles = {
+  imageContainer: {
+    width: "100%"
+  },
   summaryContainer: {
     width: "100%"
   }
 };
 
 export default breakpoint =>
-  breakpoint === editionBreakpoints.medium
-    ? { ...styles(breakpoint), ...mediumBreakpointStyles }
-    : styles(breakpoint);
+  breakpoint === editionBreakpoints.small
+    ? styles(breakpoint)
+    : { ...styles(breakpoint), ...mediumBreakpointStyles };

--- a/packages/edition-slices/src/tiles/tile-ad/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/styles/index.js
@@ -27,7 +27,6 @@ const styles = breakpoint => ({
     width: "30%"
   },
   summaryContainer: {
-    paddingHorizontal: spacing(2),
     width: "70%"
   }
 });
@@ -42,6 +41,6 @@ const mediumBreakpointStyles = {
 };
 
 export default breakpoint =>
-  breakpoint === editionBreakpoints.small
-    ? styles(breakpoint)
-    : { ...styles(breakpoint), ...mediumBreakpointStyles };
+  breakpoint === editionBreakpoints.medium
+    ? { ...styles(breakpoint), ...mediumBreakpointStyles }
+    : styles(breakpoint);

--- a/packages/edition-slices/src/tiles/tile-ae/index.js
+++ b/packages/edition-slices/src/tiles/tile-ae/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { View } from "react-native";
 import PropTypes from "prop-types";
 import {
   getTileSummary,
@@ -8,24 +9,24 @@ import {
 } from "../shared";
 import styles from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
+import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileAE = ({ onPress, tile }) => (
-  <TileLink
-    onPress={onPress}
-    style={styles.container}
-    tile={tile}
-    starStyle={styles.star}
-  >
-    <WithoutWhiteSpace
-      render={whiteSpaceHeight => (
-        <TileSummary
-          headlineStyle={styles.headline}
-          summary={getTileSummary(tile, 800)}
-          tile={tile}
-          whiteSpaceHeight={whiteSpaceHeight}
-        />
-      )}
-    />
+  <TileLink onPress={onPress} style={styles.container} tile={tile}>
+    <View style={styles.summaryContainer}>
+      <WithoutWhiteSpace
+        render={whiteSpaceHeight => (
+          <TileSummary
+            headlineStyle={styles.headline}
+            summary={getTileSummary(tile, 800)}
+            tile={tile}
+            whiteSpaceHeight={whiteSpaceHeight}
+            withStar={false}
+          />
+        )}
+      />
+      <PositionedTileStar articleId={tile.article.id} />
+    </View>
   </TileLink>
 );
 

--- a/packages/edition-slices/src/tiles/tile-ae/index.js
+++ b/packages/edition-slices/src/tiles/tile-ae/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { View } from "react-native";
 import PropTypes from "prop-types";
 import {
   getTileSummary,
@@ -13,20 +12,18 @@ import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileAE = ({ onPress, tile }) => (
   <TileLink onPress={onPress} style={styles.container} tile={tile}>
-    <View style={styles.summaryContainer}>
-      <WithoutWhiteSpace
-        render={whiteSpaceHeight => (
-          <TileSummary
-            headlineStyle={styles.headline}
-            summary={getTileSummary(tile, 800)}
-            tile={tile}
-            whiteSpaceHeight={whiteSpaceHeight}
-            withStar={false}
-          />
-        )}
-      />
-      <PositionedTileStar articleId={tile.article.id} />
-    </View>
+    <WithoutWhiteSpace
+      render={whiteSpaceHeight => (
+        <TileSummary
+          headlineStyle={styles.headline}
+          summary={getTileSummary(tile, 800)}
+          tile={tile}
+          whiteSpaceHeight={whiteSpaceHeight}
+          withStar={false}
+        />
+      )}
+    />
+    <PositionedTileStar articleId={tile.article.id} />
   </TileLink>
 );
 

--- a/packages/edition-slices/src/tiles/tile-ae/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ae/styles/index.js
@@ -1,4 +1,5 @@
 import { fonts, spacing } from "@times-components/styleguide";
+import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -12,8 +13,8 @@ const styles = {
     lineHeight: 30,
     marginBottom: spacing(2)
   },
-  star: {
-    bottom: spacing(1)
+  summaryContainer: {
+    ...fullHeightSummaryContainer
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-ae/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ae/styles/index.js
@@ -1,5 +1,4 @@
 import { fonts, spacing } from "@times-components/styleguide";
-import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -12,9 +11,6 @@ const styles = {
     fontSize: 30,
     lineHeight: 30,
     marginBottom: spacing(2)
-  },
-  summaryContainer: {
-    ...fullHeightSummaryContainer
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-ae/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ae/styles/index.js
@@ -4,7 +4,7 @@ import { fullHeightSummaryContainer } from "../../shared/styles";
 const styles = {
   container: {
     flex: 1,
-    paddingHorizontal: spacing(2),
+    padding: spacing(2),
     paddingTop: spacing(3)
   },
   headline: {

--- a/packages/edition-slices/src/tiles/tile-ag/index.js
+++ b/packages/edition-slices/src/tiles/tile-ag/index.js
@@ -29,7 +29,7 @@ const TileAG = ({ onPress, tile, breakpoint = editionBreakpoints.wide }) => {
         straplineStyle={styles.strapline}
         style={styles.summaryContainer}
         tile={tileWithoutLabelAndFlags}
-        isCenteredStar
+        centeredStar
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-ag/index.js
+++ b/packages/edition-slices/src/tiles/tile-ag/index.js
@@ -22,13 +22,14 @@ const TileAG = ({ onPress, tile, breakpoint = editionBreakpoints.wide }) => {
       onPress={onPress}
       style={styles.container}
       tile={tileWithoutLabelAndFlags}
-      starStyle={styles.star}
     >
       <TileSummary
         headlineStyle={styles.headline}
         strapline={getTileStrapline(tile)}
         straplineStyle={styles.strapline}
+        style={styles.summaryContainer}
         tile={tileWithoutLabelAndFlags}
+        isCenteredStar
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-ag/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ag/styles/index.js
@@ -11,6 +11,7 @@ const headlineFontSizeResolver = {
 
 export default breakpoint => ({
   container: {
+    flex: 1,
     paddingBottom: spacing(2),
     paddingHorizontal: spacing(4)
   },
@@ -27,5 +28,8 @@ export default breakpoint => ({
     fontSize: 14,
     lineHeight: 20,
     textAlign: "center"
+  },
+  summaryContainer: {
+    flex: 1
   }
 });

--- a/packages/edition-slices/src/tiles/tile-ag/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ag/styles/index.js
@@ -3,7 +3,6 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
-import { verticalStyles } from "../../shared/styles";
 
 const headlineFontSizeResolver = {
   [editionBreakpoints.huge]: 35,
@@ -23,7 +22,6 @@ export default breakpoint => ({
     marginTop: spacing(4),
     textAlign: "center"
   },
-  star: verticalStyles,
   strapline: {
     fontFamily: fonts.bodyRegular,
     fontSize: 14,

--- a/packages/edition-slices/src/tiles/tile-ah/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/index.js
@@ -15,12 +15,7 @@ const TileAH = ({ onPress, tile, breakpoint }) => {
   const styles = stylesFactory(breakpoint);
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      starStyle={styles.star}
-    >
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <Image
         aspectRatio={1}
         relativeWidth={crop.relativeWidth}
@@ -39,6 +34,7 @@ const TileAH = ({ onPress, tile, breakpoint }) => {
         straplineStyle={styles.strapline}
         style={styles.summaryContainer}
         tile={tile}
+        isCenteredStar
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-ah/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/index.js
@@ -34,7 +34,7 @@ const TileAH = ({ onPress, tile, breakpoint }) => {
         straplineStyle={styles.strapline}
         style={styles.summaryContainer}
         tile={tile}
-        isCenteredStar
+        centeredStar
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-ah/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/styles/index.js
@@ -5,7 +5,6 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
-import { verticalStyles } from "../../shared/styles";
 
 const headlineFontSizeResolver = {
   [editionBreakpoints.medium]: 30,
@@ -34,11 +33,6 @@ const styles = (breakpoint = editionBreakpoints.medium) => ({
     width: "40%",
     marginBottom: spacing(1)
   },
-  star: {
-    ...verticalStyles.starButton,
-    position: "relative",
-    right: "auto"
-  },
   strapline: {
     color: colours.functional.secondary,
     fontFamily: fonts.bodyRegular,
@@ -48,7 +42,7 @@ const styles = (breakpoint = editionBreakpoints.medium) => ({
     paddingBottom: spacing(1)
   },
   summaryContainer: {
-    alignItems: "center",
+    flex: 1,
     paddingTop: spacing(1)
   }
 });

--- a/packages/edition-slices/src/tiles/tile-ah/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/styles/index.js
@@ -43,7 +43,8 @@ const styles = (breakpoint = editionBreakpoints.medium) => ({
   },
   summaryContainer: {
     flex: 1,
-    paddingTop: spacing(1)
+    paddingTop: spacing(1),
+    alignItems: "center"
   }
 });
 

--- a/packages/edition-slices/src/tiles/tile-ai/index.js
+++ b/packages/edition-slices/src/tiles/tile-ai/index.js
@@ -1,19 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
-import { getTileImage, TileLink, TileStar, withTileTracking } from "../shared";
+import { getTileImage, TileLink, withTileTracking } from "../shared";
 import styles from "./styles";
 
 const TileAI = ({ onPress, tile }) => {
   const crop = getTileImage(tile, "crop32");
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      withStar={false}
-    >
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <Image
         aspectRatio={3 / 2}
         relativeWidth={crop.relativeWidth}
@@ -24,7 +19,6 @@ const TileAI = ({ onPress, tile }) => {
         uri={crop.url}
         fill
       />
-      <TileStar articleId={tile.article.id} style={styles.starButton} />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-ai/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ai/styles/index.js
@@ -1,4 +1,5 @@
 import { spacing } from "@times-components/styleguide";
+// import { fullHeightSummaryContainer } from '../../shared/styles';
 
 const styles = {
   container: {
@@ -7,10 +8,6 @@ const styles = {
   },
   imageContainer: {
     width: "100%"
-  },
-  starButton: {
-    marginTop: spacing(2),
-    textAlign: "center"
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-ai/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ai/styles/index.js
@@ -1,5 +1,4 @@
 import { spacing } from "@times-components/styleguide";
-// import { fullHeightSummaryContainer } from '../../shared/styles';
 
 const styles = {
   container: {

--- a/packages/edition-slices/src/tiles/tile-al/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
 import {
@@ -28,20 +27,19 @@ const TileAL = ({ onPress, tile }) => {
         uri={crop.url}
         fill
       />
-      <View style={styles.summaryContainer}>
-        <WithoutWhiteSpace
-          render={whiteSpaceHeight => (
-            <TileSummary
-              headlineStyle={styles.headline}
-              summary={getTileSummary(tile, 800)}
-              tile={tile}
-              whiteSpaceHeight={whiteSpaceHeight}
-              withStar={false}
-            />
-          )}
-        />
-        <PositionedTileStar articleId={tile.article.id} />
-      </View>
+      <WithoutWhiteSpace
+        style={styles.summaryContainer}
+        render={whiteSpaceHeight => (
+          <TileSummary
+            headlineStyle={styles.headline}
+            summary={getTileSummary(tile, 800)}
+            tile={tile}
+            whiteSpaceHeight={whiteSpaceHeight}
+            withStar={false}
+          />
+        )}
+      />
+      <PositionedTileStar articleId={tile.article.id} />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-al/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/index.js
@@ -34,7 +34,6 @@ const TileAL = ({ onPress, tile }) => {
             <TileSummary
               headlineStyle={styles.headline}
               summary={getTileSummary(tile, 800)}
-              // summaryStyle={styles.summaryContainer}
               tile={tile}
               whiteSpaceHeight={whiteSpaceHeight}
               withStar={false}

--- a/packages/edition-slices/src/tiles/tile-al/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
 import {
@@ -10,17 +11,13 @@ import {
 } from "../shared";
 import styles from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
+import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileAL = ({ onPress, tile }) => {
   const crop = getTileImage(tile, "crop32");
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      starStyle={styles.star}
-    >
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <Image
         aspectRatio={3 / 2}
         relativeWidth={crop.relativeWidth}
@@ -31,17 +28,21 @@ const TileAL = ({ onPress, tile }) => {
         uri={crop.url}
         fill
       />
-      <WithoutWhiteSpace
-        render={whiteSpaceHeight => (
-          <TileSummary
-            headlineStyle={styles.headline}
-            summary={getTileSummary(tile, 800)}
-            summaryStyle={styles.summaryContainer}
-            tile={tile}
-            whiteSpaceHeight={whiteSpaceHeight}
-          />
-        )}
-      />
+      <View style={styles.summaryContainer}>
+        <WithoutWhiteSpace
+          render={whiteSpaceHeight => (
+            <TileSummary
+              headlineStyle={styles.headline}
+              summary={getTileSummary(tile, 800)}
+              // summaryStyle={styles.summaryContainer}
+              tile={tile}
+              whiteSpaceHeight={whiteSpaceHeight}
+              withStar={false}
+            />
+          )}
+        />
+        <PositionedTileStar articleId={tile.article.id} />
+      </View>
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-al/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/styles/index.js
@@ -1,12 +1,9 @@
 import { fontFactory, spacing } from "@times-components/styleguide";
-import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const styles = {
   container: {
     flex: 1,
-    flexDirection: "column",
-    paddingHorizontal: spacing(2),
-    paddingVertical: spacing(2)
+    padding: spacing(2)
   },
   headline: {
     marginBottom: 0,
@@ -25,8 +22,7 @@ const styles = {
     ...fontFactory({
       font: "bodyRegular",
       fontSize: "teaser"
-    }),
-    ...fullHeightSummaryContainer
+    })
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-al/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/styles/index.js
@@ -13,10 +13,10 @@ const styles = {
     })
   },
   imageContainer: {
-    width: "100%"
+    width: "100%",
+    marginBottom: spacing(2)
   },
   summaryContainer: {
-    paddingTop: spacing(2),
     lineHeight: 1.43,
     width: "100%",
     ...fontFactory({

--- a/packages/edition-slices/src/tiles/tile-al/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/styles/index.js
@@ -1,10 +1,12 @@
 import { fontFactory, spacing } from "@times-components/styleguide";
+import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const styles = {
   container: {
     flex: 1,
     flexDirection: "column",
-    paddingHorizontal: spacing(2)
+    paddingHorizontal: spacing(2),
+    paddingVertical: spacing(2)
   },
   headline: {
     marginBottom: 0,
@@ -14,16 +16,17 @@ const styles = {
     })
   },
   imageContainer: {
-    paddingVertical: spacing(2),
     width: "100%"
   },
   summaryContainer: {
+    paddingTop: spacing(2),
     lineHeight: 1.43,
     width: "100%",
     ...fontFactory({
       font: "bodyRegular",
       fontSize: "teaser"
-    })
+    }),
+    ...fullHeightSummaryContainer
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-am/index.js
+++ b/packages/edition-slices/src/tiles/tile-am/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
 import {
@@ -10,6 +11,7 @@ import {
 } from "../shared";
 import styles from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
+import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileAM = ({ onPress, tile }) => {
   const crop = getTileImage(tile, "crop169");
@@ -26,16 +28,20 @@ const TileAM = ({ onPress, tile }) => {
         uri={crop.url}
         fill
       />
-      <WithoutWhiteSpace
-        render={whiteSpaceHeight => (
-          <TileSummary
-            headlineStyle={styles.headline}
-            summary={getTileSummary(tile, 800)}
-            tile={tile}
-            whiteSpaceHeight={whiteSpaceHeight}
-          />
-        )}
-      />
+      <View style={styles.summaryContainer}>
+        <WithoutWhiteSpace
+          render={whiteSpaceHeight => (
+            <TileSummary
+              headlineStyle={styles.headline}
+              summary={getTileSummary(tile, 800)}
+              tile={tile}
+              whiteSpaceHeight={whiteSpaceHeight}
+              withStar={false}
+            />
+          )}
+        />
+        <PositionedTileStar articleId={tile.article.id} />
+      </View>
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-am/index.js
+++ b/packages/edition-slices/src/tiles/tile-am/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
 import {
@@ -28,20 +27,18 @@ const TileAM = ({ onPress, tile }) => {
         uri={crop.url}
         fill
       />
-      <View style={styles.summaryContainer}>
-        <WithoutWhiteSpace
-          render={whiteSpaceHeight => (
-            <TileSummary
-              headlineStyle={styles.headline}
-              summary={getTileSummary(tile, 800)}
-              tile={tile}
-              whiteSpaceHeight={whiteSpaceHeight}
-              withStar={false}
-            />
-          )}
-        />
-        <PositionedTileStar articleId={tile.article.id} />
-      </View>
+      <WithoutWhiteSpace
+        render={whiteSpaceHeight => (
+          <TileSummary
+            headlineStyle={styles.headline}
+            summary={getTileSummary(tile, 800)}
+            tile={tile}
+            whiteSpaceHeight={whiteSpaceHeight}
+            withStar={false}
+          />
+        )}
+      />
+      <PositionedTileStar articleId={tile.article.id} />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-am/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-am/styles/index.js
@@ -1,5 +1,4 @@
 import { fonts, spacing } from "@times-components/styleguide";
-import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -15,9 +14,6 @@ const styles = {
   imageContainer: {
     marginBottom: spacing(2),
     width: "100%"
-  },
-  summaryContainer: {
-    ...fullHeightSummaryContainer
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-am/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-am/styles/index.js
@@ -1,10 +1,10 @@
 import { fonts, spacing } from "@times-components/styleguide";
+import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const styles = {
   container: {
     flex: 1,
-    paddingHorizontal: spacing(2),
-    paddingTop: spacing(2)
+    padding: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,
@@ -15,6 +15,9 @@ const styles = {
   imageContainer: {
     marginBottom: spacing(2),
     width: "100%"
+  },
+  summaryContainer: {
+    ...fullHeightSummaryContainer
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-an/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-an/styles/index.js
@@ -2,6 +2,7 @@ import { fontFactory, spacing } from "@times-components/styleguide";
 
 const styles = {
   container: {
+    flex: 1,
     padding: spacing(2)
   },
   headline: {
@@ -14,8 +15,8 @@ const styles = {
     overflow: "hidden"
   },
   summaryContainer: {
+    flex: 1,
     justifyContent: "center",
-    paddingHorizontal: spacing(2),
     paddingTop: spacing(2)
   }
 };

--- a/packages/edition-slices/src/tiles/tile-ap/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ap/styles/index.js
@@ -2,6 +2,7 @@ import { fontFactory, spacing } from "@times-components/styleguide";
 
 const styles = {
   container: {
+    flex: 1,
     padding: spacing(2)
   },
   headline: {
@@ -15,8 +16,8 @@ const styles = {
     overflow: "hidden"
   },
   summaryContainer: {
+    flex: 1,
     justifyContent: "center",
-    paddingHorizontal: spacing(2),
     paddingTop: spacing(1)
   }
 };

--- a/packages/edition-slices/src/tiles/tile-aq/index.js
+++ b/packages/edition-slices/src/tiles/tile-aq/index.js
@@ -11,6 +11,7 @@ import {
 } from "../shared";
 import styles from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
+import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileAQ = ({ onPress, tile }) => {
   const crop = getTileImage(tile, "crop169");
@@ -28,16 +29,20 @@ const TileAQ = ({ onPress, tile }) => {
           relativeVerticalOffset={crop.relativeVerticalOffset}
         />
       </View>
-      <WithoutWhiteSpace
-        render={whiteSpaceHeight => (
-          <TileSummary
-            headlineStyle={styles.headline}
-            summary={getTileSummary(tile, 800)}
-            tile={tile}
-            whiteSpaceHeight={whiteSpaceHeight}
-          />
-        )}
-      />
+      <View style={styles.summaryContainer}>
+        <WithoutWhiteSpace
+          render={whiteSpaceHeight => (
+            <TileSummary
+              headlineStyle={styles.headline}
+              summary={getTileSummary(tile, 800)}
+              tile={tile}
+              whiteSpaceHeight={whiteSpaceHeight}
+              withStar={false}
+            />
+          )}
+        />
+        <PositionedTileStar articleId={tile.article.id} />
+      </View>
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-aq/index.js
+++ b/packages/edition-slices/src/tiles/tile-aq/index.js
@@ -29,20 +29,18 @@ const TileAQ = ({ onPress, tile }) => {
           relativeVerticalOffset={crop.relativeVerticalOffset}
         />
       </View>
-      <View style={styles.summaryContainer}>
-        <WithoutWhiteSpace
-          render={whiteSpaceHeight => (
-            <TileSummary
-              headlineStyle={styles.headline}
-              summary={getTileSummary(tile, 800)}
-              tile={tile}
-              whiteSpaceHeight={whiteSpaceHeight}
-              withStar={false}
-            />
-          )}
-        />
-        <PositionedTileStar articleId={tile.article.id} />
-      </View>
+      <WithoutWhiteSpace
+        render={whiteSpaceHeight => (
+          <TileSummary
+            headlineStyle={styles.headline}
+            summary={getTileSummary(tile, 800)}
+            tile={tile}
+            whiteSpaceHeight={whiteSpaceHeight}
+            withStar={false}
+          />
+        )}
+      />
+      <PositionedTileStar articleId={tile.article.id} />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-aq/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-aq/styles/index.js
@@ -1,10 +1,10 @@
 import { fonts, spacing } from "@times-components/styleguide";
+import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const styles = {
   container: {
     flex: 1,
-    paddingHorizontal: spacing(2),
-    paddingTop: spacing(2)
+    padding: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,
@@ -15,12 +15,8 @@ const styles = {
     marginBottom: spacing(2),
     width: "100%"
   },
-  star: {
-    bottom: 0,
-    marginLeft: "auto",
-    marginRight: "auto",
-    position: "absolute",
-    right: 0
+  summaryContainer: {
+    ...fullHeightSummaryContainer
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-aq/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-aq/styles/index.js
@@ -1,5 +1,4 @@
 import { fonts, spacing } from "@times-components/styleguide";
-import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -14,9 +13,6 @@ const styles = {
   imageContainer: {
     marginBottom: spacing(2),
     width: "100%"
-  },
-  summaryContainer: {
-    ...fullHeightSummaryContainer
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-ar/index.js
+++ b/packages/edition-slices/src/tiles/tile-ar/index.js
@@ -29,20 +29,18 @@ const TileAR = ({ onPress, tile }) => {
           relativeVerticalOffset={crop.relativeVerticalOffset}
         />
       </View>
-      <View style={styles.summaryContainer}>
-        <WithoutWhiteSpace
-          render={whiteSpaceHeight => (
-            <TileSummary
-              headlineStyle={styles.headline}
-              summary={getTileSummary(tile, 125)}
-              tile={tile}
-              whiteSpaceHeight={whiteSpaceHeight}
-              withStar={false}
-            />
-          )}
-        />
-        <PositionedTileStar articleId={tile.article.id} />
-      </View>
+      <WithoutWhiteSpace
+        render={whiteSpaceHeight => (
+          <TileSummary
+            headlineStyle={styles.headline}
+            summary={getTileSummary(tile, 125)}
+            tile={tile}
+            whiteSpaceHeight={whiteSpaceHeight}
+            withStar={false}
+          />
+        )}
+      />
+      <PositionedTileStar articleId={tile.article.id} />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-ar/index.js
+++ b/packages/edition-slices/src/tiles/tile-ar/index.js
@@ -41,7 +41,6 @@ const TileAR = ({ onPress, tile }) => {
             />
           )}
         />
-
         <PositionedTileStar articleId={tile.article.id} />
       </View>
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-ar/index.js
+++ b/packages/edition-slices/src/tiles/tile-ar/index.js
@@ -11,17 +11,13 @@ import {
 } from "../shared";
 import styles from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
+import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileAR = ({ onPress, tile }) => {
   const crop = getTileImage(tile, "crop169");
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      starStyle={styles.star}
-    >
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <View style={styles.imageContainer}>
         <Image
           aspectRatio={16 / 9}
@@ -33,16 +29,21 @@ const TileAR = ({ onPress, tile }) => {
           relativeVerticalOffset={crop.relativeVerticalOffset}
         />
       </View>
-      <WithoutWhiteSpace
-        render={whiteSpaceHeight => (
-          <TileSummary
-            headlineStyle={styles.headline}
-            summary={getTileSummary(tile, 125)}
-            tile={tile}
-            whiteSpaceHeight={whiteSpaceHeight}
-          />
-        )}
-      />
+      <View style={styles.summaryContainer}>
+        <WithoutWhiteSpace
+          render={whiteSpaceHeight => (
+            <TileSummary
+              headlineStyle={styles.headline}
+              summary={getTileSummary(tile, 125)}
+              tile={tile}
+              whiteSpaceHeight={whiteSpaceHeight}
+              withStar={false}
+            />
+          )}
+        />
+
+        <PositionedTileStar articleId={tile.article.id} />
+      </View>
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-ar/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ar/styles/index.js
@@ -1,5 +1,4 @@
 import { fonts, spacing } from "@times-components/styleguide";
-import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -11,9 +10,6 @@ const styles = {
     fontFamily: fonts.headline,
     fontSize: 20,
     lineHeight: 20
-  },
-  summaryContainer: {
-    ...fullHeightSummaryContainer
   },
   imageContainer: {
     marginBottom: spacing(2),

--- a/packages/edition-slices/src/tiles/tile-ar/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ar/styles/index.js
@@ -1,4 +1,5 @@
 import { fonts, spacing } from "@times-components/styleguide";
+import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -11,14 +12,12 @@ const styles = {
     fontSize: 20,
     lineHeight: 20
   },
+  summaryContainer: {
+    ...fullHeightSummaryContainer
+  },
   imageContainer: {
     marginBottom: spacing(2),
     width: "100%"
-  },
-  star: {
-    starButton: {
-      right: spacing(1)
-    }
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-as/index.js
+++ b/packages/edition-slices/src/tiles/tile-as/index.js
@@ -15,12 +15,7 @@ const TileAS = ({ onPress, tile }) => {
   const crop = getTileImage(tile, "crop32");
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      starStyle={styles.star}
-    >
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <View style={styles.imageContainer}>
         <Image
           aspectRatio={3 / 2}
@@ -35,6 +30,7 @@ const TileAS = ({ onPress, tile }) => {
       <TileSummary
         headlineStyle={styles.headline}
         summary={getTileSummary(tile, 125)}
+        style={styles.summaryContainer}
         tile={tile}
       />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-as/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-as/styles/index.js
@@ -11,6 +11,9 @@ const styles = {
     fontSize: 18,
     lineHeight: 18
   },
+  summaryContainer: {
+    flex: 1
+  },
   imageContainer: {
     marginBottom: spacing(2),
     width: "100%"

--- a/packages/edition-slices/src/tiles/tile-b/index.js
+++ b/packages/edition-slices/src/tiles/tile-b/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/require-default-props */
 import React from "react";
+import { View } from "react-native";
 import PropTypes from "prop-types";
 import { editionBreakpoints } from "@times-components/styleguide";
 import {
@@ -10,22 +11,27 @@ import {
 } from "../shared";
 import stylesFactory from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
+import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileB = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
   const styles = stylesFactory(breakpoint);
 
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
-      <WithoutWhiteSpace
-        render={whiteSpaceHeight => (
-          <TileSummary
-            headlineStyle={styles.headline}
-            summary={getTileSummary(tile, 125)}
-            tile={tile}
-            whiteSpaceHeight={whiteSpaceHeight}
-          />
-        )}
-      />
+      <View style={styles.summaryContainer}>
+        <WithoutWhiteSpace
+          render={whiteSpaceHeight => (
+            <TileSummary
+              headlineStyle={styles.headline}
+              summary={getTileSummary(tile, 125)}
+              tile={tile}
+              whiteSpaceHeight={whiteSpaceHeight}
+              withStar={false}
+            />
+          )}
+        />
+        <PositionedTileStar articleId={tile.article.id} />
+      </View>
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-b/index.js
+++ b/packages/edition-slices/src/tiles/tile-b/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/require-default-props */
 import React from "react";
-import { View } from "react-native";
 import PropTypes from "prop-types";
 import { editionBreakpoints } from "@times-components/styleguide";
 import {
@@ -18,20 +17,19 @@ const TileB = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
 
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
-      <View style={styles.summaryContainer}>
-        <WithoutWhiteSpace
-          render={whiteSpaceHeight => (
-            <TileSummary
-              headlineStyle={styles.headline}
-              summary={getTileSummary(tile, 125)}
-              tile={tile}
-              whiteSpaceHeight={whiteSpaceHeight}
-              withStar={false}
-            />
-          )}
-        />
-        <PositionedTileStar articleId={tile.article.id} />
-      </View>
+      <WithoutWhiteSpace
+        style={styles.summaryContainer}
+        render={whiteSpaceHeight => (
+          <TileSummary
+            headlineStyle={styles.headline}
+            summary={getTileSummary(tile, 125)}
+            tile={tile}
+            whiteSpaceHeight={whiteSpaceHeight}
+            withStar={false}
+          />
+        )}
+      />
+      <PositionedTileStar articleId={tile.article.id} />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-b/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-b/styles/index.js
@@ -3,7 +3,6 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
-import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const sharedStyles = {
   container: {
@@ -36,9 +35,6 @@ const mediumBreakpointStyles = {
     ...sharedStyles.headline,
     fontSize: 20,
     lineHeight: 20
-  },
-  summaryContainer: {
-    ...fullHeightSummaryContainer
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-b/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-b/styles/index.js
@@ -3,6 +3,7 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
+import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const sharedStyles = {
   container: {
@@ -36,6 +37,9 @@ const mediumBreakpointStyles = {
     ...sharedStyles.headline,
     fontSize: 20,
     lineHeight: 20
+  },
+  summaryContainer: {
+    ...fullHeightSummaryContainer
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-b/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-b/styles/index.js
@@ -17,8 +17,7 @@ const sharedStyles = {
 const smallBreakpointStyles = {
   container: {
     ...sharedStyles.container,
-    paddingHorizontal: spacing(2),
-    paddingTop: spacing(2)
+    padding: spacing(2)
   },
   headline: {
     ...sharedStyles.headline,

--- a/packages/edition-slices/src/tiles/tile-c/index.js
+++ b/packages/edition-slices/src/tiles/tile-c/index.js
@@ -26,7 +26,11 @@ const TileC = ({ onPress, tile }) => {
           relativeVerticalOffset={crop.relativeVerticalOffset}
         />
       </View>
-      <TileSummary headlineStyle={styles.headline} tile={tile} />
+      <TileSummary
+        headlineStyle={styles.headline}
+        tile={tile}
+        style={styles.summaryContainer}
+      />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-c/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-c/styles/index.js
@@ -3,8 +3,7 @@ import { fonts, spacing } from "@times-components/styleguide";
 const styles = {
   container: {
     flex: 1,
-    paddingHorizontal: spacing(2),
-    paddingTop: spacing(2)
+    padding: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,
@@ -16,12 +15,8 @@ const styles = {
     marginBottom: spacing(2),
     width: "100%"
   },
-  star: {
-    bottom: 0,
-    marginLeft: "auto",
-    marginRight: "auto",
-    position: "absolute",
-    right: 0
+  summaryContainer: {
+    flex: 1
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-d/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-d/styles/index.js
@@ -17,14 +17,12 @@ const styles = {
     })
   },
   imageContainer: {
-    width: "50%",
-    paddingRight: spacing(2)
+    width: "50%"
   },
   summaryContainer: {
-    paddingBottom: spacing(1),
-    paddingTop: spacing(1),
-    paddingRight: spacing(2),
-    width: "50%"
+    width: "50%",
+    paddingLeft: spacing(2),
+    paddingBottom: spacing(1)
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-e/index.js
+++ b/packages/edition-slices/src/tiles/tile-e/index.js
@@ -14,6 +14,7 @@ import stylesFactory from "./styles";
 const TileE = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
   const crop = getTileImage(tile, "crop45");
   const styles = stylesFactory(breakpoint);
+
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <Image

--- a/packages/edition-slices/src/tiles/tile-e/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-e/styles/index.js
@@ -17,14 +17,12 @@ const styles = {
     })
   },
   imageContainer: {
-    width: "50%",
-    paddingRight: spacing(2)
+    width: "50%"
   },
   summaryContainer: {
-    paddingBottom: spacing(1),
-    paddingTop: spacing(2),
-    paddingRight: spacing(2),
-    width: "50%"
+    width: "50%",
+    paddingLeft: spacing(2),
+    paddingBottom: spacing(1)
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-e/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-e/styles/index.js
@@ -37,10 +37,8 @@ const mediumBreakpointStyles = {
     lineHeight: 20
   },
   imageContainer: {
-    width: "100%"
-  },
-  summaryContainer: {
-    paddingTop: spacing(2)
+    width: "100%",
+    marginBottom: spacing(2)
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-f/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-f/styles/index.js
@@ -2,8 +2,7 @@ import { fontFactory, spacing } from "@times-components/styleguide";
 
 const styles = {
   container: {
-    paddingHorizontal: spacing(2),
-    paddingTop: spacing(2)
+    padding: spacing(2)
   },
   headline: {
     ...fontFactory({
@@ -12,7 +11,7 @@ const styles = {
     })
   },
   summaryContainer: {
-    marginHorizontal: spacing(2),
+    marginHorizontal: spacing(8),
     marginVertical: spacing(1)
   }
 };

--- a/packages/edition-slices/src/tiles/tile-g/index.js
+++ b/packages/edition-slices/src/tiles/tile-g/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/require-default-props */
 import React from "react";
+import { View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
 import editionBreakpoints from "@times-components/styleguide";
@@ -10,6 +11,7 @@ import {
   withTileTracking
 } from "../shared";
 import stylesFactory from "./styles";
+import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileG = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
   const crop = getTileImage(tile, "crop11");
@@ -29,11 +31,15 @@ const TileG = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
         rounded
         resizeMode="cover"
       />
-      <TileSummary
-        headlineStyle={styles.headline}
-        style={styles.summaryContainer}
-        tile={tile}
-      />
+      <View style={styles.summaryContainer}>
+        <TileSummary
+          headlineStyle={styles.headline}
+          style={styles.summaryContent}
+          tile={tile}
+          withStar={false}
+        />
+        <PositionedTileStar articleId={tile.article.id} />
+      </View>
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-g/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g/styles/index.js
@@ -23,11 +23,13 @@ const styles = {
     width: "30%"
   },
   summaryContainer: {
-    justifyContent: "center",
     paddingLeft: spacing(2),
-    paddingTop: spacing(1),
     width: "70%",
-    paddingBottom: 0
+    ...fullHeightSummaryContainer
+  },
+  summaryContent: {
+    justifyContent: "center",
+    flex: 1
   }
 };
 
@@ -42,15 +44,6 @@ const mediumBreakpointStyles = {
     fontFamily: fonts.headline,
     fontSize: 20,
     lineHeight: 20
-  },
-  summaryContainer: {
-    paddingLeft: spacing(2),
-    width: "70%",
-    ...fullHeightSummaryContainer
-  },
-  summaryContent: {
-    justifyContent: "center",
-    flex: 1
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-g/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g/styles/index.js
@@ -4,7 +4,6 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
-import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -23,9 +22,9 @@ const styles = {
     width: "30%"
   },
   summaryContainer: {
+    flex: 1,
     paddingLeft: spacing(2),
-    width: "70%",
-    ...fullHeightSummaryContainer
+    width: "70%"
   },
   summaryContent: {
     justifyContent: "center",

--- a/packages/edition-slices/src/tiles/tile-g/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g/styles/index.js
@@ -4,6 +4,7 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
+import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const styles = {
   container: {
@@ -15,8 +16,7 @@ const styles = {
     ...fontFactory({
       font: "headline",
       fontSize: "infoTitle"
-    }),
-    paddingBottom: spacing(1)
+    })
   },
   imageContainer: {
     overflow: "hidden",
@@ -39,10 +39,18 @@ const mediumBreakpointStyles = {
     paddingBottom: spacing(3)
   },
   headline: {
-    ...styles.headline,
     fontFamily: fonts.headline,
     fontSize: 20,
     lineHeight: 20
+  },
+  summaryContainer: {
+    paddingLeft: spacing(2),
+    width: "70%",
+    ...fullHeightSummaryContainer
+  },
+  summaryContent: {
+    justifyContent: "center",
+    flex: 1
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-h/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-h/styles/index.js
@@ -3,7 +3,7 @@ import { fontFactory, spacing } from "@times-components/styleguide";
 const styles = {
   container: {
     flexDirection: "row",
-    paddingHorizontal: spacing(2)
+    padding: spacing(2)
   },
   headline: {
     ...fontFactory({
@@ -18,12 +18,10 @@ const styles = {
   imageContainer: {
     flexDirection: "column",
     justifyContent: "flex-end",
-    paddingTop: spacing(2),
     width: "50%"
   },
   summaryContainer: {
     paddingRight: spacing(2),
-    paddingVertical: spacing(2),
     width: "50%"
   }
 };

--- a/packages/edition-slices/src/tiles/tile-i/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/index.js
@@ -26,7 +26,6 @@ const TileI = ({ onPress, tile }) => {
       />
       <TileSummary
         headlineStyle={styles.headline}
-        starStyle={styles.star}
         style={styles.summaryContainer}
         tile={tile}
         centeredStar

--- a/packages/edition-slices/src/tiles/tile-i/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/index.js
@@ -29,8 +29,8 @@ const TileI = ({ onPress, tile }) => {
         starStyle={styles.star}
         style={styles.summaryContainer}
         tile={tile}
-        isCenteredStar
-        isAfterContentStar
+        centeredStar
+        underneathTextStar
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-i/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/index.js
@@ -13,7 +13,7 @@ const TileI = ({ onPress, tile }) => {
   const crop = getTileImage(tile, "crop169");
 
   return (
-    <TileLink onPress={onPress} tile={tile} withStar={false}>
+    <TileLink onPress={onPress} tile={tile}>
       <Image
         aspectRatio={16 / 9}
         relativeWidth={crop.relativeWidth}
@@ -29,7 +29,8 @@ const TileI = ({ onPress, tile }) => {
         starStyle={styles.star}
         style={styles.summaryContainer}
         tile={tile}
-        withStar
+        isCenteredStar
+        isAfterContentStar
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-i/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/styles/index.js
@@ -1,5 +1,4 @@
 import { colours, fonts, spacing } from "@times-components/styleguide";
-import { verticalStyles } from "../../shared/styles";
 
 const styles = {
   headline: {
@@ -12,7 +11,6 @@ const styles = {
   imageContainer: {
     width: "100%"
   },
-  star: verticalStyles,
   summaryContainer: {
     alignItems: "center",
     backgroundColor: colours.functional.border,

--- a/packages/edition-slices/src/tiles/tile-j/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-j/styles/index.js
@@ -16,7 +16,7 @@ const styles = {
     width: "40%"
   },
   summaryContainer: {
-    paddingHorizontal: spacing(2),
+    paddingLeft: spacing(2),
     width: "60%"
   }
 };

--- a/packages/edition-slices/src/tiles/tile-l/index.js
+++ b/packages/edition-slices/src/tiles/tile-l/index.js
@@ -9,7 +9,11 @@ const TileL = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
 
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
-      <TileSummary headlineStyle={styles.headlineStyle} tile={tile} />
+      <TileSummary
+        headlineStyle={styles.headlineStyle}
+        tile={tile}
+        style={styles.summaryContainer}
+      />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-l/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-l/styles/index.js
@@ -7,14 +7,16 @@ import {
 const sharedStyles = {
   container: {
     flex: 1,
-    paddingHorizontal: spacing(2),
-    paddingTop: spacing(2)
+    padding: spacing(2)
   },
   headlineStyle: {
     fontFamily: fonts.headline,
     fontSize: 20,
     lineHeight: 20,
     marginBottom: spacing(2)
+  },
+  summaryContainer: {
+    flex: 1
   }
 };
 
@@ -27,7 +29,8 @@ const mediumBreakpointStyles = {
   headlineStyle: {
     ...sharedStyles.headlineStyle,
     fontSize: 18,
-    lineHeight: 18
+    lineHeight: 18,
+    marginBottom: spacing(1)
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-m/index.js
+++ b/packages/edition-slices/src/tiles/tile-m/index.js
@@ -23,11 +23,10 @@ const TileM = ({ onPress, tile, breakpoint }) => {
     >
       <TileSummary
         headlineStyle={styles.headline}
-        starStyle={styles.star}
         strapline={getTileStrapline(tile)}
         straplineStyle={styles.strapline}
-        tile={tileWithoutLabelAndFlags}
         style={styles.summaryContainer}
+        tile={tileWithoutLabelAndFlags}
         centeredStar
       />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-m/index.js
+++ b/packages/edition-slices/src/tiles/tile-m/index.js
@@ -28,7 +28,7 @@ const TileM = ({ onPress, tile, breakpoint }) => {
         straplineStyle={styles.strapline}
         tile={tileWithoutLabelAndFlags}
         style={styles.summaryContainer}
-        isCenteredStar
+        centeredStar
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-m/index.js
+++ b/packages/edition-slices/src/tiles/tile-m/index.js
@@ -20,7 +20,6 @@ const TileM = ({ onPress, tile, breakpoint }) => {
       onPress={onPress}
       style={styles.container}
       tile={tileWithoutLabelAndFlags}
-      withStar={false}
     >
       <TileSummary
         headlineStyle={styles.headline}
@@ -28,7 +27,8 @@ const TileM = ({ onPress, tile, breakpoint }) => {
         strapline={getTileStrapline(tile)}
         straplineStyle={styles.strapline}
         tile={tileWithoutLabelAndFlags}
-        withStar
+        style={styles.summaryContainer}
+        isCenteredStar
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-m/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-m/styles/index.js
@@ -1,13 +1,8 @@
-import {
-  colours,
-  fonts,
-  spacing,
-  editionBreakpoints
-} from "@times-components/styleguide";
-import { verticalStyles } from "../../shared/styles";
+import { colours, fonts, spacing, editionBreakpoints } from "@times-components/styleguide";
 
 const smallBreakpointStyles = {
   container: {
+    flex: 1,
     paddingBottom: spacing(2)
   },
   headline: {
@@ -18,7 +13,9 @@ const smallBreakpointStyles = {
     marginTop: spacing(4),
     textAlign: "center"
   },
-  star: verticalStyles,
+  summaryContainer: {
+    flex: 1
+  },
   strapline: {
     color: colours.functional.secondary,
     fontFamily: fonts.bodyRegular,

--- a/packages/edition-slices/src/tiles/tile-m/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-m/styles/index.js
@@ -1,4 +1,9 @@
-import { colours, fonts, spacing, editionBreakpoints } from "@times-components/styleguide";
+import {
+  colours,
+  fonts,
+  spacing,
+  editionBreakpoints
+} from "@times-components/styleguide";
 
 const smallBreakpointStyles = {
   container: {
@@ -39,7 +44,6 @@ const mediumBreakpointStyles = {
     marginTop: spacing(6),
     textAlign: "center"
   },
-  star: verticalStyles,
   strapline: {
     color: colours.functional.primary,
     fontSize: 16,

--- a/packages/edition-slices/src/tiles/tile-n/index.js
+++ b/packages/edition-slices/src/tiles/tile-n/index.js
@@ -16,12 +16,7 @@ const TileN = ({ isDarkStar, onPress, tile, breakpoint }) => {
   const crop = getTileImage(tile, "crop11");
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      isDarkStar={isDarkStar}
-    >
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <Image
         aspectRatio={1}
         relativeWidth={crop.relativeWidth}
@@ -39,6 +34,7 @@ const TileN = ({ isDarkStar, onPress, tile, breakpoint }) => {
         strapline={getTileStrapline(tile)}
         style={styles.summaryContainer}
         tile={tile}
+        isDarkStar={isDarkStar}
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-n/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-n/styles/index.js
@@ -28,7 +28,7 @@ const styles = fontSize => ({
     color: colours.functional.greyLabel
   },
   summaryContainer: {
-    paddingHorizontal: spacing(2),
+    paddingLeft: spacing(2),
     width: "50%"
   }
 });

--- a/packages/edition-slices/src/tiles/tile-o/index.js
+++ b/packages/edition-slices/src/tiles/tile-o/index.js
@@ -11,6 +11,7 @@ const TileO = ({ isDarkStar, onPress, tile }) => (
       headlineStyle={styles.headlineStyle}
       labelColour={colours.functional.greyLabel}
       tile={tile}
+      style={styles.summaryContainer}
       isDarkStar={isDarkStar}
     />
   </TileLink>

--- a/packages/edition-slices/src/tiles/tile-o/index.js
+++ b/packages/edition-slices/src/tiles/tile-o/index.js
@@ -5,17 +5,13 @@ import { TileSummary, TileLink, withTileTracking } from "../shared";
 import styles from "./styles";
 
 const TileO = ({ isDarkStar, onPress, tile }) => (
-  <TileLink
-    onPress={onPress}
-    style={styles.container}
-    tile={tile}
-    isDarkStar={isDarkStar}
-  >
+  <TileLink onPress={onPress} style={styles.container} tile={tile}>
     <TileSummary
       flagColour={styles.flagColour}
       headlineStyle={styles.headlineStyle}
       labelColour={colours.functional.greyLabel}
       tile={tile}
+      isDarkStar={isDarkStar}
     />
   </TileLink>
 );

--- a/packages/edition-slices/src/tiles/tile-o/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-o/styles/index.js
@@ -2,6 +2,7 @@ import { fonts, spacing, colours } from "@times-components/styleguide";
 
 const styles = {
   container: {
+    flex: 1,
     backgroundColor: colours.functional.darkSupplement,
     paddingHorizontal: 12,
     paddingVertical: spacing(2)
@@ -16,6 +17,9 @@ const styles = {
     lineHeight: 22,
     marginBottom: 11,
     marginTop: spacing(1)
+  },
+  summaryContainer: {
+    flex: 1
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-p/index.js
+++ b/packages/edition-slices/src/tiles/tile-p/index.js
@@ -35,7 +35,7 @@ const TileP = ({ onPress, tile }) => {
         straplineStyle={styles.strapline}
         style={styles.summaryContainer}
         tile={tile}
-        isCenteredStar
+        centeredStar
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-p/index.js
+++ b/packages/edition-slices/src/tiles/tile-p/index.js
@@ -14,12 +14,7 @@ const TileP = ({ onPress, tile }) => {
   const crop = getTileImage(tile, "crop11");
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      withStar={false}
-    >
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <Image
         aspectRatio={1}
         relativeWidth={crop.relativeWidth}
@@ -39,9 +34,8 @@ const TileP = ({ onPress, tile }) => {
         strapline={getTileStrapline(tile)}
         straplineStyle={styles.strapline}
         style={styles.summaryContainer}
-        starStyle={styles.star}
         tile={tile}
-        withStar
+        isCenteredStar
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-p/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-p/styles/index.js
@@ -4,7 +4,6 @@ import {
   fontSizes,
   spacing
 } from "@times-components/styleguide";
-import { verticalStyles } from "../../shared/styles";
 
 const styles = {
   bylineOpinion: {
@@ -31,7 +30,6 @@ const styles = {
     overflow: "hidden",
     width: "30%"
   },
-  star: verticalStyles,
   strapline: {
     fontFamily: fonts.bodyRegular,
     color: colours.functional.secondary,

--- a/packages/edition-slices/src/tiles/tile-q/index.js
+++ b/packages/edition-slices/src/tiles/tile-q/index.js
@@ -20,7 +20,7 @@ const TileQ = ({ onPress, tile }) => {
         uri={crop.url}
         fill
       />
-      <PositionedTileStar articleId={tile.article.id} isCenteredStar />
+      <PositionedTileStar articleId={tile.article.id} centeredStar />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-q/index.js
+++ b/packages/edition-slices/src/tiles/tile-q/index.js
@@ -1,19 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
-import { getTileImage, TileLink, TileStar, withTileTracking } from "../shared";
+import { getTileImage, TileLink, withTileTracking } from "../shared";
 import styles from "./styles";
+import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileQ = ({ onPress, tile }) => {
   const crop = getTileImage(tile, "crop32");
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      withStar={false}
-    >
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <Image
         aspectRatio={3 / 2}
         relativeWidth={crop.relativeWidth}
@@ -24,7 +20,7 @@ const TileQ = ({ onPress, tile }) => {
         uri={crop.url}
         fill
       />
-      <TileStar articleId={tile.article.id} style={styles.starButton} />
+      <PositionedTileStar articleId={tile.article.id} isCenteredStar />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-q/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-q/styles/index.js
@@ -2,15 +2,11 @@ import { spacing } from "@times-components/styleguide";
 
 const styles = {
   container: {
-    alignItems: "center",
     paddingVertical: spacing(2)
   },
   imageContainer: {
     marginBottom: spacing(2),
     width: "100%"
-  },
-  starButton: {
-    textAlign: "center"
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-r/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/index.js
@@ -16,7 +16,7 @@ const TileR = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
 
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
-      <TileSummary headlineStyle={styles.headline} tile={tile} />
+      <TileSummary headlineStyle={styles.headline} tile={tile} style={styles.summaryContainer} />
       <Image
         aspectRatio={16 / 9}
         uri={crop.url}

--- a/packages/edition-slices/src/tiles/tile-r/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/index.js
@@ -16,7 +16,11 @@ const TileR = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
 
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
-      <TileSummary headlineStyle={styles.headline} tile={tile} style={styles.summaryContainer} />
+      <TileSummary
+        headlineStyle={styles.headline}
+        tile={tile}
+        style={styles.summaryContainer}
+      />
       <Image
         aspectRatio={16 / 9}
         uri={crop.url}

--- a/packages/edition-slices/src/tiles/tile-r/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/styles/index.js
@@ -12,16 +12,19 @@ const headlineFontSizeResolver = {
 
 export default breakpoint => ({
   container: {
-    paddingBottom: spacing(3),
-    paddingHorizontal: spacing(6),
-    paddingTop: spacing(3)
+    flex: 1,
+    padding: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,
     fontSize: headlineFontSizeResolver[breakpoint],
     lineHeight: headlineFontSizeResolver[breakpoint]
   },
+  imageContainer: {
+    width: "100%",
+    marginBottom: spacing(2)
+  },
   summaryContainer: {
-    paddingBottom: spacing(2)
+    flex: 1
   }
 });

--- a/packages/edition-slices/src/tiles/tile-r/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/styles/index.js
@@ -20,5 +20,8 @@ export default breakpoint => ({
     fontFamily: fonts.headline,
     fontSize: headlineFontSizeResolver[breakpoint],
     lineHeight: headlineFontSizeResolver[breakpoint]
+  },
+  summaryContainer: {
+    paddingBottom: spacing(2)
   }
 });

--- a/packages/edition-slices/src/tiles/tile-t/index.js
+++ b/packages/edition-slices/src/tiles/tile-t/index.js
@@ -11,6 +11,7 @@ import styles from "./styles";
 
 const TileT = ({ onPress, tile }) => {
   const crop = getTileImage(tile, "crop169");
+
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <Image

--- a/packages/edition-slices/src/tiles/tile-t/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-t/styles/index.js
@@ -15,8 +15,8 @@ const styles = {
     width: "50%"
   },
   summaryContainer: {
-    paddingHorizontal: spacing(2),
-    paddingVertical: spacing(1),
+    paddingLeft: spacing(2),
+    paddingBottom: spacing(1),
     width: "50%"
   }
 };

--- a/packages/edition-slices/src/tiles/tile-u/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/require-default-props */
 import React from "react";
+import { View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
 import { editionBreakpoints } from "@times-components/styleguide";
@@ -12,6 +13,7 @@ import {
 } from "../shared";
 import styleFactory from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
+import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileU = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
   const styles = styleFactory(breakpoint);
@@ -21,25 +23,22 @@ const TileU = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
     breakpoint !== editionBreakpoints.medium ? getTileSummary(tile, 800) : null;
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      withStar={false}
-    >
-      <WithoutWhiteSpace
-        styles={styles.summaryContainer}
-        render={whiteSpaceHeight => (
-          <TileSummary
-            headlineStyle={styles.headline}
-            summary={summary}
-            tile={tile}
-            withStar
-            whiteSpaceHeight={whiteSpaceHeight}
-            starStyle={styles.star}
-          />
-        )}
-      />
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
+      <View style={styles.summaryContainer}>
+        <WithoutWhiteSpace
+          render={whiteSpaceHeight => (
+            <TileSummary
+              headlineStyle={styles.headline}
+              summary={summary}
+              tile={tile}
+              whiteSpaceHeight={whiteSpaceHeight}
+              withStar={false}
+            />
+          )}
+        />
+        <PositionedTileStar articleId={tile.article.id} />
+      </View>
+
       <Image
         aspectRatio={3 / 2}
         relativeWidth={crop.relativeWidth}

--- a/packages/edition-slices/src/tiles/tile-u/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/styles/index.js
@@ -3,7 +3,6 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
-import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const sharedStyles = {
   container: {
@@ -39,8 +38,8 @@ const mediumBreakpointStyles = {
   },
   summaryContainer: {
     ...sharedStyles.summaryContainer,
-    paddingRight: spacing(4),
-    ...fullHeightSummaryContainer
+    flex: 1,
+    paddingRight: spacing(4)
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-u/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/styles/index.js
@@ -56,7 +56,6 @@ const wideBreakpointStyles = {
   },
   summaryContainer: {
     ...sharedStyles.summaryContainer,
-    paddingBottom: spacing(1),
     paddingRight: spacing(4)
   }
 };

--- a/packages/edition-slices/src/tiles/tile-u/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/styles/index.js
@@ -3,6 +3,7 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
+import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const sharedStyles = {
   container: {
@@ -38,14 +39,8 @@ const mediumBreakpointStyles = {
   },
   summaryContainer: {
     ...sharedStyles.summaryContainer,
-    paddingRight: spacing(4)
-  },
-  star: {
-    starButton: {
-      position: "absolute",
-      right: spacing(3),
-      bottom: -spacing(1)
-    }
+    paddingRight: spacing(4),
+    ...fullHeightSummaryContainer
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-v/index.js
+++ b/packages/edition-slices/src/tiles/tile-v/index.js
@@ -24,7 +24,11 @@ const TileV = ({ onPress, tile }) => {
         uri={crop.url}
         fill
       />
-      <TileSummary headlineStyle={styles.headline} tile={tile} />
+      <TileSummary
+        headlineStyle={styles.headline}
+        tile={tile}
+        style={styles.summaryContainer}
+      />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-v/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-v/styles/index.js
@@ -10,7 +10,10 @@ const styles = {
     fontFamily: fonts.headline,
     fontSize: 30,
     lineHeight: 30,
-    paddingBottom: spacing(1)
+    marginBottom: spacing(2)
+  },
+  summaryContainer: {
+    flex: 1
   },
   imageContainer: {
     marginBottom: spacing(2),

--- a/packages/edition-slices/src/tiles/tile-w/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
 import {
@@ -10,32 +11,29 @@ import {
 } from "../shared";
 import stylesFactory from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
+import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileW = ({ onPress, tile, breakpoint }) => {
   const styles = stylesFactory(breakpoint);
   const crop = getTileImage(tile, "crop32");
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      withStar={false}
-    >
-      <WithoutWhiteSpace
-        styles={styles.summaryContainer}
-        render={whiteSpaceHeight => (
-          <TileSummary
-            headlineStyle={styles.headline}
-            summary={getTileSummary(tile, 800)}
-            summaryStyle={styles.summary}
-            tile={tile}
-            withStar
-            starStyle={styles.star}
-            whiteSpaceHeight={whiteSpaceHeight}
-          />
-        )}
-      />
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
+      <View style={styles.summaryContainer}>
+        <WithoutWhiteSpace
+          render={whiteSpaceHeight => (
+            <TileSummary
+              headlineStyle={styles.headline}
+              summary={getTileSummary(tile, 800)}
+              tile={tile}
+              whiteSpaceHeight={whiteSpaceHeight}
+              withStar={false}
+            />
+          )}
+        />
+        <PositionedTileStar articleId={tile.article.id} />
+      </View>
+
       <Image
         aspectRatio={3 / 2}
         relativeWidth={crop.relativeWidth}

--- a/packages/edition-slices/src/tiles/tile-w/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/styles/index.js
@@ -62,18 +62,10 @@ const wideStyles = {
   }
 };
 
-const hugeStyles = {
-  headline: {
-    fontFamily: fonts.headline,
-    fontSize: 35,
-    lineHeight: 35
-  }
-};
-
 const stylesResolver = {
   medium: mediumStyles,
   wide: wideStyles,
-  huge: hugeStyles
+  huge: wideStyles
 };
 
 export default breakpoint => ({

--- a/packages/edition-slices/src/tiles/tile-w/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/styles/index.js
@@ -1,4 +1,5 @@
 import { fontFactory, spacing, fonts } from "@times-components/styleguide";
+import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const main = {
   container: {
@@ -46,17 +47,11 @@ const mediumStyles = {
   },
   summaryContainer: {
     width: "51.5%",
-    paddingRight: spacing(4)
+    paddingRight: spacing(4),
+    ...fullHeightSummaryContainer
   },
   imageContainer: {
     width: "48.5%"
-  },
-  star: {
-    starButton: {
-      position: "absolute",
-      right: -spacing(1),
-      bottom: -spacing(1)
-    }
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-w/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/styles/index.js
@@ -1,5 +1,4 @@
 import { fontFactory, spacing, fonts } from "@times-components/styleguide";
-import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const main = {
   container: {
@@ -18,10 +17,10 @@ const main = {
     width: "66.66%"
   },
   summaryContainer: {
+    flex: 1,
     paddingBottom: spacing(1),
     paddingRight: spacing(4),
-    width: "33.33%",
-    ...fullHeightSummaryContainer
+    width: "33.33%"
   }
 };
 
@@ -40,9 +39,9 @@ const mediumStyles = {
     marginBottom: spacing(2)
   },
   summaryContainer: {
+    flex: 1,
     width: "51.5%",
-    paddingRight: spacing(4),
-    ...fullHeightSummaryContainer
+    paddingRight: spacing(4)
   },
   imageContainer: {
     width: "48.5%"
@@ -56,9 +55,9 @@ const wideStyles = {
     lineHeight: 35
   },
   summaryContainer: {
+    flex: 1,
     width: "33.33%",
-    paddingRight: spacing(4),
-    ...fullHeightSummaryContainer
+    paddingRight: spacing(4)
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-w/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/styles/index.js
@@ -20,14 +20,8 @@ const main = {
   summaryContainer: {
     paddingBottom: spacing(1),
     paddingRight: spacing(4),
-    width: "33.33%"
-  },
-  star: {
-    alignItems: "flex-start",
-    flex: 1,
-    marginTop: spacing(-1),
-    marginLeft: spacing(5),
-    width: "75%"
+    width: "33.33%",
+    ...fullHeightSummaryContainer
   }
 };
 
@@ -56,16 +50,15 @@ const mediumStyles = {
 };
 
 const wideStyles = {
-  star: {
-    alignItems: "flex-start",
-    flex: 1,
-    marginTop: spacing(-1),
-    width: "72%"
-  },
   headline: {
     fontFamily: fonts.headline,
     fontSize: 35,
     lineHeight: 35
+  },
+  summaryContainer: {
+    width: "33.33%",
+    paddingRight: spacing(4),
+    ...fullHeightSummaryContainer
   }
 };
 
@@ -74,12 +67,6 @@ const hugeStyles = {
     fontFamily: fonts.headline,
     fontSize: 35,
     lineHeight: 35
-  },
-  star: {
-    alignItems: "flex-start",
-    flex: 1,
-    marginTop: spacing(-1),
-    width: "72%"
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-x/index.js
+++ b/packages/edition-slices/src/tiles/tile-x/index.js
@@ -10,30 +10,27 @@ import {
 } from "../shared";
 import stylesFactory from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
+import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileX = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
   const styles = stylesFactory(breakpoint);
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      starStyle={styles.star}
-    >
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <WithoutWhiteSpace
         render={whiteSpaceHeight => (
           <TileSummary
-            style={styles.summaryContainer}
             headlineStyle={styles.headline}
             strapline={getTileStrapline(tile)}
             straplineStyle={styles.strapline}
             summary={getTileSummary(tile, 800)}
             tile={tile}
             whiteSpaceHeight={whiteSpaceHeight}
+            withStar={false}
           />
         )}
       />
+      <PositionedTileStar articleId={tile.article.id} />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-x/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-x/styles/index.js
@@ -21,9 +21,6 @@ const mediumBreakpointStyles = {
     fontFamily: fonts.headlineRegular,
     fontSize: 24,
     lineHeight: 26
-  },
-  star: {
-    bottom: spacing(1)
   }
 };
 
@@ -43,9 +40,6 @@ const wideBreakpointStyles = {
       fontSize: "pageComponentHeadline"
     }),
     paddingBottom: spacing(1)
-  },
-  summaryContainer: {
-    marginHorizontal: spacing(2)
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-x/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-x/styles/index.js
@@ -30,8 +30,7 @@ const mediumBreakpointStyles = {
 const wideBreakpointStyles = {
   container: {
     flex: 1,
-    paddingHorizontal: spacing(2),
-    paddingTop: spacing(2)
+    padding: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,
@@ -46,8 +45,7 @@ const wideBreakpointStyles = {
     paddingBottom: spacing(1)
   },
   summaryContainer: {
-    marginHorizontal: spacing(2),
-    marginVertical: spacing(1)
+    marginHorizontal: spacing(2)
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-y/index.js
+++ b/packages/edition-slices/src/tiles/tile-y/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/require-default-props */
 import React from "react";
-import { View } from "react-native";
 import PropTypes from "prop-types";
 import editionBreakpoints from "@times-components/styleguide";
 import {

--- a/packages/edition-slices/src/tiles/tile-y/index.js
+++ b/packages/edition-slices/src/tiles/tile-y/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/require-default-props */
 import React from "react";
+import { View } from "react-native";
 import PropTypes from "prop-types";
 import editionBreakpoints from "@times-components/styleguide";
 import {

--- a/packages/edition-slices/src/tiles/tile-y/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-y/styles/index.js
@@ -3,6 +3,7 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
+import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const mediumBreakpointStyles = {
   container: {
@@ -16,12 +17,8 @@ const mediumBreakpointStyles = {
     lineHeight: 30,
     marginBottom: spacing(2)
   },
-  star: {
-    starButton: {
-      position: "absolute",
-      right: spacing(3),
-      bottom: 0
-    }
+  summaryContainer: {
+    ...fullHeightSummaryContainer
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-y/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-y/styles/index.js
@@ -3,7 +3,6 @@ import {
   spacing,
   editionBreakpoints
 } from "@times-components/styleguide";
-import { fullHeightSummaryContainer } from "../../shared/styles";
 
 const mediumBreakpointStyles = {
   container: {
@@ -16,9 +15,6 @@ const mediumBreakpointStyles = {
     fontSize: 30,
     lineHeight: 30,
     marginBottom: spacing(2)
-  },
-  summaryContainer: {
-    ...fullHeightSummaryContainer
   }
 };
 
@@ -32,8 +28,7 @@ const wideBreakpointStyles = {
     lineHeight: 30
   },
   summaryContainer: {
-    marginHorizontal: spacing(2),
-    ...fullHeightSummaryContainer
+    marginHorizontal: spacing(2)
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-y/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-y/styles/index.js
@@ -24,8 +24,7 @@ const mediumBreakpointStyles = {
 
 const wideBreakpointStyles = {
   container: {
-    paddingHorizontal: spacing(2),
-    paddingTop: spacing(2)
+    padding: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,
@@ -34,7 +33,7 @@ const wideBreakpointStyles = {
   },
   summaryContainer: {
     marginHorizontal: spacing(2),
-    marginVertical: spacing(1)
+    ...fullHeightSummaryContainer
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-z/index.js
+++ b/packages/edition-slices/src/tiles/tile-z/index.js
@@ -13,13 +13,12 @@ const TileZ = ({ onPress, tile }) => {
   const crop = getTileImage(tile, "crop45");
 
   return (
-    <TileLink
-      onPress={onPress}
-      style={styles.container}
-      tile={tile}
-      withStar={false}
-    >
-      <TileSummary headlineStyle={styles.headline} tile={tile} withStar />
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
+      <TileSummary
+        headlineStyle={styles.headline}
+        tile={tile}
+        style={styles.summaryContainer}
+      />
       <Image
         aspectRatio={4 / 5}
         relativeWidth={crop.relativeWidth}

--- a/packages/edition-slices/src/tiles/tile-z/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-z/styles/index.js
@@ -2,12 +2,15 @@ import { fonts, spacing } from "@times-components/styleguide";
 
 const styles = {
   container: {
-    margin: spacing(2)
+    padding: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,
     fontSize: 25,
     lineHeight: 25,
+    marginBottom: spacing(2)
+  },
+  summaryContainer: {
     marginBottom: spacing(2)
   }
 };

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
@@ -83,7 +83,6 @@ exports[`default styles 1`] = `
                         "fontFamily": "TimesDigitalW04",
                         "fontSize": 14,
                         "lineHeight": 20,
-                        "marginBottom": 10,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
@@ -106,7 +106,6 @@ exports[`default styles 1`] = `
                         "fontFamily": "TimesDigitalW04",
                         "fontSize": 14,
                         "lineHeight": 20,
-                        "marginBottom": 10,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
@@ -83,7 +83,6 @@ exports[`default styles 1`] = `
                         "fontFamily": "TimesDigitalW04",
                         "fontSize": 14,
                         "lineHeight": 20,
-                        "marginBottom": 10,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
@@ -83,7 +83,6 @@ exports[`default styles 1`] = `
                         "fontFamily": "TimesDigitalW04",
                         "fontSize": 14,
                         "lineHeight": 20,
-                        "marginBottom": 10,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
@@ -106,7 +106,6 @@ exports[`default styles 1`] = `
                         "fontFamily": "TimesDigitalW04",
                         "fontSize": 14,
                         "lineHeight": 20,
-                        "marginBottom": 10,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
@@ -83,7 +83,6 @@ exports[`default styles 1`] = `
                         "fontFamily": "TimesDigitalW04",
                         "fontSize": 14,
                         "lineHeight": 20,
-                        "marginBottom": 10,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -216,7 +216,6 @@ exports[`default styles 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 
 .S7 {
@@ -289,7 +288,7 @@ exports[`default styles 1`] = `
                     className="css-view-1dbjc4n"
                   >
                     <div
-                      className="summaryHidden leadSummary125Class summaryHidden leadSummary125Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S6"
+                      className="summaryHidden leadSummary125Class summaryHidden leadSummary125Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S6"
                     >
                       <span
                         className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -253,7 +253,6 @@ exports[`default styles 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 
 .S8 {
@@ -328,7 +327,7 @@ exports[`default styles 1`] = `
                     className="css-view-1dbjc4n"
                   >
                     <div
-                      className="summaryHidden opinionSummary125Class summaryHidden opinionSummary125Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S7"
+                      className="summaryHidden opinionSummary125Class summaryHidden opinionSummary125Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S7"
                     >
                       <span
                         className="css-text-901oao css-textHasAncestor-16my406"
@@ -339,7 +338,7 @@ exports[`default styles 1`] = `
                       </span>
                     </div>
                     <div
-                      className="summaryHidden opinionSummary160Class summaryHidden opinionSummary160Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S7"
+                      className="summaryHidden opinionSummary160Class summaryHidden opinionSummary160Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S7"
                     >
                       <span
                         className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -189,7 +189,6 @@ exports[`default styles 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 10px;
 }
 
 .S7 {
@@ -262,7 +261,7 @@ exports[`default styles 1`] = `
                     className="css-view-1dbjc4n"
                   >
                     <div
-                      className="summaryHidden summary125Class summaryHidden summary125Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S6"
+                      className="summaryHidden summary125Class summaryHidden summary125Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S6"
                     >
                       <span
                         className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/slice-layout/__tests__/android/__snapshots__/l2np2-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/l2np2-with-style.android.test.js.snap
@@ -165,7 +165,6 @@ exports[`3. lead two no pic and two - wide 1`] = `
   <View
     style={
       Object {
-        "paddingTop": 10,
         "width": "16%",
       }
     }
@@ -245,7 +244,6 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "paddingTop": 10,
         "width": "16%",
       }
     }

--- a/packages/slice-layout/__tests__/android/__snapshots__/s1andc-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/s1andc-with-style.android.test.js.snap
@@ -6,7 +6,7 @@ exports[`1. secondary one and columnist - small 1`] = `
     Object {
       "flex": 1,
       "flexDirection": "row",
-      "paddingHorizontal": 20,
+      "marginHorizontal": 20,
     }
   }
 >
@@ -27,7 +27,7 @@ exports[`1. secondary one and columnist - small 1`] = `
         "borderColor": "#DBDBDB",
         "borderRightWidth": 1,
         "borderStyle": "solid",
-        "marginVertical": 10,
+        "marginVertical": 15,
       }
     }
   />
@@ -51,7 +51,7 @@ exports[`2. secondary one and columnist - medium 1`] = `
     Object {
       "flex": 1,
       "flexDirection": "row",
-      "paddingHorizontal": 20,
+      "marginHorizontal": 20,
     }
   }
 >
@@ -72,7 +72,7 @@ exports[`2. secondary one and columnist - medium 1`] = `
         "borderColor": "#DBDBDB",
         "borderRightWidth": 1,
         "borderStyle": "solid",
-        "marginVertical": 10,
+        "marginVertical": 15,
       }
     }
   />

--- a/packages/slice-layout/__tests__/android/__snapshots__/sd1and4-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/sd1and4-with-style.android.test.js.snap
@@ -38,7 +38,13 @@ exports[`1. secondary one and four - small 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-1
       </Text>
@@ -53,7 +59,13 @@ exports[`1. secondary one and four - small 1`] = `
         }
       }
     />
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-3
       </Text>
@@ -76,7 +88,13 @@ exports[`1. secondary one and four - small 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-2
       </Text>
@@ -91,7 +109,13 @@ exports[`1. secondary one and four - small 1`] = `
         }
       }
     />
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-4
       </Text>
@@ -138,7 +162,13 @@ exports[`2. secondary one and four - medium 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-1
       </Text>
@@ -153,7 +183,13 @@ exports[`2. secondary one and four - medium 1`] = `
         }
       }
     />
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-3
       </Text>
@@ -176,7 +212,13 @@ exports[`2. secondary one and four - medium 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-2
       </Text>
@@ -191,7 +233,13 @@ exports[`2. secondary one and four - medium 1`] = `
         }
       }
     />
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-4
       </Text>

--- a/packages/slice-layout/__tests__/ios/__snapshots__/l2np2-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/l2np2-with-style.ios.test.js.snap
@@ -165,7 +165,6 @@ exports[`3. lead two no pic and two - wide 1`] = `
   <View
     style={
       Object {
-        "paddingTop": 10,
         "width": "16%",
       }
     }
@@ -245,7 +244,6 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "paddingTop": 10,
         "width": "16%",
       }
     }

--- a/packages/slice-layout/__tests__/ios/__snapshots__/s1andc-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/s1andc-with-style.ios.test.js.snap
@@ -6,7 +6,7 @@ exports[`1. secondary one and columnist - small 1`] = `
     Object {
       "flex": 1,
       "flexDirection": "row",
-      "paddingHorizontal": 20,
+      "marginHorizontal": 20,
     }
   }
 >
@@ -27,7 +27,7 @@ exports[`1. secondary one and columnist - small 1`] = `
         "borderColor": "#DBDBDB",
         "borderRightWidth": 1,
         "borderStyle": "solid",
-        "marginVertical": 10,
+        "marginVertical": 15,
       }
     }
   />
@@ -51,7 +51,7 @@ exports[`2. secondary one and columnist - medium 1`] = `
     Object {
       "flex": 1,
       "flexDirection": "row",
-      "paddingHorizontal": 20,
+      "marginHorizontal": 20,
     }
   }
 >
@@ -72,7 +72,7 @@ exports[`2. secondary one and columnist - medium 1`] = `
         "borderColor": "#DBDBDB",
         "borderRightWidth": 1,
         "borderStyle": "solid",
-        "marginVertical": 10,
+        "marginVertical": 15,
       }
     }
   />

--- a/packages/slice-layout/__tests__/ios/__snapshots__/sd1and4-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/sd1and4-with-style.ios.test.js.snap
@@ -38,7 +38,13 @@ exports[`1. secondary one and four - small 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-1
       </Text>
@@ -53,7 +59,13 @@ exports[`1. secondary one and four - small 1`] = `
         }
       }
     />
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-3
       </Text>
@@ -76,7 +88,13 @@ exports[`1. secondary one and four - small 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-2
       </Text>
@@ -91,7 +109,13 @@ exports[`1. secondary one and four - small 1`] = `
         }
       }
     />
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-4
       </Text>
@@ -138,7 +162,13 @@ exports[`2. secondary one and four - medium 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-1
       </Text>
@@ -153,7 +183,13 @@ exports[`2. secondary one and four - medium 1`] = `
         }
       }
     />
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-3
       </Text>
@@ -176,7 +212,13 @@ exports[`2. secondary one and four - medium 1`] = `
       }
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-2
       </Text>
@@ -191,7 +233,13 @@ exports[`2. secondary one and four - medium 1`] = `
         }
       }
     />
-    <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
       <Text>
         support-4
       </Text>

--- a/packages/slice-layout/__tests__/web/__snapshots__/l2np2-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/l2np2-with-style.web.test.js.snap
@@ -279,7 +279,6 @@ exports[`3. lead two no pic and two - wide 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "paddingTop": "10px",
         "width": "16%",
       }
     }
@@ -403,7 +402,6 @@ exports[`4. lead two no pic and two - huge 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "paddingTop": "10px",
         "width": "16%",
       }
     }

--- a/packages/slice-layout/__tests__/web/__snapshots__/s1andc-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/s1andc-with-style.web.test.js.snap
@@ -16,12 +16,12 @@ exports[`1. secondary one and columnist - small 1`] = `
       "flexDirection": "row",
       "flexGrow": 1,
       "flexShrink": 1,
+      "marginLeft": "20px",
+      "marginRight": "20px",
       "msFlexDirection": "row",
       "msFlexNegative": 1,
       "msFlexPositive": 1,
       "msFlexPreferredSize": "0%",
-      "paddingLeft": "20px",
-      "paddingRight": "20px",
     }
   }
 >
@@ -52,8 +52,8 @@ exports[`1. secondary one and columnist - small 1`] = `
         "borderRightWidth": "1px",
         "borderTopColor": "rgba(219,219,219,1.00)",
         "borderTopStyle": "solid",
-        "marginBottom": "10px",
-        "marginTop": "10px",
+        "marginBottom": "15px",
+        "marginTop": "15px",
       }
     }
   />
@@ -90,12 +90,12 @@ exports[`2. secondary one and columnist - medium 1`] = `
       "flexDirection": "row",
       "flexGrow": 1,
       "flexShrink": 1,
+      "marginLeft": "20px",
+      "marginRight": "20px",
       "msFlexDirection": "row",
       "msFlexNegative": 1,
       "msFlexPositive": 1,
       "msFlexPreferredSize": "0%",
-      "paddingLeft": "20px",
-      "paddingRight": "20px",
     }
   }
 >
@@ -126,8 +126,8 @@ exports[`2. secondary one and columnist - medium 1`] = `
         "borderRightWidth": "1px",
         "borderTopColor": "rgba(219,219,219,1.00)",
         "borderTopStyle": "solid",
-        "marginBottom": "10px",
-        "marginTop": "10px",
+        "marginBottom": "15px",
+        "marginTop": "15px",
       }
     }
   />

--- a/packages/slice-layout/__tests__/web/__snapshots__/sd1and4-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/sd1and4-with-style.web.test.js.snap
@@ -49,7 +49,22 @@ exports[`1. secondary one and four - small 1`] = `
       }
     }
   >
-    <div>
+    <div
+      style={
+        Object {
+          "WebkitBoxFlex": 1,
+          "WebkitFlexBasis": "0%",
+          "WebkitFlexGrow": 1,
+          "WebkitFlexShrink": 1,
+          "flexBasis": "0%",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "msFlexNegative": 1,
+          "msFlexPositive": 1,
+          "msFlexPreferredSize": "0%",
+        }
+      }
+    >
       <div>
         support-1
       </div>
@@ -71,7 +86,22 @@ exports[`1. secondary one and four - small 1`] = `
         }
       }
     />
-    <div>
+    <div
+      style={
+        Object {
+          "WebkitBoxFlex": 1,
+          "WebkitFlexBasis": "0%",
+          "WebkitFlexGrow": 1,
+          "WebkitFlexShrink": 1,
+          "flexBasis": "0%",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "msFlexNegative": 1,
+          "msFlexPositive": 1,
+          "msFlexPreferredSize": "0%",
+        }
+      }
+    >
       <div>
         support-3
       </div>
@@ -101,7 +131,22 @@ exports[`1. secondary one and four - small 1`] = `
       }
     }
   >
-    <div>
+    <div
+      style={
+        Object {
+          "WebkitBoxFlex": 1,
+          "WebkitFlexBasis": "0%",
+          "WebkitFlexGrow": 1,
+          "WebkitFlexShrink": 1,
+          "flexBasis": "0%",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "msFlexNegative": 1,
+          "msFlexPositive": 1,
+          "msFlexPreferredSize": "0%",
+        }
+      }
+    >
       <div>
         support-2
       </div>
@@ -123,7 +168,22 @@ exports[`1. secondary one and four - small 1`] = `
         }
       }
     />
-    <div>
+    <div
+      style={
+        Object {
+          "WebkitBoxFlex": 1,
+          "WebkitFlexBasis": "0%",
+          "WebkitFlexGrow": 1,
+          "WebkitFlexShrink": 1,
+          "flexBasis": "0%",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "msFlexNegative": 1,
+          "msFlexPositive": 1,
+          "msFlexPreferredSize": "0%",
+        }
+      }
+    >
       <div>
         support-4
       </div>
@@ -181,7 +241,22 @@ exports[`2. secondary one and four - medium 1`] = `
       }
     }
   >
-    <div>
+    <div
+      style={
+        Object {
+          "WebkitBoxFlex": 1,
+          "WebkitFlexBasis": "0%",
+          "WebkitFlexGrow": 1,
+          "WebkitFlexShrink": 1,
+          "flexBasis": "0%",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "msFlexNegative": 1,
+          "msFlexPositive": 1,
+          "msFlexPreferredSize": "0%",
+        }
+      }
+    >
       <div>
         support-1
       </div>
@@ -203,7 +278,22 @@ exports[`2. secondary one and four - medium 1`] = `
         }
       }
     />
-    <div>
+    <div
+      style={
+        Object {
+          "WebkitBoxFlex": 1,
+          "WebkitFlexBasis": "0%",
+          "WebkitFlexGrow": 1,
+          "WebkitFlexShrink": 1,
+          "flexBasis": "0%",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "msFlexNegative": 1,
+          "msFlexPositive": 1,
+          "msFlexPreferredSize": "0%",
+        }
+      }
+    >
       <div>
         support-3
       </div>
@@ -233,7 +323,22 @@ exports[`2. secondary one and four - medium 1`] = `
       }
     }
   >
-    <div>
+    <div
+      style={
+        Object {
+          "WebkitBoxFlex": 1,
+          "WebkitFlexBasis": "0%",
+          "WebkitFlexGrow": 1,
+          "WebkitFlexShrink": 1,
+          "flexBasis": "0%",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "msFlexNegative": 1,
+          "msFlexPositive": 1,
+          "msFlexPreferredSize": "0%",
+        }
+      }
+    >
       <div>
         support-2
       </div>
@@ -255,7 +360,22 @@ exports[`2. secondary one and four - medium 1`] = `
         }
       }
     />
-    <div>
+    <div
+      style={
+        Object {
+          "WebkitBoxFlex": 1,
+          "WebkitFlexBasis": "0%",
+          "WebkitFlexGrow": 1,
+          "WebkitFlexShrink": 1,
+          "flexBasis": "0%",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "msFlexNegative": 1,
+          "msFlexPositive": 1,
+          "msFlexPreferredSize": "0%",
+        }
+      }
+    >
       <div>
         support-4
       </div>

--- a/packages/slice-layout/src/templates/leadtwonopicandtwo/styles.js
+++ b/packages/slice-layout/src/templates/leadtwonopicandtwo/styles.js
@@ -31,7 +31,6 @@ const wideBreakpointStyles = {
     width: "42%"
   },
   middleTile: {
-    paddingTop: spacing(2),
     width: "16%"
   }
 };

--- a/packages/slice-layout/src/templates/secondaryoneandcolumnist/index.js
+++ b/packages/slice-layout/src/templates/secondaryoneandcolumnist/index.js
@@ -22,6 +22,7 @@ const SecondaryOneAndColumnistSlice = ({
         { style: styles.columnistContainer, tile: columnist },
         { style: styles.secondaryContainer, tile: secondary }
       ]}
+      colSeparatorStyle={styles.colSeparator}
     />
   );
 };

--- a/packages/slice-layout/src/templates/secondaryoneandcolumnist/styles.js
+++ b/packages/slice-layout/src/templates/secondaryoneandcolumnist/styles.js
@@ -3,19 +3,19 @@ import { editionBreakpoints, spacing } from "@times-components/styleguide";
 const smallBreakpointStyles = {};
 
 const mediumBreakpointStyles = {
-  columnistContainer: {
-    width: "73%"
-  },
   container: {
     flex: 1,
     flexDirection: "row",
-    paddingHorizontal: spacing(4)
+    marginHorizontal: spacing(4)
+  },
+  columnistContainer: {
+    width: "73%"
   },
   secondaryContainer: {
     width: "27%"
   },
-  separator: {
-    marginBottom: 0
+  colSeparator: {
+    marginVertical: spacing(3)
   }
 };
 

--- a/packages/slice-layout/src/templates/secondaryoneandfour/index.js
+++ b/packages/slice-layout/src/templates/secondaryoneandfour/index.js
@@ -34,7 +34,6 @@ const SecondaryOneAndFourSlice = ({
         <View>{secondary}</View>
       </View>
       <ItemColSeparator style={styles.separator} />
-
       <View style={styles.itemContainer}>
         <View style={styles.item}>{support1}</View>
         <ItemRowSeparator style={styles.separator} />

--- a/packages/slice-layout/src/templates/secondaryoneandfour/styles.js
+++ b/packages/slice-layout/src/templates/secondaryoneandfour/styles.js
@@ -20,6 +20,9 @@ const mediumBreakpointStyles = {
   itemContainer: {
     width: "25%"
   },
+  item: {
+    flex: 1
+  },
   secondaryItemContainer: {
     width: "50%"
   },

--- a/packages/star-button/__tests__/android/__snapshots__/star-button.android.test.js.snap
+++ b/packages/star-button/__tests__/android/__snapshots__/star-button.android.test.js.snap
@@ -6,10 +6,11 @@ exports[`1. renders default 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": 5,
         "width": 28,
       },
       null,
@@ -31,10 +32,11 @@ exports[`2. renders selected 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": 5,
         "width": 28,
       },
       null,
@@ -56,10 +58,11 @@ exports[`3. renders disabled 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": 5,
         "width": 28,
       },
       null,
@@ -81,10 +84,11 @@ exports[`4. renders default in dark theme 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": 5,
         "width": 28,
       },
       null,
@@ -106,10 +110,11 @@ exports[`5. renders selected in dark theme 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": 5,
         "width": 28,
       },
       null,
@@ -131,10 +136,11 @@ exports[`6. renders disabled in dark theme 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": 5,
         "width": 28,
       },
       null,

--- a/packages/star-button/__tests__/ios/__snapshots__/star-button.ios.test.js.snap
+++ b/packages/star-button/__tests__/ios/__snapshots__/star-button.ios.test.js.snap
@@ -6,10 +6,11 @@ exports[`1. renders default 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": 5,
         "width": 28,
       },
       null,
@@ -31,10 +32,11 @@ exports[`2. renders selected 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": 5,
         "width": 28,
       },
       null,
@@ -56,10 +58,11 @@ exports[`3. renders disabled 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": 5,
         "width": 28,
       },
       null,
@@ -81,10 +84,11 @@ exports[`4. renders default in dark theme 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": 5,
         "width": 28,
       },
       null,
@@ -106,10 +110,11 @@ exports[`5. renders selected in dark theme 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": 5,
         "width": 28,
       },
       null,
@@ -131,10 +136,11 @@ exports[`6. renders disabled in dark theme 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": 5,
         "width": 28,
       },
       null,

--- a/packages/star-button/__tests__/web/__snapshots__/star-button.web.test.js.snap
+++ b/packages/star-button/__tests__/web/__snapshots__/star-button.web.test.js.snap
@@ -6,10 +6,11 @@ exports[`1. renders default 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": "5px",
         "width": 28,
       },
       null,
@@ -31,10 +32,11 @@ exports[`2. renders selected 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": "5px",
         "width": 28,
       },
       null,
@@ -56,10 +58,11 @@ exports[`3. renders disabled 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": "5px",
         "width": 28,
       },
       null,
@@ -81,10 +84,11 @@ exports[`4. renders default in dark theme 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": "5px",
         "width": 28,
       },
       null,
@@ -106,10 +110,11 @@ exports[`5. renders selected in dark theme 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": "5px",
         "width": 28,
       },
       null,
@@ -131,10 +136,11 @@ exports[`6. renders disabled in dark theme 1`] = `
   linkStyle={
     Array [
       Object {
+        "alignItems": "center",
         "borderRadius": 9999,
         "height": 28,
+        "justifyContent": "center",
         "overflow": "hidden",
-        "padding": "5px",
         "width": 28,
       },
       null,

--- a/packages/star-button/package.json
+++ b/packages/star-button/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "@times-components/icons": "2.12.9",
     "@times-components/link": "3.4.38",
-    "@times-components/styleguide": "3.28.42",
     "prop-types": "15.7.2"
   },
   "peerDependencies": {

--- a/packages/star-button/src/styles/index.js
+++ b/packages/star-button/src/styles/index.js
@@ -4,8 +4,8 @@ const styles = {
     height: 28,
     overflow: "hidden",
     width: 28,
-    alignItems: 'center',
-    justifyContent: 'center'
+    alignItems: "center",
+    justifyContent: "center"
   }
 };
 

--- a/packages/star-button/src/styles/index.js
+++ b/packages/star-button/src/styles/index.js
@@ -1,12 +1,11 @@
-import { spacing } from "@times-components/styleguide";
-
 const styles = {
   container: {
     borderRadius: 9999,
     height: 28,
     overflow: "hidden",
-    padding: spacing(1),
-    width: 28
+    width: 28,
+    alignItems: 'center',
+    justifyContent: 'center'
   }
 };
 


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/REPLAT-7336

Prior to this time, the tile star had an absolute positioning that caused issues with the star itself overlapping the content and insufficient space around it.

The new slices' designs set a rule for the star positioning - 15pt above the bottom line of the slice.

This PR suggests replacing the absolute positioning with flex-end alignment. PositionedTileStar component is introduced that helps to push the star to the bottom of its parent's container.
The default place for the tile star would be the tile summary container. And when a tile needs a dynamic teaser text, the tile star has to be moved out of its default place and lifted up to the TileLink component.

Screenshots:
![Screenshot_1565609958](https://user-images.githubusercontent.com/16742525/62866395-563a3c80-bd19-11e9-93bd-9847fdfad961.png)
![Screenshot_1565610023](https://user-images.githubusercontent.com/16742525/62866407-5b978700-bd19-11e9-8e7e-0f5017ba465b.png)
![Screenshot_1565610008](https://user-images.githubusercontent.com/16742525/62866409-5b978700-bd19-11e9-8ebb-6bef4d24222d.png)
![Screenshot_1565609995](https://user-images.githubusercontent.com/16742525/62866410-5b978700-bd19-11e9-8e39-904eea47c32a.png)
![Screenshot_1565609980](https://user-images.githubusercontent.com/16742525/62866411-5b978700-bd19-11e9-9cf2-0e73c5bd9af9.png)
![Screenshot_1565610048](https://user-images.githubusercontent.com/16742525/62866430-67834900-bd19-11e9-9ba4-f58ea2e18bc8.png)
![Screenshot_1565610056](https://user-images.githubusercontent.com/16742525/62866431-681bdf80-bd19-11e9-9156-ca977afdb020.png)
![Screenshot_1565610068](https://user-images.githubusercontent.com/16742525/62866433-681bdf80-bd19-11e9-9a96-601a96ea693e.png)
![Screenshot_1565610082](https://user-images.githubusercontent.com/16742525/62866434-681bdf80-bd19-11e9-9a54-5651e553d54b.png)
![Screenshot_1565610134](https://user-images.githubusercontent.com/16742525/62866435-681bdf80-bd19-11e9-8ce4-181d6935ba95.png)
