### PR TITLE
feat: (REPLAT-8564) Leader slice redesigned for huge breakpoint

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-m.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-m.test.js.snap
@@ -17,10 +17,10 @@ exports[`tile m huge 1`] = `
         Object {
           "color": "#1D1D1B",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 20,
+          "fontSize": 24,
           "fontWeight": "400",
-          "lineHeight": 20,
-          "marginBottom": 5,
+          "lineHeight": 24,
+          "marginBottom": 10,
           "marginTop": 30,
           "textAlign": "center",
         }
@@ -172,9 +172,9 @@ exports[`tile m wide 1`] = `
         Object {
           "color": "#1D1D1B",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 20,
+          "fontSize": 24,
           "fontWeight": "400",
-          "lineHeight": 20,
+          "lineHeight": 24,
           "marginBottom": 5,
           "marginTop": 30,
           "textAlign": "center",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-m.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-m.test.js.snap
@@ -17,10 +17,10 @@ exports[`tile m huge 1`] = `
         Object {
           "color": "#1D1D1B",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 20,
+          "fontSize": 24,
           "fontWeight": "900",
-          "lineHeight": 20,
-          "marginBottom": 5,
+          "lineHeight": 24,
+          "marginBottom": 10,
           "marginTop": 30,
           "textAlign": "center",
         }
@@ -172,9 +172,9 @@ exports[`tile m wide 1`] = `
         Object {
           "color": "#1D1D1B",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 20,
+          "fontSize": 24,
           "fontWeight": "900",
-          "lineHeight": 20,
+          "lineHeight": 24,
           "marginBottom": 5,
           "marginTop": 30,
           "textAlign": "center",

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-m.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-m.test.js.snap
@@ -5,7 +5,6 @@ exports[`tile m huge 1`] = `
 .S1 {
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 5px;
 }
 
 .S2 {
@@ -15,8 +14,9 @@ exports[`tile m huge 1`] = `
 
 .IS1 {
   color: rgba(29,29,27,1.00);
-  font-size: 20px;
-  line-height: 20px;
+  font-size: 24px;
+  line-height: 24px;
+  margin-bottom: 10px;
   margin-top: 30px;
   text-align: center;
 }
@@ -42,7 +42,7 @@ exports[`tile m huge 1`] = `
   >
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S1"
+      className="css-reset-4rbku5 css-text-901oao r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S1"
       role="heading"
     >
       Driving Off
@@ -207,8 +207,8 @@ exports[`tile m wide 1`] = `
 
 .IS1 {
   color: rgba(29,29,27,1.00);
-  font-size: 20px;
-  line-height: 20px;
+  font-size: 24px;
+  line-height: 24px;
   margin-top: 30px;
   text-align: center;
 }

--- a/packages/edition-slices/src/tiles/tile-m/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-m/styles/index.js
@@ -40,7 +40,6 @@ const mediumBreakpointStyles = {
     fontFamily: fonts.headline,
     fontSize: 20,
     lineHeight: 20,
-    marginBottom: spacing(1),
     marginTop: spacing(6),
     textAlign: "center"
   },
@@ -57,6 +56,19 @@ const wideBreakpointStyles = {
   ...mediumBreakpointStyles,
   container: {
     paddingBottom: spacing(12)
+  },
+  headline: {
+    ...mediumBreakpointStyles.headline,
+    fontSize: 24,
+    lineHeight: 24
+  }
+};
+
+const hugeBreakpointStyle = {
+  ...wideBreakpointStyles,
+  headline: {
+    ...wideBreakpointStyles.headline,
+    marginBottom: spacing(2)
   }
 };
 
@@ -64,7 +76,7 @@ const breakPointsStyles = {
   [editionBreakpoints.small]: smallBreakpointStyles,
   [editionBreakpoints.medium]: mediumBreakpointStyles,
   [editionBreakpoints.wide]: wideBreakpointStyles,
-  [editionBreakpoints.huge]: wideBreakpointStyles
+  [editionBreakpoints.huge]: hugeBreakpointStyle
 };
 
 export default breakpoint => breakPointsStyles[breakpoint];


### PR DESCRIPTION
[Ticket](https://nidigitalsolutions.jira.com/browse/REPLAT-8564)

1. Headline's font size update from 20 to 24pt for wide breakpoint
2. Margin bottom between the headline and the strapline increased for huge breakpoint 

**Wide** breakpoint snapshot
![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2019-09-24 at 15 09 56](https://user-images.githubusercontent.com/16742525/65510866-9119bd80-dede-11e9-816d-47503ae594e3.png)


**Huge** breakpoint snapshot
![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2019-09-24 at 15 09 45](https://user-images.githubusercontent.com/16742525/65510872-937c1780-dede-11e9-8f2a-e9e1978640f0.png)
