### PR TITLE
fix: fix a crash where a dropcap-enabled article has a newline as the…

### DIFF
--- a/packages/article-skeleton/__tests__/common/dropcap-util.test.js
+++ b/packages/article-skeleton/__tests__/common/dropcap-util.test.js
@@ -33,45 +33,6 @@ const invalidChild = {
   name: "paragraph"
 };
 
-const invalidChildOut = [
-  {
-    attributes: {},
-    children: [
-      {
-        attributes: {},
-        children: [
-          { attributes: { dropCap: true }, children: [], name: "break" },
-          {
-            attributes: {
-              value:
-                "As I follow Chris Reynolds Gordon down the first f…fty Shades of Grey but, he says, “I’m living it.”"
-            },
-            children: [],
-            name: "text"
-          }
-        ],
-        name: "paragraph"
-      }
-    ],
-    name: "dropCap"
-  },
-  {
-    attributes: {},
-    children: [
-      { attributes: { dropCap: true }, children: [], name: "break" },
-      {
-        attributes: {
-          value:
-            "As I follow Chris Reynolds Gordon down the first f…fty Shades of Grey but, he says, “I’m living it.”"
-        },
-        children: [],
-        name: "text"
-      }
-    ],
-    name: "paragraph"
-  }
-];
-
 const childWithMarkup = {
   attributes: {},
   children: [
@@ -193,9 +154,9 @@ describe("insertDropcapIntoAST", () => {
 
   it("should fall back to no dropcap if the markup is invalid", () => {
     const template = "indepth";
-    expect(insertDropcapIntoAST([invalidChild], template)).toEqual(
-      [invalidChild]
-    );
+    expect(insertDropcapIntoAST([invalidChild], template)).toEqual([
+      invalidChild
+    ]);
   });
 
   it("should insert dropcap if it belongs to the right template with markup", () => {

--- a/packages/article-skeleton/__tests__/common/dropcap-util.test.js
+++ b/packages/article-skeleton/__tests__/common/dropcap-util.test.js
@@ -1,7 +1,7 @@
 import insertDropcapIntoAST from "../../src/dropcap-util";
 
 const child = {
-  attributes: [],
+  attributes: {},
   children: [
     {
       attributes: {
@@ -15,8 +15,65 @@ const child = {
   name: "paragraph"
 };
 
+const invalidChild = {
+  attributes: {},
+  children: [
+    {
+      name: "break"
+    },
+    {
+      attributes: {
+        value:
+          "As I follow Chris Reynolds Gordon down the first f…fty Shades of Grey but, he says, “I’m living it.”"
+      },
+      children: [],
+      name: "text"
+    }
+  ],
+  name: "paragraph"
+};
+
+const invalidChildOut = [
+  {
+    attributes: {},
+    children: [
+      {
+        attributes: {},
+        children: [
+          { attributes: { dropCap: true }, children: [], name: "break" },
+          {
+            attributes: {
+              value:
+                "As I follow Chris Reynolds Gordon down the first f…fty Shades of Grey but, he says, “I’m living it.”"
+            },
+            children: [],
+            name: "text"
+          }
+        ],
+        name: "paragraph"
+      }
+    ],
+    name: "dropCap"
+  },
+  {
+    attributes: {},
+    children: [
+      { attributes: { dropCap: true }, children: [], name: "break" },
+      {
+        attributes: {
+          value:
+            "As I follow Chris Reynolds Gordon down the first f…fty Shades of Grey but, he says, “I’m living it.”"
+        },
+        children: [],
+        name: "text"
+      }
+    ],
+    name: "paragraph"
+  }
+];
+
 const childWithMarkup = {
-  attributes: [],
+  attributes: {},
   children: [
     {
       attributes: {},
@@ -80,7 +137,7 @@ const childWithDropCapAndMarkup = [
     attributes: {},
     children: [
       {
-        attributes: [],
+        attributes: {},
         children: [
           {
             attributes: {
@@ -104,7 +161,7 @@ const childWithDropCapAndMarkup = [
     ]
   },
   {
-    attributes: [],
+    attributes: {},
     children: [
       {
         attributes: {
@@ -132,6 +189,13 @@ describe("insertDropcapIntoAST", () => {
   it("should insert dropcap if it belongs to the right template", () => {
     const template = "indepth";
     expect(insertDropcapIntoAST([child], template)).toEqual(childWithDropCap);
+  });
+
+  it("should fall back to no dropcap if the markup is invalid", () => {
+    const template = "indepth";
+    expect(insertDropcapIntoAST([invalidChild], template)).toEqual(
+      [invalidChild]
+    );
   });
 
   it("should insert dropcap if it belongs to the right template with markup", () => {

--- a/packages/article-skeleton/src/dropcap-util-common.js
+++ b/packages/article-skeleton/src/dropcap-util-common.js
@@ -73,32 +73,36 @@ const findFirstTextNode = children => {
 };
 
 const insertDropcapIntoAST = (children, template, isDropcapDisabled) => {
-  if (
-    template &&
-    templateWithDropCaps.includes(template) &&
-    !isDropcapDisabled &&
-    children.length > 0 &&
-    children[0].name === "paragraph" &&
-    children[0].children.length > 0
-  ) {
-    const withCap = splitNode(children[0]);
-    const withoutCap = splitNode(children[0]);
+  try {
+    if (
+      template &&
+      templateWithDropCaps.includes(template) &&
+      !isDropcapDisabled &&
+      children.length > 0 &&
+      children[0].name === "paragraph" &&
+      children[0].children.length > 0
+    ) {
+      const withCap = splitNode(children[0]);
+      const withoutCap = splitNode(children[0]);
 
-    const newCapChildren = findFirstTextNode(withCap.children);
-    newCapChildren.splice(1);
+      const newCapChildren = findFirstTextNode(withCap.children);
+      newCapChildren.splice(1);
 
-    const newChildren = findFirstTextNode(withoutCap.children);
-    newChildren.splice(0, 1);
+      const newChildren = findFirstTextNode(withoutCap.children);
+      newChildren.splice(0, 1);
 
-    return [
-      {
-        name: "dropCap",
-        attributes: {},
-        children: [withCap]
-      },
-      withoutCap,
-      ...children.slice(1)
-    ];
+      return [
+        {
+          name: "dropCap",
+          attributes: {},
+          children: [withCap]
+        },
+        withoutCap,
+        ...children.slice(1)
+      ];
+    }
+  } catch (error) {
+    return children;
   }
   return children;
 };


### PR DESCRIPTION
… first element

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Some articles have weird markup like a newline as the first element and dropcaps enabled, we should just fail back to rendering without dropcaps (This is what web and native do)  in these cases instead of trying to make every possible markup case work. 