### PR TITLE
fix: Prevent ad from overlapping title

### DIFF
--- a/packages/ad/__tests__/android/__snapshots__/ad-placeholder-with-style.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad-placeholder-with-style.android.test.js.snap
@@ -7,6 +7,7 @@ exports[`advert placeholder 1`] = `
       "alignItems": "center",
       "flex": 1,
       "justifyContent": "center",
+      "minHeight": "auto",
     }
   }
 >

--- a/packages/ad/__tests__/ios/__snapshots__/ad-placeholder-with-style.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad-placeholder-with-style.ios.test.js.snap
@@ -7,6 +7,7 @@ exports[`advert placeholder 1`] = `
       "alignItems": "center",
       "flex": 1,
       "justifyContent": "center",
+      "minHeight": "auto",
     }
   }
 >

--- a/packages/ad/__tests__/web/__snapshots__/ad-placeholder-with-style.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-placeholder-with-style.web.test.js.snap
@@ -128,6 +128,7 @@ exports[`advert placeholder 1`] = `
   align-items: center;
   flex: 1;
   justify-content: center;
+  min-height: auto;
   background-color: red;
 }
 
@@ -145,7 +146,7 @@ exports[`advert placeholder 1`] = `
     className="IS6"
   >
     <div
-      className="css-view-1dbjc4n r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci IS5 S4"
+      className="css-view-1dbjc4n r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci r-minHeight-tv6buo IS5 S4"
     >
       <View
         className="IS4"

--- a/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
@@ -173,6 +173,7 @@ exports[`2. placeholder when isloading 1`] = `
   align-items: center;
   flex: 1;
   justify-content: center;
+  min-height: auto;
 }
 
 .IS6 {
@@ -210,7 +211,7 @@ exports[`2. placeholder when isloading 1`] = `
             className="IS5"
           >
             <div
-              className="css-view-1dbjc4n r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci"
+              className="css-view-1dbjc4n r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci r-minHeight-tv6buo"
             >
               <View
                 className="IS4"
@@ -305,6 +306,7 @@ exports[`3. nothing if there is an error in the loading of scripts 1`] = `
   align-items: center;
   flex: 1;
   justify-content: center;
+  min-height: auto;
 }
 
 .IS7 {
@@ -351,7 +353,7 @@ exports[`3. nothing if there is an error in the loading of scripts 1`] = `
             className="IS6"
           >
             <div
-              className="css-view-1dbjc4n r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci"
+              className="css-view-1dbjc4n r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci r-minHeight-tv6buo"
             >
               <View
                 className="IS5"

--- a/packages/ad/src/styles/index.js
+++ b/packages/ad/src/styles/index.js
@@ -62,7 +62,8 @@ const styles = StyleSheet.create({
   placeholderContainer: {
     alignItems: "center",
     flex: 1,
-    justifyContent: "center"
+    justifyContent: "center",
+    minHeight: "auto" // Prevent flex shrinking it
   },
   placeholderText: {
     backgroundColor: colours.functional.backgroundPrimary,


### PR DESCRIPTION
[JIRA](https://nidigitalsolutions.jira.com/browse/REPLAT-7455)

There is a behaviour where the ad and the placeholder can be shown simultaneously after the ad has "loaded" but before it is "ready". This is likely to ensure there is no "gap" between the placeholder disappearing and the ad displaying.

However, the way the styles are done results in a container collapsing on firefox and not on Chrome. This fixes that. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
