### PR TITLE
fix: show correct saved status when user has more than 20 saved articles

### DIFF
--- a/packages/provider-queries/src/article-bookmarked.graphql
+++ b/packages/provider-queries/src/article-bookmarked.graphql
@@ -1,0 +1,7 @@
+query ArticleBookmarkedQuery($id: ID!) {
+  article(id: $id) {
+    __typename
+    id
+    isBookmarked
+  }
+}

--- a/packages/provider-queries/src/article-bookmarked.js
+++ b/packages/provider-queries/src/article-bookmarked.js
@@ -1,0 +1,4 @@
+import { addTypenameToDocument } from "apollo-utilities";
+import articleBookmarkedFragment from "./article-bookmarked.graphql";
+
+export default addTypenameToDocument(articleBookmarkedFragment);

--- a/packages/provider-queries/src/provider-queries.js
+++ b/packages/provider-queries/src/provider-queries.js
@@ -1,32 +1,24 @@
-import articleQuery from "./article";
-import articleExtrasQuery from "./article-extras";
-import getTokenisedArticleUrlQuery from "./get-tokenised-article-url";
-import * as authorArticlesNoImagesQuery from "./author-articles-no-images";
-import * as authorArticlesWithImagesQuery from "./author-articles-with-images";
-import authorQuery from "./author";
-import getBookmarksQuery from "./get-bookmarks";
-import saveBookmarksQuery from "./save-bookmark";
-import unsaveBookmarksQuery from "./unsave-bookmark";
-import editionQuery from "./edition";
-import nativeEditionQuery from "./native-edition";
-import topicQuery from "./topic";
-import * as topicArticlesQuery from "./topic-articles";
+export article from "./article";
+export articleBookmarked from "./article-bookmarked";
+export articleExtras from "./article-extras";
+export author from "./author";
+export edition from "./edition";
+export getBookmarks from "./get-bookmarks";
+export getTokenisedArticleUrl from "./get-tokenised-article-url";
+export nativeEdition from "./native-edition";
+export saveBookmarks from "./save-bookmark";
+export topic from "./topic";
+export unsaveBookmarks from "./unsave-bookmark";
 
-export const article = articleQuery;
-export const articleExtras = articleExtrasQuery;
-export const getTokenisedArticleUrl = getTokenisedArticleUrlQuery;
-export const authorArticlesNoImages = authorArticlesNoImagesQuery.default;
-export const authorArticlesNoImagesPTV =
-  authorArticlesNoImagesQuery.propsToVariables;
-export const authorArticlesWithImages = authorArticlesWithImagesQuery.default;
-export const authorArticlesWithImagesPTV =
-  authorArticlesWithImagesQuery.propsToVariables;
-export const author = authorQuery;
-export const getBookmarks = getBookmarksQuery;
-export const saveBookmarks = saveBookmarksQuery;
-export const unsaveBookmarks = unsaveBookmarksQuery;
-export const edition = editionQuery;
-export const nativeEdition = nativeEditionQuery;
-export const topic = topicQuery;
-export const topicArticles = topicArticlesQuery.default;
-export const topicArticlesPTV = topicArticlesQuery.propsToVariables;
+export {
+  default as authorArticlesNoImages,
+  propsToVariables as authorArticlesNoImagesPTV
+} from "./author-articles-no-images";
+export {
+  default as authorArticlesWithImages,
+  propsToVariables as authorArticlesWithImagesPTV
+} from "./author-articles-with-images";
+export {
+  default as topicArticles,
+  propsToVariables as topicArticlesPTV
+} from "./topic-articles";

--- a/packages/provider-test-tools/src/bookmarks.js
+++ b/packages/provider-test-tools/src/bookmarks.js
@@ -1,9 +1,9 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import {
-  getBookmarks,
   saveBookmarks,
-  unsaveBookmarks
+  unsaveBookmarks,
+  articleBookmarked
 } from "@times-components/provider-queries";
 
 import MockedProvider from "./mocked-provider";
@@ -13,17 +13,16 @@ const createBookmarkMocks = ({ id } = {}, delay) => [
   {
     defaults: {
       types: {
-        Bookmark: () => ({
-          id
-        }),
-        PageOfBookmarks: () => ({
-          bookmarks: [],
-          total: 0
+        Article: () => ({
+          __typename: "Article",
+          id,
+          isBookmarked: false
         })
       }
     },
-    query: getBookmarks,
-    variables: {},
+    query: articleBookmarked,
+    variables: { id },
+    repeatable: true,
     delay
   },
   {

--- a/packages/provider/src/article-bookmarked.js
+++ b/packages/provider/src/article-bookmarked.js
@@ -1,0 +1,4 @@
+import { articleBookmarked } from "@times-components/provider-queries";
+import connectGraphql from "./connect";
+
+export default connectGraphql(articleBookmarked);

--- a/packages/provider/src/bookmarks.js
+++ b/packages/provider/src/bookmarks.js
@@ -1,4 +1,0 @@
-import { getBookmarks } from "@times-components/provider-queries";
-import connectGraphql from "./connect";
-
-export default connectGraphql(getBookmarks);

--- a/packages/provider/src/provider.js
+++ b/packages/provider/src/provider.js
@@ -1,25 +1,13 @@
-import connect, { QueryProvider } from "./connect";
-import AuthorProfileProvider from "./author-profile";
-import AuthorArticlesNoImagesProvider from "./author-articles-no-images";
-import AuthorArticlesWithImagesProvider from "./author-articles-with-images";
-import ArticleProvider from "./article";
-import ArticleExtrasProvider from "./article-extras";
-import EditionProvider from "./edition";
-import TopicProvider from "./topic";
-import TopicArticlesProvider from "./topic-articles";
-import Bookmarks from "./bookmarks";
+export { QueryProvider } from "./connect";
+export AuthorProfileProvider from "./author-profile";
+export AuthorArticlesNoImagesProvider from "./author-articles-no-images";
+export AuthorArticlesWithImagesProvider from "./author-articles-with-images";
+export ArticleBookmarked from "./article-bookmarked";
+export ArticleProvider from "./article";
+export ArticleExtrasProvider from "./article-extras";
+export EditionProvider from "./edition";
+export TopicProvider from "./topic";
+export TopicArticlesProvider from "./topic-articles";
+export Bookmarks from "./bookmarks";
 
-export default connect;
-
-export {
-  AuthorProfileProvider,
-  AuthorArticlesNoImagesProvider,
-  AuthorArticlesWithImagesProvider,
-  ArticleProvider,
-  ArticleExtrasProvider,
-  EditionProvider,
-  TopicProvider,
-  TopicArticlesProvider,
-  QueryProvider,
-  Bookmarks
-};
+export default from "./connect";

--- a/packages/provider/src/provider.js
+++ b/packages/provider/src/provider.js
@@ -8,6 +8,5 @@ export ArticleExtrasProvider from "./article-extras";
 export EditionProvider from "./edition";
 export TopicProvider from "./topic";
 export TopicArticlesProvider from "./topic-articles";
-export Bookmarks from "./bookmarks";
 
 export default from "./connect";

--- a/packages/save-star-web/package.json
+++ b/packages/save-star-web/package.json
@@ -41,7 +41,7 @@
     "@times-components/styleguide": "3.28.46",
     "@times-components/tracking": "2.4.66",
     "@times-components/utils": "4.11.33",
-    "lodash.get": "4.4.2",
+    "react-apollo": "2.5.5",
     "prop-types": "15.7.2",
     "react-apollo": "2.5.5",
     "styled-components": "4.2.0"


### PR DESCRIPTION
[JIRA](https://nidigitalsolutions.jira.com/browse/REPLAT-8223)

Currently, in order to determine the saved status of an article for a user, we request a list of the user's bookmarked articles and check whether the article is contained within it. However, it is not possible (or desirable) to get the full list of a user's bookmarked articles consistently, as the list is paged and the query must provide a page size (which defaults to 20).

This means that under the current approach, there will always be a maximum number of saved articles a user can have before they start to experience bugs. There are also undesirable side effects on increasing the page size, as it is essentially wasted network traffic for the client to compute this, and it requires both the server and the client to load into memory increasingly large lists. This is unnecessary.

Instead, I'm using the `isBookmarked` field on articles. This continues to be lazy loaded as with the previous approach. It is unclear why this was not used in the first place, but my understanding is that this field was not available when we first implemented saved status for articles.  

I'm interested to know if there were any other reasons for why `isBookmarked` was not used. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
