### PR TITLE
feat: lead one and cartoon padding updates for 1366

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2368,7 +2368,7 @@ exports[`31. comment lead and cartoon - huge 1`] = `
         Object {
           "flex": 1,
           "flexDirection": "row",
-          "paddingHorizontal": 20,
+          "paddingHorizontal": 10,
           "paddingVertical": 5,
         }
       }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2368,7 +2368,7 @@ exports[`31. comment lead and cartoon - huge 1`] = `
         Object {
           "flex": 1,
           "flexDirection": "row",
-          "paddingHorizontal": 20,
+          "paddingHorizontal": 10,
           "paddingVertical": 5,
         }
       }

--- a/packages/slice-layout/src/templates/commentleadandcartoon/styles.js
+++ b/packages/slice-layout/src/templates/commentleadandcartoon/styles.js
@@ -28,7 +28,7 @@ const wideBreakpointStyles = {
 const stylesResolver = {
   [editionBreakpoints.medium]: defaultBreakpointStyles,
   [editionBreakpoints.wide]: wideBreakpointStyles,
-  [editionBreakpoints.huge]: defaultBreakpointStyles
+  [editionBreakpoints.huge]: wideBreakpointStyles
 };
 
 export default breakpoint => stylesResolver[breakpoint];


### PR DESCRIPTION
[Story.](https://nidigitalsolutions.jira.com/browse/REPLAT-8562)
[Design.](https://app.zeplin.io/project/5d2849a2b4a4605645afb4be/screen/5d6e69997a7ba91b1aa58544)

Minor styling updates for huge breakpoint.

![image](https://user-images.githubusercontent.com/8720661/65154449-37c01300-da34-11e9-9674-cb0411cb7ab9.png)
