### PR TITLE
feat: REPLAT-7521 lead and cartoon styled for wide breakpoint

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1188,7 +1188,7 @@ exports[`16. comment lead and cartoon - wide 1`] = `
       Object {
         "flex": 1,
         "flexDirection": "row",
-        "paddingHorizontal": 20,
+        "paddingHorizontal": 10,
         "paddingVertical": 5,
       }
     }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -2182,7 +2182,6 @@ exports[`42. tile ah 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "flex": 1,
         "paddingTop": 5,
       }
     }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -1807,6 +1807,7 @@ exports[`42. tile ah 1`] = `
     Object {
       "alignItems": "center",
       "flex": 1,
+      "justifyContent": "center",
       "padding": 10,
     }
   }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1188,7 +1188,7 @@ exports[`16. comment lead and cartoon - wide 1`] = `
       Object {
         "flex": 1,
         "flexDirection": "row",
-        "paddingHorizontal": 20,
+        "paddingHorizontal": 10,
         "paddingVertical": 5,
       }
     }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -2182,7 +2182,6 @@ exports[`42. tile ah 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "flex": 1,
         "paddingTop": 5,
       }
     }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -1807,6 +1807,7 @@ exports[`42. tile ah 1`] = `
     Object {
       "alignItems": "center",
       "flex": 1,
+      "justifyContent": "center",
       "padding": 10,
     }
   }

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -2929,8 +2929,8 @@ exports[`15. comment lead and cartoon 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 20px;
-  padding-left: 20px;
+  padding-right: 10px;
+  padding-left: 10px;
   padding-top: 5px;
   padding-bottom: 5px;
   -ms-flex-positive: 1;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -34,8 +34,8 @@ exports[`1. comment lead and cartoon - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 20px;
-  padding-left: 20px;
+  padding-right: 10px;
+  padding-left: 10px;
   padding-top: 5px;
   padding-bottom: 5px;
   -ms-flex-positive: 1;
@@ -1907,8 +1907,8 @@ exports[`16. comment lead and cartoon - wide 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 20px;
-  padding-left: 20px;
+  padding-right: 10px;
+  padding-left: 10px;
   padding-top: 5px;
   padding-bottom: 5px;
   -ms-flex-positive: 1;
@@ -3783,8 +3783,8 @@ exports[`31. comment lead and cartoon - huge 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 20px;
-  padding-left: 20px;
+  padding-right: 10px;
+  padding-left: 10px;
   padding-top: 5px;
   padding-bottom: 5px;
   -ms-flex-positive: 1;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -3671,19 +3671,9 @@ exports[`42. tile ah 1`] = `
 .IS4 {
   -webkit-align-items: center;
   align-items: center;
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
   padding-top: 5px;
   -ms-flex-align: center;
   -webkit-box-align: center;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
 }
 </style>
 
@@ -3692,6 +3682,7 @@ exports[`42. tile ah 1`] = `
     Object {
       "alignItems": "center",
       "flex": 1,
+      "justifyContent": "center",
       "padding": "10px",
     }
   }

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -1803,6 +1803,7 @@ exports[`42. tile ah 1`] = `
     Object {
       "alignItems": "center",
       "flex": 1,
+      "justifyContent": "center",
       "padding": "10px",
     }
   }

--- a/packages/edition-slices/edition-tiles.showcase.js
+++ b/packages/edition-slices/edition-tiles.showcase.js
@@ -217,7 +217,7 @@ const tileStories = [
   },
   {
     name:
-      "Tile AH - Profile roundel image, 30pt headline, no teaser, central aligned summary",
+      "Tile AH - Profile roundel image, 30pt (40pt for wide breakpoint) headline, with teaser, central aligned summary",
     Tile: TileAH
   },
   {

--- a/packages/edition-slices/src/tiles/tile-ah/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/styles/index.js
@@ -8,7 +8,7 @@ import {
 
 const headlineFontSizeResolver = {
   [editionBreakpoints.medium]: 30,
-  [editionBreakpoints.wide]: 35,
+  [editionBreakpoints.wide]: 40,
   [editionBreakpoints.huge]: 45
 };
 
@@ -16,6 +16,7 @@ const styles = (breakpoint = editionBreakpoints.medium) => ({
   container: {
     flex: 1,
     alignItems: "center",
+    justifyContent: "center",
     padding: spacing(2)
   },
   headline: {
@@ -41,7 +42,6 @@ const styles = (breakpoint = editionBreakpoints.medium) => ({
     paddingBottom: spacing(1)
   },
   summaryContainer: {
-    flex: 1,
     paddingTop: spacing(1),
     alignItems: "center"
   }

--- a/packages/slice-layout/__tests__/android/__snapshots__/clac-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/clac-with-style.android.test.js.snap
@@ -66,3 +66,49 @@ exports[`2. comment lead and cartoon - medium 1`] = `
   </View>
 </View>
 `;
+
+exports[`3. comment lead and cartoon - wide 1`] = `
+<View
+  style={
+    Object {
+      "flex": 1,
+      "flexDirection": "row",
+      "paddingHorizontal": 10,
+      "paddingVertical": 5,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "width": "33.3%",
+      }
+    }
+  >
+    <Text>
+      lead-1
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "66.7%",
+      }
+    }
+  >
+    <Text>
+      cartoon-1
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/android/__snapshots__/clac.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/clac.android.test.js.snap
@@ -27,3 +27,19 @@ exports[`2. comment lead and cartoon - medium 1`] = `
   </View>
 </View>
 `;
+
+exports[`3. comment lead and cartoon - wide 1`] = `
+<View>
+  <View>
+    <Text>
+      lead-1
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      cartoon-1
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/clac.base.js
+++ b/packages/slice-layout/__tests__/clac.base.js
@@ -33,6 +33,20 @@ export default renderComponent => {
 
         expect(output).toMatchSnapshot();
       }
+    },
+    {
+      name: "comment lead and cartoon - wide",
+      test() {
+        const output = renderComponent(
+          <CommentLeadAndCartoon
+            breakpoint={editionBreakpoints.wide}
+            cartoon={createItem("cartoon-1")}
+            lead={createItem("lead-1")}
+          />
+        );
+
+        expect(output).toMatchSnapshot();
+      }
     }
   ];
 

--- a/packages/slice-layout/__tests__/ios/__snapshots__/clac-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/clac-with-style.ios.test.js.snap
@@ -66,3 +66,49 @@ exports[`2. comment lead and cartoon - medium 1`] = `
   </View>
 </View>
 `;
+
+exports[`3. comment lead and cartoon - wide 1`] = `
+<View
+  style={
+    Object {
+      "flex": 1,
+      "flexDirection": "row",
+      "paddingHorizontal": 10,
+      "paddingVertical": 5,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "width": "33.3%",
+      }
+    }
+  >
+    <Text>
+      lead-1
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#DBDBDB",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "marginVertical": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "width": "66.7%",
+      }
+    }
+  >
+    <Text>
+      cartoon-1
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/ios/__snapshots__/clac.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/clac.ios.test.js.snap
@@ -27,3 +27,19 @@ exports[`2. comment lead and cartoon - medium 1`] = `
   </View>
 </View>
 `;
+
+exports[`3. comment lead and cartoon - wide 1`] = `
+<View>
+  <View>
+    <Text>
+      lead-1
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      cartoon-1
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/web/__snapshots__/clac-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/clac-with-style.web.test.js.snap
@@ -95,3 +95,71 @@ exports[`2. comment lead and cartoon - medium 1`] = `
   </div>
 </div>
 `;
+
+exports[`3. comment lead and cartoon - wide 1`] = `
+<div
+  style={
+    Object {
+      "WebkitBoxDirection": "normal",
+      "WebkitBoxFlex": 1,
+      "WebkitBoxOrient": "horizontal",
+      "WebkitFlexBasis": "0%",
+      "WebkitFlexDirection": "row",
+      "WebkitFlexGrow": 1,
+      "WebkitFlexShrink": 1,
+      "flexBasis": "0%",
+      "flexDirection": "row",
+      "flexGrow": 1,
+      "flexShrink": 1,
+      "msFlexDirection": "row",
+      "msFlexNegative": 1,
+      "msFlexPositive": 1,
+      "msFlexPreferredSize": "0%",
+      "paddingBottom": "5px",
+      "paddingLeft": "10px",
+      "paddingRight": "10px",
+      "paddingTop": "5px",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "width": "33.3%",
+      }
+    }
+  >
+    <div>
+      lead-1
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "borderBottomColor": "rgba(219,219,219,1.00)",
+        "borderBottomStyle": "solid",
+        "borderLeftColor": "rgba(219,219,219,1.00)",
+        "borderLeftStyle": "solid",
+        "borderRightColor": "rgba(219,219,219,1.00)",
+        "borderRightStyle": "solid",
+        "borderRightWidth": "1px",
+        "borderTopColor": "rgba(219,219,219,1.00)",
+        "borderTopStyle": "solid",
+        "marginBottom": "10px",
+        "marginTop": "10px",
+      }
+    }
+  />
+  <div
+    style={
+      Object {
+        "width": "66.7%",
+      }
+    }
+  >
+    <div>
+      cartoon-1
+    </div>
+  </div>
+</div>
+`;

--- a/packages/slice-layout/__tests__/web/__snapshots__/clac.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/clac.web.test.js.snap
@@ -27,3 +27,19 @@ exports[`2. comment lead and cartoon - medium 1`] = `
   </div>
 </div>
 `;
+
+exports[`3. comment lead and cartoon - wide 1`] = `
+<div>
+  <div>
+    <div>
+      lead-1
+    </div>
+  </div>
+  <div />
+  <div>
+    <div>
+      cartoon-1
+    </div>
+  </div>
+</div>
+`;

--- a/packages/slice-layout/src/templates/commentleadandcartoon/index.js
+++ b/packages/slice-layout/src/templates/commentleadandcartoon/index.js
@@ -3,9 +3,11 @@ import { editionBreakpoints } from "@times-components/styleguide";
 import VerticalLayout from "../verticallayout";
 import HorizontalLayout from "../horizontallayout";
 import propTypes from "./proptypes";
-import styles from "./styles";
+import styleFactory from "./styles";
 
 const CommentLeadAndCartoon = ({ breakpoint, lead, cartoon }) => {
+  const styles = styleFactory(breakpoint);
+
   if (breakpoint === editionBreakpoints.small) {
     return <VerticalLayout tiles={[lead, cartoon]} />;
   }

--- a/packages/slice-layout/src/templates/commentleadandcartoon/styles.js
+++ b/packages/slice-layout/src/templates/commentleadandcartoon/styles.js
@@ -1,6 +1,6 @@
-import { spacing } from "@times-components/styleguide";
+import { editionBreakpoints, spacing } from "@times-components/styleguide";
 
-const styles = {
+const defaultBreakpointStyles = {
   cartoon: {
     width: "66.7%"
   },
@@ -15,4 +15,20 @@ const styles = {
   }
 };
 
-export default styles;
+const wideBreakpointStyles = {
+  ...defaultBreakpointStyles,
+  container: {
+    flex: 1,
+    flexDirection: "row",
+    paddingHorizontal: spacing(2),
+    paddingVertical: spacing(1)
+  }
+};
+
+const stylesResolver = {
+  [editionBreakpoints.medium]: defaultBreakpointStyles,
+  [editionBreakpoints.wide]: wideBreakpointStyles,
+  [editionBreakpoints.huge]: defaultBreakpointStyles
+};
+
+export default breakpoint => stylesResolver[breakpoint];


### PR DESCRIPTION
[Jira Story.](https://nidigitalsolutions.jira.com/browse/REPLAT-7521)
[Design.](https://app.zeplin.io/project/5d2849a2b4a4605645afb4be/screen/5d5189891ced2b350a8f0448)

Font size of the heading is updated to 40.
Snapshot test for wide breakpoint added.
Slice horizontal spacing updated to 50.
Left tile (TileAH) vertically center.

Result:
![lead-cartoon-after-wide](https://user-images.githubusercontent.com/8720661/63431000-8d4dd380-c426-11e9-91ee-271a0ee4209d.png)
