### PR TITLE
feat: REPLAT-9112 lead 1 and 1 tile U updated for 768

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -78,7 +78,6 @@ exports[`3. lead one and one - medium 1`] = `
   <View>
     <View>
       <TileU
-        breakpoint="medium"
         tileName="lead"
       />
     </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-u.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-u.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile u huge 1`] = `
+exports[`tile u without breakpoint 1`] = `
 <Link
   linkStyle={
     Object {
@@ -11,327 +11,57 @@ exports[`tile u huge 1`] = `
   }
   url="/article/123"
 >
-  <View
-    style={
-      Object {
-        "paddingBottom": 10,
-        "width": "100%",
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
-      <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 5,
-              }
-            }
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 40,
-                "fontWeight": "400",
-                "lineHeight": 40,
-                "marginBottom": 0,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
-          />
-        </View>
-      </View>
-    </View>
-  </View>
   <Image
-    aspectRatio={1.5}
+    aspectRatio={1.7777777777777777}
     fill={true}
     style={
       Object {
+        "marginBottom": 10,
         "width": "100%",
       }
     }
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
-</Link>
-`;
-
-exports[`tile u medium 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 15,
-    }
-  }
-  url="/article/123"
->
-  <View
-    style={
-      Object {
-        "paddingBottom": 10,
-        "width": "100%",
-      }
-    }
-  >
+  <View>
     <View
       style={
         Object {
-          "flex": 1,
+          "marginBottom": 5,
         }
       }
     >
-      <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 5,
-              }
-            }
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 40,
-                "fontWeight": "400",
-                "lineHeight": 40,
-                "marginBottom": 10,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
-          />
-        </View>
-      </View>
+      <ArticleLabel
+        color="#005B8D"
+        isVideo={false}
+        title="label"
+      />
     </View>
-  </View>
-  <Image
-    aspectRatio={1.5}
-    fill={true}
-    style={
-      Object {
-        "width": "100%",
-      }
-    }
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
-  />
-</Link>
-`;
-
-exports[`tile u wide 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 15,
-    }
-  }
-  url="/article/123"
->
-  <View
-    style={
-      Object {
-        "paddingBottom": 10,
-        "width": "100%",
-      }
-    }
-  >
-    <View
+    <Text
+      accessibilityRole="header"
+      aria-level="3"
       style={
         Object {
-          "flex": 1,
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 40,
+          "fontWeight": "400",
+          "lineHeight": 40,
+          "marginBottom": 0,
         }
       }
     >
-      <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 5,
-              }
-            }
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 40,
-                "fontWeight": "400",
-                "lineHeight": 40,
-                "marginBottom": 0,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
-          />
-        </View>
-      </View>
-    </View>
+      This is tile headline
+    </Text>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
   </View>
-  <Image
-    aspectRatio={1.5}
-    fill={true}
-    style={
-      Object {
-        "width": "100%",
-      }
-    }
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
-  />
-</Link>
-`;
-
-exports[`tile u without breakpoint should be like medium 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 15,
-    }
-  }
-  url="/article/123"
->
-  <View
-    style={
-      Object {
-        "paddingBottom": 10,
-        "width": "100%",
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
-      <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 5,
-              }
-            }
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 40,
-                "fontWeight": "400",
-                "lineHeight": 40,
-                "marginBottom": 10,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
-          />
-        </View>
-      </View>
-    </View>
-  </View>
-  <Image
-    aspectRatio={1.5}
-    fill={true}
-    style={
-      Object {
-        "width": "100%",
-      }
-    }
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
-  />
 </Link>
 `;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -78,7 +78,6 @@ exports[`3. lead one and one - medium 1`] = `
   <View>
     <View>
       <TileU
-        breakpoint="medium"
         tileName="lead"
       />
     </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-u.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-u.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile u huge 1`] = `
+exports[`tile u without breakpoint 1`] = `
 <Link
   linkStyle={
     Object {
@@ -11,327 +11,57 @@ exports[`tile u huge 1`] = `
   }
   url="/article/123"
 >
-  <View
-    style={
-      Object {
-        "paddingBottom": 10,
-        "width": "100%",
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
-      <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 0,
-              }
-            }
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 40,
-                "fontWeight": "900",
-                "lineHeight": 40,
-                "marginBottom": 0,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
-          />
-        </View>
-      </View>
-    </View>
-  </View>
   <Image
-    aspectRatio={1.5}
+    aspectRatio={1.7777777777777777}
     fill={true}
     style={
       Object {
+        "marginBottom": 10,
         "width": "100%",
       }
     }
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
-</Link>
-`;
-
-exports[`tile u medium 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 15,
-    }
-  }
-  url="/article/123"
->
-  <View
-    style={
-      Object {
-        "paddingBottom": 10,
-        "width": "100%",
-      }
-    }
-  >
+  <View>
     <View
       style={
         Object {
-          "flex": 1,
+          "marginBottom": 0,
         }
       }
     >
-      <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 0,
-              }
-            }
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 40,
-                "fontWeight": "900",
-                "lineHeight": 40,
-                "marginBottom": 10,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
-          />
-        </View>
-      </View>
+      <ArticleLabel
+        color="#005B8D"
+        isVideo={false}
+        title="label"
+      />
     </View>
-  </View>
-  <Image
-    aspectRatio={1.5}
-    fill={true}
-    style={
-      Object {
-        "width": "100%",
-      }
-    }
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
-  />
-</Link>
-`;
-
-exports[`tile u wide 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 15,
-    }
-  }
-  url="/article/123"
->
-  <View
-    style={
-      Object {
-        "paddingBottom": 10,
-        "width": "100%",
-      }
-    }
-  >
-    <View
+    <Text
+      accessibilityRole="header"
+      aria-level="3"
       style={
         Object {
-          "flex": 1,
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 40,
+          "fontWeight": "900",
+          "lineHeight": 40,
+          "marginBottom": 0,
         }
       }
     >
-      <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 0,
-              }
-            }
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 40,
-                "fontWeight": "900",
-                "lineHeight": 40,
-                "marginBottom": 0,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
-          />
-        </View>
-      </View>
-    </View>
+      This is tile headline
+    </Text>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
   </View>
-  <Image
-    aspectRatio={1.5}
-    fill={true}
-    style={
-      Object {
-        "width": "100%",
-      }
-    }
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
-  />
-</Link>
-`;
-
-exports[`tile u without breakpoint should be like medium 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 15,
-    }
-  }
-  url="/article/123"
->
-  <View
-    style={
-      Object {
-        "paddingBottom": 10,
-        "width": "100%",
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
-      <View>
-        <View>
-          <View
-            style={
-              Object {
-                "marginBottom": 0,
-              }
-            }
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </View>
-          <Text
-            accessibilityRole="header"
-            aria-level="3"
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesModern-Bold",
-                "fontSize": 40,
-                "fontWeight": "900",
-                "lineHeight": 40,
-                "marginBottom": 10,
-              }
-            }
-          >
-            This is tile headline
-          </Text>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
-          />
-        </View>
-      </View>
-    </View>
-  </View>
-  <Image
-    aspectRatio={1.5}
-    fill={true}
-    style={
-      Object {
-        "width": "100%",
-      }
-    }
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
-  />
 </Link>
 `;

--- a/packages/edition-slices/__tests__/tile-u/shared-tile-u.base.js
+++ b/packages/edition-slices/__tests__/tile-u/shared-tile-u.base.js
@@ -1,23 +1,10 @@
 import "../mocks-tiles";
-import { editionBreakpoints } from "@times-components/styleguide";
 import { testTile } from "../shared-tile-utils";
 import { TileU } from "../../src/tiles";
 
 export default () => {
   describe("tile u", () => {
-    it("medium", () => {
-      testTile(TileU, editionBreakpoints.medium);
-    });
-
-    it("wide", () => {
-      testTile(TileU, editionBreakpoints.wide);
-    });
-
-    it("huge", () => {
-      testTile(TileU, editionBreakpoints.huge);
-    });
-
-    it("without breakpoint should be like medium", () => {
+    it("without breakpoint", () => {
       testTile(TileU);
     });
   });

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-u.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-u.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile u huge 1`] = `
+exports[`tile u without breakpoint 1`] = `
 <style>
 .S1 {
   margin-bottom: 0px;
@@ -14,235 +14,14 @@ exports[`tile u huge 1`] = `
 }
 
 .IS1 {
-  font-size: 40px;
-  line-height: 40px;
-}
-
-.IS2 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-
-.IS3 {
-  padding-bottom: 10px;
   width: 100%;
-}
-
-.IS4 {
-  width: 100%;
-}
-</style>
-
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingVertical": "15px",
-    }
-  }
-  url="/article/123"
->
-  <div
-    className="css-view-1dbjc4n IS3"
-  >
-    <div
-      className="css-view-1dbjc4n IS2"
-    >
-      <div
-        className="css-view-1dbjc4n"
-      >
-        <div
-          className="css-view-1dbjc4n"
-        >
-          <div
-            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-  <Image
-    aspectRatio={1.5}
-    className="IS4"
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
-  />
-</Link>
-`;
-
-exports[`tile u medium 1`] = `
-<style>
-.S1 {
-  margin-bottom: 0px;
-}
-
-.S2 {
-  color: rgba(51,51,51,1.00);
-  font-family: TimesModern-Bold;
-  font-weight: 400;
-}
-
-.IS1 {
-  font-size: 40px;
-  line-height: 40px;
   margin-bottom: 10px;
 }
 
 .IS2 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-
-.IS3 {
-  padding-bottom: 10px;
-  width: 100%;
-}
-
-.IS4 {
-  width: 100%;
-}
-</style>
-
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingVertical": "15px",
-    }
-  }
-  url="/article/123"
->
-  <div
-    className="css-view-1dbjc4n IS3"
-  >
-    <div
-      className="css-view-1dbjc4n IS2"
-    >
-      <div
-        className="css-view-1dbjc4n"
-      >
-        <div
-          className="css-view-1dbjc4n"
-        >
-          <div
-            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-  <Image
-    aspectRatio={1.5}
-    className="IS4"
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
-  />
-</Link>
-`;
-
-exports[`tile u wide 1`] = `
-<style>
-.S1 {
-  margin-bottom: 0px;
-}
-
-.S2 {
-  color: rgba(51,51,51,1.00);
-  font-family: TimesModern-Bold;
-  font-weight: 400;
-  margin-bottom: 0px;
-}
-
-.IS1 {
   font-size: 40px;
   line-height: 40px;
 }
-
-.IS2 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-
-.IS3 {
-  padding-bottom: 10px;
-  width: 100%;
-}
-
-.IS4 {
-  width: 100%;
-}
 </style>
 
 <Link
@@ -255,155 +34,41 @@ exports[`tile u wide 1`] = `
   }
   url="/article/123"
 >
+  <Image
+    aspectRatio={1.7777777777777777}
+    className="IS1"
+    fill={true}
+    uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
     >
-      <div
-        className="css-view-1dbjc4n"
-      >
-        <div
-          className="css-view-1dbjc4n"
-        >
-          <div
-            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
-          />
-        </div>
-      </div>
+      <ArticleLabel
+        color="#005B8D"
+        isVideo={false}
+        title="label"
+      />
     </div>
-  </div>
-  <Image
-    aspectRatio={1.5}
-    className="IS4"
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
-  />
-</Link>
-`;
-
-exports[`tile u without breakpoint should be like medium 1`] = `
-<style>
-.S1 {
-  margin-bottom: 0px;
-}
-
-.S2 {
-  color: rgba(51,51,51,1.00);
-  font-family: TimesModern-Bold;
-  font-weight: 400;
-}
-
-.IS1 {
-  font-size: 40px;
-  line-height: 40px;
-  margin-bottom: 10px;
-}
-
-.IS2 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-
-.IS3 {
-  padding-bottom: 10px;
-  width: 100%;
-}
-
-.IS4 {
-  width: 100%;
-}
-</style>
-
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingVertical": "15px",
-    }
-  }
-  url="/article/123"
->
-  <div
-    className="css-view-1dbjc4n IS3"
-  >
-    <div
-      className="css-view-1dbjc4n IS2"
+    <h3
+      aria-level="3"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
+      role="heading"
     >
-      <div
-        className="css-view-1dbjc4n"
-      >
-        <div
-          className="css-view-1dbjc4n"
-        >
-          <div
-            className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-          >
-            <ArticleLabel
-              color="#005B8D"
-              isVideo={false}
-              title="label"
-            />
-          </div>
-          <h3
-            aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
-            role="heading"
-          >
-            This is tile headline
-          </h3>
-          <ArticleFlags
-            flags={
-              Array [
-                Object {
-                  "expiryTime": "2030-03-14T12:00:00.000Z",
-                  "type": "EXCLUSIVE",
-                },
-              ]
-            }
-          />
-        </div>
-      </div>
-    </div>
+      This is tile headline
+    </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          Object {
+            "expiryTime": "2030-03-14T12:00:00.000Z",
+            "type": "EXCLUSIVE",
+          },
+        ]
+      }
+    />
   </div>
-  <Image
-    aspectRatio={1.5}
-    className="IS4"
-    fill={true}
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
-  />
 </Link>
 `;

--- a/packages/edition-slices/src/slices/leadoneandone/index.js
+++ b/packages/edition-slices/src/slices/leadoneandone/index.js
@@ -34,14 +34,7 @@ class LeadOneAndOne extends Component {
     return (
       <LeadOneAndOneSlice
         breakpoint={breakpoint}
-        lead={
-          <TileU
-            breakpoint={breakpoint}
-            onPress={onPress}
-            tile={lead}
-            tileName="lead"
-          />
-        }
+        lead={<TileU onPress={onPress} tile={lead} tileName="lead" />}
         support={
           <TileAA
             breakpoint={breakpoint}

--- a/packages/edition-slices/src/tiles/tile-u/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/index.js
@@ -1,44 +1,21 @@
 /* eslint-disable react/require-default-props */
 import React from "react";
-import { View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
-import { editionBreakpoints } from "@times-components/styleguide";
 import {
   getTileImage,
-  getTileSummary,
   TileLink,
   TileSummary,
   withTileTracking
 } from "../shared";
-import styleFactory from "./styles";
-import WithoutWhiteSpace from "../shared/without-white-space";
-import PositionedTileStar from "../shared/positioned-tile-star";
+import styles from "./styles";
 
-const TileU = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
-  const styles = styleFactory(breakpoint);
-  const crop = getTileImage(tile, "crop32");
-
+const TileU = ({ onPress, tile }) => {
+  const crop = getTileImage(tile, "crop169");
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
-      <View style={styles.summaryContainer}>
-        <WithoutWhiteSpace
-          render={whiteSpaceHeight => (
-            <TileSummary
-              headlineStyle={styles.headline}
-              summary={getTileSummary(tile, 800)}
-              tile={tile}
-              whiteSpaceHeight={whiteSpaceHeight}
-              linesOfTeaserToRender={3}
-              withStar={false}
-            />
-          )}
-        />
-        <PositionedTileStar articleId={tile.article.id} />
-      </View>
-
       <Image
-        aspectRatio={3 / 2}
+        aspectRatio={16 / 9}
         relativeWidth={crop.relativeWidth}
         relativeHeight={crop.relativeHeight}
         relativeHorizontalOffset={crop.relativeHorizontalOffset}
@@ -47,12 +24,12 @@ const TileU = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         uri={crop.url}
         fill
       />
+      <TileSummary headlineStyle={styles.headline} tile={tile} />
     </TileLink>
   );
 };
 
 TileU.propTypes = {
-  breakpoint: PropTypes.string,
   onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired
 };

--- a/packages/edition-slices/src/tiles/tile-u/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/styles/index.js
@@ -1,39 +1,21 @@
-import {
-  fonts,
-  spacing,
-  editionBreakpoints
-} from "@times-components/styleguide";
+import { fonts, spacing } from "@times-components/styleguide";
 
-const mediumBreakpointStyles = {
+const styles = {
   container: {
     flex: 1,
     paddingVertical: spacing(3),
     paddingHorizontal: spacing(2)
   },
   imageContainer: {
-    width: "100%"
-  },
-  summaryContainer: {
     width: "100%",
-    paddingBottom: spacing(2)
+    marginBottom: spacing(2)
   },
   headline: {
     fontFamily: fonts.headline,
     fontSize: 40,
     lineHeight: 40,
-    marginBottom: spacing(2)
-  }
-};
-
-const wideBreakpointStyles = {
-  ...mediumBreakpointStyles,
-  headline: {
-    ...mediumBreakpointStyles.headline,
     marginBottom: 0
   }
 };
 
-export default breakpoint =>
-  breakpoint === editionBreakpoints.medium
-    ? mediumBreakpointStyles
-    : wideBreakpointStyles;
+export default styles;


### PR DESCRIPTION
[Story.](https://nidigitalsolutions.jira.com/browse/REPLAT-9112)
[Design.](https://app.zeplin.io/project/5d2849a2b4a4605645afb4be/screen/5d4040cec987b90d2eaeae9a)

Places of the Image and the content swapped in the right tile of the slice.
Teaser text removed.
Image ratio updated to 16:9 according to the design.
Breakpoint functionality for TileU removed.

Before:
![lead 1 and 1 before](https://user-images.githubusercontent.com/8720661/66043878-fdbd3980-e528-11e9-9f27-7a9e41027cd0.png)

After:
![lead 1 and 1 after](https://user-images.githubusercontent.com/8720661/66043880-001f9380-e529-11e9-8e91-380bd68a5bb6.png)

