### PR TITLE
fix: REPLAT-7354 unruly expect an object always

### DIFF
--- a/packages/ad/src/dom-context.android.js
+++ b/packages/ad/src/dom-context.android.js
@@ -93,7 +93,10 @@ class DOMContext extends PureComponent {
     this.isVisible = false;
     this.webView.injectJavaScript(`
         if (typeof unrulyViewportStatus === "function") {
-          unrulyViewportStatus(false);
+          unrulyViewportStatus(${JSON.stringify({
+            ...this.deviceInfo,
+            visible: false
+          })});
         };
       `);
   };

--- a/packages/ad/src/dom-context.js
+++ b/packages/ad/src/dom-context.js
@@ -85,7 +85,10 @@ class DOMContext extends PureComponent {
     this.isVisible = false;
     this.webView.injectJavaScript(`
         if (typeof unrulyViewportStatus === "function") {
-          unrulyViewportStatus(false);
+          unrulyViewportStatus(${JSON.stringify({
+            ...this.deviceInfo,
+            visible: false
+          })})
         };
       `);
   };


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
A small change, unruly have stated they expect an object with the same properties as when in-viewport for the out-of-viewport event.