### PR TITLE
feat: REPLAT-8279 comment lead and cartoon minor styling for wide breakpoint

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -12,6 +12,7 @@ exports[`1. comment lead and cartoon - medium 1`] = `
     <View />
     <View>
       <TileAI
+        breakpoint="medium"
         tileName="cartoon"
       />
     </View>
@@ -510,6 +511,7 @@ exports[`16. comment lead and cartoon - wide 1`] = `
     <View />
     <View>
       <TileAI
+        breakpoint="wide"
         tileName="cartoon"
       />
     </View>
@@ -1016,6 +1018,7 @@ exports[`31. comment lead and cartoon - huge 1`] = `
       <View />
       <View>
         <TileAI
+          breakpoint="huge"
           tileName="cartoon"
         />
       </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -1694,6 +1694,7 @@ exports[`39. tile ah 1`] = `
       "flex": 1,
       "justifyContent": "center",
       "padding": 10,
+      "paddingRight": 10,
     }
   }
   url="/article/123"
@@ -1745,6 +1746,7 @@ exports[`40. tile ai 1`] = `
     Object {
       "alignItems": "center",
       "padding": 10,
+      "paddingLeft": 10,
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -12,6 +12,7 @@ exports[`1. comment lead and cartoon - medium 1`] = `
     <View />
     <View>
       <TileAI
+        breakpoint="medium"
         tileName="cartoon"
       />
     </View>
@@ -510,6 +511,7 @@ exports[`16. comment lead and cartoon - wide 1`] = `
     <View />
     <View>
       <TileAI
+        breakpoint="wide"
         tileName="cartoon"
       />
     </View>
@@ -1016,6 +1018,7 @@ exports[`31. comment lead and cartoon - huge 1`] = `
       <View />
       <View>
         <TileAI
+          breakpoint="huge"
           tileName="cartoon"
         />
       </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -1694,6 +1694,7 @@ exports[`39. tile ah 1`] = `
       "flex": 1,
       "justifyContent": "center",
       "padding": 10,
+      "paddingRight": 10,
     }
   }
   url="/article/123"
@@ -1745,6 +1746,7 @@ exports[`40. tile ai 1`] = `
     Object {
       "alignItems": "center",
       "padding": 10,
+      "paddingLeft": 10,
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -3154,6 +3154,7 @@ exports[`15. comment lead and cartoon 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAI
+        breakpoint="wide"
         tileName="cartoon"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -690,6 +690,7 @@ exports[`15. comment lead and cartoon 1`] = `
     <div />
     <div>
       <TileAI
+        breakpoint="wide"
         tileName="cartoon"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -78,6 +78,7 @@ exports[`1. comment lead and cartoon - medium 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAI
+        breakpoint="wide"
         tileName="cartoon"
       />
     </div>
@@ -2124,6 +2125,7 @@ exports[`16. comment lead and cartoon - wide 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAI
+        breakpoint="wide"
         tileName="cartoon"
       />
     </div>
@@ -4173,6 +4175,7 @@ exports[`31. comment lead and cartoon - huge 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAI
+        breakpoint="wide"
         tileName="cartoon"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -12,6 +12,7 @@ exports[`1. comment lead and cartoon - medium 1`] = `
     <div />
     <div>
       <TileAI
+        breakpoint="wide"
         tileName="cartoon"
       />
     </div>
@@ -509,6 +510,7 @@ exports[`16. comment lead and cartoon - wide 1`] = `
     <div />
     <div>
       <TileAI
+        breakpoint="wide"
         tileName="cartoon"
       />
     </div>
@@ -1006,6 +1008,7 @@ exports[`31. comment lead and cartoon - huge 1`] = `
     <div />
     <div>
       <TileAI
+        breakpoint="wide"
         tileName="cartoon"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -3469,6 +3469,7 @@ exports[`39. tile ah 1`] = `
       "flex": 1,
       "justifyContent": "center",
       "padding": "10px",
+      "paddingRight": "10px",
     }
   }
   url="/article/123"
@@ -3533,6 +3534,7 @@ exports[`40. tile ai 1`] = `
     Object {
       "alignItems": "center",
       "padding": "10px",
+      "paddingLeft": "10px",
     }
   }
   url="/article/123"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -1688,6 +1688,7 @@ exports[`39. tile ah 1`] = `
       "flex": 1,
       "justifyContent": "center",
       "padding": "10px",
+      "paddingRight": "10px",
     }
   }
   url="/article/123"
@@ -1739,6 +1740,7 @@ exports[`40. tile ai 1`] = `
     Object {
       "alignItems": "center",
       "padding": "10px",
+      "paddingLeft": "10px",
     }
   }
   url="/article/123"

--- a/packages/edition-slices/src/slices/commentleadandcartoon/index.js
+++ b/packages/edition-slices/src/slices/commentleadandcartoon/index.js
@@ -35,7 +35,14 @@ class CommentLeadAndCartoonSlice extends Component {
     return (
       <CommentLeadAndCartoon
         breakpoint={editionBreakpoint}
-        cartoon={<TileAI onPress={onPress} tile={cartoon} tileName="cartoon" />}
+        cartoon={
+          <TileAI
+            onPress={onPress}
+            tile={cartoon}
+            tileName="cartoon"
+            breakpoint={editionBreakpoint}
+          />
+        }
         lead={
           <TileAH
             onPress={onPress}

--- a/packages/edition-slices/src/tiles/tile-ah/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/styles/index.js
@@ -12,12 +12,19 @@ const headlineFontSizeResolver = {
   [editionBreakpoints.huge]: 45
 };
 
+const keylinePadding = {
+  [editionBreakpoints.medium]: spacing(2),
+  [editionBreakpoints.wide]: spacing(3),
+  [editionBreakpoints.huge]: spacing(3)
+};
+
 const styles = (breakpoint = editionBreakpoints.medium) => ({
   container: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    padding: spacing(2)
+    padding: spacing(2),
+    paddingRight: keylinePadding[breakpoint]
   },
   headline: {
     color: colours.functional.brandColour,

--- a/packages/edition-slices/src/tiles/tile-ai/index.js
+++ b/packages/edition-slices/src/tiles/tile-ai/index.js
@@ -1,11 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
+import { editionBreakpoints } from "@times-components/styleguide";
 import { getTileImage, TileLink, withTileTracking } from "../shared";
-import styles from "./styles";
+import styleFactory from "./styles";
 
-const TileAI = ({ onPress, tile }) => {
+const TileAI = ({ onPress, tile, breakpoint }) => {
   const crop = getTileImage(tile, "crop32");
+  const styles = styleFactory(breakpoint);
 
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
@@ -25,7 +27,12 @@ const TileAI = ({ onPress, tile }) => {
 
 TileAI.propTypes = {
   onPress: PropTypes.func.isRequired,
-  tile: PropTypes.shape({}).isRequired
+  tile: PropTypes.shape({}).isRequired,
+  breakpoint: PropTypes.string
+};
+
+TileAI.defaultProps = {
+  breakpoint: editionBreakpoints.medium
 };
 
 export default withTileTracking(TileAI);

--- a/packages/edition-slices/src/tiles/tile-ai/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ai/styles/index.js
@@ -1,13 +1,20 @@
-import { spacing } from "@times-components/styleguide";
+import { spacing, editionBreakpoints } from "@times-components/styleguide";
 
-const styles = {
+const keylinePadding = {
+  [editionBreakpoints.medium]: spacing(2),
+  [editionBreakpoints.wide]: spacing(3),
+  [editionBreakpoints.huge]: spacing(3)
+};
+
+const styles = breakpoint => ({
   container: {
     alignItems: "center",
-    padding: spacing(2)
+    padding: spacing(2),
+    paddingLeft: keylinePadding[breakpoint]
   },
   imageContainer: {
     width: "100%"
   }
-};
+});
 
 export default styles;


### PR DESCRIPTION
[Story.](https://nidigitalsolutions.jira.com/browse/REPLAT-8279)
[Design.](https://app.zeplin.io/project/5d2849a2b4a4605645afb4be/screen/5d5189891ced2b350a8f0448)

CommentLeadAndCartoon slice - Keyline spacing increased for wide breakpoint.

Result:
![image](https://user-images.githubusercontent.com/8720661/64343743-c1fc8600-cff5-11e9-8833-ed7050580549.png)
