### PR TITLE
feat: REPLAT-7504 lead 1 full width 1024 styling

### DIFF
--- a/packages/edition-slices/src/tiles/tile-r/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/styles/index.js
@@ -27,21 +27,11 @@ const mediumBreakpointStyles = {
 };
 
 const wideBreakpointStyles = {
+  ...mediumBreakpointStyles,
   container: {
     flex: 1,
-    padding: spacing(2)
-  },
-  headline: {
-    fontFamily: fonts.headline,
-    fontSize: 45,
-    lineHeight: 45
-  },
-  imageContainer: {
-    width: "100%",
-    marginBottom: spacing(2)
-  },
-  summaryContainer: {
-    flex: 1
+    paddingVertical: spacing(3),
+    paddingHorizontal: spacing(4)
   }
 };
 


### PR DESCRIPTION
[Story.](https://nidigitalsolutions.jira.com/browse/REPLAT-7504)
LeadOneFullWidth slice styled for wide breakpoint.
[Design.](https://app.zeplin.io/project/5d2849a2b4a4605645afb4be/screen/5d5186ae32e23e3516c18fbd)

Result:
![lead-1-full-width-wide-after](https://user-images.githubusercontent.com/8720661/63865471-504f8700-c9ba-11e9-97ca-7b2085516721.png)
