### PR TITLE
feat[REPLAT-7371]: Pack graphql files in ios pod

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ios:app": "react-native start --config ./ios-app/metro.config.js",
     "ios:publish-lib": "./lib/publish-ios-assets.sh -v",
     "ios:build-lib": "yarn ios:build-lib:js && cd ios-app && yarn build",
-    "ios:build-lib:js": "mkdir -p ios-app/ios-assets/js && mkdir -p ios-app/ios-assets/res && react-native bundle --platform ios --dev false --entry-file ios-app/index.ios.js --bundle-output ios-app/ios-assets/js/index.ios.bundle --assets-dest ios-app/ios-assets/res/",
+    "ios:build-lib:js": "mkdir -p ios-app/ios-assets/js && mkdir -p ios-app/ios-assets/res/graphql && cp ./packages/provider-queries/src/*.graphql ./ios-app/ios-assets/res/graphql && react-native bundle --platform ios --dev false --entry-file ios-app/index.ios.js --bundle-output ios-app/ios-assets/js/index.ios.bundle --assets-dest ios-app/ios-assets/res/",
     "start-emulator": "./lib/start_android_emulator.sh",
     "preandroid": "yarn start-emulator",
     "android": "react-native run-android --no-packager",


### PR DESCRIPTION
Bundle the graphql files in the `TimesComponents` pod file so they can be reused by the iOS app