### PR TITLE
fix: REPLAT-8453 unknown nodes no longer crash

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
@@ -160,6 +160,23 @@ exports[`1. article with header 1`] = `
       <View>
         <View>
           <View>
+            <View>
+              <Text
+                selectable={true}
+              >
+                <Text
+                  selectable={true}
+                >
+                  Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View>
+          <View>
             <Video
               accountId="5436121857001"
               height={421.875}
@@ -247,31 +264,6 @@ exports[`1. article with header 1`] = `
                 </Text>
               </Text>
             </View>
-          </View>
-        </View>
-      </View>
-      <View>
-        <View>
-          <View>
-            <ArticleImage
-              captionOptions={
-                Object {
-                  "caption": "All the latest stories in culture and books.",
-                  "credits": "The credits",
-                }
-              }
-              imageOptions={
-                Object {
-                  "display": "secondary",
-                  "ratio": "3:2",
-                  "relativeHeight": undefined,
-                  "relativeHorizontalOffset": undefined,
-                  "relativeVerticalOffset": undefined,
-                  "relativeWidth": undefined,
-                  "uri": "https://image.io",
-                }
-              }
-            />
           </View>
         </View>
       </View>

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-header-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-header-with-style.ios.test.js.snap
@@ -160,6 +160,23 @@ exports[`1. article with header 1`] = `
       <View>
         <View>
           <View>
+            <View>
+              <Text
+                selectable={true}
+              >
+                <Text
+                  selectable={true}
+                >
+                  Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View>
+          <View>
             <Video
               accountId="5436121857001"
               height={421.875}
@@ -247,31 +264,6 @@ exports[`1. article with header 1`] = `
                 </Text>
               </Text>
             </View>
-          </View>
-        </View>
-      </View>
-      <View>
-        <View>
-          <View>
-            <ArticleImage
-              captionOptions={
-                Object {
-                  "caption": "All the latest stories in culture and books.",
-                  "credits": "The credits",
-                }
-              }
-              imageOptions={
-                Object {
-                  "display": "secondary",
-                  "ratio": "3:2",
-                  "relativeHeight": undefined,
-                  "relativeHorizontalOffset": undefined,
-                  "relativeVerticalOffset": undefined,
-                  "relativeWidth": undefined,
-                  "uri": "https://image.io",
-                }
-              }
-            />
           </View>
         </View>
       </View>

--- a/packages/article-skeleton/fixtures/full-article-content.js
+++ b/packages/article-skeleton/fixtures/full-article-content.js
@@ -231,6 +231,26 @@ export default [
     name: "paragraph"
   },
   {
+    attributes: {},
+    children: [
+      {
+        attributes: {},
+        children: [
+          {
+            attributes: {
+              value:
+                "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
+            },
+            children: [],
+            name: "text"
+          }
+        ],
+        name: "unknown"
+      }
+    ],
+    name: "paragraph"
+  },
+  {
     attributes: {
       brightcoveAccountId: "5436121857001",
       brightcovePolicyKey: "1.2.3.4",

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -275,6 +275,12 @@ export default ({
       };
     },
     paragraph(key, attributes, children, indx, node) {
+      const flatChildren = children.reduce((acc, child) => {
+        if (Array.isArray(child)) {
+          return [...acc, ...child];
+        }
+        return [...acc, child];
+      }, []);
       return {
         element: new Text.Text({
           font: fontFamily,
@@ -294,10 +300,15 @@ export default ({
             );
           },
           lineHeight: lineHeight * fontScale,
-          markup: children,
+          markup: flatChildren,
           size: fontSize * fontScale,
           width: Math.min(screenWidth(), tabletWidth)
         })
+      };
+    },
+    unknown(key, attributes, children) {
+      return {
+        element: children
       };
     },
     pullQuote(

--- a/packages/markup-forest/src/markup-forest.js
+++ b/packages/markup-forest/src/markup-forest.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 export const renderTree = (tree, renderers, key = "0", indx = 0) => {
   const { name, attributes, children } = tree;
 
-  const renderer = renderers[name];
+  const renderer = renderers[name] || renderers.unknown;
 
   if (!renderer) return null;
 


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Certain articles have nodes of type "unknown", we should at least try to render these without crashing. e.g https://www.thetimes.co.uk/past-six-days/2019-09-08/style/mrs-mills-answers-your-questions-dog-days-and-childcare-conundrums-jn8w0277s
