### PR TITLE
fix: (REPLAT-9284) move topics query out of edition

### DIFF
--- a/packages/provider-queries/src/article.graphql
+++ b/packages/provider-queries/src/article.graphql
@@ -3,5 +3,9 @@
 query ArticleQuery($id: ID!) {
   article(id: $id) {
     ...articlePageProps
+    topics(maxCount: 5) {
+      name
+      slug
+    }
   }
 }

--- a/packages/provider-queries/src/article_page_props.graphql
+++ b/packages/provider-queries/src/article_page_props.graphql
@@ -43,10 +43,6 @@ fragment articlePageProps on Article {
       alpha
     }
   }
-  topics(maxCount: 5) {
-    name
-    slug
-  }
   ...articleProps
 }
 


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
For some reason 'articlepageprops' is mixed into the edition query so topics being there is breaking caching on TPA.
