### PR TITLE
fix: REPLAT-7036 delay android animation when scrolling

### DIFF
--- a/packages/link/src/link.android.js
+++ b/packages/link/src/link.android.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 
 const Link = ({ children, linkStyle, onPress, disabled }) => (
   <TouchableNativeFeedback
-    delayPressIn={0}
+    delayPressIn={100}
     disabled={disabled}
     onPress={onPress}
     useForeground={TouchableNativeFeedback.canUseNativeForeground()}


### PR DESCRIPTION
Just delay the native android touch event slightly so that it doesn't trigger when swiping and scrolling.
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
