### PR TITLE
feat: Updating the gutter of the edition slices and the item separator

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1181,7 +1181,7 @@ exports[`16. comment lead and cartoon - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1234,7 +1234,7 @@ exports[`17. daily universal register - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1340,7 +1340,7 @@ exports[`18. lead one and one - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1392,7 +1392,7 @@ exports[`19. lead one full width - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1407,7 +1407,7 @@ exports[`20. lead two no pic and two - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1489,7 +1489,7 @@ exports[`21. leaders slice - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1619,7 +1619,7 @@ exports[`22. secondary one and four - wide 1`] = `
       Object {
         "alignSelf": "center",
         "maxWidth": "100%",
-        "paddingHorizontal": 10,
+        "paddingHorizontal": 30,
         "width": 1366,
       }
     }
@@ -1776,7 +1776,7 @@ exports[`23. secondary one - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1791,7 +1791,7 @@ exports[`24. secondary four - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1884,7 +1884,7 @@ exports[`25. secondary one and columnist - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1936,7 +1936,7 @@ exports[`26. secondary two and two - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -2026,7 +2026,7 @@ exports[`27. lead one and four slice - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -2112,7 +2112,7 @@ exports[`28. standard slice - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -2183,7 +2183,7 @@ exports[`29. secondary two no pic and two - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -2275,7 +2275,7 @@ exports[`30. puzzle - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1181,7 +1181,7 @@ exports[`16. comment lead and cartoon - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1234,7 +1234,7 @@ exports[`17. daily universal register - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1340,7 +1340,7 @@ exports[`18. lead one and one - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1392,7 +1392,7 @@ exports[`19. lead one full width - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1407,7 +1407,7 @@ exports[`20. lead two no pic and two - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1489,7 +1489,7 @@ exports[`21. leaders slice - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1619,7 +1619,7 @@ exports[`22. secondary one and four - wide 1`] = `
       Object {
         "alignSelf": "center",
         "maxWidth": "100%",
-        "paddingHorizontal": 10,
+        "paddingHorizontal": 30,
         "width": 1366,
       }
     }
@@ -1776,7 +1776,7 @@ exports[`23. secondary one - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1791,7 +1791,7 @@ exports[`24. secondary four - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1884,7 +1884,7 @@ exports[`25. secondary one and columnist - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -1936,7 +1936,7 @@ exports[`26. secondary two and two - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -2026,7 +2026,7 @@ exports[`27. lead one and four slice - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -2112,7 +2112,7 @@ exports[`28. standard slice - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -2183,7 +2183,7 @@ exports[`29. secondary two no pic and two - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }
@@ -2275,7 +2275,7 @@ exports[`30. puzzle - wide 1`] = `
     Object {
       "alignSelf": "center",
       "maxWidth": "100%",
-      "paddingHorizontal": 10,
+      "paddingHorizontal": 30,
       "width": 1366,
     }
   }

--- a/packages/edition-slices/src/slices/shared/content-wrapper.js
+++ b/packages/edition-slices/src/slices/shared/content-wrapper.js
@@ -6,7 +6,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { View } from "react-native";
-import styles from "./styles";
+import styleFactory from "./styles";
+
+const styles = styleFactory();
 
 const ContentWrapper = ({ children }) => (
   <View style={styles.contentWrapperStyles}>{children}</View>

--- a/packages/edition-slices/src/slices/shared/gutter.js
+++ b/packages/edition-slices/src/slices/shared/gutter.js
@@ -2,22 +2,36 @@ import React from "react";
 import PropTypes from "prop-types";
 import { View } from "react-native";
 import { ResponsiveContext } from "@times-components/responsive";
-import { editionMaxWidth, spacing } from "@times-components/styleguide";
+import {
+  editionMaxWidth,
+  spacing,
+  editionBreakpoints
+} from "@times-components/styleguide";
 
 const Gutter = ({ children }) => (
   <ResponsiveContext.Consumer>
-    {({ isTablet }) => (
-      <View
-        style={{
-          alignSelf: "center",
-          maxWidth: "100%",
-          paddingHorizontal: isTablet ? spacing(2) : 0,
-          width: editionMaxWidth
-        }}
-      >
-        {children}
-      </View>
-    )}
+    {({ isTablet, editionBreakpoint }) => {
+      const tabletPaddingHorizontalResolver = {
+        [editionBreakpoints.medium]: spacing(2),
+        [editionBreakpoints.wide]: spacing(6),
+        [editionBreakpoints.huge]: spacing(2)
+      };
+
+      return (
+        <View
+          style={{
+            alignSelf: "center",
+            maxWidth: "100%",
+            paddingHorizontal: isTablet
+              ? tabletPaddingHorizontalResolver[editionBreakpoint]
+              : 0,
+            width: editionMaxWidth
+          }}
+        >
+          {children}
+        </View>
+      );
+    }}
   </ResponsiveContext.Consumer>
 );
 

--- a/packages/edition-slices/src/slices/shared/gutter.js
+++ b/packages/edition-slices/src/slices/shared/gutter.js
@@ -2,35 +2,14 @@ import React from "react";
 import PropTypes from "prop-types";
 import { View } from "react-native";
 import { ResponsiveContext } from "@times-components/responsive";
-import {
-  editionMaxWidth,
-  spacing,
-  editionBreakpoints
-} from "@times-components/styleguide";
+import styleFactory from "./styles";
 
 const Gutter = ({ children }) => (
   <ResponsiveContext.Consumer>
     {({ isTablet, editionBreakpoint }) => {
-      const tabletPaddingHorizontalResolver = {
-        [editionBreakpoints.medium]: spacing(2),
-        [editionBreakpoints.wide]: spacing(6),
-        [editionBreakpoints.huge]: spacing(2)
-      };
+      const styles = styleFactory(isTablet, editionBreakpoint);
 
-      return (
-        <View
-          style={{
-            alignSelf: "center",
-            maxWidth: "100%",
-            paddingHorizontal: isTablet
-              ? tabletPaddingHorizontalResolver[editionBreakpoint]
-              : 0,
-            width: editionMaxWidth
-          }}
-        >
-          {children}
-        </View>
-      );
+      return <View style={styles.gutterStyles}>{children}</View>;
     }}
   </ResponsiveContext.Consumer>
 );

--- a/packages/edition-slices/src/slices/shared/styles.js
+++ b/packages/edition-slices/src/slices/shared/styles.js
@@ -1,11 +1,29 @@
-import { sliceContentMaxWidth } from "@times-components/styleguide";
+import {
+  editionMaxWidth,
+  sliceContentMaxWidth,
+  spacing,
+  editionBreakpoints
+} from "@times-components/styleguide";
 
-const styles = {
+const tabletPaddingHorizontalResolver = {
+  [editionBreakpoints.medium]: spacing(2),
+  [editionBreakpoints.wide]: spacing(6),
+  [editionBreakpoints.huge]: spacing(2)
+};
+
+export default (isTablet, breakpoint) => ({
   contentWrapperStyles: {
     flex: 1,
     alignSelf: "center",
     width: sliceContentMaxWidth
-  }
-};
+  },
 
-export default styles;
+  gutterStyles: {
+    alignSelf: "center",
+    maxWidth: "100%",
+    paddingHorizontal: isTablet
+      ? tabletPaddingHorizontalResolver[breakpoint]
+      : 0,
+    width: editionMaxWidth
+  }
+});

--- a/packages/section/__tests__/android/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/android/__snapshots__/section.test.js.snap
@@ -321,6 +321,54 @@ exports[`puzzle bar with one puzzle 1`] = `
 </View>
 `;
 
+exports[`section item separator - huge 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#DBDBDB",
+      "height": 1,
+      "marginHorizontal": 113,
+    }
+  }
+/>
+`;
+
+exports[`section item separator - medium 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#DBDBDB",
+      "height": 1,
+      "marginHorizontal": 40,
+    }
+  }
+/>
+`;
+
+exports[`section item separator - small 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#DBDBDB",
+      "height": 1,
+      "marginHorizontal": 10,
+    }
+  }
+/>
+`;
+
+exports[`section item separator - wide 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#DBDBDB",
+      "height": 1,
+      "marginHorizontal": 50,
+    }
+  }
+/>
+`;
+
 exports[`section page 1`] = `
 <RCTScrollView
   style={

--- a/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
@@ -321,6 +321,54 @@ exports[`puzzle bar with one puzzle 1`] = `
 </View>
 `;
 
+exports[`section item separator - huge 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#DBDBDB",
+      "height": 1,
+      "marginHorizontal": 113,
+    }
+  }
+/>
+`;
+
+exports[`section item separator - medium 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#DBDBDB",
+      "height": 1,
+      "marginHorizontal": 40,
+    }
+  }
+/>
+`;
+
+exports[`section item separator - small 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#DBDBDB",
+      "height": 1,
+      "marginHorizontal": 10,
+    }
+  }
+/>
+`;
+
+exports[`section item separator - wide 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#DBDBDB",
+      "height": 1,
+      "marginHorizontal": 50,
+    }
+  }
+/>
+`;
+
 exports[`section page 1`] = `
 <RCTScrollView
   style={

--- a/packages/section/__tests__/shared.js
+++ b/packages/section/__tests__/shared.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { MockEdition } from "@times-components/fixture-generator";
 import { SectionContext } from "@times-components/context";
+import { editionBreakpoints } from "@times-components/styleguide";
 import {
   addSerializers,
   compose,
@@ -10,6 +11,7 @@ import {
   print
 } from "@times-components/jest-serializer";
 import TestRenderer from "react-test-renderer";
+import SectionItemSeparator from "../src/section-item-separator";
 import Section from "../src/section";
 import PuzzleBar from "../src/puzzle-bar";
 
@@ -121,6 +123,38 @@ export default () => {
           publicationName="SUNDAY TIMES"
           section={edition.sections[4]}
         />
+      ).toJSON()
+    ).toMatchSnapshot();
+  });
+
+  it("section item separator - small", () => {
+    expect(
+      TestRenderer.create(
+        <SectionItemSeparator breakpoint={editionBreakpoints.small} />
+      ).toJSON()
+    ).toMatchSnapshot();
+  });
+
+  it("section item separator - medium", () => {
+    expect(
+      TestRenderer.create(
+        <SectionItemSeparator breakpoint={editionBreakpoints.medium} />
+      ).toJSON()
+    ).toMatchSnapshot();
+  });
+
+  it("section item separator - wide", () => {
+    expect(
+      TestRenderer.create(
+        <SectionItemSeparator breakpoint={editionBreakpoints.wide} />
+      ).toJSON()
+    ).toMatchSnapshot();
+  });
+
+  it("section item separator - huge", () => {
+    expect(
+      TestRenderer.create(
+        <SectionItemSeparator breakpoint={editionBreakpoints.huge} />
       ).toJSON()
     ).toMatchSnapshot();
   });

--- a/packages/section/src/styles/index.js
+++ b/packages/section/src/styles/index.js
@@ -5,6 +5,13 @@ import {
   editionBreakpoints
 } from "@times-components/styleguide";
 
+const separatorSpacingResolver = {
+  [editionBreakpoints.small]: spacing(2),
+  [editionBreakpoints.medium]: spacing(8),
+  [editionBreakpoints.wide]: spacing(10),
+  [editionBreakpoints.huge]: spacing(22.6)
+};
+
 export default breakpoint => ({
   listItemContainer: {
     paddingHorizontal: spacing(2),
@@ -13,8 +20,7 @@ export default breakpoint => ({
   listItemSeparator: {
     backgroundColor: colours.functional.keyline,
     height: 1,
-    marginHorizontal:
-      breakpoint === editionBreakpoints.medium ? spacing(8) : spacing(2)
+    marginHorizontal: separatorSpacingResolver[breakpoint]
   },
   puzzleBarArrow: {
     paddingLeft: spacing(2),


### PR DESCRIPTION
Wide Before:
![wide-gutter-before](https://user-images.githubusercontent.com/8720661/63333874-d9274c80-c342-11e9-8f60-bd5742b76c1a.png)


Wide After:
![wide-gutter-after](https://user-images.githubusercontent.com/8720661/63333880-de849700-c342-11e9-984b-776966876cf2.png)


The item separator of the huge breakpoint is also updated
Before:
![wide-separator-before](https://user-images.githubusercontent.com/8720661/63334013-23103280-c343-11e9-9bf6-2b72ddd9f14f.png)

After:
![huge-separator-after](https://user-images.githubusercontent.com/8720661/63333958-0411a080-c343-11e9-9586-3a56c8f9b60d.png)
