### PR TITLE
fix: secondary 2 no pic and 2 slice minor styling

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2223,7 +2223,7 @@ exports[`29. secondary two no pic and two - wide 1`] = `
       style={
         Object {
           "flexDirection": "row",
-          "width": "65%",
+          "width": "66.6%",
         }
       }
     >
@@ -3522,7 +3522,7 @@ exports[`44. secondary two no pic and two - huge 1`] = `
         style={
           Object {
             "flexDirection": "row",
-            "width": "65%",
+            "width": "66.6%",
           }
         }
       >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2223,7 +2223,7 @@ exports[`29. secondary two no pic and two - wide 1`] = `
       style={
         Object {
           "flexDirection": "row",
-          "width": "65%",
+          "width": "66.6%",
         }
       }
     >
@@ -3522,7 +3522,7 @@ exports[`44. secondary two no pic and two - huge 1`] = `
         style={
           Object {
             "flexDirection": "row",
-            "width": "65%",
+            "width": "66.6%",
           }
         }
       >

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -2365,7 +2365,7 @@ exports[`12. secondary two no pic and two 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  width: 65%;
+  width: 66.6%;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
 }

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1735,7 +1735,7 @@ exports[`14. secondary two no pic and two - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  width: 65%;
+  width: 66.6%;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
 }
@@ -3728,7 +3728,7 @@ exports[`29. secondary two no pic and two - wide 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  width: 65%;
+  width: 66.6%;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
 }
@@ -5721,7 +5721,7 @@ exports[`44. secondary two no pic and two - huge 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  width: 65%;
+  width: 66.6%;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
 }

--- a/packages/slice-layout/__tests__/android/__snapshots__/sd2np2-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/sd2np2-with-style.android.test.js.snap
@@ -166,7 +166,7 @@ exports[`3. secondary two no pic and two - wide 1`] = `
     style={
       Object {
         "flexDirection": "row",
-        "width": "65%",
+        "width": "66.6%",
       }
     }
   >
@@ -255,7 +255,7 @@ exports[`4. secondary two no pic and two - huge 1`] = `
     style={
       Object {
         "flexDirection": "row",
-        "width": "65%",
+        "width": "66.6%",
       }
     }
   >

--- a/packages/slice-layout/__tests__/ios/__snapshots__/sd2np2-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/sd2np2-with-style.ios.test.js.snap
@@ -166,7 +166,7 @@ exports[`3. secondary two no pic and two - wide 1`] = `
     style={
       Object {
         "flexDirection": "row",
-        "width": "65%",
+        "width": "66.6%",
       }
     }
   >
@@ -255,7 +255,7 @@ exports[`4. secondary two no pic and two - huge 1`] = `
     style={
       Object {
         "flexDirection": "row",
-        "width": "65%",
+        "width": "66.6%",
       }
     }
   >

--- a/packages/slice-layout/__tests__/web/__snapshots__/sd2np2-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/sd2np2-with-style.web.test.js.snap
@@ -330,7 +330,7 @@ exports[`3. secondary two no pic and two - wide 1`] = `
         "WebkitFlexDirection": "row",
         "flexDirection": "row",
         "msFlexDirection": "row",
-        "width": "65%",
+        "width": "66.6%",
       }
     }
   >
@@ -484,7 +484,7 @@ exports[`4. secondary two no pic and two - huge 1`] = `
         "WebkitFlexDirection": "row",
         "flexDirection": "row",
         "msFlexDirection": "row",
-        "width": "65%",
+        "width": "66.6%",
       }
     }
   >

--- a/packages/slice-layout/src/templates/secondarytwonopicandtwo/styles.js
+++ b/packages/slice-layout/src/templates/secondarytwonopicandtwo/styles.js
@@ -27,7 +27,7 @@ const wideBreakpointStyles = {
     marginHorizontal: spacing(2)
   },
   secondaryContainer: {
-    width: "65%",
+    width: "66.6%",
     flexDirection: "row"
   },
   supportContainer: {


### PR DESCRIPTION
Aligning the vertical lines between SecondaryTwoNoPicAndTwo and other slices.
Breakpoint affected: wide and huge.

Before:
![alignment-before](https://user-images.githubusercontent.com/8720661/65053249-552da800-d974-11e9-850a-7b2ebdb8e8d7.png)

After:
![alignment-after](https://user-images.githubusercontent.com/8720661/65053255-57900200-d974-11e9-9a95-d95e73bf03d7.png)
