### PR TITLE
fix: lead one and cartoon styling fixes 768

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -16,7 +16,7 @@ exports[`1. comment lead and cartoon - medium 1`] = `
       Object {
         "flex": 1,
         "flexDirection": "row",
-        "paddingHorizontal": 30,
+        "paddingHorizontal": 20,
         "paddingVertical": 5,
       }
     }
@@ -1188,7 +1188,7 @@ exports[`16. comment lead and cartoon - wide 1`] = `
       Object {
         "flex": 1,
         "flexDirection": "row",
-        "paddingHorizontal": 30,
+        "paddingHorizontal": 20,
         "paddingVertical": 5,
       }
     }
@@ -2341,7 +2341,7 @@ exports[`31. comment lead and cartoon - huge 1`] = `
         Object {
           "flex": 1,
           "flexDirection": "row",
-          "paddingHorizontal": 30,
+          "paddingHorizontal": 20,
           "paddingVertical": 5,
         }
       }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -2175,7 +2175,7 @@ exports[`42. tile ah 1`] = `
       Object {
         "marginBottom": 5,
         "overflow": "hidden",
-        "width": "40%",
+        "width": 97,
       }
     }
   />

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -1808,8 +1808,7 @@ exports[`42. tile ah 1`] = `
     Object {
       "alignItems": "center",
       "flex": 1,
-      "marginRight": 10,
-      "paddingVertical": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1860,7 +1859,7 @@ exports[`43. tile ai 1`] = `
   linkStyle={
     Object {
       "alignItems": "center",
-      "paddingVertical": 10,
+      "padding": 10,
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -16,7 +16,7 @@ exports[`1. comment lead and cartoon - medium 1`] = `
       Object {
         "flex": 1,
         "flexDirection": "row",
-        "paddingHorizontal": 30,
+        "paddingHorizontal": 20,
         "paddingVertical": 5,
       }
     }
@@ -1188,7 +1188,7 @@ exports[`16. comment lead and cartoon - wide 1`] = `
       Object {
         "flex": 1,
         "flexDirection": "row",
-        "paddingHorizontal": 30,
+        "paddingHorizontal": 20,
         "paddingVertical": 5,
       }
     }
@@ -2341,7 +2341,7 @@ exports[`31. comment lead and cartoon - huge 1`] = `
         Object {
           "flex": 1,
           "flexDirection": "row",
-          "paddingHorizontal": 30,
+          "paddingHorizontal": 20,
           "paddingVertical": 5,
         }
       }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -2175,7 +2175,7 @@ exports[`42. tile ah 1`] = `
       Object {
         "marginBottom": 5,
         "overflow": "hidden",
-        "width": "40%",
+        "width": 97,
       }
     }
   />

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -1808,8 +1808,7 @@ exports[`42. tile ah 1`] = `
     Object {
       "alignItems": "center",
       "flex": 1,
-      "marginRight": 10,
-      "paddingVertical": 10,
+      "padding": 10,
     }
   }
   url="/article/123"
@@ -1860,7 +1859,7 @@ exports[`43. tile ai 1`] = `
   linkStyle={
     Object {
       "alignItems": "center",
-      "paddingVertical": 10,
+      "padding": 10,
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -2929,8 +2929,8 @@ exports[`15. comment lead and cartoon 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 30px;
-  padding-left: 30px;
+  padding-right: 20px;
+  padding-left: 20px;
   padding-top: 5px;
   padding-bottom: 5px;
   -ms-flex-positive: 1;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -34,8 +34,8 @@ exports[`1. comment lead and cartoon - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 30px;
-  padding-left: 30px;
+  padding-right: 20px;
+  padding-left: 20px;
   padding-top: 5px;
   padding-bottom: 5px;
   -ms-flex-positive: 1;
@@ -1907,8 +1907,8 @@ exports[`16. comment lead and cartoon - wide 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 30px;
-  padding-left: 30px;
+  padding-right: 20px;
+  padding-left: 20px;
   padding-top: 5px;
   padding-bottom: 5px;
   -ms-flex-positive: 1;
@@ -3783,8 +3783,8 @@ exports[`31. comment lead and cartoon - huge 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 30px;
-  padding-left: 30px;
+  padding-right: 20px;
+  padding-left: 20px;
   padding-top: 5px;
   padding-bottom: 5px;
   -ms-flex-positive: 1;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -3704,8 +3704,7 @@ exports[`42. tile ah 1`] = `
     Object {
       "alignItems": "center",
       "flex": 1,
-      "marginRight": "10px",
-      "paddingVertical": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -3769,7 +3768,7 @@ exports[`43. tile ai 1`] = `
   linkStyle={
     Object {
       "alignItems": "center",
-      "paddingVertical": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -3661,7 +3661,7 @@ exports[`42. tile ah 1`] = `
 
 .IS1 {
   overflow: hidden;
-  width: 40%;
+  width: 97;
   margin-bottom: 5px;
 }
 

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -1804,8 +1804,7 @@ exports[`42. tile ah 1`] = `
     Object {
       "alignItems": "center",
       "flex": 1,
-      "marginRight": "10px",
-      "paddingVertical": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"
@@ -1856,7 +1855,7 @@ exports[`43. tile ai 1`] = `
   linkStyle={
     Object {
       "alignItems": "center",
-      "paddingVertical": "10px",
+      "padding": "10px",
     }
   }
   url="/article/123"

--- a/packages/edition-slices/src/tiles/tile-ah/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/styles/index.js
@@ -29,7 +29,7 @@ const styles = (breakpoint = editionBreakpoints.medium) => ({
   },
   imageContainer: {
     overflow: "hidden",
-    width: "40%",
+    width: 97,
     marginBottom: spacing(1)
   },
   strapline: {

--- a/packages/edition-slices/src/tiles/tile-ah/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/styles/index.js
@@ -16,8 +16,7 @@ const styles = (breakpoint = editionBreakpoints.medium) => ({
   container: {
     flex: 1,
     alignItems: "center",
-    marginRight: spacing(2),
-    paddingVertical: spacing(2)
+    padding: spacing(2)
   },
   headline: {
     color: colours.functional.brandColour,

--- a/packages/edition-slices/src/tiles/tile-ai/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ai/styles/index.js
@@ -3,7 +3,7 @@ import { spacing } from "@times-components/styleguide";
 const styles = {
   container: {
     alignItems: "center",
-    paddingVertical: spacing(2)
+    padding: spacing(2)
   },
   imageContainer: {
     width: "100%"

--- a/packages/slice-layout/__tests__/android/__snapshots__/clac-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/clac-with-style.android.test.js.snap
@@ -1,48 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`1. comment lead and cartoon - small 1`] = `
-<View
-  style={
-    Object {
-      "flex": 1,
-      "flexDirection": "row",
-      "paddingHorizontal": 30,
-      "paddingVertical": 5,
-    }
-  }
->
+<View>
+  <Text>
+    lead-1
+  </Text>
   <View
     style={
       Object {
-        "width": "33.3%",
-      }
-    }
-  >
-    <Text>
-      lead-1
-    </Text>
-  </View>
-  <View
-    style={
-      Object {
+        "borderBottomWidth": 1,
         "borderColor": "#DBDBDB",
-        "borderRightWidth": 1,
         "borderStyle": "solid",
-        "marginVertical": 10,
+        "marginHorizontal": 10,
       }
     }
   />
-  <View
-    style={
-      Object {
-        "width": "66.7%",
-      }
-    }
-  >
-    <Text>
-      cartoon-1
-    </Text>
-  </View>
+  <Text>
+    cartoon-1
+  </Text>
 </View>
 `;
 
@@ -52,7 +27,7 @@ exports[`2. comment lead and cartoon - medium 1`] = `
     Object {
       "flex": 1,
       "flexDirection": "row",
-      "paddingHorizontal": 30,
+      "paddingHorizontal": 20,
       "paddingVertical": 5,
     }
   }

--- a/packages/slice-layout/__tests__/android/__snapshots__/clac.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/clac.android.test.js.snap
@@ -2,17 +2,13 @@
 
 exports[`1. comment lead and cartoon - small 1`] = `
 <View>
-  <View>
-    <Text>
-      lead-1
-    </Text>
-  </View>
+  <Text>
+    lead-1
+  </Text>
   <View />
-  <View>
-    <Text>
-      cartoon-1
-    </Text>
-  </View>
+  <Text>
+    cartoon-1
+  </Text>
 </View>
 `;
 

--- a/packages/slice-layout/__tests__/clac.base.js
+++ b/packages/slice-layout/__tests__/clac.base.js
@@ -11,6 +11,7 @@ export default renderComponent => {
       test() {
         const output = renderComponent(
           <CommentLeadAndCartoon
+            breakpoint={editionBreakpoints.small}
             cartoon={createItem("cartoon-1")}
             lead={createItem("lead-1")}
           />

--- a/packages/slice-layout/__tests__/ios/__snapshots__/clac-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/clac-with-style.ios.test.js.snap
@@ -1,48 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`1. comment lead and cartoon - small 1`] = `
-<View
-  style={
-    Object {
-      "flex": 1,
-      "flexDirection": "row",
-      "paddingHorizontal": 30,
-      "paddingVertical": 5,
-    }
-  }
->
+<View>
+  <Text>
+    lead-1
+  </Text>
   <View
     style={
       Object {
-        "width": "33.3%",
-      }
-    }
-  >
-    <Text>
-      lead-1
-    </Text>
-  </View>
-  <View
-    style={
-      Object {
+        "borderBottomWidth": 1,
         "borderColor": "#DBDBDB",
-        "borderRightWidth": 1,
         "borderStyle": "solid",
-        "marginVertical": 10,
+        "marginHorizontal": 10,
       }
     }
   />
-  <View
-    style={
-      Object {
-        "width": "66.7%",
-      }
-    }
-  >
-    <Text>
-      cartoon-1
-    </Text>
-  </View>
+  <Text>
+    cartoon-1
+  </Text>
 </View>
 `;
 
@@ -52,7 +27,7 @@ exports[`2. comment lead and cartoon - medium 1`] = `
     Object {
       "flex": 1,
       "flexDirection": "row",
-      "paddingHorizontal": 30,
+      "paddingHorizontal": 20,
       "paddingVertical": 5,
     }
   }

--- a/packages/slice-layout/__tests__/ios/__snapshots__/clac.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/clac.ios.test.js.snap
@@ -2,17 +2,13 @@
 
 exports[`1. comment lead and cartoon - small 1`] = `
 <View>
-  <View>
-    <Text>
-      lead-1
-    </Text>
-  </View>
+  <Text>
+    lead-1
+  </Text>
   <View />
-  <View>
-    <Text>
-      cartoon-1
-    </Text>
-  </View>
+  <Text>
+    cartoon-1
+  </Text>
 </View>
 `;
 

--- a/packages/slice-layout/__tests__/web/__snapshots__/clac-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/clac-with-style.web.test.js.snap
@@ -1,69 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`1. comment lead and cartoon - small 1`] = `
-<div
-  style={
-    Object {
-      "WebkitBoxDirection": "normal",
-      "WebkitBoxFlex": 1,
-      "WebkitBoxOrient": "horizontal",
-      "WebkitFlexBasis": "0%",
-      "WebkitFlexDirection": "row",
-      "WebkitFlexGrow": 1,
-      "WebkitFlexShrink": 1,
-      "flexBasis": "0%",
-      "flexDirection": "row",
-      "flexGrow": 1,
-      "flexShrink": 1,
-      "msFlexDirection": "row",
-      "msFlexNegative": 1,
-      "msFlexPositive": 1,
-      "msFlexPreferredSize": "0%",
-      "paddingBottom": "5px",
-      "paddingLeft": "30px",
-      "paddingRight": "30px",
-      "paddingTop": "5px",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "width": "33.3%",
-      }
-    }
-  >
-    <div>
-      lead-1
-    </div>
+<div>
+  <div>
+    lead-1
   </div>
   <div
     style={
       Object {
         "borderBottomColor": "rgba(219,219,219,1.00)",
         "borderBottomStyle": "solid",
+        "borderBottomWidth": "1px",
         "borderLeftColor": "rgba(219,219,219,1.00)",
         "borderLeftStyle": "solid",
         "borderRightColor": "rgba(219,219,219,1.00)",
         "borderRightStyle": "solid",
-        "borderRightWidth": "1px",
         "borderTopColor": "rgba(219,219,219,1.00)",
         "borderTopStyle": "solid",
-        "marginBottom": "10px",
-        "marginTop": "10px",
+        "marginLeft": "10px",
+        "marginRight": "10px",
       }
     }
   />
-  <div
-    style={
-      Object {
-        "width": "66.7%",
-      }
-    }
-  >
-    <div>
-      cartoon-1
-    </div>
+  <div>
+    cartoon-1
   </div>
 </div>
 `;
@@ -88,8 +48,8 @@ exports[`2. comment lead and cartoon - medium 1`] = `
       "msFlexPositive": 1,
       "msFlexPreferredSize": "0%",
       "paddingBottom": "5px",
-      "paddingLeft": "30px",
-      "paddingRight": "30px",
+      "paddingLeft": "20px",
+      "paddingRight": "20px",
       "paddingTop": "5px",
     }
   }

--- a/packages/slice-layout/__tests__/web/__snapshots__/clac.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/clac.web.test.js.snap
@@ -3,15 +3,11 @@
 exports[`1. comment lead and cartoon - small 1`] = `
 <div>
   <div>
-    <div>
-      lead-1
-    </div>
+    lead-1
   </div>
   <div />
   <div>
-    <div>
-      cartoon-1
-    </div>
+    cartoon-1
   </div>
 </div>
 `;

--- a/packages/slice-layout/src/templates/commentleadandcartoon/styles.js
+++ b/packages/slice-layout/src/templates/commentleadandcartoon/styles.js
@@ -7,7 +7,7 @@ const styles = {
   container: {
     flex: 1,
     flexDirection: "row",
-    paddingHorizontal: spacing(6),
+    paddingHorizontal: spacing(4),
     paddingVertical: spacing(1)
   },
   lead: {


### PR DESCRIPTION
Styling fixes to align tile separator and image placeholder of lead 1 and cartoon.
Also the snapshot tests are fixed for small breakpoint.

Before:
![lead-image-before](https://user-images.githubusercontent.com/8720661/63347751-747aea80-c360-11e9-84ad-8a04a020ff8f.png)
![lead-cartoon-before](https://user-images.githubusercontent.com/8720661/63347759-780e7180-c360-11e9-8ae7-d6ee7c608849.png)

After:
![lead-image-after](https://user-images.githubusercontent.com/8720661/63347705-54e3c200-c360-11e9-8b3d-1eb7f26a2ab2.png)
![lead-cartoon-after](https://user-images.githubusercontent.com/8720661/63347717-5a410c80-c360-11e9-801a-a37f4c3db657.png)
