### PR TITLE
feat: REPLAT-8278 Secondary 1 font size of headline increased for 1024

### DIFF
--- a/packages/edition-slices/src/tiles/tile-w/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/styles/index.js
@@ -29,6 +29,12 @@ const wideBreakpointStyles = {
   container: {
     ...mediumBreakpointStyles.container,
     marginHorizontal: spacing(2)
+  },
+  headline: {
+    fontFamily: fonts.headline,
+    fontSize: 40,
+    lineHeight: 40,
+    marginBottom: spacing(2)
   }
 };
 


### PR DESCRIPTION
[Story.](https://nidigitalsolutions.jira.com/browse/REPLAT-8278)
Secondary 1 slice headline font size updated to 40px for wide breakpoint.
[Design.](https://app.zeplin.io/project/5d2849a2b4a4605645afb4be/screen/5d51892c38345e9b5afbc471)

![image](https://user-images.githubusercontent.com/8720661/64336362-6de9a580-cfe5-11e9-826c-80911954e675.png)
