### PR TITLE
chore: codeowners updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # The following people are responsible for this project and its live instances:
-*    @nehasri89 @nathggns @aronshamash @jmars @ValGeorgiev
+*    @nehasri89 @aronshamash @jmars @ValGeorgiev @infreezer @apostolnikov


### PR DESCRIPTION
Nate removed.
Apostol and Georgi added as code owners.