### PR TITLE
fix: (REPLAT-9280) disable fontSizing on tile article headlines

### DIFF
--- a/packages/article-summary/src/article-summary-headline.js
+++ b/packages/article-summary/src/article-summary-headline.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text } from "react-native";
+import { Text, Platform } from "react-native";
 import PropTypes from "prop-types";
 import styles from "./styles";
 
@@ -9,6 +9,7 @@ const ArticleSummaryHeadline = ({ className, headline, style }) => (
   <Text
     accessibilityRole="header"
     aria-level="3"
+    allowFontScaling={Platform.OS === "ios"}
     className={className}
     style={[styles.headline, styles.headlineWrapper, style]}
   >


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
We have limited space on tiles for article headlines and allowFontSizing with a large OS size causes clipping issues :(

edit: This appears to only be a bug on react-native android, iOS text containers are flexed correctly.

android: before
![Screenshot_1570017907](https://user-images.githubusercontent.com/615608/66051253-8090c500-e526-11e9-8ded-c5f206fa015a.png)

android:after
![Screenshot_1570017968](https://user-images.githubusercontent.com/615608/66051266-87b7d300-e526-11e9-848d-060864ed24af.png)

ios: before
![Screenshot_20191002_135622](https://user-images.githubusercontent.com/615608/66051288-943c2b80-e526-11e9-9e83-089a9d0951d7.png)

ios:after - it scales fine
![Screenshot_20191002_135458](https://user-images.githubusercontent.com/615608/66051313-9f8f5700-e526-11e9-9190-8398bd46ff52.png)



