### PR TITLE
feat: leadOneAndFour for 1366px

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -346,18 +346,22 @@ exports[`12. lead one and four slice - medium 1`] = `
     <View />
     <View>
       <TileAD
+        breakpoint="medium"
         tileName="support1"
       />
       <View />
       <TileAD
+        breakpoint="medium"
         tileName="support2"
       />
       <View />
       <TileAD
+        breakpoint="medium"
         tileName="support3"
       />
       <View />
       <TileAD
+        breakpoint="medium"
         tileName="support4"
       />
     </View>
@@ -852,18 +856,22 @@ exports[`27. lead one and four slice - wide 1`] = `
     <View />
     <View>
       <TileAD
+        breakpoint="wide"
         tileName="support1"
       />
       <View />
       <TileAD
+        breakpoint="wide"
         tileName="support2"
       />
       <View />
       <TileAD
+        breakpoint="wide"
         tileName="support3"
       />
       <View />
       <TileAD
+        breakpoint="wide"
         tileName="support4"
       />
     </View>
@@ -1363,18 +1371,22 @@ exports[`42. lead one and four slice - huge 1`] = `
       <View />
       <View>
         <TileAD
+          breakpoint="huge"
           tileName="support1"
         />
         <View />
         <TileAD
+          breakpoint="huge"
           tileName="support2"
         />
         <View />
         <TileAD
+          breakpoint="huge"
           tileName="support3"
         />
         <View />
         <TileAD
+          breakpoint="huge"
           tileName="support4"
         />
       </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -1772,10 +1772,10 @@ exports[`34. tile ad 1`] = `
             Object {
               "color": "#333333",
               "fontFamily": "TimesModern-Bold",
-              "fontSize": 20,
+              "fontSize": undefined,
               "fontWeight": "400",
-              "lineHeight": 20,
-              "marginBottom": 0,
+              "lineHeight": undefined,
+              "marginBottom": 5,
             }
           }
         >
@@ -1795,7 +1795,7 @@ exports[`34. tile ad 1`] = `
         >
           <Text>
             
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.
             ...
           </Text>
         </Text>
@@ -1841,9 +1841,9 @@ exports[`35. tile ac 1`] = `
         Object {
           "color": "#1D1D1B",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 30,
+          "fontSize": undefined,
           "fontWeight": "400",
-          "lineHeight": 30,
+          "lineHeight": undefined,
           "marginBottom": 0,
           "textAlign": "center",
         }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -1781,24 +1781,6 @@ exports[`34. tile ad 1`] = `
         >
           This is tile headline
         </Text>
-        <Text
-          style={
-            Object {
-              "color": "#696969",
-              "flexWrap": "wrap",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 14,
-              "lineHeight": 20,
-              "marginBottom": 0,
-            }
-          }
-        >
-          <Text>
-            
-            ‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.
-            ...
-          </Text>
-        </Text>
         <ArticleFlags />
       </View>
     </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -1772,9 +1772,9 @@ exports[`34. tile ad 1`] = `
             Object {
               "color": "#333333",
               "fontFamily": "TimesModern-Bold",
-              "fontSize": undefined,
+              "fontSize": 20,
               "fontWeight": "400",
-              "lineHeight": undefined,
+              "lineHeight": 20,
               "marginBottom": 5,
             }
           }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -1465,15 +1465,6 @@ exports[`34. tile ad 1`] = `
         >
           This is tile headline
         </Text>
-        <Text
-          numberOfLines={2}
-        >
-          <Text>
-            
-            ‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.
-            ...
-          </Text>
-        </Text>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -1470,7 +1470,7 @@ exports[`34. tile ad 1`] = `
         >
           <Text>
             
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.
             ...
           </Text>
         </Text>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -346,18 +346,22 @@ exports[`12. lead one and four slice - medium 1`] = `
     <View />
     <View>
       <TileAD
+        breakpoint="medium"
         tileName="support1"
       />
       <View />
       <TileAD
+        breakpoint="medium"
         tileName="support2"
       />
       <View />
       <TileAD
+        breakpoint="medium"
         tileName="support3"
       />
       <View />
       <TileAD
+        breakpoint="medium"
         tileName="support4"
       />
     </View>
@@ -852,18 +856,22 @@ exports[`27. lead one and four slice - wide 1`] = `
     <View />
     <View>
       <TileAD
+        breakpoint="wide"
         tileName="support1"
       />
       <View />
       <TileAD
+        breakpoint="wide"
         tileName="support2"
       />
       <View />
       <TileAD
+        breakpoint="wide"
         tileName="support3"
       />
       <View />
       <TileAD
+        breakpoint="wide"
         tileName="support4"
       />
     </View>
@@ -1363,18 +1371,22 @@ exports[`42. lead one and four slice - huge 1`] = `
       <View />
       <View>
         <TileAD
+          breakpoint="huge"
           tileName="support1"
         />
         <View />
         <TileAD
+          breakpoint="huge"
           tileName="support2"
         />
         <View />
         <TileAD
+          breakpoint="huge"
           tileName="support3"
         />
         <View />
         <TileAD
+          breakpoint="huge"
           tileName="support4"
         />
       </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -1772,9 +1772,9 @@ exports[`34. tile ad 1`] = `
             Object {
               "color": "#333333",
               "fontFamily": "TimesModern-Bold",
-              "fontSize": undefined,
+              "fontSize": 20,
               "fontWeight": "900",
-              "lineHeight": undefined,
+              "lineHeight": 20,
               "marginBottom": 5,
             }
           }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -1781,24 +1781,6 @@ exports[`34. tile ad 1`] = `
         >
           This is tile headline
         </Text>
-        <Text
-          style={
-            Object {
-              "color": "#696969",
-              "flexWrap": "wrap",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 14,
-              "lineHeight": 20,
-              "marginBottom": 0,
-            }
-          }
-        >
-          <Text>
-            
-            ‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.
-            ...
-          </Text>
-        </Text>
         <ArticleFlags />
       </View>
     </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -1772,10 +1772,10 @@ exports[`34. tile ad 1`] = `
             Object {
               "color": "#333333",
               "fontFamily": "TimesModern-Bold",
-              "fontSize": 20,
+              "fontSize": undefined,
               "fontWeight": "900",
-              "lineHeight": 20,
-              "marginBottom": 0,
+              "lineHeight": undefined,
+              "marginBottom": 5,
             }
           }
         >
@@ -1795,7 +1795,7 @@ exports[`34. tile ad 1`] = `
         >
           <Text>
             
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.
             ...
           </Text>
         </Text>
@@ -1841,9 +1841,9 @@ exports[`35. tile ac 1`] = `
         Object {
           "color": "#1D1D1B",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 30,
+          "fontSize": undefined,
           "fontWeight": "900",
-          "lineHeight": 30,
+          "lineHeight": undefined,
           "marginBottom": 0,
           "textAlign": "center",
         }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -1465,15 +1465,6 @@ exports[`34. tile ad 1`] = `
         >
           This is tile headline
         </Text>
-        <Text
-          numberOfLines={2}
-        >
-          <Text>
-            
-            ‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.
-            ...
-          </Text>
-        </Text>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -1470,7 +1470,7 @@ exports[`34. tile ad 1`] = `
         >
           <Text>
             
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.
             ...
           </Text>
         </Text>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -1335,24 +1335,28 @@ exports[`4. lead one and four 1`] = `
       className="css-view-1dbjc4n IS6"
     >
       <TileAD
+        breakpoint="wide"
         tileName="support1"
       />
       <div
         className="css-view-1dbjc4n IS3"
       />
       <TileAD
+        breakpoint="wide"
         tileName="support2"
       />
       <div
         className="css-view-1dbjc4n IS4"
       />
       <TileAD
+        breakpoint="wide"
         tileName="support3"
       />
       <div
         className="css-view-1dbjc4n IS5"
       />
       <TileAD
+        breakpoint="wide"
         tileName="support4"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -288,18 +288,22 @@ exports[`4. lead one and four 1`] = `
     <div />
     <div>
       <TileAD
+        breakpoint="wide"
         tileName="support1"
       />
       <div />
       <TileAD
+        breakpoint="wide"
         tileName="support2"
       />
       <div />
       <TileAD
+        breakpoint="wide"
         tileName="support3"
       />
       <div />
       <TileAD
+        breakpoint="wide"
         tileName="support4"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1550,24 +1550,28 @@ exports[`12. lead one and four slice - medium 1`] = `
       className="css-view-1dbjc4n IS6"
     >
       <TileAD
+        breakpoint="wide"
         tileName="support1"
       />
       <div
         className="css-view-1dbjc4n IS3"
       />
       <TileAD
+        breakpoint="wide"
         tileName="support2"
       />
       <div
         className="css-view-1dbjc4n IS4"
       />
       <TileAD
+        breakpoint="wide"
         tileName="support3"
       />
       <div
         className="css-view-1dbjc4n IS5"
       />
       <TileAD
+        breakpoint="wide"
         tileName="support4"
       />
     </div>
@@ -3541,24 +3545,28 @@ exports[`27. lead one and four slice - wide 1`] = `
       className="css-view-1dbjc4n IS6"
     >
       <TileAD
+        breakpoint="wide"
         tileName="support1"
       />
       <div
         className="css-view-1dbjc4n IS3"
       />
       <TileAD
+        breakpoint="wide"
         tileName="support2"
       />
       <div
         className="css-view-1dbjc4n IS4"
       />
       <TileAD
+        breakpoint="wide"
         tileName="support3"
       />
       <div
         className="css-view-1dbjc4n IS5"
       />
       <TileAD
+        breakpoint="wide"
         tileName="support4"
       />
     </div>
@@ -5532,24 +5540,28 @@ exports[`42. lead one and four slice - huge 1`] = `
       className="css-view-1dbjc4n IS6"
     >
       <TileAD
+        breakpoint="wide"
         tileName="support1"
       />
       <div
         className="css-view-1dbjc4n IS3"
       />
       <TileAD
+        breakpoint="wide"
         tileName="support2"
       />
       <div
         className="css-view-1dbjc4n IS4"
       />
       <TileAD
+        breakpoint="wide"
         tileName="support3"
       />
       <div
         className="css-view-1dbjc4n IS5"
       />
       <TileAD
+        breakpoint="wide"
         tileName="support4"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -343,18 +343,22 @@ exports[`12. lead one and four slice - medium 1`] = `
     <div />
     <div>
       <TileAD
+        breakpoint="wide"
         tileName="support1"
       />
       <div />
       <TileAD
+        breakpoint="wide"
         tileName="support2"
       />
       <div />
       <TileAD
+        breakpoint="wide"
         tileName="support3"
       />
       <div />
       <TileAD
+        breakpoint="wide"
         tileName="support4"
       />
     </div>
@@ -837,18 +841,22 @@ exports[`27. lead one and four slice - wide 1`] = `
     <div />
     <div>
       <TileAD
+        breakpoint="wide"
         tileName="support1"
       />
       <div />
       <TileAD
+        breakpoint="wide"
         tileName="support2"
       />
       <div />
       <TileAD
+        breakpoint="wide"
         tileName="support3"
       />
       <div />
       <TileAD
+        breakpoint="wide"
         tileName="support4"
       />
     </div>
@@ -1331,18 +1339,22 @@ exports[`42. lead one and four slice - huge 1`] = `
     <div />
     <div>
       <TileAD
+        breakpoint="wide"
         tileName="support1"
       />
       <div />
       <TileAD
+        breakpoint="wide"
         tileName="support2"
       />
       <div />
       <TileAD
+        breakpoint="wide"
         tileName="support3"
       />
       <div />
       <TileAD
+        breakpoint="wide"
         tileName="support4"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -2923,10 +2923,15 @@ exports[`34. tile ad 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  line-height: 20px;
   margin-bottom: 5px;
 }
 
 .IS1 {
+  font-size: 20px;
+}
+
+.IS2 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -2951,7 +2956,7 @@ exports[`34. tile ad 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS1"
+    className="css-view-1dbjc4n IS2"
   >
     <div
       className="css-view-1dbjc4n"
@@ -2970,7 +2975,7 @@ exports[`34. tile ad 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS1 S2"
           role="heading"
         >
           This is tile headline

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -2923,8 +2923,7 @@ exports[`34. tile ad 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  line-height: 20px;
-  margin-bottom: 0px;
+  margin-bottom: 5px;
 }
 
 .S3 {
@@ -2940,14 +2939,10 @@ exports[`34. tile ad 1`] = `
 }
 
 .IS1 {
-  font-size: 20px;
-}
-
-.IS2 {
   -webkit-line-clamp: 2;
 }
 
-.IS3 {
+.IS2 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -2972,7 +2967,7 @@ exports[`34. tile ad 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS2"
   >
     <div
       className="css-view-1dbjc4n"
@@ -2991,19 +2986,19 @@ exports[`34. tile ad 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-p1pxzi IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 S2"
           role="heading"
         >
           This is tile headline
         </h3>
         <div
-          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS1 S3"
         >
           <span
             className="css-text-901oao css-textHasAncestor-16my406"
           >
             
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.
             ...
           </span>
         </div>
@@ -3041,8 +3036,6 @@ exports[`35. tile ac 1`] = `
 
 .IS2 {
   color: rgba(29,29,27,1.00);
-  font-size: 30px;
-  line-height: 30px;
   text-align: center;
 }
 

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -2926,23 +2926,7 @@ exports[`34. tile ad 1`] = `
   margin-bottom: 5px;
 }
 
-.S3 {
-  color: rgba(105,105,105,1.00);
-  -ms-flex-wrap: wrap;
-  -webkit-box-lines: multiple;
-  -webkit-flex-wrap: wrap;
-  flex-wrap: wrap;
-  font-family: TimesDigitalW04;
-  font-size: 14px;
-  line-height: 20px;
-  margin-bottom: 10px;
-}
-
 .IS1 {
-  -webkit-line-clamp: 2;
-}
-
-.IS2 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -2967,7 +2951,7 @@ exports[`34. tile ad 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n IS1"
   >
     <div
       className="css-view-1dbjc4n"
@@ -2991,17 +2975,6 @@ exports[`34. tile ad 1`] = `
         >
           This is tile headline
         </h3>
-        <div
-          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS1 S3"
-        >
-          <span
-            className="css-text-901oao css-textHasAncestor-16my406"
-          >
-            
-            ‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.
-            ...
-          </span>
-        </div>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -1466,7 +1466,7 @@ exports[`34. tile ad 1`] = `
         <div>
           <span>
             
-            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.
             ...
           </span>
         </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -1463,13 +1463,6 @@ exports[`34. tile ad 1`] = `
         >
           This is tile headline
         </h3>
-        <div>
-          <span>
-            
-            ‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.
-            ...
-          </span>
-        </div>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/src/slices/leadoneandfour/index.js
+++ b/packages/edition-slices/src/slices/leadoneandfour/index.js
@@ -93,8 +93,8 @@ class LeadOneAndFour extends Component {
   render() {
     return (
       <ResponsiveSlice
-        renderMedium={this.renderMedium}
         renderSmall={this.renderSmall}
+        renderMedium={this.renderMedium}
       />
     );
   }

--- a/packages/edition-slices/src/slices/leadoneandfour/index.js
+++ b/packages/edition-slices/src/slices/leadoneandfour/index.js
@@ -55,16 +55,36 @@ class LeadOneAndFour extends Component {
           />
         }
         support1={
-          <TileAD onPress={onPress} tile={support1} tileName="support1" />
+          <TileAD
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={support1}
+            tileName="support1"
+          />
         }
         support2={
-          <TileAD onPress={onPress} tile={support2} tileName="support2" />
+          <TileAD
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={support2}
+            tileName="support2"
+          />
         }
         support3={
-          <TileAD onPress={onPress} tile={support3} tileName="support3" />
+          <TileAD
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={support3}
+            tileName="support3"
+          />
         }
         support4={
-          <TileAD onPress={onPress} tile={support4} tileName="support4" />
+          <TileAD
+            breakpoint={breakpoint}
+            onPress={onPress}
+            tile={support4}
+            tileName="support4"
+          />
         }
       />
     );
@@ -73,8 +93,8 @@ class LeadOneAndFour extends Component {
   render() {
     return (
       <ResponsiveSlice
-        renderSmall={this.renderSmall}
         renderMedium={this.renderMedium}
+        renderSmall={this.renderSmall}
       />
     );
   }

--- a/packages/edition-slices/src/tiles/tile-ac/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ac/styles/index.js
@@ -13,6 +13,7 @@ const paddingVerticalResolver = {
 };
 
 const fontSizeResolver = {
+  [editionBreakpoints.medium]: 30,
   [editionBreakpoints.wide]: 30,
   [editionBreakpoints.huge]: 35
 };

--- a/packages/edition-slices/src/tiles/tile-ac/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ac/styles/index.js
@@ -5,11 +5,16 @@ import {
   editionBreakpoints
 } from "@times-components/styleguide";
 
-const paddingVertical = {
+const paddingVerticalResolver = {
   [editionBreakpoints.small]: spacing(3),
-  [editionBreakpoints.medium]: spacing(3),
+  [editionBreakpoints.medium]: spacing(8),
   [editionBreakpoints.wide]: spacing(6),
-  [editionBreakpoints.huge]: spacing(6)
+  [editionBreakpoints.huge]: spacing(14)
+};
+
+const fontSizeResolver = {
+  [editionBreakpoints.wide]: 30,
+  [editionBreakpoints.huge]: 35
 };
 
 export default breakpoint => ({
@@ -20,8 +25,8 @@ export default breakpoint => ({
   headline: {
     color: colours.functional.brandColour,
     fontFamily: fonts.headline,
-    fontSize: 30,
-    lineHeight: 30,
+    fontSize: fontSizeResolver[breakpoint],
+    lineHeight: fontSizeResolver[breakpoint],
     marginBottom: 0,
     textAlign: "center"
   },
@@ -34,6 +39,6 @@ export default breakpoint => ({
     justifyContent: "center",
     backgroundColor: colours.functional.border,
     paddingHorizontal: spacing(4),
-    paddingVertical: paddingVertical[breakpoint] || spacing(3)
+    paddingVertical: paddingVerticalResolver[breakpoint] || spacing(3)
   }
 });

--- a/packages/edition-slices/src/tiles/tile-ad/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/require-default-props */
 import React from "react";
 import PropTypes from "prop-types";
 import { editionBreakpoints } from "@times-components/styleguide";
@@ -10,7 +11,7 @@ import {
 import stylesFactory from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
 
-const TileAD = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
+const TileAD = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
   const styles = stylesFactory(breakpoint);
   const showSummary = breakpoint !== editionBreakpoints.medium;
   return (
@@ -33,7 +34,7 @@ const TileAD = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
 TileAD.propTypes = {
   onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired,
-  breakpoint: PropTypes.string.isRequired
+  breakpoint: PropTypes.string
 };
 
 export default withTileTracking(TileAD);

--- a/packages/edition-slices/src/tiles/tile-ad/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/index.js
@@ -1,33 +1,39 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { editionBreakpoints } from "@times-components/styleguide";
 import {
   TileLink,
   TileSummary,
   withTileTracking,
   getTileSummary
 } from "../shared";
-import styles from "./styles";
+import stylesFactory from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
 
-const TileAD = ({ onPress, tile }) => (
-  <TileLink onPress={onPress} style={styles.container} tile={tile}>
-    <WithoutWhiteSpace
-      style={styles.summaryContainer}
-      render={whiteSpaceHeight => (
-        <TileSummary
-          headlineStyle={styles.headline}
-          summary={getTileSummary(tile, 125)}
-          tile={tile}
-          whiteSpaceHeight={whiteSpaceHeight}
-        />
-      )}
-    />
-  </TileLink>
-);
+const TileAD = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
+  const styles = stylesFactory(breakpoint);
+  const showSummary = breakpoint !== editionBreakpoints.medium;
+  return (
+    <TileLink onPress={onPress} style={styles.container} tile={tile}>
+      <WithoutWhiteSpace
+        style={styles.summaryContainer}
+        render={whiteSpaceHeight => (
+          <TileSummary
+            headlineStyle={styles.headline}
+            summary={showSummary && getTileSummary(tile, 300)}
+            tile={tile}
+            whiteSpaceHeight={whiteSpaceHeight}
+          />
+        )}
+      />
+    </TileLink>
+  );
+};
 
 TileAD.propTypes = {
   onPress: PropTypes.func.isRequired,
-  tile: PropTypes.shape({}).isRequired
+  tile: PropTypes.shape({}).isRequired,
+  breakpoint: PropTypes.string.isRequired
 };
 
 export default withTileTracking(TileAD);

--- a/packages/edition-slices/src/tiles/tile-ad/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/styles/index.js
@@ -1,6 +1,15 @@
-import { fonts, spacing } from "@times-components/styleguide";
+import {
+  fonts,
+  spacing,
+  editionBreakpoints
+} from "@times-components/styleguide";
 
-const styles = {
+const fontSizeResolver = {
+  [editionBreakpoints.wide]: 20,
+  [editionBreakpoints.huge]: 22
+};
+
+export default breakpoint => ({
   container: {
     flex: 1,
     flexDirection: "row",
@@ -8,13 +17,11 @@ const styles = {
   },
   headline: {
     fontFamily: fonts.headline,
-    fontSize: 20,
-    lineHeight: 20,
-    marginBottom: 0
+    fontSize: fontSizeResolver[breakpoint],
+    lineHeight: fontSizeResolver[breakpoint],
+    marginBottom: spacing(1)
   },
   summaryContainer: {
     width: "100%"
   }
-};
-
-export default styles;
+});

--- a/packages/edition-slices/src/tiles/tile-ad/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/styles/index.js
@@ -5,6 +5,7 @@ import {
 } from "@times-components/styleguide";
 
 const fontSizeResolver = {
+  [editionBreakpoints.medium]: 20,
   [editionBreakpoints.wide]: 20,
   [editionBreakpoints.huge]: 22
 };

--- a/packages/provider-queries/src/section_fragment.graphql
+++ b/packages/provider-queries/src/section_fragment.graphql
@@ -145,7 +145,9 @@ fragment standardSection on StandardSection {
           listingAsset {
             ...listingAsset32
           }
+          summary300: summary(maxCharCount: 300)
         }
+        teaser300: teaser(maxCharCount: 300)
       }
       support2 {
         headline
@@ -160,7 +162,9 @@ fragment standardSection on StandardSection {
           listingAsset {
             ...listingAsset32
           }
+          summary300: summary(maxCharCount: 300)
         }
+        teaser300: teaser(maxCharCount: 300)
       }
       support3 {
         headline
@@ -175,7 +179,9 @@ fragment standardSection on StandardSection {
           listingAsset {
             ...listingAsset32
           }
+          summary300: summary(maxCharCount: 300)
         }
+        teaser300: teaser(maxCharCount: 300)
       }
       support4 {
         headline
@@ -190,7 +196,9 @@ fragment standardSection on StandardSection {
           listingAsset {
             ...listingAsset32
           }
+          summary300: summary(maxCharCount: 300)
         }
+        teaser300: teaser(maxCharCount: 300)
       }
     }
     ... on LeadOneAndOneSlice {
@@ -813,7 +821,9 @@ fragment magazineSection on MagazineSection {
           listingAsset {
             ...listingAsset32
           }
+          summary300: summary(maxCharCount: 300)
         }
+        teaser300: teaser(maxCharCount: 300)
       }
       support2 {
         headline
@@ -828,7 +838,9 @@ fragment magazineSection on MagazineSection {
           listingAsset {
             ...listingAsset32
           }
+          summary300: summary(maxCharCount: 300)
         }
+        teaser300: teaser(maxCharCount: 300)
       }
       support3 {
         headline
@@ -843,7 +855,9 @@ fragment magazineSection on MagazineSection {
           listingAsset {
             ...listingAsset32
           }
+          summary300: summary(maxCharCount: 300)
         }
+        teaser300: teaser(maxCharCount: 300)
       }
       support4 {
         headline
@@ -858,7 +872,9 @@ fragment magazineSection on MagazineSection {
           listingAsset {
             ...listingAsset32
           }
+          summary300: summary(maxCharCount: 300)
         }
+        teaser300: teaser(maxCharCount: 300)
       }
     }
     ... on LeadOneAndOneSlice {


### PR DESCRIPTION
[Story](https://nidigitalsolutions.jira.com/browse/REPLAT-8553)

As discussed with the designers, if there is no star or flags we should fill the left whitespace with teaser text for TileAD(right four slices in the slice)

Section fragment is updated by adding summary300 and teaser300 on LeadOneAndFourSlice.

![image](https://user-images.githubusercontent.com/7889661/65028360-9b6b1300-d944-11e9-9665-949b00f26319.png)

With star: 
![image](https://user-images.githubusercontent.com/7889661/65036806-f278e400-d954-11e9-908a-1c1710a4050f.png)

