### PR TITLE
Fix: Replat-7828 fix article-list headlines

### DIFF
--- a/packages/article-list/__tests__/android/__snapshots__/article-list-states.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list-states.android.test.js.snap
@@ -69,7 +69,9 @@ exports[`4. loading state 1`] = `
                 isLoading={true}
                 showImage={true}
               >
-                <ArticleSummary />
+                <ArticleSummary
+                  headline={<ArticleSummaryHeadline />}
+                />
               </Card>
             </View>
           </Link>
@@ -91,7 +93,9 @@ exports[`4. loading state 1`] = `
                 isLoading={true}
                 showImage={true}
               >
-                <ArticleSummary />
+                <ArticleSummary
+                  headline={<ArticleSummaryHeadline />}
+                />
               </Card>
             </View>
           </Link>
@@ -113,7 +117,9 @@ exports[`4. loading state 1`] = `
                 isLoading={true}
                 showImage={true}
               >
-                <ArticleSummary />
+                <ArticleSummary
+                  headline={<ArticleSummaryHeadline />}
+                />
               </Card>
             </View>
           </Link>

--- a/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
@@ -28,6 +28,11 @@ exports[`1. article list 1`] = `
                       "publication": "TIMES",
                     }
                   }
+                  headline={
+                    <ArticleSummaryHeadline
+                      headline="ShortHeadline 1"
+                    />
+                  }
                   labelProps={
                     Object {
                       "color": "#636C17",
@@ -90,6 +95,11 @@ exports[`1. article list 1`] = `
                       "publication": "SUNDAYTIMES",
                     }
                   }
+                  headline={
+                    <ArticleSummaryHeadline
+                      headline="ShortHeadline 2"
+                    />
+                  }
                   labelProps={
                     Object {
                       "color": "#1D1D1B",
@@ -148,6 +158,11 @@ exports[`2. article list with no images 1`] = `
                       "date": "2017-11-17T00:01:00.000Z",
                       "publication": "TIMES",
                     }
+                  }
+                  headline={
+                    <ArticleSummaryHeadline
+                      headline="ShortHeadline 1"
+                    />
                   }
                   labelProps={
                     Object {
@@ -208,6 +223,11 @@ exports[`3. a retry button when load more fails 1`] = `
                       "publication": "TIMES",
                     }
                   }
+                  headline={
+                    <ArticleSummaryHeadline
+                      headline="ShortHeadline 1"
+                    />
+                  }
                   labelProps={
                     Object {
                       "color": "#636C17",
@@ -263,6 +283,11 @@ exports[`4. no footer with data equalling the count 1`] = `
                       "date": "2017-11-17T00:01:00.000Z",
                       "publication": "TIMES",
                     }
+                  }
+                  headline={
+                    <ArticleSummaryHeadline
+                      headline="ShortHeadline 1"
+                    />
                   }
                   labelProps={
                     Object {
@@ -444,6 +469,11 @@ exports[`6. removes the retry button when successfully pressed 1`] = `
                       "date": "2017-11-17T00:01:00.000Z",
                       "publication": "TIMES",
                     }
+                  }
+                  headline={
+                    <ArticleSummaryHeadline
+                      headline="ShortHeadline 1"
+                    />
                   }
                   labelProps={
                     Object {

--- a/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
@@ -256,7 +256,7 @@ exports[`3. a retry button when load more fails 1`] = `
 </RCTScrollView>
 `;
 
-exports[`4. no footer with data equalling the count 1`] = `
+exports[`5. no footer with data equalling the count 1`] = `
 <RCTScrollView
   nestedScrollEnabled={true}
   removeClippedSubviews={true}
@@ -308,7 +308,7 @@ exports[`4. no footer with data equalling the count 1`] = `
 </RCTScrollView>
 `;
 
-exports[`5. onviewed is called with changed items 1`] = `
+exports[`6. onviewed is called with changed items 1`] = `
 Array [
   Array [
     Object {
@@ -442,7 +442,7 @@ Array [
 ]
 `;
 
-exports[`6. removes the retry button when successfully pressed 1`] = `
+exports[`7. removes the retry button when successfully pressed 1`] = `
 <RCTScrollView
   nestedScrollEnabled={true}
   removeClippedSubviews={true}

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list-states.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list-states.ios.test.js.snap
@@ -69,7 +69,9 @@ exports[`4. loading state 1`] = `
                 isLoading={true}
                 showImage={true}
               >
-                <ArticleSummary />
+                <ArticleSummary
+                  headline={<ArticleSummaryHeadline />}
+                />
               </Card>
             </View>
           </Link>
@@ -91,7 +93,9 @@ exports[`4. loading state 1`] = `
                 isLoading={true}
                 showImage={true}
               >
-                <ArticleSummary />
+                <ArticleSummary
+                  headline={<ArticleSummaryHeadline />}
+                />
               </Card>
             </View>
           </Link>
@@ -113,7 +117,9 @@ exports[`4. loading state 1`] = `
                 isLoading={true}
                 showImage={true}
               >
-                <ArticleSummary />
+                <ArticleSummary
+                  headline={<ArticleSummaryHeadline />}
+                />
               </Card>
             </View>
           </Link>

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
@@ -28,6 +28,11 @@ exports[`1. article list 1`] = `
                       "publication": "TIMES",
                     }
                   }
+                  headline={
+                    <ArticleSummaryHeadline
+                      headline="ShortHeadline 1"
+                    />
+                  }
                   labelProps={
                     Object {
                       "color": "#636C17",
@@ -90,6 +95,11 @@ exports[`1. article list 1`] = `
                       "publication": "SUNDAYTIMES",
                     }
                   }
+                  headline={
+                    <ArticleSummaryHeadline
+                      headline="ShortHeadline 2"
+                    />
+                  }
                   labelProps={
                     Object {
                       "color": "#1D1D1B",
@@ -148,6 +158,11 @@ exports[`2. article list with no images 1`] = `
                       "date": "2017-11-17T00:01:00.000Z",
                       "publication": "TIMES",
                     }
+                  }
+                  headline={
+                    <ArticleSummaryHeadline
+                      headline="ShortHeadline 1"
+                    />
                   }
                   labelProps={
                     Object {
@@ -208,6 +223,11 @@ exports[`3. a retry button when load more fails 1`] = `
                       "publication": "TIMES",
                     }
                   }
+                  headline={
+                    <ArticleSummaryHeadline
+                      headline="ShortHeadline 1"
+                    />
+                  }
                   labelProps={
                     Object {
                       "color": "#636C17",
@@ -263,6 +283,11 @@ exports[`4. no footer with data equalling the count 1`] = `
                       "date": "2017-11-17T00:01:00.000Z",
                       "publication": "TIMES",
                     }
+                  }
+                  headline={
+                    <ArticleSummaryHeadline
+                      headline="ShortHeadline 1"
+                    />
                   }
                   labelProps={
                     Object {
@@ -444,6 +469,11 @@ exports[`6. removes the retry button when successfully pressed 1`] = `
                       "date": "2017-11-17T00:01:00.000Z",
                       "publication": "TIMES",
                     }
+                  }
+                  headline={
+                    <ArticleSummaryHeadline
+                      headline="ShortHeadline 1"
+                    />
                   }
                   labelProps={
                     Object {

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
@@ -256,7 +256,7 @@ exports[`3. a retry button when load more fails 1`] = `
 </RCTScrollView>
 `;
 
-exports[`4. no footer with data equalling the count 1`] = `
+exports[`5. no footer with data equalling the count 1`] = `
 <RCTScrollView
   nestedScrollEnabled={true}
   removeClippedSubviews={true}
@@ -308,7 +308,7 @@ exports[`4. no footer with data equalling the count 1`] = `
 </RCTScrollView>
 `;
 
-exports[`5. onviewed is called with changed items 1`] = `
+exports[`6. onviewed is called with changed items 1`] = `
 Array [
   Array [
     Object {
@@ -442,7 +442,7 @@ Array [
 ]
 `;
 
-exports[`6. removes the retry button when successfully pressed 1`] = `
+exports[`7. removes the retry button when successfully pressed 1`] = `
 <RCTScrollView
   nestedScrollEnabled={true}
   removeClippedSubviews={true}

--- a/packages/article-list/__tests__/shared.native.js
+++ b/packages/article-list/__tests__/shared.native.js
@@ -13,6 +13,7 @@ import { omitNative as omitProps } from "./utils";
 import ArticleList from "../src/article-list";
 import articlesFixture from "../fixtures/articles.json";
 import shared from "./shared.base.native";
+import ArticleSummaryHeadline from "@times-components/article-summary"
 
 export default () => {
   addSerializers(
@@ -25,6 +26,24 @@ export default () => {
   );
 
   const tests = [
+    {
+      name: 'headlines should render',
+      test() {
+        const testInstance = TestRenderer.create(
+          <ArticleList
+            articles={articlesFixture.slice(0, 1)}
+            count={1}
+            emptyStateMessage="Empty state"
+            onArticlePress={() => {}}
+            pageSize={3}
+            refetch={() => {}}
+          />
+        );
+
+        const headline = testInstance.root.findByType(ArticleSummaryHeadline);
+        expect(headline).toBeDefined();
+      }
+    },
     {
       name: "no footer with data equalling the count",
       test() {

--- a/packages/article-list/__tests__/shared.native.js
+++ b/packages/article-list/__tests__/shared.native.js
@@ -9,11 +9,11 @@ import {
 } from "@times-components/jest-serializer";
 import TestRenderer from "react-test-renderer";
 import "./mocks";
+import ArticleSummaryHeadline from "@times-components/article-summary";
 import { omitNative as omitProps } from "./utils";
 import ArticleList from "../src/article-list";
 import articlesFixture from "../fixtures/articles.json";
 import shared from "./shared.base.native";
-import ArticleSummaryHeadline from "@times-components/article-summary"
 
 export default () => {
   addSerializers(
@@ -27,7 +27,7 @@ export default () => {
 
   const tests = [
     {
-      name: 'headlines should render',
+      name: "headlines should render",
       test() {
         const testInstance = TestRenderer.create(
           <ArticleList

--- a/packages/article-list/src/article-list-item.js
+++ b/packages/article-list/src/article-list-item.js
@@ -45,8 +45,8 @@ class ArticleListItem extends Component {
   }
 
   renderHeadline() {
-    const { article = {} } = this.props;
-    const { headline, shortHeadline } = article;
+    const { article } = this.props;
+    const { headline, shortHeadline } = article || {};
     return (
       <ArticleSummaryHeadline headline={getHeadline(headline, shortHeadline)} />
     );
@@ -107,7 +107,7 @@ class ArticleListItem extends Component {
                         date: publishedTime,
                         publication: publicationName
                       }}
-                      headline={this.renderHeadline}
+                      headline={this.renderHeadline()}
                       labelProps={{
                         color:
                           colours.section[section] || colours.section.default,


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Article headlines were not rendering in article summary due to a missing function call.
![Screenshot_1567432404](https://user-images.githubusercontent.com/615608/64119312-721d8500-cd91-11e9-8a4a-d8317761b987.png)

