### PR TITLE
fix: output correct metadata when lead asset is a video

### DIFF
--- a/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
@@ -72,6 +72,78 @@ exports[`Head outputs correct metadata 1`] = `
 </Helmet>
 `;
 
+exports[`Head outputs correct metadata for a video article 1`] = `
+<Helmet>
+  <title>
+    Some Headline
+     | 
+    Comment | 
+    The Times
+  </title>
+  <meta
+    content="Some Headline"
+    name="article:title"
+  />
+  <meta
+    content="The Times"
+    name="article:publication"
+  />
+  <meta
+    content="Boris Johnson’s sister an ex-BBC broadcaster and John Major’s health secretary will stand for Change UK in next month’s European elections.The pro-Remain party announced its MEP hopefuls from almost 4"
+    name="description"
+  />
+  <meta
+    content="Some byline"
+    name="author"
+  />
+  <meta
+    content="Some Headline"
+    property="og:title"
+  />
+  <meta
+    content="article"
+    property="og:type"
+  />
+  <meta
+    content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+    property="og:url"
+  />
+  <meta
+    content="Boris Johnson’s sister an ex-BBC broadcaster and John Major’s health secretary will stand for Change UK in next month’s European elections.The pro-Remain party announced its MEP hopefuls from almost 4"
+    property="og:description"
+  />
+  <meta
+    content="https://video169.io?resize=685"
+    property="og:image"
+  />
+  <meta
+    content="Some Headline"
+    name="twitter:title"
+  />
+  <meta
+    content="summary_large_image"
+    name="twitter:card"
+  />
+  <meta
+    content="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+    name="twitter:url"
+  />
+  <meta
+    content="Boris Johnson’s sister an ex-BBC broadcaster and John Major’s health secretary will stand for Change UK in next month’s European elections.The pro-Remain party announced its MEP hopefuls from almost 4"
+    name="twitter:description"
+  />
+  <meta
+    content="https://video169.io?resize=685"
+    name="twitter:image"
+  />
+  <script
+    type="application/ld+json"
+  >
+    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times","logo":"https://www.thetimes.co.uk/d/img/icons/favicon.ico"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"image":{"@type":"ImageObject","url":"https://video169.io?resize=685","caption":"This is video caption"},"thumbnailUrl":"https://video169.io"}
+  </script>
+</Helmet>
+`;
+
 exports[`Head removes section from title if there are no tiles 1`] = `
 Array [
   "Some Headline",

--- a/packages/article-skeleton/__tests__/web/head.web.test.js
+++ b/packages/article-skeleton/__tests__/web/head.web.test.js
@@ -11,7 +11,7 @@ import {
 } from "@times-components/jest-serializer";
 
 import Head from "../../src/head.web";
-import articleFixture, { testFixture } from "../../fixtures/full-article";
+import articleFixture, { testFixture, videoLeadAsset } from "../../fixtures/full-article";
 
 jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
 
@@ -33,6 +33,12 @@ addSerializers(
 );
 
 const article = articleFixture({ ...testFixture });
+const videoArticle = articleFixture({
+  ...testFixture,
+  hasVideo: true,
+  leadAsset: videoLeadAsset()
+});
+
 const paidContentClassName = "class-name";
 const faviconUrl = "https://www.thetimes.co.uk/d/img/icons/favicon.ico";
 
@@ -41,6 +47,18 @@ describe("Head", () => {
     const testRenderer = TestRenderer.create(
       <Head
         article={article}
+        paidContentClassName={paidContentClassName}
+        faviconUrl={faviconUrl}
+      />
+    );
+
+    expect(testRenderer).toMatchSnapshot();
+  });
+
+  it("outputs correct metadata for a video article", () => {
+    const testRenderer = TestRenderer.create(
+      <Head
+        article={videoArticle}
         paidContentClassName={paidContentClassName}
         faviconUrl={faviconUrl}
       />

--- a/packages/article-skeleton/__tests__/web/head.web.test.js
+++ b/packages/article-skeleton/__tests__/web/head.web.test.js
@@ -11,7 +11,10 @@ import {
 } from "@times-components/jest-serializer";
 
 import Head from "../../src/head.web";
-import articleFixture, { testFixture, videoLeadAsset } from "../../fixtures/full-article";
+import articleFixture, {
+  testFixture,
+  videoLeadAsset
+} from "../../fixtures/full-article";
 
 jest.mock("react-helmet-async", () => ({ Helmet: "Helmet" }));
 

--- a/packages/article-skeleton/src/head.web.js
+++ b/packages/article-skeleton/src/head.web.js
@@ -120,7 +120,11 @@ function Head({ article, paidContentClassName, faviconUrl }) {
       : null;
   const sectionname = getSectionName(article);
   const leadassetUrl = appendToUrl(
-    get(leadAsset, "crop169.url", null),
+    get(
+      hasVideo ? get(leadAsset, "posterImage", null) : leadAsset,
+      "crop169.url",
+      null
+    ),
     "resize",
     685
   );

--- a/packages/article-skeleton/src/head.web.js
+++ b/packages/article-skeleton/src/head.web.js
@@ -79,8 +79,16 @@ const PUBLICATION_NAMES = {
   TIMES: "The Times"
 };
 
-const getThumbnailUrlFromVideo = article =>
-  get(article.leadAsset.posterImage, "crop169.url", null);
+const get169CropUrl = asset => get(asset, "crop169.url", null);
+
+const getVideoLeadAssetUrl = article =>
+  get169CropUrl(get(article, "leadAsset.posterImage", null));
+
+const getImageLeadAssetUrl = article =>
+  get169CropUrl(get(article, "leadAsset", null));
+
+const getArticleLeadAssetUrl = article =>
+  (article.hasVideo ? getVideoLeadAssetUrl : getImageLeadAssetUrl)(article);
 
 const getThumbnailUrlFromImage = article => {
   const tileUrl =
@@ -120,11 +128,7 @@ function Head({ article, paidContentClassName, faviconUrl }) {
       : null;
   const sectionname = getSectionName(article);
   const leadassetUrl = appendToUrl(
-    get(
-      hasVideo ? get(leadAsset, "posterImage", null) : leadAsset,
-      "crop169.url",
-      null
-    ),
+    getArticleLeadAssetUrl(article),
     "resize",
     685
   );
@@ -132,7 +136,7 @@ function Head({ article, paidContentClassName, faviconUrl }) {
   const title = headline || shortHeadline;
   const datePublished = new Date(publishedTime).toISOString().split("T")[0];
   const thumbnailUrl = hasVideo
-    ? getThumbnailUrlFromVideo(article)
+    ? getVideoLeadAssetUrl(article)
     : getThumbnailUrlFromImage(article);
 
   const jsonLD = {


### PR DESCRIPTION
We need to ensure image metadata is correct when the lead asset is a video. This PR ensures that. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
