### PR TITLE
chore: bump rn60.5

### DIFF
--- a/android-app/package.json
+++ b/android-app/package.json
@@ -16,14 +16,14 @@
     "prop-types": "15.7.2",
     "react": "16.9.0",
     "react-native-device-info": "3.0.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-svg": "9.9.3",
     "react-native-webview": "7.0.5",
     "url-polyfill": "1.1.0"
   },
   "devDependencies": {
     "@bam.tech/react-native-graphql-transformer": "0.1.5",
-    "metro-react-native-babel-preset": "0.53.1",
+    "metro-react-native-babel-preset": "0.54.1",
     "prettier": "1.14.3",
     "webpack": "4.30.0"
   },

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -74,6 +74,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
+        entryFile   : "fructose/index.js",
         enableHermes: true,
 ]
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -74,7 +74,6 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-        entryFile   : "fructose/index.js",
         enableHermes: true,
 ]
 

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -14,11 +14,11 @@
     "@times-components/text-flow": "0.2.12",
     "prop-types": "15.7.2",
     "react": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "url-polyfill": "1.1.0"
   },
   "devDependencies": {
-    "metro-react-native-babel-preset": "0.53.1",
+    "metro-react-native-babel-preset": "0.54.1",
     "prettier": "1.14.3",
     "webpack": "4.30.0"
   },

--- a/lib/cli/package-json.js
+++ b/lib/cli/package-json.js
@@ -53,7 +53,7 @@ module.exports = variables => ({
     prettier: "1.14.3",
     react: "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     webpack: "4.30.0",
     "webpack-cli": "3.3.1"

--- a/lib/hermes.js
+++ b/lib/hermes.js
@@ -2,9 +2,7 @@ const { exec } = require("child_process");
 const os = require("os");
 const path = require("path");
 
-const puts = (error, stdout, stderr) => {
-  console.error(stderr);
-  console.log(stdout);
+const puts = (error) => {
   if (error) {
     throw new Error(error);
   }

--- a/lib/hermes.js
+++ b/lib/hermes.js
@@ -2,7 +2,9 @@ const { exec } = require("child_process");
 const os = require("os");
 const path = require("path");
 
-const puts = (error) => {
+const puts = (error, stdout, stderr) => {
+  console.error(stderr);
+  console.log(stdout);
   if (error) {
     throw new Error(error);
   }

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "jest": "24.8.0",
     "lcov-result-merger": "1.2.0",
     "lerna": "3.2.1",
-    "metro-react-native-babel-preset": "0.53.1",
+    "metro-react-native-babel-preset": "0.54.1",
     "mkdirp": "0.5.1",
     "mockdate": "2.0.2",
     "node-fetch": "2.2.0",
@@ -161,7 +161,7 @@
     "newskit": "0.0.0-70b3f4d2c",
     "react-art": "16.6.3",
     "react-native-device-info": "3.0.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-showcase-loader": "1.1.0"
   }
 }

--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -53,7 +53,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -56,7 +56,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/article-comments/package.json
+++ b/packages/article-comments/package.json
@@ -60,7 +60,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-error/package.json
+++ b/packages/article-error/package.json
@@ -46,7 +46,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3"
   },
   "peerDependencies": {

--- a/packages/article-extras/package.json
+++ b/packages/article-extras/package.json
@@ -51,7 +51,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-flag/package.json
+++ b/packages/article-flag/package.json
@@ -55,7 +55,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/article-image/package.json
+++ b/packages/article-image/package.json
@@ -58,7 +58,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/article-in-depth/package.json
+++ b/packages/article-in-depth/package.json
@@ -55,7 +55,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-label/package.json
+++ b/packages/article-label/package.json
@@ -60,7 +60,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/article-lead-asset/package.json
+++ b/packages/article-lead-asset/package.json
@@ -48,7 +48,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-list/package.json
+++ b/packages/article-list/package.json
@@ -61,7 +61,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/article-magazine-comment/package.json
+++ b/packages/article-magazine-comment/package.json
@@ -55,7 +55,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-magazine-standard/package.json
+++ b/packages/article-magazine-standard/package.json
@@ -55,7 +55,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-main-comment/package.json
+++ b/packages/article-main-comment/package.json
@@ -55,7 +55,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-main-standard/package.json
+++ b/packages/article-main-standard/package.json
@@ -54,7 +54,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-paragraph/package.json
+++ b/packages/article-paragraph/package.json
@@ -64,7 +64,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article-skeleton/package.json
+++ b/packages/article-skeleton/package.json
@@ -63,7 +63,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/article-summary/package.json
+++ b/packages/article-summary/package.json
@@ -54,7 +54,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/article-topics/package.json
+++ b/packages/article-topics/package.json
@@ -56,7 +56,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -53,7 +53,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -61,7 +61,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/brightcove-video/package.json
+++ b/packages/brightcove-video/package.json
@@ -60,7 +60,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -56,7 +56,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -56,7 +56,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -51,7 +51,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/date-publication/package.json
+++ b/packages/date-publication/package.json
@@ -53,7 +53,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/edition-slices/package.json
+++ b/packages/edition-slices/package.json
@@ -68,7 +68,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/error-view/package.json
+++ b/packages/error-view/package.json
@@ -55,7 +55,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/gestures/package.json
+++ b/packages/gestures/package.json
@@ -53,7 +53,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-art": "16.6.3",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/gradient/package.json
+++ b/packages/gradient/package.json
@@ -66,7 +66,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -56,7 +56,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -56,7 +56,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/interactive-wrapper/package.json
+++ b/packages/interactive-wrapper/package.json
@@ -52,7 +52,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/key-facts/package.json
+++ b/packages/key-facts/package.json
@@ -55,7 +55,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/lazy-load/package.json
+++ b/packages/lazy-load/package.json
@@ -48,7 +48,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "styled-components": "4.3.2",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -56,7 +56,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/markup/package.json
+++ b/packages/markup/package.json
@@ -57,7 +57,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/message-bar/package.json
+++ b/packages/message-bar/package.json
@@ -51,7 +51,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -42,7 +42,7 @@
     "jest": "24.8.0",
     "prettier": "1.14.3",
     "react": "16.9.0",
-    "react-native": "0.60.4"
+    "react-native": "0.60.5"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -48,7 +48,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0"
   },

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -57,7 +57,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -56,7 +56,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/pull-quote/package.json
+++ b/packages/pull-quote/package.json
@@ -56,7 +56,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/related-articles/package.json
+++ b/packages/related-articles/package.json
@@ -61,7 +61,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/responsive/package.json
+++ b/packages/responsive/package.json
@@ -50,7 +50,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/save-and-share-bar/package.json
+++ b/packages/save-and-share-bar/package.json
@@ -60,7 +60,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/save-star-web/package.json
+++ b/packages/save-star-web/package.json
@@ -61,7 +61,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -64,7 +64,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/slice-layout/package.json
+++ b/packages/slice-layout/package.json
@@ -55,7 +55,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -73,7 +73,7 @@
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
     "react-helmet-async": "1.0.2",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "styled-components": "4.3.2",
     "unfetch": "^3.0.0"

--- a/packages/star-button/package.json
+++ b/packages/star-button/package.json
@@ -50,7 +50,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/sticky/package.json
+++ b/packages/sticky/package.json
@@ -54,7 +54,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "stylelint": "9.4.0",
     "stylelint-config-recommended": "2.1.0",
     "stylelint-config-styled-components": "0.1.1",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -39,7 +39,7 @@
     "prettier": "1.14.3",
     "react-art": "16.6.3",
     "react-native-web": "0.11.4",
-    "react-native": "0.60.4"
+    "react-native": "0.60.5"
   },
   "dependencies": {
     "@babel/core": "7.4.4",

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -54,7 +54,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/svgs/package.json
+++ b/packages/svgs/package.json
@@ -64,7 +64,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/text-flow/package.json
+++ b/packages/text-flow/package.json
@@ -49,7 +49,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"
   },

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -58,7 +58,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "stylelint": "9.4.0",

--- a/packages/user-state/package.json
+++ b/packages/user-state/package.json
@@ -52,7 +52,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -57,7 +57,7 @@
     "apollo-link-http": "1.5.14",
     "lodash.omitby": "4.6.0",
     "prop-types": "15.7.2",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "styled-components": "4.3.2",
     "unfetch": "^3.0.0"
   },

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -67,7 +67,7 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-web": "0.11.4",
     "react-test-renderer": "16.6.3",
     "webpack": "4.30.0",

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -54,7 +54,7 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"
   },

--- a/storybook-native/package.json
+++ b/storybook-native/package.json
@@ -31,13 +31,13 @@
     "core-js": "^2.6.5",
     "prop-types": "15.7.2",
     "react": "16.9.0",
-    "react-native": "0.60.4",
+    "react-native": "0.60.5",
     "react-native-svg": "9.9.3",
     "regenerator-runtime": "0.13.2",
     "url-polyfill": "1.1.0"
   },
   "devDependencies": {
-    "metro-react-native-babel-preset": "0.53.1",
+    "metro-react-native-babel-preset": "0.54.1",
     "prettier": "1.14.3",
     "react-native-storybook-loader": "1.8.0",
     "webpack": "4.30.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2778,7 +2778,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@react-native-community/cli-platform-android@^2.0.1", "@react-native-community/cli-platform-android@^2.9.0":
+"@react-native-community/cli-platform-android@^2.6.0", "@react-native-community/cli-platform-android@^2.9.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-2.9.0.tgz#28831e61ce565a2c7d1905852fce1eecfd33cb5e"
   integrity sha512-VEQs4Q6R5tnlYFrQIFoPEWjLc43whRHC9HeH+idbFymwDqysLVUffQbb9D6PJUj+C/AvrDhBhU6S3tDjGbSsag==
@@ -2791,7 +2791,7 @@
     slash "^3.0.0"
     xmldoc "^1.1.2"
 
-"@react-native-community/cli-platform-ios@^2.0.1", "@react-native-community/cli-platform-ios@^2.9.0":
+"@react-native-community/cli-platform-ios@^2.4.1", "@react-native-community/cli-platform-ios@^2.9.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-2.9.0.tgz#21adb8ee813d6ca6fd9d4d9be63f92024f7e2fe7"
   integrity sha512-vg6EOamtFaaQ02FiWu+jzJTfeTJ0OVjJSAoR2rhJKNye6RgJLoQlfp0Hg3waF6XrO72a7afYZsPdKSlN3ewlHg==
@@ -2810,7 +2810,7 @@
     mime "^2.4.1"
     node-fetch "^2.5.0"
 
-"@react-native-community/cli@^2.0.1":
+"@react-native-community/cli@^2.6.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-2.9.0.tgz#f0d18dc3e5a8f68e3d6ad353c444dc2f08d3fbdc"
   integrity sha512-6TYkrR1pwIEPpiPZnOYscCGr5Xh8RijqBPVAOGTaEdpQQpc/J7GDPrePwbyTzwmCPtiK6XT+T5+1AiAK5bz/sw==
@@ -14186,13 +14186,6 @@ metro-babel-transformer@0.54.1:
   dependencies:
     "@babel/core" "^7.0.0"
 
-metro-babel7-plugin-react-transform@0.53.1:
-  version "0.53.1"
-  resolved "https://registry.yarnpkg.com/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.53.1.tgz#9ad31e5c84f5003333a6a3cf79f2d093cd3b2ddc"
-  integrity sha512-98lEpTu7mox/7QurxVuLnbjrGDdayjpS2Z1T4vkLcP+mBxzloKJuTRnmtyWC8cNlx9qjimHGDlqtNY78rQ8rsA==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-
 metro-babel7-plugin-react-transform@0.54.1:
   version "0.54.1"
   resolved "https://registry.yarnpkg.com/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.54.1.tgz#5335b810284789724886dc483d5bde9c149a1996"
@@ -14249,48 +14242,6 @@ metro-minify-uglify@0.54.1:
   integrity sha512-z+pOPna/8IxD4OhjW6Xo1mV2EszgqqQHqBm1FdmtdF6IpWkQp33qpDBNEi9NGZTOr7pp2bvcxZnvNJdC2lrK9Q==
   dependencies:
     uglify-es "^3.1.9"
-
-metro-react-native-babel-preset@0.53.1:
-  version "0.53.1"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.53.1.tgz#6cd9e41a1b9a6e210e71ef2adf114219b4eaf2ec"
-  integrity sha512-Uf8EGL8kIPhDkoSdAAysNPxPQclUS2R1QC4cwnc8bkk2f6yqGn+1CorfiY9AaqlLEth5mKQqdtRYFDTFfB9QyA==
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "^7.0.0"
-    "@babel/plugin-proposal-export-default-from" "^7.0.0"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.0.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
-    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
-    "@babel/plugin-syntax-dynamic-import" "^7.0.0"
-    "@babel/plugin-syntax-export-default-from" "^7.0.0"
-    "@babel/plugin-syntax-flow" "^7.2.0"
-    "@babel/plugin-transform-arrow-functions" "^7.0.0"
-    "@babel/plugin-transform-block-scoping" "^7.0.0"
-    "@babel/plugin-transform-classes" "^7.0.0"
-    "@babel/plugin-transform-computed-properties" "^7.0.0"
-    "@babel/plugin-transform-destructuring" "^7.0.0"
-    "@babel/plugin-transform-exponentiation-operator" "^7.0.0"
-    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
-    "@babel/plugin-transform-for-of" "^7.0.0"
-    "@babel/plugin-transform-function-name" "^7.0.0"
-    "@babel/plugin-transform-literals" "^7.0.0"
-    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
-    "@babel/plugin-transform-object-assign" "^7.0.0"
-    "@babel/plugin-transform-parameters" "^7.0.0"
-    "@babel/plugin-transform-react-display-name" "^7.0.0"
-    "@babel/plugin-transform-react-jsx" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-source" "^7.0.0"
-    "@babel/plugin-transform-regenerator" "^7.0.0"
-    "@babel/plugin-transform-runtime" "^7.0.0"
-    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
-    "@babel/plugin-transform-spread" "^7.0.0"
-    "@babel/plugin-transform-sticky-regex" "^7.0.0"
-    "@babel/plugin-transform-template-literals" "^7.0.0"
-    "@babel/plugin-transform-typescript" "^7.0.0"
-    "@babel/plugin-transform-unicode-regex" "^7.0.0"
-    "@babel/template" "^7.0.0"
-    metro-babel7-plugin-react-transform "0.53.1"
-    react-transform-hmr "^1.0.4"
 
 metro-react-native-babel-preset@0.54.1:
   version "0.54.1"
@@ -17584,15 +17535,15 @@ react-native-webview@7.0.5:
     escape-string-regexp "1.0.5"
     invariant "2.2.4"
 
-react-native@0.60.4:
-  version "0.60.4"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.60.4.tgz#4378171e63dd5310497e15e54ec9185cb470752d"
-  integrity sha512-WE41lbGQjnzM9srIFtMDtMJkQAvk95iZwuFvAxl68s80bkYa7Ou9sGFHpeYIV6cY8yHtheCSo5q6YMxhdfkdOw==
+react-native@0.60.5:
+  version "0.60.5"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.60.5.tgz#3c1d9c06a0fbab9807220b6acac09488d39186ee"
+  integrity sha512-cZwI0XzzihACN+7an1Dy46A83FRaAe2Xyd7laCalFFAppZIYeMVphZQWrVljJk5kIZBNtYG35TY1VsghQ0Oc2Q==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@react-native-community/cli" "^2.0.1"
-    "@react-native-community/cli-platform-android" "^2.0.1"
-    "@react-native-community/cli-platform-ios" "^2.0.1"
+    "@react-native-community/cli" "^2.6.0"
+    "@react-native-community/cli-platform-android" "^2.6.0"
+    "@react-native-community/cli-platform-ios" "^2.4.1"
     abort-controller "^3.0.0"
     art "^0.10.0"
     base64-js "^1.1.2"


### PR DESCRIPTION
why?

see https://github.com/facebook/react-native/releases/tag/v0.60.5
includes new cli https://github.com/facebook/react-native/commit/72473c7
and new metro bundler https://github.com/facebook/react-native/commit/1bb197a