### PR TITLE
fix: section fragment query updates

### DIFF
--- a/packages/provider-queries/src/section_fragment.graphql
+++ b/packages/provider-queries/src/section_fragment.graphql
@@ -280,36 +280,36 @@ fragment standardSection on StandardSection {
       support1 {
         headline
         leadAsset {
-          ...leadAsset32
+          ...leadAsset32and45
         }
         article {
           ...baseArticleProps
           leadAsset {
-            ...leadAsset32
+            ...leadAsset32and45
           }
           listingAsset {
-            ...listingAsset32
+            ...listingAsset32and45
+          }
+        }
+      }
+      support2 {
+        headline
+        leadAsset {
+          ...leadAsset32and45
+        }
+        article {
+          ...baseArticleProps
+          leadAsset {
+            ...leadAsset32and45
+          }
+          listingAsset {
+            ...listingAsset32and45
           }
           summary125: summary(maxCharCount: 125)
           summary800: summary(maxCharCount: 800)
         }
         teaser125: teaser(maxCharCount: 125)
         teaser800: teaser(maxCharCount: 800)
-      }
-      support2 {
-        headline
-        leadAsset {
-          ...leadAsset45
-        }
-        article {
-          ...baseArticleProps
-          leadAsset {
-            ...leadAsset45
-          }
-          listingAsset {
-            ...listingAsset45
-          }
-        }
       }
     }
     ... on SecondaryFourSlice {
@@ -417,7 +417,9 @@ fragment standardSection on StandardSection {
           listingAsset {
             ...listingAsset169
           }
+          summary800: summary(maxCharCount: 800)
         }
+        teaser800: teaser(maxCharCount: 800)
       }
       columnist {
         headline
@@ -946,34 +948,36 @@ fragment magazineSection on MagazineSection {
       support1 {
         headline
         leadAsset {
-          ...leadAsset32
+          ...leadAsset32and45
         }
         article {
           ...baseArticleProps
           leadAsset {
-            ...leadAsset32
+            ...leadAsset32and45
           }
           listingAsset {
-            ...listingAsset32
+            ...listingAsset32and45
           }
-          summary800: summary(maxCharCount: 800)
         }
-        teaser800: teaser(maxCharCount: 800)
       }
       support2 {
         headline
         leadAsset {
-          ...leadAsset45
+          ...leadAsset32and45
         }
         article {
           ...baseArticleProps
           leadAsset {
-            ...leadAsset45
+            ...leadAsset32and45
           }
           listingAsset {
-            ...listingAsset45
+            ...listingAsset32and45
           }
+          summary125: summary(maxCharCount: 125)
+          summary800: summary(maxCharCount: 800)
         }
+        teaser125: teaser(maxCharCount: 125)
+        teaser800: teaser(maxCharCount: 800)
       }
     }
     ... on SecondaryFourSlice {
@@ -1081,7 +1085,9 @@ fragment magazineSection on MagazineSection {
           listingAsset {
             ...listingAsset169
           }
+          summary800: summary(maxCharCount: 800)
         }
+        teaser800: teaser(maxCharCount: 800)
       }
       columnist {
         headline
@@ -1577,6 +1583,50 @@ fragment leadAsset169and32 on Media {
       ...sectionCropProps
     }
     crop169: crop(ratio: "16:9") {
+      ...sectionCropProps
+    }
+  }
+}
+
+fragment leadAsset32and45 on Media {
+  __typename
+  ... on Video {
+    posterImage {
+      crop32: crop(ratio: "3:2") {
+        ...sectionCropProps
+      }
+      crop45: crop(ratio: "4:5") {
+        ...sectionCropProps
+      }
+    }
+  }
+  ... on Image {
+    crop32: crop(ratio: "3:2") {
+      ...sectionCropProps
+    }
+    crop45: crop(ratio: "4:5") {
+      ...sectionCropProps
+    }
+  }
+}
+
+fragment listingAsset32and45 on Media {
+  __typename
+  ... on Video {
+    posterImage {
+      crop32: crop(ratio: "3:2") {
+        ...sectionCropProps
+      }
+      crop45: crop(ratio: "4:5") {
+        ...sectionCropProps
+      }
+    }
+  }
+  ... on Image {
+    crop32: crop(ratio: "3:2") {
+      ...sectionCropProps
+    }
+    crop45: crop(ratio: "4:5") {
       ...sectionCropProps
     }
   }


### PR DESCRIPTION
Fix for LeadTwoNoPicAndTwoSlice and SecondaryOneAndColumnistSlice queries

For some reason updating those queries was missed during the development and merging to master the changes of 1024 slices.

In order to keep the lead 2 no pic and 2 small breakpoint unchanged. We need both 3:2 and 4:5 ratio of the pictures. To show you that the changes doesn't affect mobile I have provided screenshots.
Please check them below:

**LeadTwoNoPicAndTwoSlice Before:**
<img width="1443" alt="lead-2-no-pic-and-two-query-before" src="https://user-images.githubusercontent.com/8720661/64185658-33adc600-ce76-11e9-9faa-68077d32ea0a.png">

---

**LeadTwoNoPicAndTwoSlice After:**
<img width="1458" alt="lead-2-no-pic-and-2-query-after" src="https://user-images.githubusercontent.com/8720661/64185669-37414d00-ce76-11e9-8a1f-92448f227c48.png">


---

**SecondaryOneAndColumnistSlice Before:**
<img width="980" alt="columnist-no-teaser-before" src="https://user-images.githubusercontent.com/8720661/64186376-63110280-ce77-11e9-8731-f40dc6c25ad3.png">


---

**SecondaryOneAndColumnistSlice After:**
<img width="959" alt="columnist-teaser-after" src="https://user-images.githubusercontent.com/8720661/64186393-6ad0a700-ce77-11e9-9f92-1b2843e7174a.png">

