### PR TITLE
feat: lead 1 and 1 slice - styling for 1366 and 1024

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1367,7 +1367,7 @@ exports[`18. lead one and one - wide 1`] = `
     <View
       style={
         Object {
-          "width": "84%",
+          "width": "83.5%",
         }
       }
     >
@@ -1386,7 +1386,7 @@ exports[`18. lead one and one - wide 1`] = `
     <View
       style={
         Object {
-          "width": "16%",
+          "width": "16.5%",
         }
       }
     >
@@ -2556,7 +2556,7 @@ exports[`33. lead one and one - huge 1`] = `
       <View
         style={
           Object {
-            "width": "84%",
+            "width": "83.5%",
           }
         }
       >
@@ -2575,7 +2575,7 @@ exports[`33. lead one and one - huge 1`] = `
       <View
         style={
           Object {
-            "width": "16%",
+            "width": "16.5%",
           }
         }
       >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -579,12 +579,14 @@ exports[`18. lead one and one - wide 1`] = `
   <View>
     <View>
       <TileZ
+        breakpoint="wide"
         tileName="lead"
       />
     </View>
     <View />
     <View>
       <TileAF
+        breakpoint="wide"
         tileName="support"
       />
     </View>
@@ -1086,12 +1088,14 @@ exports[`33. lead one and one - huge 1`] = `
     <View>
       <View>
         <TileZ
+          breakpoint="huge"
           tileName="lead"
         />
       </View>
       <View />
       <View>
         <TileAF
+          breakpoint="huge"
           tileName="support"
         />
       </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -2113,7 +2113,7 @@ exports[`41. tile z 1`] = `
       Object {
         "flex": 1,
         "paddingRight": 20,
-        "width": "40%",
+        "width": "41%",
       }
     }
   >
@@ -2157,7 +2157,7 @@ exports[`41. tile z 1`] = `
   <Image
     style={
       Object {
-        "width": "60%",
+        "width": "59%",
       }
     }
   />

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1367,7 +1367,7 @@ exports[`18. lead one and one - wide 1`] = `
     <View
       style={
         Object {
-          "width": "84%",
+          "width": "83.5%",
         }
       }
     >
@@ -1386,7 +1386,7 @@ exports[`18. lead one and one - wide 1`] = `
     <View
       style={
         Object {
-          "width": "16%",
+          "width": "16.5%",
         }
       }
     >
@@ -2556,7 +2556,7 @@ exports[`33. lead one and one - huge 1`] = `
       <View
         style={
           Object {
-            "width": "84%",
+            "width": "83.5%",
           }
         }
       >
@@ -2575,7 +2575,7 @@ exports[`33. lead one and one - huge 1`] = `
       <View
         style={
           Object {
-            "width": "16%",
+            "width": "16.5%",
           }
         }
       >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -579,12 +579,14 @@ exports[`18. lead one and one - wide 1`] = `
   <View>
     <View>
       <TileZ
+        breakpoint="wide"
         tileName="lead"
       />
     </View>
     <View />
     <View>
       <TileAF
+        breakpoint="wide"
         tileName="support"
       />
     </View>
@@ -1086,12 +1088,14 @@ exports[`33. lead one and one - huge 1`] = `
     <View>
       <View>
         <TileZ
+          breakpoint="huge"
           tileName="lead"
         />
       </View>
       <View />
       <View>
         <TileAF
+          breakpoint="huge"
           tileName="support"
         />
       </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -2113,7 +2113,7 @@ exports[`41. tile z 1`] = `
       Object {
         "flex": 1,
         "paddingRight": 20,
-        "width": "40%",
+        "width": "41%",
       }
     }
   >
@@ -2157,7 +2157,7 @@ exports[`41. tile z 1`] = `
   <Image
     style={
       Object {
-        "width": "60%",
+        "width": "59%",
       }
     }
   />

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -1136,7 +1136,7 @@ exports[`2. leaders 2`] = `
 exports[`3. lead one and one 1`] = `
 <style>
 .IS1 {
-  width: 84%;
+  width: 83.5%;
 }
 
 .IS2 {
@@ -1154,7 +1154,7 @@ exports[`3. lead one and one 1`] = `
 }
 
 .IS3 {
-  width: 16%;
+  width: 16.5%;
 }
 
 .IS4 {
@@ -1198,6 +1198,7 @@ exports[`3. lead one and one 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileZ
+        breakpoint="wide"
         tileName="lead"
       />
     </div>
@@ -1208,6 +1209,7 @@ exports[`3. lead one and one 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAF
+        breakpoint="wide"
         tileName="support"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -263,12 +263,14 @@ exports[`3. lead one and one 1`] = `
   <div>
     <div>
       <TileZ
+        breakpoint="wide"
         tileName="lead"
       />
     </div>
     <div />
     <div>
       <TileAF
+        breakpoint="wide"
         tileName="support"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -311,7 +311,7 @@ exports[`2. daily universal register - medium 1`] = `
 exports[`3. lead one and one - medium 1`] = `
 <style>
 .IS1 {
-  width: 84%;
+  width: 83.5%;
 }
 
 .IS2 {
@@ -329,7 +329,7 @@ exports[`3. lead one and one - medium 1`] = `
 }
 
 .IS3 {
-  width: 16%;
+  width: 16.5%;
 }
 
 .IS4 {
@@ -373,6 +373,7 @@ exports[`3. lead one and one - medium 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileZ
+        breakpoint="wide"
         tileName="lead"
       />
     </div>
@@ -383,6 +384,7 @@ exports[`3. lead one and one - medium 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAF
+        breakpoint="wide"
         tileName="support"
       />
     </div>
@@ -2299,7 +2301,7 @@ exports[`17. daily universal register - wide 1`] = `
 exports[`18. lead one and one - wide 1`] = `
 <style>
 .IS1 {
-  width: 84%;
+  width: 83.5%;
 }
 
 .IS2 {
@@ -2317,7 +2319,7 @@ exports[`18. lead one and one - wide 1`] = `
 }
 
 .IS3 {
-  width: 16%;
+  width: 16.5%;
 }
 
 .IS4 {
@@ -2361,6 +2363,7 @@ exports[`18. lead one and one - wide 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileZ
+        breakpoint="wide"
         tileName="lead"
       />
     </div>
@@ -2371,6 +2374,7 @@ exports[`18. lead one and one - wide 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAF
+        breakpoint="wide"
         tileName="support"
       />
     </div>
@@ -4290,7 +4294,7 @@ exports[`32. daily universal register - huge 1`] = `
 exports[`33. lead one and one - huge 1`] = `
 <style>
 .IS1 {
-  width: 84%;
+  width: 83.5%;
 }
 
 .IS2 {
@@ -4308,7 +4312,7 @@ exports[`33. lead one and one - huge 1`] = `
 }
 
 .IS3 {
-  width: 16%;
+  width: 16.5%;
 }
 
 .IS4 {
@@ -4352,6 +4356,7 @@ exports[`33. lead one and one - huge 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileZ
+        breakpoint="wide"
         tileName="lead"
       />
     </div>
@@ -4362,6 +4367,7 @@ exports[`33. lead one and one - huge 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAF
+        breakpoint="wide"
         tileName="support"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -74,12 +74,14 @@ exports[`3. lead one and one - medium 1`] = `
   <div>
     <div>
       <TileZ
+        breakpoint="wide"
         tileName="lead"
       />
     </div>
     <div />
     <div>
       <TileAF
+        breakpoint="wide"
         tileName="support"
       />
     </div>
@@ -568,12 +570,14 @@ exports[`18. lead one and one - wide 1`] = `
   <div>
     <div>
       <TileZ
+        breakpoint="wide"
         tileName="lead"
       />
     </div>
     <div />
     <div>
       <TileAF
+        breakpoint="wide"
         tileName="support"
       />
     </div>
@@ -1062,12 +1066,14 @@ exports[`33. lead one and one - huge 1`] = `
   <div>
     <div>
       <TileZ
+        breakpoint="wide"
         tileName="lead"
       />
     </div>
     <div />
     <div>
       <TileAF
+        breakpoint="wide"
         tileName="support"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -3614,7 +3614,7 @@ exports[`41. tile z 1`] = `
   -webkit-flex-basis: 0%;
   flex-basis: 0%;
   padding-right: 20px;
-  width: 40%;
+  width: 41%;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -3622,7 +3622,7 @@ exports[`41. tile z 1`] = `
 }
 
 .IS4 {
-  width: 60%;
+  width: 59%;
 }
 </style>
 

--- a/packages/edition-slices/src/slices/leadoneandone/index.js
+++ b/packages/edition-slices/src/slices/leadoneandone/index.js
@@ -62,8 +62,22 @@ class LeadOneAndOne extends Component {
     return (
       <LeadOneAndOneSlice
         breakpoint={breakpoint}
-        lead={<TileZ onPress={onPress} tile={lead} tileName="lead" />}
-        support={<TileAF onPress={onPress} tile={support} tileName="support" />}
+        lead={
+          <TileZ
+            onPress={onPress}
+            tile={lead}
+            breakpoint={breakpoint}
+            tileName="lead"
+          />
+        }
+        support={
+          <TileAF
+            onPress={onPress}
+            tile={support}
+            breakpoint={breakpoint}
+            tileName="support"
+          />
+        }
       />
     );
   }

--- a/packages/edition-slices/src/tiles/tile-af/index.js
+++ b/packages/edition-slices/src/tiles/tile-af/index.js
@@ -1,36 +1,43 @@
+/* eslint-disable react/require-default-props */
 import React from "react";
 import PropTypes from "prop-types";
+import { editionBreakpoints } from "@times-components/styleguide";
 import {
   getTileSummary,
   TileLink,
   TileSummary,
   withTileTracking
 } from "../shared";
-import styles from "./styles";
+import styleFactory from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
 import PositionedTileStar from "../shared/positioned-tile-star";
 
-const TileAF = ({ onPress, tile }) => (
-  <TileLink onPress={onPress} style={styles.container} tile={tile}>
-    <WithoutWhiteSpace
-      style={styles.summaryContainer}
-      render={whiteSpaceHeight => (
-        <TileSummary
-          headlineStyle={styles.headline}
-          summary={getTileSummary(tile, 800)}
-          tile={tile}
-          whiteSpaceHeight={whiteSpaceHeight}
-          withStar={false}
-        />
-      )}
-    />
-    <PositionedTileStar articleId={tile.article.id} />
-  </TileLink>
-);
+const TileAF = ({ onPress, tile, breakpoint = editionBreakpoints.wide }) => {
+  const styles = styleFactory(breakpoint);
+
+  return (
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
+      <WithoutWhiteSpace
+        style={styles.summaryContainer}
+        render={whiteSpaceHeight => (
+          <TileSummary
+            headlineStyle={styles.headline}
+            summary={getTileSummary(tile, 800)}
+            tile={tile}
+            whiteSpaceHeight={whiteSpaceHeight}
+            withStar={false}
+          />
+        )}
+      />
+      <PositionedTileStar articleId={tile.article.id} />
+    </TileLink>
+  );
+};
 
 TileAF.propTypes = {
   onPress: PropTypes.func.isRequired,
-  tile: PropTypes.shape({}).isRequired
+  tile: PropTypes.shape({}).isRequired,
+  breakpoint: PropTypes.string
 };
 
 export default withTileTracking(TileAF);

--- a/packages/edition-slices/src/tiles/tile-af/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-af/styles/index.js
@@ -1,6 +1,15 @@
-import { fonts, spacing } from "@times-components/styleguide";
+import {
+  fonts,
+  spacing,
+  editionBreakpoints
+} from "@times-components/styleguide";
 
-const styles = {
+const fontSizeResolver = {
+  [editionBreakpoints.wide]: 20,
+  [editionBreakpoints.huge]: 22
+};
+
+export default breakpoint => ({
   container: {
     flex: 1,
     paddingVertical: spacing(3),
@@ -8,9 +17,7 @@ const styles = {
   },
   headline: {
     fontFamily: fonts.headline,
-    fontSize: 20,
-    lineHeight: 20
+    fontSize: fontSizeResolver[breakpoint],
+    lineHeight: fontSizeResolver[breakpoint]
   }
-};
-
-export default styles;
+});

--- a/packages/edition-slices/src/tiles/tile-z/index.js
+++ b/packages/edition-slices/src/tiles/tile-z/index.js
@@ -1,7 +1,9 @@
+/* eslint-disable react/require-default-props */
 import React from "react";
 import { View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
+import { editionBreakpoints } from "@times-components/styleguide";
 import {
   getTileImage,
   getTileSummary,
@@ -9,12 +11,13 @@ import {
   TileSummary,
   withTileTracking
 } from "../shared";
-import styles from "./styles";
+import styleFactory from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
 import PositionedTileStar from "../shared/positioned-tile-star";
 
-const TileZ = ({ onPress, tile }) => {
+const TileZ = ({ onPress, tile, breakpoint = editionBreakpoints.wide }) => {
   const crop = getTileImage(tile, "crop32");
+  const styles = styleFactory(breakpoint);
 
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
@@ -49,7 +52,8 @@ const TileZ = ({ onPress, tile }) => {
 
 TileZ.propTypes = {
   onPress: PropTypes.func.isRequired,
-  tile: PropTypes.shape({}).isRequired
+  tile: PropTypes.shape({}).isRequired,
+  breakpoint: PropTypes.string
 };
 
 export default withTileTracking(TileZ);

--- a/packages/edition-slices/src/tiles/tile-z/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-z/styles/index.js
@@ -1,6 +1,15 @@
-import { spacing, fonts } from "@times-components/styleguide";
+import {
+  spacing,
+  fonts,
+  editionBreakpoints
+} from "@times-components/styleguide";
 
-const styles = {
+const fontSizeResolver = {
+  [editionBreakpoints.wide]: 40,
+  [editionBreakpoints.huge]: 45
+};
+
+export default breakpoint => ({
   container: {
     flex: 1,
     flexDirection: "row",
@@ -9,18 +18,16 @@ const styles = {
   },
   headline: {
     fontFamily: fonts.headline,
-    fontSize: 40,
-    lineHeight: 40,
+    fontSize: fontSizeResolver[breakpoint],
+    lineHeight: fontSizeResolver[breakpoint],
     marginBottom: spacing(2)
   },
   summaryContainer: {
     flex: 1,
-    width: "40%",
+    width: "41%",
     paddingRight: spacing(4)
   },
   imageContainer: {
-    width: "60%"
+    width: "59%"
   }
-};
-
-export default styles;
+});

--- a/packages/slice-layout/__tests__/android/__snapshots__/l1and1-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/l1and1-with-style.android.test.js.snap
@@ -77,7 +77,7 @@ exports[`3. lead one and one - wide 1`] = `
   <View
     style={
       Object {
-        "width": "84%",
+        "width": "83.5%",
       }
     }
   >
@@ -98,7 +98,7 @@ exports[`3. lead one and one - wide 1`] = `
   <View
     style={
       Object {
-        "width": "16%",
+        "width": "16.5%",
       }
     }
   >
@@ -122,7 +122,7 @@ exports[`4. lead one and one - huge 1`] = `
   <View
     style={
       Object {
-        "width": "84%",
+        "width": "83.5%",
       }
     }
   >
@@ -143,7 +143,7 @@ exports[`4. lead one and one - huge 1`] = `
   <View
     style={
       Object {
-        "width": "16%",
+        "width": "16.5%",
       }
     }
   >

--- a/packages/slice-layout/__tests__/ios/__snapshots__/l1and1-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/l1and1-with-style.ios.test.js.snap
@@ -77,7 +77,7 @@ exports[`3. lead one and one - wide 1`] = `
   <View
     style={
       Object {
-        "width": "84%",
+        "width": "83.5%",
       }
     }
   >
@@ -98,7 +98,7 @@ exports[`3. lead one and one - wide 1`] = `
   <View
     style={
       Object {
-        "width": "16%",
+        "width": "16.5%",
       }
     }
   >
@@ -122,7 +122,7 @@ exports[`4. lead one and one - huge 1`] = `
   <View
     style={
       Object {
-        "width": "84%",
+        "width": "83.5%",
       }
     }
   >
@@ -143,7 +143,7 @@ exports[`4. lead one and one - huge 1`] = `
   <View
     style={
       Object {
-        "width": "16%",
+        "width": "16.5%",
       }
     }
   >

--- a/packages/slice-layout/__tests__/web/__snapshots__/l1and1-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/l1and1-with-style.web.test.js.snap
@@ -129,7 +129,7 @@ exports[`3. lead one and one - wide 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "84%",
+        "width": "83.5%",
       }
     }
   >
@@ -161,7 +161,7 @@ exports[`3. lead one and one - wide 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "16%",
+        "width": "16.5%",
       }
     }
   >
@@ -203,7 +203,7 @@ exports[`4. lead one and one - huge 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "84%",
+        "width": "83.5%",
       }
     }
   >
@@ -235,7 +235,7 @@ exports[`4. lead one and one - huge 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "16%",
+        "width": "16.5%",
       }
     }
   >

--- a/packages/slice-layout/src/templates/leadoneandone/styles.js
+++ b/packages/slice-layout/src/templates/leadoneandone/styles.js
@@ -28,10 +28,10 @@ const wideBreakpointStyles = {
     marginHorizontal: spacing(2)
   },
   leadItem: {
-    width: "84%"
+    width: "83.5%"
   },
   supportItem: {
-    width: "16%"
+    width: "16.5%"
   }
 };
 


### PR DESCRIPTION
[Story.](https://nidigitalsolutions.jira.com/browse/REPLAT-8550)
[Design.](https://app.zeplin.io/project/5d2849a2b4a4605645afb4be/screen/5d6e698d1b6c9e18dbe0369f)

Font sizes of the headlines increased on 1366px.
Width of the tiles updated for both wide and huge in order to be more accurate to the design and be aligned with other slices (please check the seconds screenshot if it doesn't make sense)

Result:
![image](https://user-images.githubusercontent.com/8720661/64971703-bb50f700-d8b0-11e9-973d-b8e33a5c0a52.png)

slices alignment on wide breakpoint:
![image](https://user-images.githubusercontent.com/8720661/64972002-361a1200-d8b1-11e9-9b9e-d4fccba1dff7.png)

