### PR TITLE
Lead one will width slice styling updates for 768

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -880,6 +880,7 @@ exports[`18. tile r 1`] = `
     style={
       Object {
         "flex": 1,
+        "paddingBottom": 10,
       }
     }
   >
@@ -900,7 +901,7 @@ exports[`18. tile r 1`] = `
           "fontSize": 40,
           "fontWeight": "400",
           "lineHeight": 40,
-          "marginBottom": 5,
+          "marginBottom": 0,
         }
       }
     >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -740,7 +740,8 @@ exports[`18. tile r 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "padding": 10,
+      "paddingHorizontal": 30,
+      "paddingVertical": 15,
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -880,6 +880,7 @@ exports[`18. tile r 1`] = `
     style={
       Object {
         "flex": 1,
+        "paddingBottom": 10,
       }
     }
   >
@@ -900,7 +901,7 @@ exports[`18. tile r 1`] = `
           "fontSize": 40,
           "fontWeight": "900",
           "lineHeight": 40,
-          "marginBottom": 5,
+          "marginBottom": 0,
         }
       }
     >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -740,7 +740,8 @@ exports[`18. tile r 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "padding": 10,
+      "paddingHorizontal": 30,
+      "paddingVertical": 15,
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -1470,7 +1470,7 @@ exports[`18. tile r 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
 }
 
 .IS1 {
@@ -1496,13 +1496,14 @@ exports[`18. tile r 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "padding": "10px",
+      "paddingHorizontal": "30px",
+      "paddingVertical": "15px",
     }
   }
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n r-paddingBottom-1mi0q7o IS2"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -1515,7 +1516,7 @@ exports[`18. tile r 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
       role="heading"
     >
       This is tile headline

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -738,7 +738,8 @@ exports[`18. tile r 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "padding": "10px",
+      "paddingHorizontal": "30px",
+      "paddingVertical": "15px",
     }
   }
   url="/article/123"

--- a/packages/edition-slices/edition-tiles.showcase.js
+++ b/packages/edition-slices/edition-tiles.showcase.js
@@ -159,7 +159,7 @@ const tileStories = [
     Tile: TileQ
   },
   {
-    name: "Tile R - Bottom image, 45pt headline, no teaser",
+    name: "Tile R - Bottom image, 40pt headline, no teaser",
     Tile: TileR
   },
   {

--- a/packages/edition-slices/src/tiles/tile-r/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/styles/index.js
@@ -4,21 +4,37 @@ import {
   editionBreakpoints
 } from "@times-components/styleguide";
 
-const headlineFontSizeResolver = {
-  [editionBreakpoints.medium]: 40,
-  [editionBreakpoints.huge]: 45,
-  [editionBreakpoints.wide]: 45
+const mediumBreakpointStyles = {
+  container: {
+    flex: 1,
+    paddingVertical: spacing(3),
+    paddingHorizontal: spacing(6)
+  },
+  headline: {
+    fontFamily: fonts.headline,
+    fontSize: 40,
+    lineHeight: 40,
+    marginBottom: 0
+  },
+  imageContainer: {
+    width: "100%",
+    marginBottom: spacing(2)
+  },
+  summaryContainer: {
+    flex: 1,
+    paddingBottom: spacing(2)
+  }
 };
 
-export default breakpoint => ({
+const wideBreakpointStyles = {
   container: {
     flex: 1,
     padding: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,
-    fontSize: headlineFontSizeResolver[breakpoint],
-    lineHeight: headlineFontSizeResolver[breakpoint]
+    fontSize: 45,
+    lineHeight: 45
   },
   imageContainer: {
     width: "100%",
@@ -27,4 +43,9 @@ export default breakpoint => ({
   summaryContainer: {
     flex: 1
   }
-});
+};
+
+export default breakpoint =>
+  breakpoint === editionBreakpoints.medium
+    ? mediumBreakpointStyles
+    : wideBreakpointStyles;


### PR DESCRIPTION
Mainly spacing updates for medium breakpoint of LeadOneFullWidthSlice.
The slice can be found in the edition from November 11 2018.
Edition id: 6c26f8dc-db1d-11e8-8b34-49942b38308d

Before:
![lead-one-full-width-768-before](https://user-images.githubusercontent.com/8720661/63751562-4b0a1380-c8b8-11e9-98a5-f746dbe30b45.png)


After:
![lead-one-full-width-768-after](https://user-images.githubusercontent.com/8720661/63751567-4cd3d700-c8b8-11e9-9bf3-a08632862ed4.png)
