### PR TITLE
feat: REPLAT-7421 lead1and4 styling tablet

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -861,7 +861,7 @@ exports[`12. lead one and four slice - medium 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "60%",
         }
       }
     >
@@ -880,7 +880,7 @@ exports[`12. lead one and four slice - medium 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "40%",
         }
       }
     >
@@ -2008,7 +2008,7 @@ exports[`27. lead one and four slice - wide 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "60%",
         }
       }
     >
@@ -2027,7 +2027,7 @@ exports[`27. lead one and four slice - wide 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "40%",
         }
       }
     >
@@ -3340,7 +3340,7 @@ exports[`42. lead one and four slice - huge 1`] = `
       <View
         style={
           Object {
-            "width": "50%",
+            "width": "60%",
           }
         }
       >
@@ -3359,7 +3359,7 @@ exports[`42. lead one and four slice - huge 1`] = `
       <View
         style={
           Object {
-            "width": "50%",
+            "width": "40%",
           }
         }
       >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -1898,7 +1898,7 @@ exports[`37. tile ad 1`] = `
           "fontSize": 20,
           "fontWeight": "400",
           "lineHeight": 20,
-          "marginBottom": 5,
+          "marginBottom": 0,
         }
       }
     >
@@ -1942,12 +1942,12 @@ exports[`38. tile ac 1`] = `
     <Text
       style={
         Object {
-          "color": "#333333",
+          "color": "#1D1D1B",
           "fontFamily": "TimesModern-Bold",
           "fontSize": 30,
           "fontWeight": "400",
           "lineHeight": 30,
-          "marginBottom": 10,
+          "marginBottom": 0,
           "textAlign": "center",
         }
       }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -1557,6 +1557,7 @@ exports[`37. tile ad 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "flexDirection": "row",
       "padding": 10,
     }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -861,7 +861,7 @@ exports[`12. lead one and four slice - medium 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "60%",
         }
       }
     >
@@ -880,7 +880,7 @@ exports[`12. lead one and four slice - medium 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "40%",
         }
       }
     >
@@ -2008,7 +2008,7 @@ exports[`27. lead one and four slice - wide 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "60%",
         }
       }
     >
@@ -2027,7 +2027,7 @@ exports[`27. lead one and four slice - wide 1`] = `
     <View
       style={
         Object {
-          "width": "50%",
+          "width": "40%",
         }
       }
     >
@@ -3340,7 +3340,7 @@ exports[`42. lead one and four slice - huge 1`] = `
       <View
         style={
           Object {
-            "width": "50%",
+            "width": "60%",
           }
         }
       >
@@ -3359,7 +3359,7 @@ exports[`42. lead one and four slice - huge 1`] = `
       <View
         style={
           Object {
-            "width": "50%",
+            "width": "40%",
           }
         }
       >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -1898,7 +1898,7 @@ exports[`37. tile ad 1`] = `
           "fontSize": 20,
           "fontWeight": "900",
           "lineHeight": 20,
-          "marginBottom": 5,
+          "marginBottom": 0,
         }
       }
     >
@@ -1942,12 +1942,12 @@ exports[`38. tile ac 1`] = `
     <Text
       style={
         Object {
-          "color": "#333333",
+          "color": "#1D1D1B",
           "fontFamily": "TimesModern-Bold",
           "fontSize": 30,
           "fontWeight": "900",
           "lineHeight": 30,
-          "marginBottom": 10,
+          "marginBottom": 0,
           "textAlign": "center",
         }
       }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -1557,6 +1557,7 @@ exports[`37. tile ad 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "flexDirection": "row",
       "padding": 10,
     }

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -1039,7 +1039,7 @@ exports[`3. lead one and one 1`] = `
 exports[`4. lead one and four 1`] = `
 <style>
 .IS1 {
-  width: 50%;
+  width: 60%;
 }
 
 .IS2 {
@@ -1099,7 +1099,7 @@ exports[`4. lead one and four 1`] = `
 }
 
 .IS6 {
-  width: 50%;
+  width: 40%;
 }
 
 .IS7 {

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1275,7 +1275,7 @@ exports[`11. secondary two and two - medium 1`] = `
 exports[`12. lead one and four slice - medium 1`] = `
 <style>
 .IS1 {
-  width: 50%;
+  width: 60%;
 }
 
 .IS2 {
@@ -1335,7 +1335,7 @@ exports[`12. lead one and four slice - medium 1`] = `
 }
 
 .IS6 {
-  width: 50%;
+  width: 40%;
 }
 
 .IS7 {
@@ -3093,7 +3093,7 @@ exports[`26. secondary two and two - wide 1`] = `
 exports[`27. lead one and four slice - wide 1`] = `
 <style>
 .IS1 {
-  width: 50%;
+  width: 60%;
 }
 
 .IS2 {
@@ -3153,7 +3153,7 @@ exports[`27. lead one and four slice - wide 1`] = `
 }
 
 .IS6 {
-  width: 50%;
+  width: 40%;
 }
 
 .IS7 {
@@ -4911,7 +4911,7 @@ exports[`41. secondary two and two - huge 1`] = `
 exports[`42. lead one and four slice - huge 1`] = `
 <style>
 .IS1 {
-  width: 50%;
+  width: 60%;
 }
 
 .IS2 {
@@ -4971,7 +4971,7 @@ exports[`42. lead one and four slice - huge 1`] = `
 }
 
 .IS6 {
-  width: 50%;
+  width: 40%;
 }
 
 .IS7 {

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -3030,7 +3030,7 @@ exports[`37. tile ad 1`] = `
   font-family: TimesModern-Bold;
   font-weight: 400;
   line-height: 20px;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
 }
 
 .IS1 {
@@ -3051,6 +3051,7 @@ exports[`37. tile ad 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "flexDirection": "row",
       "padding": "10px",
     }
@@ -3077,7 +3078,7 @@ exports[`37. tile ad 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-p1pxzi IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -3103,10 +3104,9 @@ exports[`38. tile ac 1`] = `
 }
 
 .S2 {
-  color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 10px;
+  margin-bottom: 0px;
 }
 
 .IS1 {
@@ -3114,6 +3114,7 @@ exports[`38. tile ac 1`] = `
 }
 
 .IS2 {
+  color: rgba(29,29,27,1.00);
   font-size: 30px;
   line-height: 30px;
   text-align: center;
@@ -3175,7 +3176,7 @@ exports[`38. tile ac 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
       role="heading"
     >
       This is tile headline

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -1555,6 +1555,7 @@ exports[`37. tile ad 1`] = `
 <Link
   linkStyle={
     Object {
+      "flex": 1,
       "flexDirection": "row",
       "padding": "10px",
     }

--- a/packages/edition-slices/src/tiles/tile-ac/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ac/styles/index.js
@@ -19,10 +19,11 @@ export default breakpoint => ({
     padding: spacing(2)
   },
   headline: {
+    color: colours.functional.brandColour,
     fontFamily: fonts.headline,
     fontSize: headlineFontSizeResolver[breakpoint],
     lineHeight: headlineFontSizeResolver[breakpoint],
-    marginBottom: spacing(2),
+    marginBottom: 0,
     textAlign: "center"
   },
   imageContainer: {

--- a/packages/edition-slices/src/tiles/tile-ad/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/styles/index.js
@@ -11,15 +11,17 @@ const headlineFontSizeResolver = {
   [editionBreakpoints.medium]: 20
 };
 
-export default breakpoint => ({
+const styles = breakpoint => ({
   container: {
+    flex: 1,
     flexDirection: "row",
     padding: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,
     fontSize: headlineFontSizeResolver[breakpoint],
-    lineHeight: headlineFontSizeResolver[breakpoint]
+    lineHeight: headlineFontSizeResolver[breakpoint],
+    marginBottom: 0
   },
   imageContainer: {
     width: "30%"
@@ -29,3 +31,14 @@ export default breakpoint => ({
     width: "70%"
   }
 });
+
+const mediumBreakpointStyles = {
+  summaryContainer: {
+    width: "100%"
+  }
+};
+
+export default breakpoint =>
+  breakpoint === editionBreakpoints.medium
+    ? { ...styles(breakpoint), ...mediumBreakpointStyles }
+    : styles(breakpoint);

--- a/packages/slice-layout/__tests__/android/__snapshots__/l1and4-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/l1and4-with-style.android.test.js.snap
@@ -66,7 +66,7 @@ exports[`2. lead one and four - medium 1`] = `
   <View
     style={
       Object {
-        "width": "50%",
+        "width": "60%",
       }
     }
   >
@@ -87,7 +87,7 @@ exports[`2. lead one and four - medium 1`] = `
   <View
     style={
       Object {
-        "width": "50%",
+        "width": "40%",
       }
     }
   >

--- a/packages/slice-layout/__tests__/ios/__snapshots__/l1and4-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/l1and4-with-style.ios.test.js.snap
@@ -66,7 +66,7 @@ exports[`2. lead one and four - medium 1`] = `
   <View
     style={
       Object {
-        "width": "50%",
+        "width": "60%",
       }
     }
   >
@@ -87,7 +87,7 @@ exports[`2. lead one and four - medium 1`] = `
   <View
     style={
       Object {
-        "width": "50%",
+        "width": "40%",
       }
     }
   >

--- a/packages/slice-layout/__tests__/web/__snapshots__/l1and4-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/l1and4-with-style.web.test.js.snap
@@ -119,7 +119,7 @@ exports[`2. lead one and four - medium 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "50%",
+        "width": "60%",
       }
     }
   >
@@ -151,7 +151,7 @@ exports[`2. lead one and four - medium 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "50%",
+        "width": "40%",
       }
     }
   >

--- a/packages/slice-layout/src/templates/leadoneandfour/styles.js
+++ b/packages/slice-layout/src/templates/leadoneandfour/styles.js
@@ -8,10 +8,10 @@ const mediumBreakpointStyles = {
     paddingVertical: spacing(1)
   },
   leadContainer: {
-    width: "50%"
+    width: "60%"
   },
   supportContainer: {
-    width: "50%"
+    width: "40%"
   }
 };
 


### PR DESCRIPTION
[Jira story.](https://nidigitalsolutions.jira.com/browse/REPLAT-7421)

Lead one and four slice tablet styles updated according to [this design](https://app.zeplin.io/project/5d2849a2b4a4605645afb4be/screen/5d2c84226b3c9a4d03e881bd).

<img width="666" alt="lead-one-and-four-ios" src="https://user-images.githubusercontent.com/8720661/63010810-be129380-be8f-11e9-8d94-059db6b64a7a.png">


This is how it's going to look with the stars on Android after [this PR](https://github.com/newsuk/times-components/pull/2171) is merged:

<img width="582" alt="lead-one-and-four-ratio" src="https://user-images.githubusercontent.com/8720661/63010831-cb2f8280-be8f-11e9-945e-266814c2b7cd.png">
