### PR TITLE
feat: REPLAT-8552 Lead 1 Full width 1366 styling

### DIFF
--- a/packages/edition-slices/src/tiles/tile-r/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/styles/index.js
@@ -35,7 +35,20 @@ const wideBreakpointStyles = {
   }
 };
 
-export default breakpoint =>
-  breakpoint === editionBreakpoints.medium
-    ? mediumBreakpointStyles
-    : wideBreakpointStyles;
+const hugeBreakpointStyles = {
+  ...wideBreakpointStyles,
+  headline: {
+    fontFamily: fonts.headline,
+    fontSize: 45,
+    lineHeight: 45,
+    marginBottom: 0
+  }
+};
+
+const stylesResolver = {
+  [editionBreakpoints.medium]: mediumBreakpointStyles,
+  [editionBreakpoints.wide]: wideBreakpointStyles,
+  [editionBreakpoints.huge]: hugeBreakpointStyles
+};
+
+export default breakpoint => stylesResolver[breakpoint] || {};


### PR DESCRIPTION
[Story](https://nidigitalsolutions.jira.com/browse/REPLAT-8552)
[Design](https://app.zeplin.io/project/5d2849a2b4a4605645afb4be/screen/5d6e6999a4f1a31857f879bf)

Font size of headline increased to 45 on huge breakpoint.

Snapshot testing of the tile is expected when [this](https://nidigitalsolutions.jira.com/browse/REPLAT-8110) story is finished.

![image](https://user-images.githubusercontent.com/8720661/64863413-6d808880-d63d-11e9-9f01-1efeabee064c.png)
