### PR TITLE
fix: REPLAT-7797 fix referral url passing

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -411,7 +411,7 @@ Object {
     "linkUrl": "https://link.io",
     "pageName": "this-is-slug-2k629tpvh",
     "publishedTime": "2015-03-13T18:54:58.000Z",
-    "referralUrl": "",
+    "referralUrl": "referralUrl.com",
     "section": "Some Section",
     "template": "mainstandard",
   },

--- a/packages/article-skeleton/__tests__/android/__snapshots__/tracking.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/tracking.android.test.js.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`[Article page analytics] should get the referralUrl from data if it's not passed in 1`] = `
+Array [
+  Array [
+    Object {
+      "action": "Viewed",
+      "attrs": Object {
+        "articleId": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
+        "bylines": "Camilla Long",
+        "eventTime": "2018-01-01T00:00:00.000Z",
+        "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+        "label": "HURRICANE IRMA",
+        "pageName": "france-defies-may-over-russia-37b27qd2s",
+        "publishedTime": "2015-03-13T18:54:58.000Z",
+        "referralUrl": "from-data.com",
+        "section": "news",
+        "template": "mainstandard",
+      },
+      "component": "Page",
+      "object": "Article",
+    },
+  ],
+]
+`;
+
+exports[`[Article page analytics] should get the referralUrl if its passed in 1`] = `
+Array [
+  Array [
+    Object {
+      "action": "Viewed",
+      "attrs": Object {
+        "articleId": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
+        "bylines": "Camilla Long",
+        "eventTime": "2018-01-01T00:00:00.000Z",
+        "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+        "label": "HURRICANE IRMA",
+        "pageName": "france-defies-may-over-russia-37b27qd2s",
+        "publishedTime": "2015-03-13T18:54:58.000Z",
+        "referralUrl": "from-props.com",
+        "section": "news",
+        "template": "mainstandard",
+      },
+      "component": "Page",
+      "object": "Article",
+    },
+  ],
+]
+`;
+
 exports[`[Article page analytics] should match snapshot when rendering an article page 1`] = `
 Array [
   Array [
@@ -13,7 +61,7 @@ Array [
         "label": "HURRICANE IRMA",
         "pageName": "france-defies-may-over-russia-37b27qd2s",
         "publishedTime": "2015-03-13T18:54:58.000Z",
-        "referralUrl": "",
+        "referralUrl": "referralUrl.com",
         "section": "news",
         "template": "mainstandard",
       },

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -411,7 +411,7 @@ Object {
     "linkUrl": "https://link.io",
     "pageName": "this-is-slug-2k629tpvh",
     "publishedTime": "2015-03-13T18:54:58.000Z",
-    "referralUrl": "",
+    "referralUrl": "referralUrl.com",
     "section": "Some Section",
     "template": "mainstandard",
   },

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/tracking.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/tracking.ios.test.js.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`[Article page analytics] should get the referralUrl from data if it's not passed in 1`] = `
+Array [
+  Array [
+    Object {
+      "action": "Viewed",
+      "attrs": Object {
+        "articleId": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
+        "bylines": "Camilla Long",
+        "eventTime": "2018-01-01T00:00:00.000Z",
+        "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+        "label": "HURRICANE IRMA",
+        "pageName": "france-defies-may-over-russia-37b27qd2s",
+        "publishedTime": "2015-03-13T18:54:58.000Z",
+        "referralUrl": "from-data.com",
+        "section": "news",
+        "template": "mainstandard",
+      },
+      "component": "Page",
+      "object": "Article",
+    },
+  ],
+]
+`;
+
+exports[`[Article page analytics] should get the referralUrl if its passed in 1`] = `
+Array [
+  Array [
+    Object {
+      "action": "Viewed",
+      "attrs": Object {
+        "articleId": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
+        "bylines": "Camilla Long",
+        "eventTime": "2018-01-01T00:00:00.000Z",
+        "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+        "label": "HURRICANE IRMA",
+        "pageName": "france-defies-may-over-russia-37b27qd2s",
+        "publishedTime": "2015-03-13T18:54:58.000Z",
+        "referralUrl": "from-props.com",
+        "section": "news",
+        "template": "mainstandard",
+      },
+      "component": "Page",
+      "object": "Article",
+    },
+  ],
+]
+`;
+
 exports[`[Article page analytics] should match snapshot when rendering an article page 1`] = `
 Array [
   Array [
@@ -13,7 +61,7 @@ Array [
         "label": "HURRICANE IRMA",
         "pageName": "france-defies-may-over-russia-37b27qd2s",
         "publishedTime": "2015-03-13T18:54:58.000Z",
-        "referralUrl": "",
+        "referralUrl": "referralUrl.com",
         "section": "news",
         "template": "mainstandard",
       },

--- a/packages/article-skeleton/__tests__/shared-tracking.base.js
+++ b/packages/article-skeleton/__tests__/shared-tracking.base.js
@@ -38,5 +38,44 @@ export default () => {
       );
       expect(stream.mock.calls).toMatchSnapshot();
     });
+
+    it("should get the referralUrl if its passed in", () => {
+      renderer.create(
+        <ArticleSkeleton
+          {...articleSkeletonProps}
+          analyticsStream={stream}
+          data={articleFixture()}
+          referralUrl="from-props.com"
+          Header={() => null}
+          onAuthorPress={() => {}}
+          onCommentGuidelinesPress={() => {}}
+          onCommentsPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTwitterLinkPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      );
+      expect(stream.mock.calls).toMatchSnapshot();
+    });
+
+    it("should get the referralUrl from data if it's not passed in", () => {
+      renderer.create(
+        <ArticleSkeleton
+          {...articleSkeletonProps}
+          analyticsStream={stream}
+          data={articleFixture({ withAds: true, referralUrl: "from-data.com" })}
+          Header={() => null}
+          onAuthorPress={() => {}}
+          onCommentGuidelinesPress={() => {}}
+          onCommentsPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTwitterLinkPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      );
+      expect(stream.mock.calls).toMatchSnapshot();
+    });
   });
 };

--- a/packages/article-skeleton/__tests__/web/__snapshots__/tracking.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/tracking.web.test.js.snap
@@ -1,5 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`[Article page analytics] should get the referralUrl from data if it's not passed in 1`] = `
+Array [
+  Array [
+    Object {
+      "action": "Viewed",
+      "attrs": Object {
+        "articleId": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
+        "article_topic_tags": Array [
+          "Football",
+          "Manchester United FC",
+          "Chelsea FC",
+          "Arsenal",
+          "Rugby Union",
+        ],
+        "bylines": "Camilla Long",
+        "edition_type": "",
+        "eventTime": "2018-01-01T00:00:00.000Z",
+        "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+        "label": "HURRICANE IRMA",
+        "pageName": "france-defies-may-over-russia-37b27qd2s",
+        "parent_site": "TIMES",
+        "publishedTime": "2015-03-13T18:54:58.000Z",
+        "referralUrl": "",
+        "registrationType": "logged out",
+        "section": "news",
+        "shared": "no",
+        "template": "mainstandard",
+      },
+      "component": "Page",
+      "object": "Article",
+    },
+  ],
+]
+`;
+
+exports[`[Article page analytics] should get the referralUrl if its passed in 1`] = `
+Array [
+  Array [
+    Object {
+      "action": "Viewed",
+      "attrs": Object {
+        "articleId": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
+        "article_topic_tags": Array [
+          "Football",
+          "Manchester United FC",
+          "Chelsea FC",
+          "Arsenal",
+          "Rugby Union",
+        ],
+        "bylines": "Camilla Long",
+        "edition_type": "",
+        "eventTime": "2018-01-01T00:00:00.000Z",
+        "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+        "label": "HURRICANE IRMA",
+        "pageName": "france-defies-may-over-russia-37b27qd2s",
+        "parent_site": "TIMES",
+        "publishedTime": "2015-03-13T18:54:58.000Z",
+        "referralUrl": "from-props.com",
+        "registrationType": "logged out",
+        "section": "news",
+        "shared": "no",
+        "template": "mainstandard",
+      },
+      "component": "Page",
+      "object": "Article",
+    },
+  ],
+]
+`;
+
 exports[`[Article page analytics] should match snapshot when rendering an article page 1`] = `
 Array [
   Array [

--- a/packages/article-skeleton/fixtures/full-article.js
+++ b/packages/article-skeleton/fixtures/full-article.js
@@ -897,6 +897,7 @@ const defaultFlags = ["NEW", "EXCLUSIVE"];
 const defaultHasVideo = false;
 const defaultHeadline =
   "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record";
+const defaultReferralUrl = "referralUrl.com";
 const defaultKeywords = ["Supplement", "In", "Depth", "Template", "Style"];
 const defaultLabel = "HURRICANE IRMA";
 const defaultLeadAsset = {
@@ -1642,6 +1643,7 @@ const makeDefaultConfig = ({
   flags = defaultFlags,
   hasVideo = defaultHasVideo,
   headline = defaultHeadline,
+  referralUrl = defaultReferralUrl,
   keywords = defaultKeywords,
   label = defaultLabel,
   leadAsset = defaultLeadAsset,
@@ -1667,6 +1669,7 @@ const makeDefaultConfig = ({
   flags,
   hasVideo,
   headline,
+  referralUrl,
   keywords,
   label,
   leadAsset,

--- a/packages/article-skeleton/src/tracking/article-tracking-context.js
+++ b/packages/article-skeleton/src/tracking/article-tracking-context.js
@@ -14,7 +14,7 @@ export default Component =>
       label: get(data, "label", ""),
       pageName: `${get(data, "slug", "")}-${get(data, "shortIdentifier", "")}`,
       publishedTime: get(data, "publishedTime", ""),
-      referralUrl,
+      referralUrl: referralUrl || get(data, "referralUrl", ""),
       section: pageSection || get(data, "section", ""),
       template: get(data, "template", "Default")
     }),


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
The referral url was not being passed through to native in the same way as everything else and so they were sometimes getting null values.

https://nidigitalsolutions.jira.com/browse/REPLAT-7797
