### PR TITLE
fix: broken flags and article summary

### DIFF
--- a/packages/article-flag/__tests__/android/__snapshots__/article-flag-with-style.android.test.js.snap
+++ b/packages/article-flag/__tests__/android/__snapshots__/article-flag-with-style.android.test.js.snap
@@ -43,8 +43,7 @@ exports[`2. multiple article flags 1`] = `
 <View
   style={
     Object {
-      "flexDirection": "row",
-      "flexWrap": "wrap",
+      "marginBottom": 0,
       "marginTop": 10,
     }
   }

--- a/packages/article-flag/__tests__/android/__snapshots__/article-flag-with-style.android.test.js.snap
+++ b/packages/article-flag/__tests__/android/__snapshots__/article-flag-with-style.android.test.js.snap
@@ -43,6 +43,8 @@ exports[`2. multiple article flags 1`] = `
 <View
   style={
     Object {
+      "flexDirection": "row",
+      "flexWrap": "wrap",
       "marginBottom": 0,
       "marginTop": 10,
     }

--- a/packages/article-flag/__tests__/ios/__snapshots__/article-flag-with-style.ios.test.js.snap
+++ b/packages/article-flag/__tests__/ios/__snapshots__/article-flag-with-style.ios.test.js.snap
@@ -43,8 +43,7 @@ exports[`2. multiple article flags 1`] = `
 <View
   style={
     Object {
-      "flexDirection": "row",
-      "flexWrap": "wrap",
+      "marginBottom": 0,
       "marginTop": 10,
     }
   }

--- a/packages/article-flag/__tests__/ios/__snapshots__/article-flag-with-style.ios.test.js.snap
+++ b/packages/article-flag/__tests__/ios/__snapshots__/article-flag-with-style.ios.test.js.snap
@@ -43,6 +43,8 @@ exports[`2. multiple article flags 1`] = `
 <View
   style={
     Object {
+      "flexDirection": "row",
+      "flexWrap": "wrap",
       "marginBottom": 0,
       "marginTop": 10,
     }

--- a/packages/article-flag/__tests__/web/__snapshots__/article-flag-with-style.web.test.js.snap
+++ b/packages/article-flag/__tests__/web/__snapshots__/article-flag-with-style.web.test.js.snap
@@ -202,7 +202,7 @@ exports[`2. multiple article flags 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  margin-top: 10px;
+  margin-bottom: 10px;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
   -webkit-box-lines: multiple;

--- a/packages/article-flag/src/style/index.js
+++ b/packages/article-flag/src/style/index.js
@@ -4,6 +4,7 @@ import sharedStyles from "./shared";
 const styles = {
   ...sharedStyles,
   flags: {
+    ...sharedStyles.flags,
     marginBottom: 0,
     marginTop: spacing(2)
   },

--- a/packages/article-flag/src/style/index.js
+++ b/packages/article-flag/src/style/index.js
@@ -3,6 +3,10 @@ import sharedStyles from "./shared";
 
 const styles = {
   ...sharedStyles,
+  flags: {
+    marginBottom: 0,
+    marginTop: spacing(2)
+  },
   title: {
     ...sharedStyles.title,
     fontSize: fontSizes.meta,

--- a/packages/article-flag/src/style/index.js
+++ b/packages/article-flag/src/style/index.js
@@ -1,4 +1,4 @@
-import { fontSizes } from "@times-components/styleguide";
+import { fontSizes, spacing } from "@times-components/styleguide";
 import sharedStyles from "./shared";
 
 const styles = {

--- a/packages/article-flag/src/style/shared.js
+++ b/packages/article-flag/src/style/shared.js
@@ -13,7 +13,7 @@ const styles = {
   flags: {
     flexDirection: "row",
     flexWrap: "wrap",
-    marginTop: spacing(2)
+    marginBottom: spacing(2)
   },
   title: {
     ...fontFactory({

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
@@ -38,6 +38,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
         "fontFamily": "TimesDigitalW04",
         "fontSize": 14,
         "lineHeight": 20,
+        "marginBottom": 10,
       }
     }
   >
@@ -125,6 +126,7 @@ exports[`2. article summary content component with the given style 1`] = `
       "fontFamily": "TimesDigitalW04",
       "fontSize": 14,
       "lineHeight": 20,
+      "marginBottom": 10,
     }
   }
 >

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
@@ -38,7 +38,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
         "fontFamily": "TimesDigitalW04",
         "fontSize": 14,
         "lineHeight": 20,
-        "marginBottom": 10,
+        "marginBottom": 0,
       }
     }
   >
@@ -126,7 +126,7 @@ exports[`2. article summary content component with the given style 1`] = `
       "fontFamily": "TimesDigitalW04",
       "fontSize": 14,
       "lineHeight": 20,
-      "marginBottom": 10,
+      "marginBottom": 0,
     }
   }
 >

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
@@ -33,11 +33,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
   <Text
     style={
       Object {
-        "color": "#696969",
-        "flexWrap": "wrap",
-        "fontFamily": "TimesDigitalW04",
-        "fontSize": 14,
-        "lineHeight": 20,
+        "marginBottom": 0,
       }
     }
   >
@@ -120,11 +116,7 @@ exports[`2. article summary content component with the given style 1`] = `
 <Text
   style={
     Object {
-      "color": "#696969",
-      "flexWrap": "wrap",
-      "fontFamily": "TimesDigitalW04",
-      "fontSize": 14,
-      "lineHeight": 20,
+      "marginBottom": 0,
     }
   }
 >

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
@@ -33,6 +33,11 @@ exports[`1. article summary component with a single paragraph 1`] = `
   <Text
     style={
       Object {
+        "color": "#696969",
+        "flexWrap": "wrap",
+        "fontFamily": "TimesDigitalW04",
+        "fontSize": 14,
+        "lineHeight": 20,
         "marginBottom": 0,
       }
     }
@@ -116,6 +121,11 @@ exports[`2. article summary content component with the given style 1`] = `
 <Text
   style={
     Object {
+      "color": "#696969",
+      "flexWrap": "wrap",
+      "fontFamily": "TimesDigitalW04",
+      "fontSize": 14,
+      "lineHeight": 20,
       "marginBottom": 0,
     }
   }

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
@@ -24,6 +24,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .S4 {
@@ -54,7 +55,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S3"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -139,11 +140,12 @@ exports[`2. article summary content component with the given style 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 </style>
 
 <div
-  className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S1"
+  className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S1"
 >
   <span
     className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -141,7 +141,7 @@ exports[`2. article summary with opinion byline 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -174,7 +174,7 @@ exports[`3. article summary component with multiple paragraphs 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -233,7 +233,7 @@ exports[`4. article summary component with content including line breaks 1`] = `
   className="css-view-1dbjc4n"
 >
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -290,7 +290,7 @@ exports[`5. article summary component containing links 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -372,7 +372,7 @@ exports[`7. article summary component with empty content at the end trimmed 1`] 
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -443,7 +443,7 @@ exports[`8. article summary component with no byline 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -476,7 +476,7 @@ exports[`9. article summary component with no label 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -537,7 +537,7 @@ exports[`10. article summary component with no headline 1`] = `
     />
   </div>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -578,7 +578,7 @@ exports[`11. article summary component with no date publication 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -639,7 +639,7 @@ exports[`12. article summary component with a video label 1`] = `
     Test Headline
   </h3>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"
@@ -714,7 +714,7 @@ exports[`13. article summary component with a strapline 1`] = `
     Test Strapline
   </h4>
   <div
-    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe"
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
   >
     <span
       className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/article-summary/src/styles/index.android.js
+++ b/packages/article-summary/src/styles/index.android.js
@@ -11,6 +11,10 @@ const styles = StyleSheet.create({
   labelWrapper: {
     ...sharedStyles.labelWrapper,
     marginBottom: spacing(1)
+  },
+  text: {
+    ...sharedStyles.text,
+    marginBottom: 0
   }
 });
 

--- a/packages/article-summary/src/styles/index.js
+++ b/packages/article-summary/src/styles/index.js
@@ -6,6 +6,9 @@ const styles = StyleSheet.create({
   headlineWrapper: {
     ...sharedStyles.headlineWrapper,
     lineHeight: 25
+  },
+  text: {
+    marginBottom: 0
   }
 });
 

--- a/packages/article-summary/src/styles/index.js
+++ b/packages/article-summary/src/styles/index.js
@@ -8,6 +8,7 @@ const styles = StyleSheet.create({
     lineHeight: 25
   },
   text: {
+    ...sharedStyles.text,
     marginBottom: 0
   }
 });

--- a/packages/article-summary/src/styles/shared.js
+++ b/packages/article-summary/src/styles/shared.js
@@ -36,6 +36,7 @@ const sharedStyles = {
   text: {
     color: colours.functional.secondary,
     flexWrap: "wrap",
+    marginBottom: spacing(2),
     ...fontFactory({
       font: "body",
       fontSize: "teaser"

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -86,6 +86,7 @@ exports[`2. tile b 1`] = `
               "fontFamily": "TimesDigitalW04",
               "fontSize": 14,
               "lineHeight": 20,
+              "marginBottom": 10,
             }
           }
         >
@@ -289,6 +290,7 @@ exports[`6. tile f 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
+          "marginBottom": 10,
         }
       }
     >
@@ -400,6 +402,7 @@ exports[`8. tile h 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
+          "marginBottom": 10,
         }
       }
     >
@@ -1383,6 +1386,7 @@ exports[`26. tile y 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
+          "marginBottom": 10,
         }
       }
     >
@@ -1828,6 +1832,7 @@ exports[`35. tile an 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
+          "marginBottom": 10,
         }
       }
     >
@@ -2087,6 +2092,7 @@ exports[`40. tile ar 1`] = `
               "fontFamily": "TimesDigitalW04",
               "fontSize": 14,
               "lineHeight": 20,
+              "marginBottom": 10,
             }
           }
         >
@@ -2153,6 +2159,7 @@ exports[`41. tile as 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
+          "marginBottom": 10,
         }
       }
     >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -86,7 +86,7 @@ exports[`2. tile b 1`] = `
               "fontFamily": "TimesDigitalW04",
               "fontSize": 14,
               "lineHeight": 20,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
@@ -290,7 +290,7 @@ exports[`6. tile f 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >
@@ -402,7 +402,7 @@ exports[`8. tile h 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >
@@ -1386,7 +1386,7 @@ exports[`26. tile y 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >
@@ -1832,7 +1832,7 @@ exports[`35. tile an 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >
@@ -2092,7 +2092,7 @@ exports[`40. tile ar 1`] = `
               "fontFamily": "TimesDigitalW04",
               "fontSize": 14,
               "lineHeight": 20,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
@@ -2159,7 +2159,7 @@ exports[`41. tile as 1`] = `
           "fontFamily": "TimesDigitalW04",
           "fontSize": 14,
           "lineHeight": 20,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -81,11 +81,7 @@ exports[`2. tile b 1`] = `
         <Text
           style={
             Object {
-              "color": "#696969",
-              "flexWrap": "wrap",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 14,
-              "lineHeight": 20,
+              "marginBottom": 0,
             }
           }
         >
@@ -284,11 +280,7 @@ exports[`6. tile f 1`] = `
     <Text
       style={
         Object {
-          "color": "#696969",
-          "flexWrap": "wrap",
-          "fontFamily": "TimesDigitalW04",
-          "fontSize": 14,
-          "lineHeight": 20,
+          "marginBottom": 0,
         }
       }
     >
@@ -395,11 +387,7 @@ exports[`8. tile h 1`] = `
     <Text
       style={
         Object {
-          "color": "#696969",
-          "flexWrap": "wrap",
-          "fontFamily": "TimesDigitalW04",
-          "fontSize": 14,
-          "lineHeight": 20,
+          "marginBottom": 0,
         }
       }
     >
@@ -1378,11 +1366,7 @@ exports[`26. tile y 1`] = `
     <Text
       style={
         Object {
-          "color": "#696969",
-          "flexWrap": "wrap",
-          "fontFamily": "TimesDigitalW04",
-          "fontSize": 14,
-          "lineHeight": 20,
+          "marginBottom": 0,
         }
       }
     >
@@ -1823,11 +1807,7 @@ exports[`35. tile an 1`] = `
     <Text
       style={
         Object {
-          "color": "#696969",
-          "flexWrap": "wrap",
-          "fontFamily": "TimesDigitalW04",
-          "fontSize": 14,
-          "lineHeight": 20,
+          "marginBottom": 0,
         }
       }
     >
@@ -2082,11 +2062,7 @@ exports[`40. tile ar 1`] = `
         <Text
           style={
             Object {
-              "color": "#696969",
-              "flexWrap": "wrap",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 14,
-              "lineHeight": 20,
+              "marginBottom": 0,
             }
           }
         >
@@ -2148,11 +2124,7 @@ exports[`41. tile as 1`] = `
     <Text
       style={
         Object {
-          "color": "#696969",
-          "flexWrap": "wrap",
-          "fontFamily": "TimesDigitalW04",
-          "fontSize": 14,
-          "lineHeight": 20,
+          "marginBottom": 0,
         }
       }
     >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -81,6 +81,11 @@ exports[`2. tile b 1`] = `
         <Text
           style={
             Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
               "marginBottom": 0,
             }
           }
@@ -280,6 +285,11 @@ exports[`6. tile f 1`] = `
     <Text
       style={
         Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
           "marginBottom": 0,
         }
       }
@@ -387,6 +397,11 @@ exports[`8. tile h 1`] = `
     <Text
       style={
         Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
           "marginBottom": 0,
         }
       }
@@ -1366,6 +1381,11 @@ exports[`26. tile y 1`] = `
     <Text
       style={
         Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
           "marginBottom": 0,
         }
       }
@@ -1807,6 +1827,11 @@ exports[`35. tile an 1`] = `
     <Text
       style={
         Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
           "marginBottom": 0,
         }
       }
@@ -2062,6 +2087,11 @@ exports[`40. tile ar 1`] = `
         <Text
           style={
             Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
               "marginBottom": 0,
             }
           }
@@ -2124,6 +2154,11 @@ exports[`41. tile as 1`] = `
     <Text
       style={
         Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
           "marginBottom": 0,
         }
       }

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -94,6 +94,7 @@ exports[`2. tile b 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -154,7 +155,7 @@ exports[`2. tile b 1`] = `
           This is tile headline
         </h3>
         <div
-          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe IS2 S3"
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
         >
           <span
             className="css-text-901oao css-textHasAncestor-16my406"
@@ -183,10 +184,14 @@ exports[`2. tile b 1`] = `
 exports[`3. tile c 1`] = `
 <style>
 .S1 {
-  margin-bottom: 0px;
+  margin-bottom: 10px;
 }
 
 .S2 {
+  margin-bottom: 0px;
+}
+
+.S3 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-size: 22px;
@@ -195,7 +200,6 @@ exports[`3. tile c 1`] = `
 }
 
 .IS1 {
-  margin-bottom: 10px;
   width: 100%;
 }
 
@@ -228,7 +232,7 @@ exports[`3. tile c 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS1"
+    className="css-view-1dbjc4n r-marginBottom-15d164r IS1 S1"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -240,7 +244,7 @@ exports[`3. tile c 1`] = `
     className="css-view-1dbjc4n IS3"
   >
     <div
-      className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+      className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
     >
       <ArticleLabel
         color="#005B8D"
@@ -250,7 +254,7 @@ exports[`3. tile c 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S3"
       role="heading"
     >
       This is tile headline
@@ -452,6 +456,7 @@ exports[`6. tile f 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -495,7 +500,7 @@ exports[`6. tile f 1`] = `
       Three Conservative MPs resign
     </h4>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S4"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S4"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -641,6 +646,7 @@ exports[`8. tile h 1`] = `
   font-family: TimesModern-Bold;
   font-size: 22px;
   font-weight: 400;
+  margin-bottom: 10px;
 }
 
 .S3 {
@@ -652,6 +658,7 @@ exports[`8. tile h 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .S4 {
@@ -663,7 +670,6 @@ exports[`8. tile h 1`] = `
 
 .IS1 {
   line-height: 22px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
@@ -701,13 +707,13 @@ exports[`8. tile h 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
       role="heading"
     >
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S3"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -761,6 +767,7 @@ exports[`9. tile i 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -770,7 +777,6 @@ exports[`9. tile i 1`] = `
 .IS2 {
   font-size: 35px;
   line-height: 35px;
-  margin-bottom: 10px;
   text-align: center;
 }
 
@@ -810,7 +816,7 @@ exports[`9. tile i 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -840,6 +846,7 @@ exports[`10. tile j 1`] = `
   font-family: TimesModern-Bold;
   font-size: 22px;
   font-weight: 400;
+  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -848,7 +855,6 @@ exports[`10. tile j 1`] = `
 
 .IS2 {
   line-height: 22px;
-  margin-bottom: 10px;
 }
 
 .IS3 {
@@ -886,7 +892,7 @@ exports[`10. tile j 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-15d164r IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -915,6 +921,7 @@ exports[`11. tile k 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -925,7 +932,6 @@ exports[`11. tile k 1`] = `
 .IS2 {
   font-size: 18px;
   line-height: 18px;
-  margin-bottom: 10px;
 }
 
 .IS3 {
@@ -962,7 +968,7 @@ exports[`11. tile k 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -992,11 +998,11 @@ exports[`12. tile l 1`] = `
   font-family: TimesModern-Bold;
   font-weight: 400;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 20px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
@@ -1036,7 +1042,7 @@ exports[`12. tile l 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-15d164r IS1 S2"
       role="heading"
     >
       This is tile headline
@@ -1783,12 +1789,12 @@ exports[`22. tile u 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 40px;
   line-height: 40px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
@@ -1846,7 +1852,7 @@ exports[`22. tile u 1`] = `
           </div>
           <h3
             aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
             role="heading"
           >
             This is tile headline
@@ -1884,6 +1890,7 @@ exports[`23. tile v 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -1894,7 +1901,6 @@ exports[`23. tile v 1`] = `
 .IS2 {
   font-size: 30px;
   line-height: 30px;
-  margin-bottom: 10px;
 }
 
 .IS3 {
@@ -1941,7 +1947,7 @@ exports[`23. tile v 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -2196,6 +2202,7 @@ exports[`26. tile y 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -2232,7 +2239,7 @@ exports[`26. tile y 1`] = `
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S3"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -2266,16 +2273,16 @@ exports[`27. tile z 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 10px;
+}
+
+.S3 {
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 25px;
   line-height: 25px;
-  margin-bottom: 10px;
-}
-
-.IS2 {
-  margin-bottom: 10px;
 }
 </style>
 
@@ -2288,7 +2295,7 @@ exports[`27. tile z 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n r-marginBottom-15d164r S3"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -2301,7 +2308,7 @@ exports[`27. tile z 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
       role="heading"
     >
       This is tile headline
@@ -2468,12 +2475,12 @@ exports[`29. tile ae 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 30px;
   line-height: 30px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
@@ -2520,7 +2527,7 @@ exports[`29. tile ae 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
           role="heading"
         >
           This is tile headline
@@ -2942,6 +2949,7 @@ exports[`35. tile an 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -3008,7 +3016,7 @@ exports[`35. tile an 1`] = `
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S3"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -3302,10 +3310,14 @@ exports[`38. tile ac 1`] = `
 exports[`39. tile aq 1`] = `
 <style>
 .S1 {
-  margin-bottom: 0px;
+  margin-bottom: 10px;
 }
 
 .S2 {
+  margin-bottom: 0px;
+}
+
+.S3 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-size: 22px;
@@ -3314,7 +3326,6 @@ exports[`39. tile aq 1`] = `
 }
 
 .IS1 {
-  margin-bottom: 10px;
   width: 100%;
 }
 
@@ -3346,7 +3357,7 @@ exports[`39. tile aq 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS1"
+    className="css-view-1dbjc4n r-marginBottom-15d164r IS1 S1"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -3364,7 +3375,7 @@ exports[`39. tile aq 1`] = `
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
         >
           <ArticleLabel
             color="#005B8D"
@@ -3374,7 +3385,7 @@ exports[`39. tile aq 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S3"
           role="heading"
         >
           This is tile headline
@@ -3398,10 +3409,14 @@ exports[`39. tile aq 1`] = `
 exports[`40. tile ar 1`] = `
 <style>
 .S1 {
-  margin-bottom: 0px;
+  margin-bottom: 10px;
 }
 
 .S2 {
+  margin-bottom: 0px;
+}
+
+.S3 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
@@ -3409,7 +3424,7 @@ exports[`40. tile ar 1`] = `
   margin-bottom: 5px;
 }
 
-.S3 {
+.S4 {
   color: rgba(105,105,105,1.00);
   -ms-flex-wrap: wrap;
   -webkit-box-lines: multiple;
@@ -3418,10 +3433,10 @@ exports[`40. tile ar 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
-  margin-bottom: 10px;
   width: 100%;
 }
 
@@ -3458,7 +3473,7 @@ exports[`40. tile ar 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS1"
+    className="css-view-1dbjc4n r-marginBottom-15d164r IS1 S1"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -3476,7 +3491,7 @@ exports[`40. tile ar 1`] = `
         className="css-view-1dbjc4n"
       >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
         >
           <ArticleLabel
             color="#005B8D"
@@ -3486,13 +3501,13 @@ exports[`40. tile ar 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS2 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS2 S3"
           role="heading"
         >
           This is tile headline
         </h3>
         <div
-          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe IS3 S3"
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S4"
         >
           <span
             className="css-text-901oao css-textHasAncestor-16my406"
@@ -3521,17 +3536,21 @@ exports[`40. tile ar 1`] = `
 exports[`41. tile as 1`] = `
 <style>
 .S1 {
-  margin-bottom: 0px;
+  margin-bottom: 10px;
 }
 
 .S2 {
+  margin-bottom: 0px;
+}
+
+.S3 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
   margin-bottom: 5px;
 }
 
-.S3 {
+.S4 {
   color: rgba(105,105,105,1.00);
   -ms-flex-wrap: wrap;
   -webkit-box-lines: multiple;
@@ -3540,10 +3559,10 @@ exports[`41. tile as 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
-  margin-bottom: 10px;
   width: 100%;
 }
 
@@ -3577,7 +3596,7 @@ exports[`41. tile as 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS1"
+    className="css-view-1dbjc4n r-marginBottom-15d164r IS1 S1"
   >
     <Image
       aspectRatio={1.5}
@@ -3589,7 +3608,7 @@ exports[`41. tile as 1`] = `
     className="css-view-1dbjc4n IS3"
   >
     <div
-      className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+      className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
     >
       <ArticleLabel
         color="#005B8D"
@@ -3599,13 +3618,13 @@ exports[`41. tile as 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S3"
       role="heading"
     >
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S3"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S4"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
@@ -83,6 +83,7 @@ exports[`default styles 1`] = `
                         "fontFamily": "TimesDigitalW04",
                         "fontSize": 14,
                         "lineHeight": 20,
+                        "marginBottom": 10,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
@@ -83,7 +83,7 @@ exports[`default styles 1`] = `
                         "fontFamily": "TimesDigitalW04",
                         "fontSize": 14,
                         "lineHeight": 20,
-                        "marginBottom": 10,
+                        "marginBottom": 0,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
@@ -106,6 +106,7 @@ exports[`default styles 1`] = `
                         "fontFamily": "TimesDigitalW04",
                         "fontSize": 14,
                         "lineHeight": 20,
+                        "marginBottom": 10,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
@@ -106,7 +106,7 @@ exports[`default styles 1`] = `
                         "fontFamily": "TimesDigitalW04",
                         "fontSize": 14,
                         "lineHeight": 20,
-                        "marginBottom": 10,
+                        "marginBottom": 0,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
@@ -83,6 +83,7 @@ exports[`default styles 1`] = `
                         "fontFamily": "TimesDigitalW04",
                         "fontSize": 14,
                         "lineHeight": 20,
+                        "marginBottom": 10,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
@@ -83,7 +83,7 @@ exports[`default styles 1`] = `
                         "fontFamily": "TimesDigitalW04",
                         "fontSize": 14,
                         "lineHeight": 20,
-                        "marginBottom": 10,
+                        "marginBottom": 0,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
@@ -78,11 +78,7 @@ exports[`default styles 1`] = `
                   <Text
                     style={
                       Object {
-                        "color": "#696969",
-                        "flexWrap": "wrap",
-                        "fontFamily": "TimesDigitalW04",
-                        "fontSize": 14,
-                        "lineHeight": 20,
+                        "marginBottom": 0,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
@@ -78,6 +78,11 @@ exports[`default styles 1`] = `
                   <Text
                     style={
                       Object {
+                        "color": "#696969",
+                        "flexWrap": "wrap",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 14,
+                        "lineHeight": 20,
                         "marginBottom": 0,
                       }
                     }

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
@@ -101,6 +101,11 @@ exports[`default styles 1`] = `
                   <Text
                     style={
                       Object {
+                        "color": "#696969",
+                        "flexWrap": "wrap",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 14,
+                        "lineHeight": 20,
                         "marginBottom": 0,
                       }
                     }

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
@@ -101,11 +101,7 @@ exports[`default styles 1`] = `
                   <Text
                     style={
                       Object {
-                        "color": "#696969",
-                        "flexWrap": "wrap",
-                        "fontFamily": "TimesDigitalW04",
-                        "fontSize": 14,
-                        "lineHeight": 20,
+                        "marginBottom": 0,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
@@ -78,11 +78,7 @@ exports[`default styles 1`] = `
                   <Text
                     style={
                       Object {
-                        "color": "#696969",
-                        "flexWrap": "wrap",
-                        "fontFamily": "TimesDigitalW04",
-                        "fontSize": 14,
-                        "lineHeight": 20,
+                        "marginBottom": 0,
                       }
                     }
                   >

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
@@ -78,6 +78,11 @@ exports[`default styles 1`] = `
                   <Text
                     style={
                       Object {
+                        "color": "#696969",
+                        "flexWrap": "wrap",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 14,
+                        "lineHeight": 20,
                         "marginBottom": 0,
                       }
                     }

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -216,6 +216,7 @@ exports[`default styles 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .S7 {
@@ -288,7 +289,7 @@ exports[`default styles 1`] = `
                     className="css-view-1dbjc4n"
                   >
                     <div
-                      className="summaryHidden leadSummary125Class summaryHidden leadSummary125Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S6"
+                      className="summaryHidden leadSummary125Class summaryHidden leadSummary125Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S6"
                     >
                       <span
                         className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -253,6 +253,7 @@ exports[`default styles 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .S8 {
@@ -327,7 +328,7 @@ exports[`default styles 1`] = `
                     className="css-view-1dbjc4n"
                   >
                     <div
-                      className="summaryHidden opinionSummary125Class summaryHidden opinionSummary125Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S7"
+                      className="summaryHidden opinionSummary125Class summaryHidden opinionSummary125Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S7"
                     >
                       <span
                         className="css-text-901oao css-textHasAncestor-16my406"
@@ -338,7 +339,7 @@ exports[`default styles 1`] = `
                       </span>
                     </div>
                     <div
-                      className="summaryHidden opinionSummary160Class summaryHidden opinionSummary160Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S7"
+                      className="summaryHidden opinionSummary160Class summaryHidden opinionSummary160Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S7"
                     >
                       <span
                         className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -189,6 +189,7 @@ exports[`default styles 1`] = `
   font-family: TimesDigitalW04;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .S7 {
@@ -261,7 +262,7 @@ exports[`default styles 1`] = `
                     className="css-view-1dbjc4n"
                   >
                     <div
-                      className="summaryHidden summary125Class summaryHidden summary125Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe S6"
+                      className="summaryHidden summary125Class summaryHidden summary125Class css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S6"
                     >
                       <span
                         className="css-text-901oao css-textHasAncestor-16my406"


### PR DESCRIPTION
- Fixes issue with flags and article summary on web, which we supposed to be for edition slices only.
- I have retained the original code but made it for native only as edition slices are only for native for now.

### Profile page (`article-summary` fix)
<img width="861" alt="Screenshot 2019-08-23 at 17 41 43" src="https://user-images.githubusercontent.com/1736782/63608628-5fef5a00-c5cd-11e9-9a53-3d53cab6ff34.png">

### Article page (`article-flag` fix)
<img width="895" alt="Screenshot 2019-08-23 at 17 41 34" src="https://user-images.githubusercontent.com/1736782/63608667-75648400-c5cd-11e9-8f58-4274c638c520.png">

