### PR TITLE
fix: fix styles for lead 1 and 1 slice wide breakpoint

### DIFF
--- a/packages/edition-slices/src/tiles/tile-aa/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-aa/styles/index.js
@@ -22,7 +22,8 @@ const wideBreakpointStyles = {
   headline: {
     fontFamily: fonts.headline,
     fontSize: 28,
-    lineHeight: 28
+    lineHeight: 28,
+    marginBottom: spacing(2)
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-u/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/index.js
@@ -11,11 +11,12 @@ import {
   TileSummary,
   withTileTracking
 } from "../shared";
-import styles from "./styles";
+import stylesFactory from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
 import PositionedTileStar from "../shared/positioned-tile-star";
 
 const TileU = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
+  const styles = stylesFactory(breakpoint);
   const crop = getTileImage(tile, "crop169");
   const summary =
     breakpoint === editionBreakpoints.medium ? getTileSummary(tile, 300) : null;

--- a/packages/edition-slices/src/tiles/tile-u/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/styles/index.js
@@ -1,4 +1,8 @@
-import { fonts, spacing } from "@times-components/styleguide";
+import {
+  fonts,
+  spacing,
+  editionBreakpoints
+} from "@times-components/styleguide";
 
 const mediumBreakpointStyles = {
   container: {
@@ -21,4 +25,15 @@ const mediumBreakpointStyles = {
   }
 };
 
-export default mediumBreakpointStyles;
+const wideBreakpointStyles = {
+  ...mediumBreakpointStyles,
+  headline: {
+    ...mediumBreakpointStyles.headline,
+    marginBottom: 0
+  }
+};
+
+export default breakpoint =>
+  breakpoint === editionBreakpoints.medium
+    ? mediumBreakpointStyles
+    : wideBreakpointStyles;


### PR DESCRIPTION
Fixing the space below the headlines:

![Screenshot_1566465160](https://user-images.githubusercontent.com/16742525/63502553-7961aa80-c4d6-11e9-8aa8-9b1bd2f9a992.png)

