### PR TITLE
feat: update secondary2NoPicAnd2 for 768px

### DIFF
--- a/packages/article-summary/src/article-summary-content.js
+++ b/packages/article-summary/src/article-summary-content.js
@@ -5,9 +5,13 @@ import { propTypes as treePropType } from "@times-components/markup-forest";
 import { renderAst } from "./article-summary";
 import styles from "./styles";
 
-const initialLines = 2;
-
-const ArticleSummaryContent = ({ ast, className, style, whiteSpaceHeight }) => {
+const ArticleSummaryContent = ({
+  ast,
+  className,
+  style,
+  whiteSpaceHeight,
+  initialLines = 2
+}) => {
   const lineHeight = (style && style.lineHeight) || styles.text.lineHeight;
   const numberOfLinesToRender =
     whiteSpaceHeight > 0

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -23,7 +23,7 @@ class TileSummary extends Component {
       summary,
       summaryStyle,
       whiteSpaceHeight,
-      linesOfTeserToRender
+      linesOfTeaserToRender
     } = this.props;
 
     return (
@@ -31,7 +31,7 @@ class TileSummary extends Component {
         ast={summary}
         style={summaryStyle}
         whiteSpaceHeight={whiteSpaceHeight}
-        initialLines={linesOfTeserToRender}
+        initialLines={linesOfTeaserToRender}
       />
     );
   }

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -19,13 +19,19 @@ class TileSummary extends Component {
   }
 
   renderContent() {
-    const { summary, summaryStyle, whiteSpaceHeight } = this.props;
+    const {
+      summary,
+      summaryStyle,
+      whiteSpaceHeight,
+      linesOfTeserToRender
+    } = this.props;
 
     return (
       <ArticleSummaryContent
         ast={summary}
         style={summaryStyle}
         whiteSpaceHeight={whiteSpaceHeight}
+        initialLines={linesOfTeserToRender}
       />
     );
   }

--- a/packages/edition-slices/src/tiles/tile-ae/index.js
+++ b/packages/edition-slices/src/tiles/tile-ae/index.js
@@ -20,7 +20,7 @@ const TileAE = ({ onPress, tile }) => (
           tile={tile}
           whiteSpaceHeight={whiteSpaceHeight}
           withStar={false}
-          linesOfTeserToRender={5}
+          linesOfTeaserToRender={5}
         />
       )}
     />

--- a/packages/edition-slices/src/tiles/tile-ae/index.js
+++ b/packages/edition-slices/src/tiles/tile-ae/index.js
@@ -20,6 +20,7 @@ const TileAE = ({ onPress, tile }) => (
           tile={tile}
           whiteSpaceHeight={whiteSpaceHeight}
           withStar={false}
+          linesOfTeserToRender={5}
         />
       )}
     />


### PR DESCRIPTION
Jira: https://nidigitalsolutions.jira.com/browse/REPLAT-7498

Update SecondaryTwoNoPicAndTwo so it can have minimum 5 lines of teaser text for both upper Tiles (TileAE).

**Before:** 
![beforeS](https://user-images.githubusercontent.com/7889661/63169325-2f447900-c03f-11e9-9cb7-fa6bfdf50478.png)

**=============================================================**

**After:** 
![afterS](https://user-images.githubusercontent.com/7889661/63169343-3a97a480-c03f-11e9-8f99-7961c3fd08b7.png)
