### PR TITLE
fix: broken querys

### DIFF
--- a/packages/provider-queries/src/section_fragment.graphql
+++ b/packages/provider-queries/src/section_fragment.graphql
@@ -1432,22 +1432,6 @@ fragment listingAsset11 on Media {
   }
 }
 
-fragment listingAsset45 on Media {
-  __typename
-  ... on Video {
-    posterImage {
-      crop45: crop(ratio: "4:5") {
-        ...sectionCropProps
-      }
-    }
-  }
-  ... on Image {
-    crop45: crop(ratio: "4:5") {
-      ...sectionCropProps
-    }
-  }
-}
-
 fragment listingAsset23 on Media {
   __typename
   ... on Video {
@@ -1513,22 +1497,6 @@ fragment leadAsset11 on Media {
   }
   ... on Image {
     crop11: crop(ratio: "1:1") {
-      ...sectionCropProps
-    }
-  }
-}
-
-fragment leadAsset45 on Media {
-  __typename
-  ... on Video {
-    posterImage {
-      crop45: crop(ratio: "4:5") {
-        ...sectionCropProps
-      }
-    }
-  }
-  ... on Image {
-    crop45: crop(ratio: "4:5") {
       ...sectionCropProps
     }
   }

--- a/packages/provider/__tests__/edition-provider.test.js
+++ b/packages/provider/__tests__/edition-provider.test.js
@@ -32,7 +32,7 @@ describe("Edition provider", () => {
   it("returns query result", done => {
     renderComponent(({ isLoading, edition, error }) => {
       if (error) {
-        throw error
+        throw error;
       }
       if (!isLoading) {
         expect(edition).toMatchSnapshot();

--- a/packages/provider/__tests__/edition-provider.test.js
+++ b/packages/provider/__tests__/edition-provider.test.js
@@ -30,7 +30,10 @@ const renderComponent = child => {
 
 describe("Edition provider", () => {
   it("returns query result", done => {
-    renderComponent(({ isLoading, edition }) => {
+    renderComponent(({ isLoading, edition, error }) => {
+      if (error) {
+        throw error
+      }
       if (!isLoading) {
         expect(edition).toMatchSnapshot();
         done();


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
There is no longer any usage of leadAsset45 and listingAsset45, so having the fragments there causes queries to fail with unused fragment errors. :(

Also, the test should spit out the error when it fails, instead of just failing with an undefined snapshot comparison.