### PR TITLE
feat: REPLAT-9309 lead 1 full width structure updated 

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-r.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-r.test.js.snap
@@ -11,14 +11,18 @@ exports[`tile r huge 1`] = `
   }
   url="/article/123"
 >
-  <View
+  <Image
+    aspectRatio={1.7777777777777777}
+    fill={true}
     style={
       Object {
-        "flex": 1,
-        "paddingBottom": 10,
+        "marginBottom": 10,
+        "width": "100%",
       }
     }
-  >
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+  <View>
     <View
       style={
         Object {
@@ -59,11 +63,6 @@ exports[`tile r huge 1`] = `
       }
     />
   </View>
-  <Image
-    aspectRatio={1.7777777777777777}
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
-  />
 </Link>
 `;
 
@@ -78,14 +77,18 @@ exports[`tile r medium 1`] = `
   }
   url="/article/123"
 >
-  <View
+  <Image
+    aspectRatio={1.7777777777777777}
+    fill={true}
     style={
       Object {
-        "flex": 1,
-        "paddingBottom": 10,
+        "marginBottom": 10,
+        "width": "100%",
       }
     }
-  >
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+  <View>
     <View
       style={
         Object {
@@ -126,11 +129,6 @@ exports[`tile r medium 1`] = `
       }
     />
   </View>
-  <Image
-    aspectRatio={1.7777777777777777}
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
-  />
 </Link>
 `;
 
@@ -145,14 +143,18 @@ exports[`tile r wide 1`] = `
   }
   url="/article/123"
 >
-  <View
+  <Image
+    aspectRatio={1.7777777777777777}
+    fill={true}
     style={
       Object {
-        "flex": 1,
-        "paddingBottom": 10,
+        "marginBottom": 10,
+        "width": "100%",
       }
     }
-  >
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+  <View>
     <View
       style={
         Object {
@@ -193,11 +195,6 @@ exports[`tile r wide 1`] = `
       }
     />
   </View>
-  <Image
-    aspectRatio={1.7777777777777777}
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
-  />
 </Link>
 `;
 
@@ -212,14 +209,18 @@ exports[`tile r without breakpoint should be like medium 1`] = `
   }
   url="/article/123"
 >
-  <View
+  <Image
+    aspectRatio={1.7777777777777777}
+    fill={true}
     style={
       Object {
-        "flex": 1,
-        "paddingBottom": 10,
+        "marginBottom": 10,
+        "width": "100%",
       }
     }
-  >
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+  <View>
     <View
       style={
         Object {
@@ -260,10 +261,5 @@ exports[`tile r without breakpoint should be like medium 1`] = `
       }
     />
   </View>
-  <Image
-    aspectRatio={1.7777777777777777}
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
-  />
 </Link>
 `;

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-r.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-r.test.js.snap
@@ -16,7 +16,7 @@ exports[`tile r huge 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 15,
         "width": "100%",
       }
     }
@@ -148,7 +148,7 @@ exports[`tile r wide 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 15,
         "width": "100%",
       }
     }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-r.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-r.test.js.snap
@@ -11,14 +11,18 @@ exports[`tile r huge 1`] = `
   }
   url="/article/123"
 >
-  <View
+  <Image
+    aspectRatio={1.7777777777777777}
+    fill={true}
     style={
       Object {
-        "flex": 1,
-        "paddingBottom": 10,
+        "marginBottom": 10,
+        "width": "100%",
       }
     }
-  >
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+  <View>
     <View
       style={
         Object {
@@ -59,11 +63,6 @@ exports[`tile r huge 1`] = `
       }
     />
   </View>
-  <Image
-    aspectRatio={1.7777777777777777}
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
-  />
 </Link>
 `;
 
@@ -78,14 +77,18 @@ exports[`tile r medium 1`] = `
   }
   url="/article/123"
 >
-  <View
+  <Image
+    aspectRatio={1.7777777777777777}
+    fill={true}
     style={
       Object {
-        "flex": 1,
-        "paddingBottom": 10,
+        "marginBottom": 10,
+        "width": "100%",
       }
     }
-  >
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+  <View>
     <View
       style={
         Object {
@@ -126,11 +129,6 @@ exports[`tile r medium 1`] = `
       }
     />
   </View>
-  <Image
-    aspectRatio={1.7777777777777777}
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
-  />
 </Link>
 `;
 
@@ -145,14 +143,18 @@ exports[`tile r wide 1`] = `
   }
   url="/article/123"
 >
-  <View
+  <Image
+    aspectRatio={1.7777777777777777}
+    fill={true}
     style={
       Object {
-        "flex": 1,
-        "paddingBottom": 10,
+        "marginBottom": 10,
+        "width": "100%",
       }
     }
-  >
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+  <View>
     <View
       style={
         Object {
@@ -193,11 +195,6 @@ exports[`tile r wide 1`] = `
       }
     />
   </View>
-  <Image
-    aspectRatio={1.7777777777777777}
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
-  />
 </Link>
 `;
 
@@ -212,14 +209,18 @@ exports[`tile r without breakpoint should be like medium 1`] = `
   }
   url="/article/123"
 >
-  <View
+  <Image
+    aspectRatio={1.7777777777777777}
+    fill={true}
     style={
       Object {
-        "flex": 1,
-        "paddingBottom": 10,
+        "marginBottom": 10,
+        "width": "100%",
       }
     }
-  >
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+  <View>
     <View
       style={
         Object {
@@ -260,10 +261,5 @@ exports[`tile r without breakpoint should be like medium 1`] = `
       }
     />
   </View>
-  <Image
-    aspectRatio={1.7777777777777777}
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
-  />
 </Link>
 `;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-r.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-r.test.js.snap
@@ -16,7 +16,7 @@ exports[`tile r huge 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 15,
         "width": "100%",
       }
     }
@@ -148,7 +148,7 @@ exports[`tile r wide 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 15,
         "width": "100%",
       }
     }

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-r.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-r.test.js.snap
@@ -15,7 +15,7 @@ exports[`tile r huge 1`] = `
 
 .IS1 {
   width: 100%;
-  margin-bottom: 10px;
+  margin-bottom: 15px;
 }
 
 .IS2 {
@@ -161,7 +161,7 @@ exports[`tile r wide 1`] = `
 
 .IS1 {
   width: 100%;
-  margin-bottom: 10px;
+  margin-bottom: 15px;
 }
 
 .IS2 {

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-r.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-r.test.js.snap
@@ -14,22 +14,13 @@ exports[`tile r huge 1`] = `
 }
 
 .IS1 {
-  font-size: 45px;
-  line-height: 45px;
+  width: 100%;
+  margin-bottom: 10px;
 }
 
 .IS2 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  padding-bottom: 10px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
+  font-size: 45px;
+  line-height: 45px;
 }
 </style>
 
@@ -43,8 +34,14 @@ exports[`tile r huge 1`] = `
   }
   url="/article/123"
 >
+  <Image
+    aspectRatio={1.7777777777777777}
+    className="IS1"
+    fill={true}
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -57,7 +54,7 @@ exports[`tile r huge 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -73,11 +70,6 @@ exports[`tile r huge 1`] = `
       }
     />
   </div>
-  <Image
-    aspectRatio={1.7777777777777777}
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
-  />
 </Link>
 `;
 
@@ -95,22 +87,13 @@ exports[`tile r medium 1`] = `
 }
 
 .IS1 {
-  font-size: 40px;
-  line-height: 40px;
+  width: 100%;
+  margin-bottom: 10px;
 }
 
 .IS2 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  padding-bottom: 10px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
+  font-size: 40px;
+  line-height: 40px;
 }
 </style>
 
@@ -124,8 +107,14 @@ exports[`tile r medium 1`] = `
   }
   url="/article/123"
 >
+  <Image
+    aspectRatio={1.7777777777777777}
+    className="IS1"
+    fill={true}
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -138,7 +127,7 @@ exports[`tile r medium 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -154,11 +143,6 @@ exports[`tile r medium 1`] = `
       }
     />
   </div>
-  <Image
-    aspectRatio={1.7777777777777777}
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
-  />
 </Link>
 `;
 
@@ -176,22 +160,13 @@ exports[`tile r wide 1`] = `
 }
 
 .IS1 {
-  font-size: 40px;
-  line-height: 40px;
+  width: 100%;
+  margin-bottom: 10px;
 }
 
 .IS2 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  padding-bottom: 10px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
+  font-size: 40px;
+  line-height: 40px;
 }
 </style>
 
@@ -205,8 +180,14 @@ exports[`tile r wide 1`] = `
   }
   url="/article/123"
 >
+  <Image
+    aspectRatio={1.7777777777777777}
+    className="IS1"
+    fill={true}
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -219,7 +200,7 @@ exports[`tile r wide 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -235,11 +216,6 @@ exports[`tile r wide 1`] = `
       }
     />
   </div>
-  <Image
-    aspectRatio={1.7777777777777777}
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
-  />
 </Link>
 `;
 
@@ -257,22 +233,13 @@ exports[`tile r without breakpoint should be like medium 1`] = `
 }
 
 .IS1 {
-  font-size: 40px;
-  line-height: 40px;
+  width: 100%;
+  margin-bottom: 10px;
 }
 
 .IS2 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  padding-bottom: 10px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
+  font-size: 40px;
+  line-height: 40px;
 }
 </style>
 
@@ -286,8 +253,14 @@ exports[`tile r without breakpoint should be like medium 1`] = `
   }
   url="/article/123"
 >
+  <Image
+    aspectRatio={1.7777777777777777}
+    className="IS1"
+    fill={true}
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -300,7 +273,7 @@ exports[`tile r without breakpoint should be like medium 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -316,10 +289,5 @@ exports[`tile r without breakpoint should be like medium 1`] = `
       }
     />
   </div>
-  <Image
-    aspectRatio={1.7777777777777777}
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
-  />
 </Link>
 `;

--- a/packages/edition-slices/src/tiles/tile-r/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/index.js
@@ -17,11 +17,6 @@ const TileR = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
 
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
-      <TileSummary
-        headlineStyle={styles.headline}
-        tile={tile}
-        style={styles.summaryContainer}
-      />
       <Image
         aspectRatio={16 / 9}
         uri={crop.url}
@@ -30,7 +25,9 @@ const TileR = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         relativeHeight={crop.relativeHeight}
         relativeHorizontalOffset={crop.relativeHorizontalOffset}
         relativeVerticalOffset={crop.relativeVerticalOffset}
+        style={styles.imageContainer}
       />
+      <TileSummary headlineStyle={styles.headline} tile={tile} />
     </TileLink>
   );
 };

--- a/packages/edition-slices/src/tiles/tile-r/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/styles/index.js
@@ -19,10 +19,6 @@ const mediumBreakpointStyles = {
   imageContainer: {
     width: "100%",
     marginBottom: spacing(2)
-  },
-  summaryContainer: {
-    flex: 1,
-    paddingBottom: spacing(2)
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-r/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/styles/index.js
@@ -28,6 +28,10 @@ const wideBreakpointStyles = {
     flex: 1,
     paddingVertical: spacing(3),
     paddingHorizontal: spacing(4)
+  },
+  imageContainer: {
+    width: "100%",
+    marginBottom: spacing(3)
   }
 };
 


### PR DESCRIPTION
[Story.](https://nidigitalsolutions.jira.com/browse/REPLAT-9309)
[Design.](https://app.zeplin.io/project/5d2849a2b4a4605645afb4be/screen/5d28524f9cb5a063a8a20ac2)
Tile rearranged and minor styling updates for all breakpoints.

Before:
![full width 768 before](https://user-images.githubusercontent.com/8720661/66042673-c39e6880-e525-11e9-838d-757fa15dea6e.png)

After:
768:
![full width 768 after](https://user-images.githubusercontent.com/8720661/66042683-ce58fd80-e525-11e9-8bae-e36e9d8f36ce.png)

1024:
![full width 1024 after](https://user-images.githubusercontent.com/8720661/66042686-cf8a2a80-e525-11e9-8479-2182eb55fb09.png)

1366:
![full width 1366 after](https://user-images.githubusercontent.com/8720661/66042692-d2851b00-e525-11e9-8481-9fb8031be6fe.png)

