### PR TITLE
fix: replat-7475 Fix font scaling using native font scale

### DIFF
--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-scaling.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-scaling.ios.test.js.snap
@@ -58,7 +58,7 @@ exports[`1. scaled medium full article 1`] = `
                     Object {
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 34,
+                      "fontSize": 17,
                       "fontStyle": "normal",
                       "fontWeight": "normal",
                       "lineHeight": 60,
@@ -185,7 +185,7 @@ exports[`2. scaled large full article 1`] = `
                     Object {
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 34,
+                      "fontSize": 17,
                       "fontStyle": "normal",
                       "fontWeight": "normal",
                       "lineHeight": 60,
@@ -312,7 +312,7 @@ exports[`3. scaled xlarge full article 1`] = `
                     Object {
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 34,
+                      "fontSize": 17,
                       "fontStyle": "normal",
                       "fontWeight": "normal",
                       "lineHeight": 60,

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -34,12 +34,15 @@ const viewabilityConfig = {
   waitForInteraction: false
 };
 
-const convertStyles = ({ font, size }) => ({
-  fontFamily: font.replace(/-Bold|-Italic/gi, ""),
-  fontSize: size,
-  fontStyle: font.includes("Italic") ? "italic" : "normal",
-  fontWeight: font.includes("Bold") ? "bold" : "normal"
-});
+const convertStyles = ({ font, size }) => {
+  const { fontScale } = Dimensions.get("window");
+  return {
+    fontFamily: font.replace(/-Bold|-Italic/gi, ""),
+    fontSize: size / fontScale,
+    fontStyle: font.includes("Italic") ? "italic" : "normal",
+    fontWeight: font.includes("Bold") ? "bold" : "normal"
+  };
+};
 
 const renderRow = (
   rowData,


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
The in-app font size was working fine, but when the OS font scale was not 1.0 the scale was applied for layout and then again when rendering, resulting in defects. This is a small change that divides the font size by the scale factor when rendering (as the OS does the scaling and we can't control that without disabling accessible sizing).
