### PR TITLE
fix: remove top margin of section for tablet

### DIFF
--- a/packages/section/__tests__/android/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/android/__snapshots__/section.test.js.snap
@@ -1,13 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Sunday Times magazine section 1`] = `
-<RCTScrollView
-  style={
-    Object {
-      "marginTop": 10,
-    }
-  }
->
+<RCTScrollView>
   <View>
     <View>
       <View
@@ -123,13 +117,7 @@ exports[`Sunday Times magazine section 1`] = `
 `;
 
 exports[`Times magazine section 1`] = `
-<RCTScrollView
-  style={
-    Object {
-      "marginTop": 10,
-    }
-  }
->
+<RCTScrollView>
   <View>
     <View>
       <View
@@ -370,13 +358,7 @@ exports[`section item separator - wide 1`] = `
 `;
 
 exports[`section page 1`] = `
-<RCTScrollView
-  style={
-    Object {
-      "marginTop": 10,
-    }
-  }
->
+<RCTScrollView>
   <View>
     <View>
       <LeadOneAndFourSlice />

--- a/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
@@ -1,13 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Sunday Times magazine section 1`] = `
-<RCTScrollView
-  style={
-    Object {
-      "marginTop": 10,
-    }
-  }
->
+<RCTScrollView>
   <View>
     <View>
       <View
@@ -123,13 +117,7 @@ exports[`Sunday Times magazine section 1`] = `
 `;
 
 exports[`Times magazine section 1`] = `
-<RCTScrollView
-  style={
-    Object {
-      "marginTop": 10,
-    }
-  }
->
+<RCTScrollView>
   <View>
     <View>
       <View
@@ -370,13 +358,7 @@ exports[`section item separator - wide 1`] = `
 `;
 
 exports[`section page 1`] = `
-<RCTScrollView
-  style={
-    Object {
-      "marginTop": 10,
-    }
-  }
->
+<RCTScrollView>
   <View>
     <View>
       <LeadOneAndFourSlice />

--- a/packages/section/src/section.js
+++ b/packages/section/src/section.js
@@ -124,7 +124,6 @@ class Section extends Component {
                   onViewed ? this.onViewableItemsChanged : null
                 }
                 renderItem={this.renderItem}
-                style={isTablet ? styles.tabletSpacing : null}
                 windowSize={3}
               />
             );

--- a/packages/section/src/styles/index.js
+++ b/packages/section/src/styles/index.js
@@ -37,8 +37,5 @@ export default breakpoint => ({
     color: colours.functional.brandColour,
     fontFamily: fonts.headlineRegular,
     fontSize: 20
-  },
-  tabletSpacing: {
-    marginTop: spacing(2)
   }
 });


### PR DESCRIPTION
As discussed with the designers, we do not want to have additional space between every top most slice and the navigation on tablet.

![image](https://user-images.githubusercontent.com/7889661/64529825-6e02e180-d314-11e9-81e3-ff77b27521f5.png)

