### PR TITLE
fix: increase test coverage for slices on web

### DIFF
--- a/packages/edition-slices/__tests__/shared-slices.base.js
+++ b/packages/edition-slices/__tests__/shared-slices.base.js
@@ -2,7 +2,6 @@ import React from "react";
 import TestRenderer from "react-test-renderer";
 import { SectionContext } from "@times-components/context";
 import { iterator } from "@times-components/test-utils";
-import { getDimentions } from "@times-components/utils";
 import {
   mockCommentLeadAndCartoonSlice,
   mockDailyRegisterSlice,
@@ -155,7 +154,7 @@ const testsWithPublictaion = publicationName =>
       const output = TestRenderer.create(
         <Responsive>
           <SectionContext.Provider value={{ publicationName }}>
-            <Slice onPress={() => { }} slice={mock} />
+            <Slice onPress={() => {}} slice={mock} />
           </SectionContext.Provider>
         </Responsive>
       );
@@ -170,7 +169,7 @@ export default () => {
     test: () => {
       const output = TestRenderer.create(
         <Responsive>
-          <Slice onPress={() => { }} slice={mock} />
+          <Slice onPress={() => {}} slice={mock} />
         </Responsive>
       );
 

--- a/packages/edition-slices/__tests__/shared-slices.base.js
+++ b/packages/edition-slices/__tests__/shared-slices.base.js
@@ -143,7 +143,7 @@ jest.mock("@times-components/utils", () => {
 
   return {
     ...actualUtils,
-    getDimentions: jest.fn(() => ({ height: 700, width: 500 }))
+    getDimensions: jest.fn(() => ({ height: 700, width: 500 }))
   };
 });
 

--- a/packages/edition-slices/__tests__/shared-slices.base.js
+++ b/packages/edition-slices/__tests__/shared-slices.base.js
@@ -2,6 +2,7 @@ import React from "react";
 import TestRenderer from "react-test-renderer";
 import { SectionContext } from "@times-components/context";
 import { iterator } from "@times-components/test-utils";
+import { getDimentions } from "@times-components/utils";
 import {
   mockCommentLeadAndCartoonSlice,
   mockDailyRegisterSlice,
@@ -137,6 +138,16 @@ const slicesWithPubLogo = [
   }
 ];
 
+jest.mock("@times-components/utils", () => {
+  // eslint-disable-next-line global-require
+  const actualUtils = jest.requireActual("@times-components/utils");
+
+  return {
+    ...actualUtils,
+    getDimentions: jest.fn(() => ({ height: 700, width: 500 }))
+  };
+});
+
 const testsWithPublictaion = publicationName =>
   slicesWithPubLogo.map(({ mock, name, Slice }) => ({
     name,
@@ -144,7 +155,7 @@ const testsWithPublictaion = publicationName =>
       const output = TestRenderer.create(
         <Responsive>
           <SectionContext.Provider value={{ publicationName }}>
-            <Slice onPress={() => {}} slice={mock} />
+            <Slice onPress={() => { }} slice={mock} />
           </SectionContext.Provider>
         </Responsive>
       );
@@ -159,7 +170,7 @@ export default () => {
     test: () => {
       const output = TestRenderer.create(
         <Responsive>
-          <Slice onPress={() => {}} slice={mock} />
+          <Slice onPress={() => { }} slice={mock} />
         </Responsive>
       );
 

--- a/packages/edition-slices/__tests__/shared-tablet-slices.base.js
+++ b/packages/edition-slices/__tests__/shared-tablet-slices.base.js
@@ -2,7 +2,7 @@ import React from "react";
 import TestRenderer from "react-test-renderer";
 import { editionBreakpointWidths } from "@times-components/styleguide";
 import { iterator } from "@times-components/test-utils";
-import { getDimentions } from "@times-components/utils";
+import { getDimensions } from "@times-components/utils";
 import {
   mockCommentLeadAndCartoonSlice,
   mockDailyRegisterSlice,
@@ -131,7 +131,7 @@ jest.mock("@times-components/utils", () => {
 
   return {
     ...actualUtils,
-    getDimentions: jest.fn()
+    getDimensions: jest.fn()
   };
 });
 
@@ -139,7 +139,7 @@ const tabletTester = type =>
   slices.map(({ mock, name, Slice }) => ({
     name: `${name} - ${type}`,
     test: () => {
-      getDimentions.mockImplementation(() => ({
+      getDimensions.mockImplementation(() => ({
         width: editionBreakpointWidths[type]
       }));
       const output = TestRenderer.create(

--- a/packages/edition-slices/__tests__/shared-tablet-slices.base.js
+++ b/packages/edition-slices/__tests__/shared-tablet-slices.base.js
@@ -2,7 +2,7 @@ import React from "react";
 import TestRenderer from "react-test-renderer";
 import { editionBreakpointWidths } from "@times-components/styleguide";
 import { iterator } from "@times-components/test-utils";
-import { setDimension } from "@times-components/mocks/dimensions";
+import { getDimentions } from "@times-components/utils";
 import {
   mockCommentLeadAndCartoonSlice,
   mockDailyRegisterSlice,
@@ -125,11 +125,23 @@ const slices = [
   }
 ];
 
+jest.mock("@times-components/utils", () => {
+  // eslint-disable-next-line global-require
+  const actualUtils = jest.requireActual("@times-components/utils");
+
+  return {
+    ...actualUtils,
+    getDimentions: jest.fn()
+  };
+});
+
 const tabletTester = type =>
   slices.map(({ mock, name, Slice }) => ({
     name: `${name} - ${type}`,
     test: () => {
-      setDimension({ width: editionBreakpointWidths[type] });
+      getDimentions.mockImplementation(() => ({
+        width: editionBreakpointWidths[type]
+      }));
       const output = TestRenderer.create(
         <Responsive>
           <Slice onPress={() => {}} slice={mock} />
@@ -141,6 +153,10 @@ const tabletTester = type =>
   }));
 
 export default () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   const tests = [
     ...tabletTester("medium"),
     ...tabletTester("wide"),

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -3,119 +3,80 @@
 exports[`1. daily universal register 1`] = `
 <style>
 .IS1 {
-  width: 237;
-  height: 60;
-  margin-bottom: 10px;
-  margin-top: 15px;
+  width: 285;
+  height: 73;
+  margin-vertical: 10px;
 }
 
 .IS2 {
   color: rgba(133,0,41,1.00);
   font-family: TimesDigitalW04;
-  font-size: 15px;
-  line-height: 21px;
-  margin-bottom: 15px;
+  font-size: 16px;
+  margin-bottom: 25px;
 }
 
 .IS3 {
+  border-bottom-color: rgba(219,219,219,1.00);
   border-bottom-width: 1px;
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
   border-top-style: solid;
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-right: 15px;
-  margin-left: 15px;
+  margin-right: 10px;
+  margin-left: 10px;
+  margin-top: 25px;
+  margin-bottom: 25px;
+  width: 100%;
 }
 
 .IS4 {
-  width: 60;
-  height: 45;
-  margin-right: 15px;
-}
-
-.IS5 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-
-.IS6 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
   border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 15px;
-  margin-bottom: 15px;
-}
-
-.IS7 {
   border-bottom-width: 1px;
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
   border-top-style: solid;
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-right: 15px;
-  margin-left: 15px;
+  margin-right: 10px;
+  margin-left: 10px;
+  margin-top: 25px;
+  margin-bottom: 25px;
+  width: 100%;
+}
+
+.IS5 {
+  width: 60;
+  height: 45;
+}
+
+.IS6 {
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+  margin-top: 25px;
+  margin-bottom: 25px;
+  width: 100%;
+}
+
+.IS7 {
+  width: 60;
+  height: 45;
 }
 
 .IS8 {
-  width: 60;
-  height: 45;
-  margin-right: 15px;
-}
-
-.IS9 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-
-.IS10 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS11 {
   -webkit-align-items: center;
   align-items: center;
   background-color: rgba(240,240,240,1.00);
@@ -125,14 +86,10 @@ exports[`1. daily universal register 1`] = `
   flex-shrink: 1;
   -webkit-flex-basis: 0%;
   flex-basis: 0%;
-  margin-right: 20px;
-  margin-left: 20px;
-  margin-top: 15px;
-  margin-bottom: 15px;
-  padding-top: 15px;
-  padding-right: 15px;
-  padding-bottom: 15px;
-  padding-left: 15px;
+  padding-top: 10px;
+  padding-right: 10px;
+  padding-bottom: 10px;
+  padding-left: 10px;
   -ms-flex-align: center;
   -webkit-box-align: center;
   -ms-flex-positive: 1;
@@ -140,84 +97,52 @@ exports[`1. daily universal register 1`] = `
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
 }
-
-.IS12 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
-}
 </style>
 
 <div
-  className="css-view-1dbjc4n IS12"
+  className="css-view-1dbjc4n IS8"
 >
+  <Image
+    aspectRatio={1}
+    className="IS1"
+    uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
+  />
   <div
-    className="css-view-1dbjc4n IS11"
+    className="css-text-901oao IS2"
   >
-    <Image
-      aspectRatio={1}
-      className="IS1"
-      uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-    />
-    <div
-      className="css-text-901oao IS2"
-    >
-      Daily Universal Register
-    </div>
-    <div
-      className="css-view-1dbjc4n IS10"
-    >
-      <div
-        className="css-view-1dbjc4n IS5"
-      >
-        <TileS
-          breakpoint="wide"
-        />
-        <div
-          className="css-view-1dbjc4n IS3"
-        />
-        <TileS
-          breakpoint="wide"
-          logo={
-            <Logo
-              className="IS4"
-              imageUri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
-              ratio={1}
-              type="nature notes"
-            />
-          }
-        />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS6"
-      />
-      <div
-        className="css-view-1dbjc4n IS9"
-      >
-        <TileS
-          breakpoint="wide"
-        />
-        <div
-          className="css-view-1dbjc4n IS7"
-        />
-        <TileS
-          breakpoint="wide"
-          logo={
-            <Logo
-              className="IS8"
-              imageUri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
-              ratio={1}
-              type="birthdays"
-            />
-          }
-        />
-      </div>
-    </div>
+    Daily Universal Register
   </div>
+  <TileS
+    breakpoint="small"
+  />
+  <div
+    className="css-view-1dbjc4n IS3"
+  />
+  <TileS
+    breakpoint="small"
+  />
+  <div
+    className="css-view-1dbjc4n IS4"
+  />
+  <Image
+    aspectRatio={1}
+    className="IS5"
+    uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
+  />
+  <TileS
+    breakpoint="small"
+  />
+  <div
+    className="css-view-1dbjc4n IS6"
+  />
+  <Image
+    aspectRatio={1}
+    className="IS7"
+    uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
+  />
+  <TileS
+    breakpoint="small"
+  />
 </div>
 `;
 
@@ -228,10 +153,10 @@ exports[`1. secondary one and four 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-top: 15px;
-  margin-right: 15px;
-  margin-left: 15px;
+  margin-top: 10px;
+  margin-right: 10px;
   margin-bottom: 10px;
+  margin-left: 10px;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
 }
@@ -246,74 +171,16 @@ exports[`1. secondary one and four 1`] = `
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-right: 15px;
-  margin-left: 15px;
+  margin-right: 10px;
+  margin-left: 10px;
 }
 
 .IS3 {
-  width: 50%;
-}
-
-.IS4 {
-  border-top-color: rgba(77,77,77,1.00);
-  border-right-color: rgba(77,77,77,1.00);
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-left-color: rgba(77,77,77,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS5 {
-  width: 50%;
-}
-
-.IS6 {
-  border-top-color: rgba(77,77,77,1.00);
-  border-right-color: rgba(77,77,77,1.00);
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-left-color: rgba(77,77,77,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS7 {
-  width: 50%;
-}
-
-.IS8 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS9 {
   border-bottom-width: 1px;
-  border-top-color: rgba(77,77,77,1.00);
-  border-right-color: rgba(77,77,77,1.00);
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-left-color: rgba(77,77,77,1.00);
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
   border-top-style: solid;
   border-right-style: solid;
   border-bottom-style: solid;
@@ -322,175 +189,110 @@ exports[`1. secondary one and four 1`] = `
   margin-left: 10px;
 }
 
-.IS10 {
-  width: 50%;
-}
-
-.IS11 {
-  border-top-color: rgba(77,77,77,1.00);
-  border-right-color: rgba(77,77,77,1.00);
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-left-color: rgba(77,77,77,1.00);
-  border-right-width: 1px;
+.IS4 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
   border-top-style: solid;
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-right: 10px;
+  margin-left: 10px;
 }
 
-.IS12 {
-  width: 50%;
+.IS5 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
 }
 
-.IS13 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS14 {
-  width: 50%;
-}
-
-.IS15 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding-right: 5px;
-  padding-bottom: 5px;
-  padding-left: 5px;
-  padding-top: 0px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS16 {
+.IS6 {
   background-color: rgba(39,45,52,1.00);
-  margin-right: 20px;
-  margin-left: 20px;
-  margin-top: 15px;
-  margin-bottom: 15px;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 
-.IS17 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
+.IS7 {
+  background-color: rgba(39,45,52,1.00);
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS17"
+  className="css-view-1dbjc4n IS7"
 >
   <div
-    className="css-view-1dbjc4n IS16"
+    className="css-view-1dbjc4n IS1"
+  >
+    <TheSTLogo
+      height={40}
+      width={60}
+    />
+  </div>
+  <div
+    className="css-view-1dbjc4n IS2"
+  />
+  <div
+    className="css-view-1dbjc4n IS6"
   >
     <div
-      className="css-view-1dbjc4n IS1"
-    >
-      <TheSTLogo
-        height={40}
-        width={60}
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS15"
+      className="css-view-1dbjc4n"
     >
       <div
-        className="css-view-1dbjc4n IS3"
+        className="css-view-1dbjc4n"
       >
         <TileN
-          breakpoint="wide"
+          breakpoint="small"
           tileName="secondary"
         />
       </div>
+    </div>
+    <div
+      className="css-view-1dbjc4n"
+    >
+      <TileO
+        breakpoint="small"
+        tileName="support1"
+      />
+      <div
+        className="css-view-1dbjc4n IS3"
+      />
+      <TileO
+        breakpoint="small"
+        tileName="support2"
+      />
       <div
         className="css-view-1dbjc4n IS4"
       />
+      <TileO
+        breakpoint="small"
+        tileName="support3"
+      />
       <div
-        className="css-view-1dbjc4n IS14"
-      >
-        <div
-          className="css-view-1dbjc4n IS8"
-        >
-          <div
-            className="css-view-1dbjc4n IS5"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support1"
-            />
-          </div>
-          <div
-            className="css-view-1dbjc4n IS6"
-          />
-          <div
-            className="css-view-1dbjc4n IS7"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support2"
-            />
-          </div>
-        </div>
-        <div
-          className="css-view-1dbjc4n IS9"
-        />
-        <div
-          className="css-view-1dbjc4n IS13"
-        >
-          <div
-            className="css-view-1dbjc4n IS10"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support3"
-            />
-          </div>
-          <div
-            className="css-view-1dbjc4n IS11"
-          />
-          <div
-            className="css-view-1dbjc4n IS12"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support4"
-            />
-          </div>
-        </div>
-      </div>
+        className="css-view-1dbjc4n IS5"
+      />
+      <TileO
+        breakpoint="small"
+        tileName="support4"
+      />
     </div>
   </div>
 </div>
@@ -503,10 +305,10 @@ exports[`1. secondary one and four 2`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-top: 15px;
-  margin-right: 15px;
-  margin-left: 15px;
+  margin-top: 10px;
+  margin-right: 10px;
   margin-bottom: 10px;
+  margin-left: 10px;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
 }
@@ -521,74 +323,16 @@ exports[`1. secondary one and four 2`] = `
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-right: 15px;
-  margin-left: 15px;
+  margin-right: 10px;
+  margin-left: 10px;
 }
 
 .IS3 {
-  width: 50%;
-}
-
-.IS4 {
-  border-top-color: rgba(77,77,77,1.00);
-  border-right-color: rgba(77,77,77,1.00);
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-left-color: rgba(77,77,77,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS5 {
-  width: 50%;
-}
-
-.IS6 {
-  border-top-color: rgba(77,77,77,1.00);
-  border-right-color: rgba(77,77,77,1.00);
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-left-color: rgba(77,77,77,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS7 {
-  width: 50%;
-}
-
-.IS8 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS9 {
   border-bottom-width: 1px;
-  border-top-color: rgba(77,77,77,1.00);
-  border-right-color: rgba(77,77,77,1.00);
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-left-color: rgba(77,77,77,1.00);
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
   border-top-style: solid;
   border-right-style: solid;
   border-bottom-style: solid;
@@ -597,727 +341,183 @@ exports[`1. secondary one and four 2`] = `
   margin-left: 10px;
 }
 
-.IS10 {
-  width: 50%;
-}
-
-.IS11 {
-  border-top-color: rgba(77,77,77,1.00);
-  border-right-color: rgba(77,77,77,1.00);
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-left-color: rgba(77,77,77,1.00);
-  border-right-width: 1px;
+.IS4 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
   border-top-style: solid;
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-right: 10px;
+  margin-left: 10px;
 }
 
-.IS12 {
-  width: 50%;
+.IS5 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
 }
 
-.IS13 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS14 {
-  width: 50%;
-}
-
-.IS15 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding-right: 5px;
-  padding-bottom: 5px;
-  padding-left: 5px;
-  padding-top: 0px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS16 {
+.IS6 {
   background-color: rgba(39,45,52,1.00);
-  margin-right: 20px;
-  margin-left: 20px;
-  margin-top: 15px;
-  margin-bottom: 15px;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 
-.IS17 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
+.IS7 {
+  background-color: rgba(39,45,52,1.00);
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS17"
+  className="css-view-1dbjc4n IS7"
 >
   <div
-    className="css-view-1dbjc4n IS16"
+    className="css-view-1dbjc4n IS1"
+  >
+    <TheTimesLogo
+      height={37}
+      width={35}
+    />
+  </div>
+  <div
+    className="css-view-1dbjc4n IS2"
+  />
+  <div
+    className="css-view-1dbjc4n IS6"
   >
     <div
-      className="css-view-1dbjc4n IS1"
-    >
-      <TheTimesLogo
-        height={37}
-        width={35}
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS15"
+      className="css-view-1dbjc4n"
     >
       <div
-        className="css-view-1dbjc4n IS3"
+        className="css-view-1dbjc4n"
       >
         <TileN
-          breakpoint="wide"
+          breakpoint="small"
           tileName="secondary"
         />
       </div>
+    </div>
+    <div
+      className="css-view-1dbjc4n"
+    >
+      <TileO
+        breakpoint="small"
+        tileName="support1"
+      />
+      <div
+        className="css-view-1dbjc4n IS3"
+      />
+      <TileO
+        breakpoint="small"
+        tileName="support2"
+      />
       <div
         className="css-view-1dbjc4n IS4"
       />
+      <TileO
+        breakpoint="small"
+        tileName="support3"
+      />
       <div
-        className="css-view-1dbjc4n IS14"
-      >
-        <div
-          className="css-view-1dbjc4n IS8"
-        >
-          <div
-            className="css-view-1dbjc4n IS5"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support1"
-            />
-          </div>
-          <div
-            className="css-view-1dbjc4n IS6"
-          />
-          <div
-            className="css-view-1dbjc4n IS7"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support2"
-            />
-          </div>
-        </div>
-        <div
-          className="css-view-1dbjc4n IS9"
-        />
-        <div
-          className="css-view-1dbjc4n IS13"
-        >
-          <div
-            className="css-view-1dbjc4n IS10"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support3"
-            />
-          </div>
-          <div
-            className="css-view-1dbjc4n IS11"
-          />
-          <div
-            className="css-view-1dbjc4n IS12"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support4"
-            />
-          </div>
-        </div>
-      </div>
+        className="css-view-1dbjc4n IS5"
+      />
+      <TileO
+        breakpoint="small"
+        tileName="support4"
+      />
     </div>
   </div>
 </div>
 `;
 
 exports[`2. lead one full width 1`] = `
-<style>
-.IS1 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
-}
-</style>
-
-<div
-  className="css-view-1dbjc4n IS1"
->
-  <TileR
-    breakpoint="wide"
-    tileName="lead"
-  />
-</div>
+<TileA
+  tileName="lead"
+/>
 `;
 
 exports[`2. leaders 1`] = `
 <style>
 .IS1 {
-  height: 42;
-  width: 227;
+  height: 54;
+  width: 283;
 }
 
 .IS2 {
   color: rgba(133,0,41,1.00);
   font-family: TimesDigitalW04-Regular;
-  font-size: 15px;
-  line-height: 15px;
+  font-size: 16px;
+  line-height: 18px;
   text-align: center;
 }
 
 .IS3 {
-  padding-top: 10px;
-}
-
-.IS4 {
-  -webkit-align-items: center;
-  align-items: center;
-  -ms-flex-align: center;
-  -webkit-box-align: center;
-}
-
-.IS5 {
-  padding-right: 20px;
-  padding-left: 20px;
-  width: 33%;
-}
-
-.IS6 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-bottom: 60px;
-  margin-top: 30px;
-}
-
-.IS7 {
-  padding-right: 20px;
-  padding-left: 20px;
-  width: 33%;
-}
-
-.IS8 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-bottom: 60px;
-  margin-top: 30px;
-}
-
-.IS9 {
-  padding-right: 20px;
-  padding-left: 20px;
-  width: 33%;
-}
-
-.IS10 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS11 {
-  background-color: rgba(240,240,240,1.00);
-  margin-right: 20px;
-  margin-left: 20px;
-  margin-top: 15px;
-  margin-bottom: 15px;
-  padding-top: 30px;
-}
-
-.IS12 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
-}
-</style>
-
-<div
-  className="css-view-1dbjc4n IS12"
->
-  <div
-    className="css-view-1dbjc4n IS11"
-  >
-    <div
-      className="css-view-1dbjc4n IS4"
-    >
-      <Image
-        aspectRatio={5.4}
-        className="IS1"
-        uri="https://www.thetimes.co.uk/d/img/logos/sundaytimes-with-crest-black-53d6e31fb8.png"
-      />
-      <div
-        className="css-view-1dbjc4n IS3"
-      >
-        <div
-          className="css-text-901oao IS2"
-        >
-           Leading Articles 
-        </div>
-      </div>
-    </div>
-    <div
-      className="css-view-1dbjc4n IS10"
-    >
-      <div
-        className="css-view-1dbjc4n IS5"
-      >
-        <TileM
-          breakpoint="wide"
-          tileName="leader2"
-        />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS6"
-      />
-      <div
-        className="css-view-1dbjc4n IS7"
-      >
-        <TileM
-          breakpoint="wide"
-          tileName="leader1"
-        />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS8"
-      />
-      <div
-        className="css-view-1dbjc4n IS9"
-      >
-        <TileM
-          breakpoint="wide"
-          tileName="leader3"
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`2. leaders 2`] = `
-<style>
-.IS1 {
-  height: 42;
-  width: 237;
-}
-
-.IS2 {
-  color: rgba(133,0,41,1.00);
-  font-family: TimesDigitalW04-Regular;
-  font-size: 15px;
-  line-height: 15px;
-  text-align: center;
-}
-
-.IS3 {
-  padding-top: 10px;
-}
-
-.IS4 {
-  -webkit-align-items: center;
-  align-items: center;
-  -ms-flex-align: center;
-  -webkit-box-align: center;
-}
-
-.IS5 {
-  padding-right: 20px;
-  padding-left: 20px;
-  width: 33%;
-}
-
-.IS6 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-bottom: 60px;
-  margin-top: 30px;
-}
-
-.IS7 {
-  padding-right: 20px;
-  padding-left: 20px;
-  width: 33%;
-}
-
-.IS8 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-bottom: 60px;
-  margin-top: 30px;
-}
-
-.IS9 {
-  padding-right: 20px;
-  padding-left: 20px;
-  width: 33%;
-}
-
-.IS10 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS11 {
-  background-color: rgba(240,240,240,1.00);
-  margin-right: 20px;
-  margin-left: 20px;
-  margin-top: 15px;
-  margin-bottom: 15px;
-  padding-top: 30px;
-}
-
-.IS12 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
-}
-</style>
-
-<div
-  className="css-view-1dbjc4n IS12"
->
-  <div
-    className="css-view-1dbjc4n IS11"
-  >
-    <div
-      className="css-view-1dbjc4n IS4"
-    >
-      <Image
-        aspectRatio={5.74}
-        className="IS1"
-        uri="https://www.thetimes.co.uk/d/img/leaders-masthead-d17db00289.png"
-      />
-      <div
-        className="css-view-1dbjc4n IS3"
-      >
-        <div
-          className="css-text-901oao IS2"
-        >
-           Leading Articles 
-        </div>
-      </div>
-    </div>
-    <div
-      className="css-view-1dbjc4n IS10"
-    >
-      <div
-        className="css-view-1dbjc4n IS5"
-      >
-        <TileM
-          breakpoint="wide"
-          tileName="leader2"
-        />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS6"
-      />
-      <div
-        className="css-view-1dbjc4n IS7"
-      >
-        <TileM
-          breakpoint="wide"
-          tileName="leader1"
-        />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS8"
-      />
-      <div
-        className="css-view-1dbjc4n IS9"
-      >
-        <TileM
-          breakpoint="wide"
-          tileName="leader3"
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`3. lead one and one 1`] = `
-<style>
-.IS1 {
-  width: 83.5%;
-}
-
-.IS2 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 15px;
-  margin-bottom: 15px;
-}
-
-.IS3 {
-  width: 16.5%;
-}
-
-.IS4 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS5 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
-}
-</style>
-
-<div
-  className="css-view-1dbjc4n IS5"
->
-  <div
-    className="css-view-1dbjc4n IS4"
-  >
-    <div
-      className="css-view-1dbjc4n IS1"
-    >
-      <TileZ
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS3"
-    >
-      <TileAF
-        breakpoint="wide"
-        tileName="support"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`4. lead one and four 1`] = `
-<style>
-.IS1 {
-  width: 60%;
-}
-
-.IS2 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS3 {
-  border-bottom-width: 1px;
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-right: 10px;
-  margin-left: 10px;
-}
-
-.IS4 {
-  border-bottom-width: 1px;
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-right: 10px;
-  margin-left: 10px;
-}
-
-.IS5 {
-  border-bottom-width: 1px;
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-right: 10px;
-  margin-left: 10px;
-}
-
-.IS6 {
-  width: 40%;
-}
-
-.IS7 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
-  padding-top: 5px;
   padding-bottom: 5px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
+  padding-top: 10px;
+}
+
+.IS4 {
+  -webkit-align-items: center;
+  align-items: center;
+  -ms-flex-align: center;
+  -webkit-box-align: center;
+}
+
+.IS5 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS6 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS7 {
+  padding-bottom: 5px;
 }
 
 .IS8 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
+  background-color: rgba(240,240,240,1.00);
+  padding-top: 20px;
 }
 </style>
 
@@ -1325,50 +525,257 @@ exports[`4. lead one and four 1`] = `
   className="css-view-1dbjc4n IS8"
 >
   <div
+    className="css-view-1dbjc4n IS4"
+  >
+    <Image
+      aspectRatio={5.4}
+      className="IS1"
+      uri="https://www.thetimes.co.uk/d/img/logos/sundaytimes-with-crest-black-53d6e31fb8.png"
+    />
+    <div
+      className="css-view-1dbjc4n IS3"
+    >
+      <div
+        className="css-text-901oao IS2"
+      >
+         Leading Articles 
+      </div>
+    </div>
+  </div>
+  <div
     className="css-view-1dbjc4n IS7"
   >
+    <TileM
+      breakpoint="small"
+      tileName="leader1"
+    />
     <div
-      className="css-view-1dbjc4n IS1"
-    >
-      <TileAC
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS5"
+    />
+    <TileM
+      breakpoint="small"
+      tileName="leader2"
     />
     <div
       className="css-view-1dbjc4n IS6"
-    >
-      <TileAD
-        breakpoint="wide"
-        tileName="support1"
-      />
-      <div
-        className="css-view-1dbjc4n IS3"
-      />
-      <TileAD
-        breakpoint="wide"
-        tileName="support2"
-      />
-      <div
-        className="css-view-1dbjc4n IS4"
-      />
-      <TileAD
-        breakpoint="wide"
-        tileName="support3"
-      />
-      <div
-        className="css-view-1dbjc4n IS5"
-      />
-      <TileAD
-        breakpoint="wide"
-        tileName="support4"
-      />
-    </div>
+    />
+    <TileM
+      breakpoint="small"
+      tileName="leader3"
+    />
   </div>
 </div>
+`;
+
+exports[`2. leaders 2`] = `
+<style>
+.IS1 {
+  height: 51;
+  width: 283;
+}
+
+.IS2 {
+  color: rgba(133,0,41,1.00);
+  font-family: TimesDigitalW04-Regular;
+  font-size: 16px;
+  line-height: 18px;
+  text-align: center;
+}
+
+.IS3 {
+  padding-bottom: 5px;
+  padding-top: 10px;
+}
+
+.IS4 {
+  -webkit-align-items: center;
+  align-items: center;
+  -ms-flex-align: center;
+  -webkit-box-align: center;
+}
+
+.IS5 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS6 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS7 {
+  padding-bottom: 5px;
+}
+
+.IS8 {
+  background-color: rgba(240,240,240,1.00);
+  padding-top: 20px;
+}
+</style>
+
+<div
+  className="css-view-1dbjc4n IS8"
+>
+  <div
+    className="css-view-1dbjc4n IS4"
+  >
+    <Image
+      aspectRatio={5.74}
+      className="IS1"
+      uri="https://www.thetimes.co.uk/d/img/leaders-masthead-d17db00289.png"
+    />
+    <div
+      className="css-view-1dbjc4n IS3"
+    >
+      <div
+        className="css-text-901oao IS2"
+      >
+         Leading Articles 
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-view-1dbjc4n IS7"
+  >
+    <TileM
+      breakpoint="small"
+      tileName="leader1"
+    />
+    <div
+      className="css-view-1dbjc4n IS5"
+    />
+    <TileM
+      breakpoint="small"
+      tileName="leader2"
+    />
+    <div
+      className="css-view-1dbjc4n IS6"
+    />
+    <TileM
+      breakpoint="small"
+      tileName="leader3"
+    />
+  </div>
+</div>
+`;
+
+exports[`3. lead one and one 1`] = `
+<style>
+.IS1 {
+  background-color: rgba(219,219,219,1.00);
+  height: 1px;
+}
+</style>
+
+<div
+  className="css-view-1dbjc4n"
+>
+  <TileA
+    tileName="lead"
+  />
+  <div
+    className="css-view-1dbjc4n IS1"
+  />
+  <TileB
+    tileName="support"
+  />
+</div>
+`;
+
+exports[`4. lead one and four 1`] = `
+Array [
+  <TileI
+    tileName="lead"
+  />,
+  <style>
+.IS1 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS2 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS3 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+</style>
+
+<div
+    className="css-view-1dbjc4n"
+  >
+    <TileJ
+      tileName="support1"
+    />
+    <div
+      className="css-view-1dbjc4n IS1"
+    />
+    <TileJ
+      tileName="support2"
+    />
+    <div
+      className="css-view-1dbjc4n IS2"
+    />
+    <TileJ
+      tileName="support3"
+    />
+    <div
+      className="css-view-1dbjc4n IS3"
+    />
+    <TileJ
+      tileName="support4"
+    />
+  </div>,
+]
 `;
 
 exports[`5. standard 1`] = `
@@ -1428,79 +835,85 @@ exports[`5. standard 1`] = `
   margin-right: 10px;
   margin-left: 10px;
 }
-
-.IS5 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding-right: 50px;
-  padding-left: 50px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS6 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
-}
 </style>
 
 <div
-  className="css-view-1dbjc4n IS6"
+  className="css-view-1dbjc4n r-WebkitOverflowScrolling-150rngu r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-11yh6sk r-overflowY-1rnoaur r-transform-1sncvnh"
 >
   <div
-    className="css-view-1dbjc4n IS5"
+    className="css-view-1dbjc4n"
   >
     <div
       className="css-view-1dbjc4n"
     >
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem1"
-      />
       <div
-        className="css-view-1dbjc4n IS1"
-      />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem2"
-      />
+        className="css-view-1dbjc4n"
+      >
+        <TileK
+          breakpoint="small"
+          tileName="standardItem1"
+        />
+        <div
+          className="css-view-1dbjc4n IS1"
+        />
+      </div>
+    </div>
+    <div
+      className="css-view-1dbjc4n"
+    >
       <div
-        className="css-view-1dbjc4n IS2"
-      />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem3"
-      />
+        className="css-view-1dbjc4n"
+      >
+        <TileK
+          breakpoint="small"
+          tileName="standardItem2"
+        />
+        <div
+          className="css-view-1dbjc4n IS2"
+        />
+      </div>
+    </div>
+    <div
+      className="css-view-1dbjc4n"
+    >
       <div
-        className="css-view-1dbjc4n IS3"
-      />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem4"
-      />
+        className="css-view-1dbjc4n"
+      >
+        <TileK
+          breakpoint="small"
+          tileName="standardItem3"
+        />
+        <div
+          className="css-view-1dbjc4n IS3"
+        />
+      </div>
+    </div>
+    <div
+      className="css-view-1dbjc4n"
+    >
       <div
-        className="css-view-1dbjc4n IS4"
-      />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem5"
-      />
+        className="css-view-1dbjc4n"
+      >
+        <TileK
+          breakpoint="small"
+          tileName="standardItem4"
+        />
+        <div
+          className="css-view-1dbjc4n IS4"
+        />
+      </div>
+    </div>
+    <div
+      className="css-view-1dbjc4n"
+    >
+      <div
+        className="css-view-1dbjc4n"
+      >
+        <TileK
+          breakpoint="small"
+          tileName="standardItem5"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -1523,150 +936,104 @@ exports[`6. lead two no pic and two 1`] = `
 }
 
 .IS2 {
-  width: 42%;
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
 }
 
 .IS3 {
+  border-bottom-width: 1px;
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-bottom-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
   border-top-style: solid;
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-top: 15px;
-  margin-bottom: 15px;
-}
-
-.IS4 {
-  width: 42%;
-}
-
-.IS5 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 15px;
-  margin-bottom: 15px;
-}
-
-.IS6 {
-  width: 16%;
-}
-
-.IS7 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   margin-right: 10px;
   margin-left: 10px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS8 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS8"
+  className="css-view-1dbjc4n"
 >
+  <TileF
+    tileName="lead1"
+  />
   <div
-    className="css-view-1dbjc4n IS7"
-  >
-    <div
-      className="css-view-1dbjc4n IS2"
-    >
-      <TileX
-        breakpoint="wide"
-        tileName="lead1"
-      />
-      <div
-        className="css-view-1dbjc4n IS1"
-      />
-      <TileY
-        breakpoint="wide"
-        tileName="lead2"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS3"
-    />
-    <div
-      className="css-view-1dbjc4n IS4"
-    >
-      <TileE
-        breakpoint="wide"
-        tileName="support1"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS5"
-    />
-    <div
-      className="css-view-1dbjc4n IS6"
-    >
-      <TileAL
-        breakpoint="wide"
-        tileName="support2"
-      />
-    </div>
-  </div>
+    className="css-view-1dbjc4n IS1"
+  />
+  <TileB
+    tileName="lead2"
+  />
+  <div
+    className="css-view-1dbjc4n IS2"
+  />
+  <TileD
+    tileName="support1"
+  />
+  <div
+    className="css-view-1dbjc4n IS3"
+  />
+  <TileE
+    tileName="support2"
+  />
 </div>
 `;
 
 exports[`7. secondary one 1`] = `
-<style>
-.IS1 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
-}
-</style>
-
-<div
-  className="css-view-1dbjc4n IS1"
->
-  <TileW
-    breakpoint="wide"
-    tileName="secondary"
-  />
-</div>
+<TileA
+  tileName="secondary"
+/>
 `;
 
 exports[`8. secondary one and columnist 1`] = `
 <style>
 .IS1 {
-  width: 66.7%;
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+</style>
+
+<div
+  className="css-view-1dbjc4n"
+>
+  <TileT
+    tileName="secondary"
+  />
+  <div
+    className="css-view-1dbjc4n IS1"
+  />
+  <TileH
+    tileName="columnist"
+  />
+</div>
+`;
+
+exports[`9. secondary four 1`] = `
+Array [
+  <style>
+.IS1 {
+  width: 50%;
 }
 
 .IS2 {
@@ -1679,14 +1046,12 @@ exports[`8. secondary one and columnist 1`] = `
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-top: 15px;
-  margin-bottom: 15px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 .IS3 {
-  padding-top: 5px;
-  padding-bottom: 5px;
-  width: 33.3%;
+  width: 50%;
 }
 
 .IS4 {
@@ -1699,8 +1064,6 @@ exports[`8. secondary one and columnist 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -1708,623 +1071,15 @@ exports[`8. secondary one and columnist 1`] = `
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
 }
-
-.IS5 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
-}
 </style>
 
 <div
-  className="css-view-1dbjc4n IS5"
->
-  <div
     className="css-view-1dbjc4n IS4"
   >
     <div
       className="css-view-1dbjc4n IS1"
     >
-      <TileAB
-        breakpoint="wide"
-        tileName="columnist"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS3"
-    >
-      <TileB
-        breakpoint="wide"
-        tileName="secondary"
-        withMoreTeaser={true}
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`9. secondary four 1`] = `
-<style>
-.IS1 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-
-.IS2 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 15px;
-  margin-bottom: 15px;
-}
-
-.IS3 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-
-.IS4 {
-  -webkit-flex-grow: 2;
-  flex-grow: 2;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 2;
-  -webkit-box-flex: 2;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS5 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 15px;
-  margin-bottom: 15px;
-}
-
-.IS6 {
-  border-bottom-width: 1px;
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-right: 10px;
-  margin-left: 10px;
-}
-
-.IS7 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  padding-top: 5px;
-  padding-bottom: 5px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-
-.IS8 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS9 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
-}
-</style>
-
-<div
-  className="css-view-1dbjc4n IS9"
->
-  <div
-    className="css-view-1dbjc4n IS8"
-  >
-    <div
-      className="css-view-1dbjc4n IS4"
-    >
-      <div
-        className="css-view-1dbjc4n IS1"
-      >
-        <TileAR
-          breakpoint="wide"
-          tileName="secondary1"
-        />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS2"
-      />
-      <div
-        className="css-view-1dbjc4n IS3"
-      >
-        <TileAR
-          breakpoint="wide"
-          tileName="secondary2"
-        />
-      </div>
-    </div>
-    <div
-      className="css-view-1dbjc4n IS5"
-    />
-    <div
-      className="css-view-1dbjc4n IS7"
-    >
-      <TileB
-        additionalHeadlineStyles={
-          Object {
-            "fontSize": 20,
-            "lineHeight": 20,
-            "marginBottom": "5px",
-          }
-        }
-        breakpoint="wide"
-        tileName="secondary3"
-      />
-      <div
-        className="css-view-1dbjc4n IS6"
-      />
-      <TileB
-        additionalHeadlineStyles={
-          Object {
-            "fontSize": 20,
-            "lineHeight": 20,
-            "marginBottom": "5px",
-          }
-        }
-        breakpoint="wide"
-        tileName="secondary4"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`10. secondary one and four 1`] = `
-<style>
-.IS1 {
-  background-color: rgba(39,45,52,1.00);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: 15px;
-  margin-right: 15px;
-  margin-left: 15px;
-  margin-bottom: 10px;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS2 {
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-bottom-width: 1px;
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-right: 15px;
-  margin-left: 15px;
-}
-
-.IS3 {
-  width: 50%;
-}
-
-.IS4 {
-  border-top-color: rgba(77,77,77,1.00);
-  border-right-color: rgba(77,77,77,1.00);
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-left-color: rgba(77,77,77,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS5 {
-  width: 50%;
-}
-
-.IS6 {
-  border-top-color: rgba(77,77,77,1.00);
-  border-right-color: rgba(77,77,77,1.00);
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-left-color: rgba(77,77,77,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS7 {
-  width: 50%;
-}
-
-.IS8 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS9 {
-  border-bottom-width: 1px;
-  border-top-color: rgba(77,77,77,1.00);
-  border-right-color: rgba(77,77,77,1.00);
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-left-color: rgba(77,77,77,1.00);
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-right: 10px;
-  margin-left: 10px;
-}
-
-.IS10 {
-  width: 50%;
-}
-
-.IS11 {
-  border-top-color: rgba(77,77,77,1.00);
-  border-right-color: rgba(77,77,77,1.00);
-  border-bottom-color: rgba(77,77,77,1.00);
-  border-left-color: rgba(77,77,77,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS12 {
-  width: 50%;
-}
-
-.IS13 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS14 {
-  width: 50%;
-}
-
-.IS15 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding-right: 5px;
-  padding-bottom: 5px;
-  padding-left: 5px;
-  padding-top: 0px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS16 {
-  background-color: rgba(39,45,52,1.00);
-  margin-right: 20px;
-  margin-left: 20px;
-  margin-top: 15px;
-  margin-bottom: 15px;
-}
-
-.IS17 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
-}
-</style>
-
-<div
-  className="css-view-1dbjc4n IS17"
->
-  <div
-    className="css-view-1dbjc4n IS16"
-  >
-    <div
-      className="css-view-1dbjc4n IS1"
-    >
-      <TheTimesLogo
-        height={37}
-        width={35}
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS15"
-    >
-      <div
-        className="css-view-1dbjc4n IS3"
-      >
-        <TileN
-          breakpoint="wide"
-          tileName="secondary"
-        />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS4"
-      />
-      <div
-        className="css-view-1dbjc4n IS14"
-      >
-        <div
-          className="css-view-1dbjc4n IS8"
-        >
-          <div
-            className="css-view-1dbjc4n IS5"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support1"
-            />
-          </div>
-          <div
-            className="css-view-1dbjc4n IS6"
-          />
-          <div
-            className="css-view-1dbjc4n IS7"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support2"
-            />
-          </div>
-        </div>
-        <div
-          className="css-view-1dbjc4n IS9"
-        />
-        <div
-          className="css-view-1dbjc4n IS13"
-        >
-          <div
-            className="css-view-1dbjc4n IS10"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support3"
-            />
-          </div>
-          <div
-            className="css-view-1dbjc4n IS11"
-          />
-          <div
-            className="css-view-1dbjc4n IS12"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support4"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`11. secondary two and two 1`] = `
-<style>
-.IS1 {
-  width: 33.4%;
-}
-
-.IS2 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS3 {
-  width: 16.6%;
-}
-
-.IS4 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS5 {
-  width: 33.4%;
-}
-
-.IS6 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS7 {
-  width: 16.6%;
-}
-
-.IS8 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS9 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
-}
-</style>
-
-<div
-  className="css-view-1dbjc4n IS9"
->
-  <div
-    className="css-view-1dbjc4n IS8"
-  >
-    <div
-      className="css-view-1dbjc4n IS1"
-    >
-      <TileAM
+      <TileC
         tileName="secondary1"
       />
     </div>
@@ -2334,82 +1089,371 @@ exports[`11. secondary two and two 1`] = `
     <div
       className="css-view-1dbjc4n IS3"
     >
-      <TileAN
-        tileName="support1"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS4"
-    />
-    <div
-      className="css-view-1dbjc4n IS5"
-    >
-      <TileAM
+      <TileC
         tileName="secondary2"
       />
     </div>
+  </div>,
+  <style>
+.IS1 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+</style>
+
+<div
+    className="css-view-1dbjc4n IS1"
+  />,
+  <style>
+.IS1 {
+  width: 50%;
+}
+
+.IS2 {
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-right-width: 1px;
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.IS3 {
+  width: 50%;
+}
+
+.IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+</style>
+
+<div
+    className="css-view-1dbjc4n IS4"
+  >
     <div
-      className="css-view-1dbjc4n IS6"
+      className="css-view-1dbjc4n IS1"
+    >
+      <TileC
+        tileName="secondary3"
+      />
+    </div>
+    <div
+      className="css-view-1dbjc4n IS2"
     />
     <div
-      className="css-view-1dbjc4n IS7"
+      className="css-view-1dbjc4n IS3"
     >
-      <TileAN
+      <TileC
+        tileName="secondary4"
+      />
+    </div>
+  </div>,
+]
+`;
+
+exports[`10. secondary one and four 1`] = `
+<style>
+.IS1 {
+  background-color: rgba(39,45,52,1.00);
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  margin-top: 10px;
+  margin-right: 10px;
+  margin-bottom: 10px;
+  margin-left: 10px;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+
+.IS2 {
+  border-bottom-color: rgba(77,77,77,1.00);
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS3 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS4 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS5 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS6 {
+  background-color: rgba(39,45,52,1.00);
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS7 {
+  background-color: rgba(39,45,52,1.00);
+}
+</style>
+
+<div
+  className="css-view-1dbjc4n IS7"
+>
+  <div
+    className="css-view-1dbjc4n IS1"
+  >
+    <TheTimesLogo
+      height={37}
+      width={35}
+    />
+  </div>
+  <div
+    className="css-view-1dbjc4n IS2"
+  />
+  <div
+    className="css-view-1dbjc4n IS6"
+  >
+    <div
+      className="css-view-1dbjc4n"
+    >
+      <div
+        className="css-view-1dbjc4n"
+      >
+        <TileN
+          breakpoint="small"
+          tileName="secondary"
+        />
+      </div>
+    </div>
+    <div
+      className="css-view-1dbjc4n"
+    >
+      <TileO
+        breakpoint="small"
+        tileName="support1"
+      />
+      <div
+        className="css-view-1dbjc4n IS3"
+      />
+      <TileO
+        breakpoint="small"
         tileName="support2"
+      />
+      <div
+        className="css-view-1dbjc4n IS4"
+      />
+      <TileO
+        breakpoint="small"
+        tileName="support3"
+      />
+      <div
+        className="css-view-1dbjc4n IS5"
+      />
+      <TileO
+        breakpoint="small"
+        tileName="support4"
       />
     </div>
   </div>
 </div>
+`;
+
+exports[`11. secondary two and two 1`] = `
+Array [
+  <style>
+.IS1 {
+  width: 50%;
+}
+
+.IS2 {
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-right-width: 1px;
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.IS3 {
+  width: 50%;
+}
+
+.IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+</style>
+
+<div
+    className="css-view-1dbjc4n IS4"
+  >
+    <div
+      className="css-view-1dbjc4n IS1"
+    >
+      <TileC
+        tileName="secondary1"
+      />
+    </div>
+    <div
+      className="css-view-1dbjc4n IS2"
+    />
+    <div
+      className="css-view-1dbjc4n IS3"
+    >
+      <TileC
+        tileName="secondary2"
+      />
+    </div>
+  </div>,
+  <style>
+.IS1 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+</style>
+
+<div
+    className="css-view-1dbjc4n IS1"
+  />,
+  <div
+    className="css-view-1dbjc4n"
+  >
+    <TileG
+      tileName="support1"
+    />
+  </div>,
+  <style>
+.IS1 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+</style>
+
+<div
+    className="css-view-1dbjc4n IS1"
+  />,
+  <div
+    className="css-view-1dbjc4n"
+  >
+    <TileG
+      tileName="support2"
+    />
+  </div>,
+]
 `;
 
 exports[`12. secondary two no pic and two 1`] = `
 <style>
 .IS1 {
-  width: 50%;
-}
-
-.IS2 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 15px;
-  margin-bottom: 15px;
-}
-
-.IS3 {
-  width: 50%;
-}
-
-.IS4 {
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  width: 66.6%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS5 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 15px;
-  margin-bottom: 15px;
-}
-
-.IS6 {
   border-bottom-width: 1px;
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
@@ -2423,116 +1467,68 @@ exports[`12. secondary two no pic and two 1`] = `
   margin-left: 10px;
 }
 
-.IS7 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  margin-top: 5px;
-  margin-bottom: 5px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-
-.IS8 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+.IS2 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
   margin-right: 10px;
   margin-left: 10px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
 }
 
-.IS9 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
+.IS3 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS9"
+  className="css-view-1dbjc4n"
 >
+  <TileB
+    tileName="secondary1"
+  />
   <div
-    className="css-view-1dbjc4n IS8"
-  >
-    <div
-      className="css-view-1dbjc4n IS4"
-    >
-      <div
-        className="css-view-1dbjc4n IS1"
-      >
-        <TileAE
-          breakpoint="wide"
-          tileName="secondary1"
-        />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS2"
-      />
-      <div
-        className="css-view-1dbjc4n IS3"
-      >
-        <TileAE
-          breakpoint="wide"
-          tileName="secondary2"
-        />
-      </div>
-    </div>
-    <div
-      className="css-view-1dbjc4n IS5"
-    />
-    <div
-      className="css-view-1dbjc4n IS7"
-    >
-      <TileG
-        breakpoint="wide"
-        tileName="support1"
-      />
-      <div
-        className="css-view-1dbjc4n IS6"
-      />
-      <TileG
-        breakpoint="wide"
-        tileName="support2"
-      />
-    </div>
-  </div>
+    className="css-view-1dbjc4n IS1"
+  />
+  <TileB
+    tileName="secondary2"
+  />
+  <div
+    className="css-view-1dbjc4n IS2"
+  />
+  <TileG
+    tileName="support1"
+  />
+  <div
+    className="css-view-1dbjc4n IS3"
+  />
+  <TileG
+    tileName="support2"
+  />
 </div>
 `;
 
 exports[`13. list two and six no pic 1`] = `
-<style>
+Array [
+  <style>
 .IS1 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
+  padding-bottom: 5px;
+  width: 50%;
 }
 
 .IS2 {
@@ -2550,55 +1546,11 @@ exports[`13. list two and six no pic 1`] = `
 }
 
 .IS3 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
+  padding-bottom: 5px;
+  width: 50%;
 }
 
 .IS4 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS5 {
-  width: 50%;
-}
-
-.IS6 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS7 {
-  width: 50%;
-}
-
-.IS8 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -2614,164 +1566,16 @@ exports[`13. list two and six no pic 1`] = `
   -ms-flex-preferred-size: 0%;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
-}
-
-.IS9 {
-  border-bottom-width: 1px;
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-right: 10px;
-  margin-left: 10px;
-}
-
-.IS10 {
-  width: 50%;
-}
-
-.IS11 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS12 {
-  width: 50%;
-}
-
-.IS13 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS14 {
-  border-bottom-width: 1px;
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-right: 10px;
-  margin-left: 10px;
-}
-
-.IS15 {
-  width: 50%;
-}
-
-.IS16 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS17 {
-  width: 50%;
-}
-
-.IS18 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS19 {
-  width: 50%;
-}
-
-.IS20 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
-  margin-top: 5px;
-  margin-bottom: 5px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS21 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS21"
->
-  <div
-    className="css-view-1dbjc4n IS20"
+    className="css-view-1dbjc4n IS4"
   >
     <div
       className="css-view-1dbjc4n IS1"
     >
-      <TileAS
-        breakpoint="wide"
+      <TileC
         tileName="lead1"
       />
     </div>
@@ -2781,113 +1585,159 @@ exports[`13. list two and six no pic 1`] = `
     <div
       className="css-view-1dbjc4n IS3"
     >
-      <TileAS
-        breakpoint="wide"
+      <TileC
         tileName="lead2"
       />
     </div>
+  </div>,
+  <style>
+.IS1 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+</style>
+
+<div
+    className="css-view-1dbjc4n IS1"
+  />,
+  <style>
+.IS1 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS2 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS3 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS4 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS5 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+</style>
+
+<div
+    className="css-view-1dbjc4n"
+  >
+    <TileL
+      tileName="support1"
+    />
+    <div
+      className="css-view-1dbjc4n IS1"
+    />
+    <TileL
+      tileName="support2"
+    />
+    <div
+      className="css-view-1dbjc4n IS2"
+    />
+    <TileL
+      tileName="support3"
+    />
+    <div
+      className="css-view-1dbjc4n IS3"
+    />
+    <TileL
+      tileName="support4"
+    />
     <div
       className="css-view-1dbjc4n IS4"
     />
+    <TileL
+      tileName="support5"
+    />
     <div
-      className="css-view-1dbjc4n IS19"
-    >
-      <div
-        className="css-view-1dbjc4n IS8"
-      >
-        <div
-          className="css-view-1dbjc4n IS5"
-        >
-          <TileL
-            breakpoint="wide"
-            tileName="support1"
-          />
-        </div>
-        <div
-          className="css-view-1dbjc4n IS6"
-        />
-        <div
-          className="css-view-1dbjc4n IS7"
-        >
-          <TileL
-            breakpoint="wide"
-            tileName="support2"
-          />
-        </div>
-      </div>
-      <div
-        className="css-view-1dbjc4n IS9"
-      />
-      <div
-        className="css-view-1dbjc4n IS13"
-      >
-        <div
-          className="css-view-1dbjc4n IS10"
-        >
-          <TileL
-            breakpoint="wide"
-            tileName="support3"
-          />
-        </div>
-        <div
-          className="css-view-1dbjc4n IS11"
-        />
-        <div
-          className="css-view-1dbjc4n IS12"
-        >
-          <TileL
-            breakpoint="wide"
-            tileName="support4"
-          />
-        </div>
-      </div>
-      <div
-        className="css-view-1dbjc4n IS14"
-      />
-      <div
-        className="css-view-1dbjc4n IS18"
-      >
-        <div
-          className="css-view-1dbjc4n IS15"
-        >
-          <TileL
-            breakpoint="wide"
-            tileName="support5"
-          />
-        </div>
-        <div
-          className="css-view-1dbjc4n IS16"
-        />
-        <div
-          className="css-view-1dbjc4n IS17"
-        >
-          <TileL
-            breakpoint="wide"
-            tileName="support6"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+      className="css-view-1dbjc4n IS5"
+    />
+    <TileL
+      tileName="support6"
+    />
+  </div>,
+]
 `;
 
 exports[`14. leaders 1`] = `
 <style>
 .IS1 {
-  height: 42;
-  width: 237;
+  height: 51;
+  width: 283;
 }
 
 .IS2 {
   color: rgba(133,0,41,1.00);
   font-family: TimesDigitalW04-Regular;
-  font-size: 15px;
-  line-height: 15px;
+  font-size: 16px;
+  line-height: 18px;
   text-align: center;
 }
 
 .IS3 {
+  padding-bottom: 5px;
   padding-top: 10px;
 }
 
@@ -2899,147 +1749,85 @@ exports[`14. leaders 1`] = `
 }
 
 .IS5 {
-  padding-right: 20px;
-  padding-left: 20px;
-  width: 33%;
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
 }
 
 .IS6 {
+  border-bottom-width: 1px;
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-bottom-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
   border-top-style: solid;
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-bottom: 60px;
-  margin-top: 30px;
+  margin-right: 10px;
+  margin-left: 10px;
 }
 
 .IS7 {
-  padding-right: 20px;
-  padding-left: 20px;
-  width: 33%;
+  padding-bottom: 5px;
 }
 
 .IS8 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-bottom: 60px;
-  margin-top: 30px;
-}
-
-.IS9 {
-  padding-right: 20px;
-  padding-left: 20px;
-  width: 33%;
-}
-
-.IS10 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS11 {
   background-color: rgba(240,240,240,1.00);
-  margin-right: 20px;
-  margin-left: 20px;
-  margin-top: 15px;
-  margin-bottom: 15px;
-  padding-top: 30px;
-}
-
-.IS12 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
+  padding-top: 20px;
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS12"
+  className="css-view-1dbjc4n IS8"
 >
   <div
-    className="css-view-1dbjc4n IS11"
+    className="css-view-1dbjc4n IS4"
   >
+    <Image
+      aspectRatio={5.74}
+      className="IS1"
+      uri="https://www.thetimes.co.uk/d/img/leaders-masthead-d17db00289.png"
+    />
     <div
-      className="css-view-1dbjc4n IS4"
-    >
-      <Image
-        aspectRatio={5.74}
-        className="IS1"
-        uri="https://www.thetimes.co.uk/d/img/leaders-masthead-d17db00289.png"
-      />
-      <div
-        className="css-view-1dbjc4n IS3"
-      >
-        <div
-          className="css-text-901oao IS2"
-        >
-           Leading Articles 
-        </div>
-      </div>
-    </div>
-    <div
-      className="css-view-1dbjc4n IS10"
+      className="css-view-1dbjc4n IS3"
     >
       <div
-        className="css-view-1dbjc4n IS5"
+        className="css-text-901oao IS2"
       >
-        <TileM
-          breakpoint="wide"
-          tileName="leader2"
-        />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS6"
-      />
-      <div
-        className="css-view-1dbjc4n IS7"
-      >
-        <TileM
-          breakpoint="wide"
-          tileName="leader1"
-        />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS8"
-      />
-      <div
-        className="css-view-1dbjc4n IS9"
-      >
-        <TileM
-          breakpoint="wide"
-          tileName="leader3"
-        />
+         Leading Articles 
       </div>
     </div>
+  </div>
+  <div
+    className="css-view-1dbjc4n IS7"
+  >
+    <TileM
+      breakpoint="small"
+      tileName="leader1"
+    />
+    <div
+      className="css-view-1dbjc4n IS5"
+    />
+    <TileM
+      breakpoint="small"
+      tileName="leader2"
+    />
+    <div
+      className="css-view-1dbjc4n IS6"
+    />
+    <TileM
+      breakpoint="small"
+      tileName="leader3"
+    />
   </div>
 </div>
 `;
@@ -3047,101 +1835,74 @@ exports[`14. leaders 1`] = `
 exports[`15. comment lead and cartoon 1`] = `
 <style>
 .IS1 {
-  width: 33.3%;
-}
-
-.IS2 {
+  border-bottom-width: 1px;
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-bottom-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
   border-top-style: solid;
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS3 {
-  width: 66.7%;
-}
-
-.IS4 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding-right: 10px;
-  padding-left: 10px;
-  padding-top: 5px;
-  padding-bottom: 5px;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS5 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
+  margin-right: 10px;
+  margin-left: 10px;
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS5"
+  className="css-view-1dbjc4n"
 >
+  <TileP
+    tileName="lead"
+  />
   <div
-    className="css-view-1dbjc4n IS4"
-  >
-    <div
-      className="css-view-1dbjc4n IS1"
-    >
-      <TileAH
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS3"
-    >
-      <TileAI
-        breakpoint="wide"
-        tileName="cartoon"
-      />
-    </div>
-  </div>
+    className="css-view-1dbjc4n IS1"
+  />
+  <TileQ
+    tileName="cartoon"
+  />
 </div>
 `;
 
 exports[`16. puzzle 1`] = `
 <style>
 .IS1 {
-  width: 33.3%;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 
 .IS2 {
-  width: 33.3%;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 
 .IS3 {
-  width: 33.3%;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 
 .IS4 {
@@ -3151,106 +1912,83 @@ exports[`16. puzzle 1`] = `
   flex-shrink: 1;
   -webkit-flex-basis: 0%;
   flex-basis: 0%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   padding-right: 10px;
   padding-left: 10px;
-  padding-top: 15px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-}
-
-.IS5 {
-  -webkit-align-self: center;
-  align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
-  -ms-flex-item-align: center;
 }
 </style>
 
 <div
-  className="css-view-1dbjc4n IS5"
+  className="css-view-1dbjc4n IS4"
 >
   <div
-    className="css-view-1dbjc4n IS4"
+    className="css-view-1dbjc4n IS1"
   >
-    <div
-      className="css-view-1dbjc4n IS1"
-    >
-      <TileAK
-        breakpoint="wide"
-        id="0"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          }
+    <TileAJ
+      id="0"
+      image={
+        Object {
+          "crop11": null,
+          "crop169": null,
+          "crop23": null,
+          "crop32": Object {
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+          },
+          "crop45": null,
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
         }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    >
-      <TileAK
-        breakpoint="wide"
-        id="1"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          }
+      }
+      title="Times Concise medium No 7881"
+      url="/crossword/123"
+    />
+  </div>
+  <div
+    className="css-view-1dbjc4n IS2"
+  >
+    <TileAJ
+      id="1"
+      image={
+        Object {
+          "crop11": null,
+          "crop169": null,
+          "crop23": null,
+          "crop32": Object {
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+          },
+          "crop45": null,
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
         }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS3"
-    >
-      <TileAK
-        breakpoint="wide"
-        id="2"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          }
+      }
+      title="Times Concise medium No 7881"
+      url="/crossword/123"
+    />
+  </div>
+  <div
+    className="css-view-1dbjc4n IS3"
+  >
+    <TileAJ
+      id="2"
+      image={
+        Object {
+          "crop11": null,
+          "crop169": null,
+          "crop23": null,
+          "crop32": Object {
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+          },
+          "crop45": null,
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
         }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </div>
+      }
+      title="Times Concise medium No 7881"
+      url="/crossword/123"
+    />
   </div>
 </div>
 `;

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -2,104 +2,77 @@
 
 exports[`1. daily universal register 1`] = `
 <div>
+  <Image
+    aspectRatio={1}
+    uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
+  />
   <div>
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-    />
-    <div>
-      Daily Universal Register
-    </div>
-    <div>
-      <div>
-        <TileS
-          breakpoint="wide"
-        />
-        <div />
-        <TileS
-          breakpoint="wide"
-          logo={
-            <Logo
-              imageUri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
-              ratio={1}
-              type="nature notes"
-            />
-          }
-        />
-      </div>
-      <div />
-      <div>
-        <TileS
-          breakpoint="wide"
-        />
-        <div />
-        <TileS
-          breakpoint="wide"
-          logo={
-            <Logo
-              imageUri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
-              ratio={1}
-              type="birthdays"
-            />
-          }
-        />
-      </div>
-    </div>
+    Daily Universal Register
   </div>
+  <TileS
+    breakpoint="small"
+  />
+  <div />
+  <TileS
+    breakpoint="small"
+  />
+  <div />
+  <Image
+    aspectRatio={1}
+    uri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
+  />
+  <TileS
+    breakpoint="small"
+  />
+  <div />
+  <Image
+    aspectRatio={1}
+    uri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
+  />
+  <TileS
+    breakpoint="small"
+  />
 </div>
 `;
 
 exports[`1. secondary one and four 1`] = `
 <div>
   <div>
-    <div>
-      <TheSTLogo
-        height={40}
-        width={60}
-      />
-    </div>
-    <div />
+    <TheSTLogo
+      height={40}
+      width={60}
+    />
+  </div>
+  <div />
+  <div>
     <div>
       <div>
         <TileN
-          breakpoint="wide"
+          breakpoint="small"
           tileName="secondary"
         />
       </div>
+    </div>
+    <div>
+      <TileO
+        breakpoint="small"
+        tileName="support1"
+      />
       <div />
-      <div>
-        <div>
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support1"
-            />
-          </div>
-          <div />
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support2"
-            />
-          </div>
-        </div>
-        <div />
-        <div>
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support3"
-            />
-          </div>
-          <div />
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support4"
-            />
-          </div>
-        </div>
-      </div>
+      <TileO
+        breakpoint="small"
+        tileName="support2"
+      />
+      <div />
+      <TileO
+        breakpoint="small"
+        tileName="support3"
+      />
+      <div />
+      <TileO
+        breakpoint="small"
+        tileName="support4"
+      />
     </div>
   </div>
 </div>
@@ -108,196 +81,39 @@ exports[`1. secondary one and four 1`] = `
 exports[`1. secondary one and four 2`] = `
 <div>
   <div>
-    <div>
-      <TheTimesLogo
-        height={37}
-        width={35}
-      />
-    </div>
-    <div />
+    <TheTimesLogo
+      height={37}
+      width={35}
+    />
+  </div>
+  <div />
+  <div>
     <div>
       <div>
         <TileN
-          breakpoint="wide"
+          breakpoint="small"
           tileName="secondary"
         />
       </div>
-      <div />
-      <div>
-        <div>
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support1"
-            />
-          </div>
-          <div />
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support2"
-            />
-          </div>
-        </div>
-        <div />
-        <div>
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support3"
-            />
-          </div>
-          <div />
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support4"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`2. lead one full width 1`] = `
-<div>
-  <TileR
-    breakpoint="wide"
-    tileName="lead"
-  />
-</div>
-`;
-
-exports[`2. leaders 1`] = `
-<div>
-  <div>
-    <div>
-      <Image
-        aspectRatio={5.4}
-        uri="https://www.thetimes.co.uk/d/img/logos/sundaytimes-with-crest-black-53d6e31fb8.png"
-      />
-      <div>
-        <div>
-           Leading Articles 
-        </div>
-      </div>
     </div>
     <div>
-      <div>
-        <TileM
-          breakpoint="wide"
-          tileName="leader2"
-        />
-      </div>
-      <div />
-      <div>
-        <TileM
-          breakpoint="wide"
-          tileName="leader1"
-        />
-      </div>
-      <div />
-      <div>
-        <TileM
-          breakpoint="wide"
-          tileName="leader3"
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`2. leaders 2`] = `
-<div>
-  <div>
-    <div>
-      <Image
-        aspectRatio={5.74}
-        uri="https://www.thetimes.co.uk/d/img/leaders-masthead-d17db00289.png"
-      />
-      <div>
-        <div>
-           Leading Articles 
-        </div>
-      </div>
-    </div>
-    <div>
-      <div>
-        <TileM
-          breakpoint="wide"
-          tileName="leader2"
-        />
-      </div>
-      <div />
-      <div>
-        <TileM
-          breakpoint="wide"
-          tileName="leader1"
-        />
-      </div>
-      <div />
-      <div>
-        <TileM
-          breakpoint="wide"
-          tileName="leader3"
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`3. lead one and one 1`] = `
-<div>
-  <div>
-    <div>
-      <TileZ
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAF
-        breakpoint="wide"
-        tileName="support"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`4. lead one and four 1`] = `
-<div>
-  <div>
-    <div>
-      <TileAC
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAD
-        breakpoint="wide"
+      <TileO
+        breakpoint="small"
         tileName="support1"
       />
       <div />
-      <TileAD
-        breakpoint="wide"
+      <TileO
+        breakpoint="small"
         tileName="support2"
       />
       <div />
-      <TileAD
-        breakpoint="wide"
+      <TileO
+        breakpoint="small"
         tileName="support3"
       />
       <div />
-      <TileAD
-        breakpoint="wide"
+      <TileO
+        breakpoint="small"
         tileName="support4"
       />
     </div>
@@ -305,34 +121,159 @@ exports[`4. lead one and four 1`] = `
 </div>
 `;
 
+exports[`2. lead one full width 1`] = `
+<TileA
+  tileName="lead"
+/>
+`;
+
+exports[`2. leaders 1`] = `
+<div>
+  <div>
+    <Image
+      aspectRatio={5.4}
+      uri="https://www.thetimes.co.uk/d/img/logos/sundaytimes-with-crest-black-53d6e31fb8.png"
+    />
+    <div>
+      <div>
+         Leading Articles 
+      </div>
+    </div>
+  </div>
+  <div>
+    <TileM
+      breakpoint="small"
+      tileName="leader1"
+    />
+    <div />
+    <TileM
+      breakpoint="small"
+      tileName="leader2"
+    />
+    <div />
+    <TileM
+      breakpoint="small"
+      tileName="leader3"
+    />
+  </div>
+</div>
+`;
+
+exports[`2. leaders 2`] = `
+<div>
+  <div>
+    <Image
+      aspectRatio={5.74}
+      uri="https://www.thetimes.co.uk/d/img/leaders-masthead-d17db00289.png"
+    />
+    <div>
+      <div>
+         Leading Articles 
+      </div>
+    </div>
+  </div>
+  <div>
+    <TileM
+      breakpoint="small"
+      tileName="leader1"
+    />
+    <div />
+    <TileM
+      breakpoint="small"
+      tileName="leader2"
+    />
+    <div />
+    <TileM
+      breakpoint="small"
+      tileName="leader3"
+    />
+  </div>
+</div>
+`;
+
+exports[`3. lead one and one 1`] = `
+<div>
+  <TileA
+    tileName="lead"
+  />
+  <div />
+  <TileB
+    tileName="support"
+  />
+</div>
+`;
+
+exports[`4. lead one and four 1`] = `
+Array [
+  <TileI
+    tileName="lead"
+  />,
+  <div>
+    <TileJ
+      tileName="support1"
+    />
+    <div />
+    <TileJ
+      tileName="support2"
+    />
+    <div />
+    <TileJ
+      tileName="support3"
+    />
+    <div />
+    <TileJ
+      tileName="support4"
+    />
+  </div>,
+]
+`;
+
 exports[`5. standard 1`] = `
 <div>
   <div>
     <div>
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem1"
-      />
-      <div />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem2"
-      />
-      <div />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem3"
-      />
-      <div />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem4"
-      />
-      <div />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem5"
-      />
+      <div>
+        <TileK
+          breakpoint="small"
+          tileName="standardItem1"
+        />
+        <div />
+      </div>
+    </div>
+    <div>
+      <div>
+        <TileK
+          breakpoint="small"
+          tileName="standardItem2"
+        />
+        <div />
+      </div>
+    </div>
+    <div>
+      <div>
+        <TileK
+          breakpoint="small"
+          tileName="standardItem3"
+        />
+        <div />
+      </div>
+    </div>
+    <div>
+      <div>
+        <TileK
+          breakpoint="small"
+          tileName="standardItem4"
+        />
+        <div />
+      </div>
+    </div>
+    <div>
+      <div>
+        <TileK
+          breakpoint="small"
+          tileName="standardItem5"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -340,430 +281,316 @@ exports[`5. standard 1`] = `
 
 exports[`6. lead two no pic and two 1`] = `
 <div>
-  <div>
-    <div>
-      <TileX
-        breakpoint="wide"
-        tileName="lead1"
-      />
-      <div />
-      <TileY
-        breakpoint="wide"
-        tileName="lead2"
-      />
-    </div>
-    <div />
-    <div>
-      <TileE
-        breakpoint="wide"
-        tileName="support1"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAL
-        breakpoint="wide"
-        tileName="support2"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`7. secondary one 1`] = `
-<div>
-  <TileW
-    breakpoint="wide"
-    tileName="secondary"
+  <TileF
+    tileName="lead1"
+  />
+  <div />
+  <TileB
+    tileName="lead2"
+  />
+  <div />
+  <TileD
+    tileName="support1"
+  />
+  <div />
+  <TileE
+    tileName="support2"
   />
 </div>
 `;
 
+exports[`7. secondary one 1`] = `
+<TileA
+  tileName="secondary"
+/>
+`;
+
 exports[`8. secondary one and columnist 1`] = `
 <div>
-  <div>
-    <div>
-      <TileAB
-        breakpoint="wide"
-        tileName="columnist"
-      />
-    </div>
-    <div />
-    <div>
-      <TileB
-        breakpoint="wide"
-        tileName="secondary"
-        withMoreTeaser={true}
-      />
-    </div>
-  </div>
+  <TileT
+    tileName="secondary"
+  />
+  <div />
+  <TileH
+    tileName="columnist"
+  />
 </div>
 `;
 
 exports[`9. secondary four 1`] = `
-<div>
+Array [
   <div>
     <div>
-      <div>
-        <TileAR
-          breakpoint="wide"
-          tileName="secondary1"
-        />
-      </div>
-      <div />
-      <div>
-        <TileAR
-          breakpoint="wide"
-          tileName="secondary2"
-        />
-      </div>
+      <TileC
+        tileName="secondary1"
+      />
     </div>
     <div />
     <div>
-      <TileB
-        additionalHeadlineStyles={
-          Object {
-            "fontSize": 20,
-            "lineHeight": 20,
-            "marginBottom": "5px",
-          }
-        }
-        breakpoint="wide"
+      <TileC
+        tileName="secondary2"
+      />
+    </div>
+  </div>,
+  <div />,
+  <div>
+    <div>
+      <TileC
         tileName="secondary3"
       />
-      <div />
-      <TileB
-        additionalHeadlineStyles={
-          Object {
-            "fontSize": 20,
-            "lineHeight": 20,
-            "marginBottom": "5px",
-          }
-        }
-        breakpoint="wide"
+    </div>
+    <div />
+    <div>
+      <TileC
         tileName="secondary4"
       />
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`10. secondary one and four 1`] = `
 <div>
   <div>
-    <div>
-      <TheTimesLogo
-        height={37}
-        width={35}
-      />
-    </div>
-    <div />
+    <TheTimesLogo
+      height={37}
+      width={35}
+    />
+  </div>
+  <div />
+  <div>
     <div>
       <div>
         <TileN
-          breakpoint="wide"
+          breakpoint="small"
           tileName="secondary"
         />
       </div>
+    </div>
+    <div>
+      <TileO
+        breakpoint="small"
+        tileName="support1"
+      />
       <div />
-      <div>
-        <div>
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support1"
-            />
-          </div>
-          <div />
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support2"
-            />
-          </div>
-        </div>
-        <div />
-        <div>
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support3"
-            />
-          </div>
-          <div />
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support4"
-            />
-          </div>
-        </div>
-      </div>
+      <TileO
+        breakpoint="small"
+        tileName="support2"
+      />
+      <div />
+      <TileO
+        breakpoint="small"
+        tileName="support3"
+      />
+      <div />
+      <TileO
+        breakpoint="small"
+        tileName="support4"
+      />
     </div>
   </div>
 </div>
 `;
 
 exports[`11. secondary two and two 1`] = `
-<div>
+Array [
   <div>
     <div>
-      <TileAM
+      <TileC
         tileName="secondary1"
       />
     </div>
     <div />
     <div>
-      <TileAN
-        tileName="support1"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAM
+      <TileC
         tileName="secondary2"
       />
     </div>
-    <div />
-    <div>
-      <TileAN
-        tileName="support2"
-      />
-    </div>
-  </div>
-</div>
+  </div>,
+  <div />,
+  <div>
+    <TileG
+      tileName="support1"
+    />
+  </div>,
+  <div />,
+  <div>
+    <TileG
+      tileName="support2"
+    />
+  </div>,
+]
 `;
 
 exports[`12. secondary two no pic and two 1`] = `
 <div>
-  <div>
-    <div>
-      <div>
-        <TileAE
-          breakpoint="wide"
-          tileName="secondary1"
-        />
-      </div>
-      <div />
-      <div>
-        <TileAE
-          breakpoint="wide"
-          tileName="secondary2"
-        />
-      </div>
-    </div>
-    <div />
-    <div>
-      <TileG
-        breakpoint="wide"
-        tileName="support1"
-      />
-      <div />
-      <TileG
-        breakpoint="wide"
-        tileName="support2"
-      />
-    </div>
-  </div>
+  <TileB
+    tileName="secondary1"
+  />
+  <div />
+  <TileB
+    tileName="secondary2"
+  />
+  <div />
+  <TileG
+    tileName="support1"
+  />
+  <div />
+  <TileG
+    tileName="support2"
+  />
 </div>
 `;
 
 exports[`13. list two and six no pic 1`] = `
-<div>
+Array [
   <div>
     <div>
-      <TileAS
-        breakpoint="wide"
+      <TileC
         tileName="lead1"
       />
     </div>
     <div />
     <div>
-      <TileAS
-        breakpoint="wide"
+      <TileC
         tileName="lead2"
       />
     </div>
+  </div>,
+  <div />,
+  <div>
+    <TileL
+      tileName="support1"
+    />
     <div />
-    <div>
-      <div>
-        <div>
-          <TileL
-            breakpoint="wide"
-            tileName="support1"
-          />
-        </div>
-        <div />
-        <div>
-          <TileL
-            breakpoint="wide"
-            tileName="support2"
-          />
-        </div>
-      </div>
-      <div />
-      <div>
-        <div>
-          <TileL
-            breakpoint="wide"
-            tileName="support3"
-          />
-        </div>
-        <div />
-        <div>
-          <TileL
-            breakpoint="wide"
-            tileName="support4"
-          />
-        </div>
-      </div>
-      <div />
-      <div>
-        <div>
-          <TileL
-            breakpoint="wide"
-            tileName="support5"
-          />
-        </div>
-        <div />
-        <div>
-          <TileL
-            breakpoint="wide"
-            tileName="support6"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+    <TileL
+      tileName="support2"
+    />
+    <div />
+    <TileL
+      tileName="support3"
+    />
+    <div />
+    <TileL
+      tileName="support4"
+    />
+    <div />
+    <TileL
+      tileName="support5"
+    />
+    <div />
+    <TileL
+      tileName="support6"
+    />
+  </div>,
+]
 `;
 
 exports[`14. leaders 1`] = `
 <div>
   <div>
-    <div>
-      <Image
-        aspectRatio={5.74}
-        uri="https://www.thetimes.co.uk/d/img/leaders-masthead-d17db00289.png"
-      />
-      <div>
-        <div>
-           Leading Articles 
-        </div>
-      </div>
-    </div>
+    <Image
+      aspectRatio={5.74}
+      uri="https://www.thetimes.co.uk/d/img/leaders-masthead-d17db00289.png"
+    />
     <div>
       <div>
-        <TileM
-          breakpoint="wide"
-          tileName="leader2"
-        />
-      </div>
-      <div />
-      <div>
-        <TileM
-          breakpoint="wide"
-          tileName="leader1"
-        />
-      </div>
-      <div />
-      <div>
-        <TileM
-          breakpoint="wide"
-          tileName="leader3"
-        />
+         Leading Articles 
       </div>
     </div>
+  </div>
+  <div>
+    <TileM
+      breakpoint="small"
+      tileName="leader1"
+    />
+    <div />
+    <TileM
+      breakpoint="small"
+      tileName="leader2"
+    />
+    <div />
+    <TileM
+      breakpoint="small"
+      tileName="leader3"
+    />
   </div>
 </div>
 `;
 
 exports[`15. comment lead and cartoon 1`] = `
 <div>
-  <div>
-    <div>
-      <TileAH
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAI
-        breakpoint="wide"
-        tileName="cartoon"
-      />
-    </div>
-  </div>
+  <TileP
+    tileName="lead"
+  />
+  <div />
+  <TileQ
+    tileName="cartoon"
+  />
 </div>
 `;
 
 exports[`16. puzzle 1`] = `
 <div>
   <div>
-    <div>
-      <TileAK
-        breakpoint="wide"
-        id="0"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          }
+    <TileAJ
+      id="0"
+      image={
+        Object {
+          "crop11": null,
+          "crop169": null,
+          "crop23": null,
+          "crop32": Object {
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+          },
+          "crop45": null,
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
         }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </div>
-    <div>
-      <TileAK
-        breakpoint="wide"
-        id="1"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          }
+      }
+      title="Times Concise medium No 7881"
+      url="/crossword/123"
+    />
+  </div>
+  <div>
+    <TileAJ
+      id="1"
+      image={
+        Object {
+          "crop11": null,
+          "crop169": null,
+          "crop23": null,
+          "crop32": Object {
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+          },
+          "crop45": null,
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
         }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </div>
-    <div>
-      <TileAK
-        breakpoint="wide"
-        id="2"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          }
+      }
+      title="Times Concise medium No 7881"
+      url="/crossword/123"
+    />
+  </div>
+  <div>
+    <TileAJ
+      id="2"
+      image={
+        Object {
+          "crop11": null,
+          "crop169": null,
+          "crop23": null,
+          "crop32": Object {
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+          },
+          "crop45": null,
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
         }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </div>
+      }
+      title="Times Concise medium No 7881"
+      url="/crossword/123"
+    />
   </div>
 </div>
 `;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -34,8 +34,8 @@ exports[`1. comment lead and cartoon - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 10px;
-  padding-left: 10px;
+  padding-right: 20px;
+  padding-left: 20px;
   padding-top: 5px;
   padding-bottom: 5px;
   -ms-flex-positive: 1;
@@ -67,7 +67,7 @@ exports[`1. comment lead and cartoon - medium 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileAH
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="lead"
       />
     </div>
@@ -78,7 +78,7 @@ exports[`1. comment lead and cartoon - medium 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAI
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="cartoon"
       />
     </div>
@@ -120,7 +120,7 @@ exports[`2. daily universal register - medium 1`] = `
 .IS4 {
   width: 60;
   height: 45;
-  margin-right: 15px;
+  margin-right: 10px;
 }
 
 .IS5 {
@@ -167,7 +167,7 @@ exports[`2. daily universal register - medium 1`] = `
 .IS8 {
   width: 60;
   height: 45;
-  margin-right: 15px;
+  margin-right: 10px;
 }
 
 .IS9 {
@@ -211,8 +211,8 @@ exports[`2. daily universal register - medium 1`] = `
   flex-shrink: 1;
   -webkit-flex-basis: 0%;
   flex-basis: 0%;
-  margin-right: 20px;
-  margin-left: 20px;
+  margin-right: 30px;
+  margin-left: 30px;
   margin-top: 15px;
   margin-bottom: 15px;
   padding-top: 15px;
@@ -261,13 +261,13 @@ exports[`2. daily universal register - medium 1`] = `
         className="css-view-1dbjc4n IS5"
       >
         <TileS
-          breakpoint="wide"
+          breakpoint="medium"
         />
         <div
           className="css-view-1dbjc4n IS3"
         />
         <TileS
-          breakpoint="wide"
+          breakpoint="medium"
           logo={
             <Logo
               className="IS4"
@@ -285,13 +285,13 @@ exports[`2. daily universal register - medium 1`] = `
         className="css-view-1dbjc4n IS9"
       >
         <TileS
-          breakpoint="wide"
+          breakpoint="medium"
         />
         <div
           className="css-view-1dbjc4n IS7"
         />
         <TileS
-          breakpoint="wide"
+          breakpoint="medium"
           logo={
             <Logo
               className="IS8"
@@ -310,7 +310,7 @@ exports[`2. daily universal register - medium 1`] = `
 exports[`3. lead one and one - medium 1`] = `
 <style>
 .IS1 {
-  width: 83.5%;
+  width: 75%;
 }
 
 .IS2 {
@@ -328,7 +328,7 @@ exports[`3. lead one and one - medium 1`] = `
 }
 
 .IS3 {
-  width: 16.5%;
+  width: 25%;
 }
 
 .IS4 {
@@ -341,8 +341,8 @@ exports[`3. lead one and one - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
+  margin-right: 20px;
+  margin-left: 20px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -371,8 +371,8 @@ exports[`3. lead one and one - medium 1`] = `
     <div
       className="css-view-1dbjc4n IS1"
     >
-      <TileZ
-        breakpoint="wide"
+      <TileU
+        breakpoint="medium"
         tileName="lead"
       />
     </div>
@@ -382,8 +382,8 @@ exports[`3. lead one and one - medium 1`] = `
     <div
       className="css-view-1dbjc4n IS3"
     >
-      <TileAF
-        breakpoint="wide"
+      <TileAA
+        breakpoint="medium"
         tileName="support"
       />
     </div>
@@ -408,7 +408,7 @@ exports[`4. lead one full width - medium 1`] = `
   className="css-view-1dbjc4n IS1"
 >
   <TileR
-    breakpoint="wide"
+    breakpoint="medium"
     tileName="lead"
   />
 </div>
@@ -431,7 +431,7 @@ exports[`5. lead two no pic and two - medium 1`] = `
 }
 
 .IS2 {
-  width: 42%;
+  width: 50%;
 }
 
 .IS3 {
@@ -449,28 +449,24 @@ exports[`5. lead two no pic and two - medium 1`] = `
 }
 
 .IS4 {
-  width: 42%;
-}
-
-.IS5 {
+  border-bottom-width: 1px;
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
   border-bottom-color: rgba(219,219,219,1.00);
   border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
   border-top-style: solid;
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-top: 15px;
-  margin-bottom: 15px;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS5 {
+  width: 50%;
 }
 
 .IS6 {
-  width: 16%;
-}
-
-.IS7 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -480,8 +476,8 @@ exports[`5. lead two no pic and two - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
+  margin-right: 20px;
+  margin-left: 20px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -490,7 +486,7 @@ exports[`5. lead two no pic and two - medium 1`] = `
   -webkit-box-direction: normal;
 }
 
-.IS8 {
+.IS7 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -502,23 +498,23 @@ exports[`5. lead two no pic and two - medium 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS8"
+  className="css-view-1dbjc4n IS7"
 >
   <div
-    className="css-view-1dbjc4n IS7"
+    className="css-view-1dbjc4n IS6"
   >
     <div
       className="css-view-1dbjc4n IS2"
     >
       <TileX
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="lead1"
       />
       <div
         className="css-view-1dbjc4n IS1"
       />
       <TileY
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="lead2"
       />
     </div>
@@ -526,21 +522,17 @@ exports[`5. lead two no pic and two - medium 1`] = `
       className="css-view-1dbjc4n IS3"
     />
     <div
-      className="css-view-1dbjc4n IS4"
+      className="css-view-1dbjc4n IS5"
     >
       <TileE
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="support1"
       />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS5"
-    />
-    <div
-      className="css-view-1dbjc4n IS6"
-    >
-      <TileAL
-        breakpoint="wide"
+      <div
+        className="css-view-1dbjc4n IS4"
+      />
+      <TileD
+        breakpoint="medium"
         tileName="support2"
       />
     </div>
@@ -575,8 +567,8 @@ exports[`6. leaders slice - medium 1`] = `
 }
 
 .IS5 {
-  padding-right: 20px;
-  padding-left: 20px;
+  padding-right: 15px;
+  padding-left: 15px;
   width: 33%;
 }
 
@@ -590,13 +582,13 @@ exports[`6. leaders slice - medium 1`] = `
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-bottom: 60px;
   margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 .IS7 {
-  padding-right: 20px;
-  padding-left: 20px;
+  padding-right: 15px;
+  padding-left: 15px;
   width: 33%;
 }
 
@@ -610,13 +602,13 @@ exports[`6. leaders slice - medium 1`] = `
   border-right-style: solid;
   border-bottom-style: solid;
   border-left-style: solid;
-  margin-bottom: 60px;
   margin-top: 30px;
+  margin-bottom: 30px;
 }
 
 .IS9 {
-  padding-right: 20px;
-  padding-left: 20px;
+  padding-right: 15px;
+  padding-left: 15px;
   width: 33%;
 }
 
@@ -630,6 +622,8 @@ exports[`6. leaders slice - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  padding-right: 5px;
+  padding-left: 5px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -640,8 +634,8 @@ exports[`6. leaders slice - medium 1`] = `
 
 .IS11 {
   background-color: rgba(240,240,240,1.00);
-  margin-right: 20px;
-  margin-left: 20px;
+  margin-right: 30px;
+  margin-left: 30px;
   margin-top: 15px;
   margin-bottom: 15px;
   padding-top: 30px;
@@ -689,7 +683,7 @@ exports[`6. leaders slice - medium 1`] = `
         className="css-view-1dbjc4n IS5"
       >
         <TileM
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="leader2"
         />
       </div>
@@ -700,7 +694,7 @@ exports[`6. leaders slice - medium 1`] = `
         className="css-view-1dbjc4n IS7"
       >
         <TileM
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="leader1"
         />
       </div>
@@ -711,7 +705,7 @@ exports[`6. leaders slice - medium 1`] = `
         className="css-view-1dbjc4n IS9"
       >
         <TileM
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="leader3"
         />
       </div>
@@ -889,8 +883,8 @@ exports[`7. secondary one and four - medium 1`] = `
 
 .IS16 {
   background-color: rgba(39,45,52,1.00);
-  margin-right: 20px;
-  margin-left: 20px;
+  margin-right: 30px;
+  margin-left: 30px;
   margin-top: 15px;
   margin-bottom: 15px;
 }
@@ -930,7 +924,7 @@ exports[`7. secondary one and four - medium 1`] = `
         className="css-view-1dbjc4n IS3"
       >
         <TileN
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="secondary"
         />
       </div>
@@ -947,7 +941,7 @@ exports[`7. secondary one and four - medium 1`] = `
             className="css-view-1dbjc4n IS5"
           >
             <TileO
-              breakpoint="wide"
+              breakpoint="medium"
               tileName="support1"
             />
           </div>
@@ -958,7 +952,7 @@ exports[`7. secondary one and four - medium 1`] = `
             className="css-view-1dbjc4n IS7"
           >
             <TileO
-              breakpoint="wide"
+              breakpoint="medium"
               tileName="support2"
             />
           </div>
@@ -973,7 +967,7 @@ exports[`7. secondary one and four - medium 1`] = `
             className="css-view-1dbjc4n IS10"
           >
             <TileO
-              breakpoint="wide"
+              breakpoint="medium"
               tileName="support3"
             />
           </div>
@@ -984,7 +978,7 @@ exports[`7. secondary one and four - medium 1`] = `
             className="css-view-1dbjc4n IS12"
           >
             <TileO
-              breakpoint="wide"
+              breakpoint="medium"
               tileName="support4"
             />
           </div>
@@ -1012,7 +1006,7 @@ exports[`8. secondary one - medium 1`] = `
   className="css-view-1dbjc4n IS1"
 >
   <TileW
-    breakpoint="wide"
+    breakpoint="medium"
     tileName="secondary"
   />
 </div>
@@ -1131,8 +1125,8 @@ exports[`9. secondary four - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
+  margin-right: 20px;
+  margin-left: 20px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -1165,7 +1159,7 @@ exports[`9. secondary four - medium 1`] = `
         className="css-view-1dbjc4n IS1"
       >
         <TileAR
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="secondary1"
         />
       </div>
@@ -1176,7 +1170,7 @@ exports[`9. secondary four - medium 1`] = `
         className="css-view-1dbjc4n IS3"
       >
         <TileAR
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="secondary2"
         />
       </div>
@@ -1188,28 +1182,14 @@ exports[`9. secondary four - medium 1`] = `
       className="css-view-1dbjc4n IS7"
     >
       <TileB
-        additionalHeadlineStyles={
-          Object {
-            "fontSize": 20,
-            "lineHeight": 20,
-            "marginBottom": "5px",
-          }
-        }
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="secondary3"
       />
       <div
         className="css-view-1dbjc4n IS6"
       />
       <TileB
-        additionalHeadlineStyles={
-          Object {
-            "fontSize": 20,
-            "lineHeight": 20,
-            "marginBottom": "5px",
-          }
-        }
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="secondary4"
       />
     </div>
@@ -1220,7 +1200,7 @@ exports[`9. secondary four - medium 1`] = `
 exports[`10. secondary one and columnist - medium 1`] = `
 <style>
 .IS1 {
-  width: 66.7%;
+  width: 75%;
 }
 
 .IS2 {
@@ -1240,7 +1220,7 @@ exports[`10. secondary one and columnist - medium 1`] = `
 .IS3 {
   padding-top: 5px;
   padding-bottom: 5px;
-  width: 33.3%;
+  width: 25%;
 }
 
 .IS4 {
@@ -1253,8 +1233,8 @@ exports[`10. secondary one and columnist - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
+  margin-right: 20px;
+  margin-left: 20px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -1284,7 +1264,7 @@ exports[`10. secondary one and columnist - medium 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileAB
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="columnist"
       />
     </div>
@@ -1295,7 +1275,7 @@ exports[`10. secondary one and columnist - medium 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileB
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="secondary"
         withMoreTeaser={true}
       />
@@ -1307,7 +1287,7 @@ exports[`10. secondary one and columnist - medium 1`] = `
 exports[`11. secondary two and two - medium 1`] = `
 <style>
 .IS1 {
-  width: 33.4%;
+  width: 50%;
 }
 
 .IS2 {
@@ -1325,46 +1305,10 @@ exports[`11. secondary two and two - medium 1`] = `
 }
 
 .IS3 {
-  width: 16.6%;
+  width: 50%;
 }
 
 .IS4 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS5 {
-  width: 33.4%;
-}
-
-.IS6 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.IS7 {
-  width: 16.6%;
-}
-
-.IS8 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -1374,8 +1318,7 @@ exports[`11. secondary two and two - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
+  padding-bottom: 5px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -1384,7 +1327,77 @@ exports[`11. secondary two and two - medium 1`] = `
   -webkit-box-direction: normal;
 }
 
+.IS5 {
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS6 {
+  width: 50%;
+}
+
+.IS7 {
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-right-width: 1px;
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.IS8 {
+  width: 50%;
+}
+
 .IS9 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding-bottom: 5px;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+
+.IS10 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  margin-right: 20px;
+  margin-left: 20px;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS11 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -1396,47 +1409,57 @@ exports[`11. secondary two and two - medium 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS9"
+  className="css-view-1dbjc4n IS11"
 >
   <div
-    className="css-view-1dbjc4n IS8"
+    className="css-view-1dbjc4n IS10"
   >
     <div
-      className="css-view-1dbjc4n IS1"
-    >
-      <TileAM
-        tileName="secondary1"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS3"
-    >
-      <TileAN
-        tileName="support1"
-      />
-    </div>
-    <div
       className="css-view-1dbjc4n IS4"
-    />
+    >
+      <div
+        className="css-view-1dbjc4n IS1"
+      >
+        <TileV
+          tileName="secondary1"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS2"
+      />
+      <div
+        className="css-view-1dbjc4n IS3"
+      >
+        <TileV
+          tileName="secondary2"
+        />
+      </div>
+    </div>
     <div
       className="css-view-1dbjc4n IS5"
-    >
-      <TileAM
-        tileName="secondary2"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS6"
     />
     <div
-      className="css-view-1dbjc4n IS7"
+      className="css-view-1dbjc4n IS9"
     >
-      <TileAN
-        tileName="support2"
+      <div
+        className="css-view-1dbjc4n IS6"
+      >
+        <TileG
+          breakpoint="medium"
+          tileName="support1"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS7"
       />
+      <div
+        className="css-view-1dbjc4n IS8"
+      >
+        <TileG
+          breakpoint="medium"
+          tileName="support2"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -1518,8 +1541,8 @@ exports[`12. lead one and four slice - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
+  margin-right: 20px;
+  margin-left: 20px;
   padding-top: 5px;
   padding-bottom: 5px;
   -ms-flex-positive: 1;
@@ -1551,7 +1574,7 @@ exports[`12. lead one and four slice - medium 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileAC
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="lead"
       />
     </div>
@@ -1562,28 +1585,28 @@ exports[`12. lead one and four slice - medium 1`] = `
       className="css-view-1dbjc4n IS6"
     >
       <TileAD
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="support1"
       />
       <div
         className="css-view-1dbjc4n IS3"
       />
       <TileAD
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="support2"
       />
       <div
         className="css-view-1dbjc4n IS4"
       />
       <TileAD
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="support3"
       />
       <div
         className="css-view-1dbjc4n IS5"
       />
       <TileAD
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="support4"
       />
     </div>
@@ -1690,35 +1713,35 @@ exports[`13. standard slice - medium 1`] = `
       className="css-view-1dbjc4n"
     >
       <TileK
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="standardItem1"
       />
       <div
         className="css-view-1dbjc4n IS1"
       />
       <TileK
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="standardItem2"
       />
       <div
         className="css-view-1dbjc4n IS2"
       />
       <TileK
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="standardItem3"
       />
       <div
         className="css-view-1dbjc4n IS3"
       />
       <TileK
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="standardItem4"
       />
       <div
         className="css-view-1dbjc4n IS4"
       />
       <TileK
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="standardItem5"
       />
     </div>
@@ -1729,7 +1752,16 @@ exports[`13. standard slice - medium 1`] = `
 exports[`14. secondary two no pic and two - medium 1`] = `
 <style>
 .IS1 {
-  width: 50%;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 
 .IS2 {
@@ -1747,33 +1779,37 @@ exports[`14. secondary two no pic and two - medium 1`] = `
 }
 
 .IS3 {
-  width: 50%;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
 
 .IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  width: 66.6%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
 }
 
 .IS5 {
-  border-top-color: rgba(219,219,219,1.00);
-  border-right-color: rgba(219,219,219,1.00);
-  border-bottom-color: rgba(219,219,219,1.00);
-  border-left-color: rgba(219,219,219,1.00);
-  border-right-width: 1px;
-  border-top-style: solid;
-  border-right-style: solid;
-  border-bottom-style: solid;
-  border-left-style: solid;
-  margin-top: 15px;
-  margin-bottom: 15px;
-}
-
-.IS6 {
   border-bottom-width: 1px;
   border-top-color: rgba(219,219,219,1.00);
   border-right-color: rgba(219,219,219,1.00);
@@ -1787,19 +1823,31 @@ exports[`14. secondary two no pic and two - medium 1`] = `
   margin-left: 10px;
 }
 
-.IS7 {
+.IS6 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
   flex-shrink: 1;
   -webkit-flex-basis: 0%;
   flex-basis: 0%;
-  margin-top: 5px;
-  margin-bottom: 5px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
   -ms-flex-preferred-size: 0%;
+}
+
+.IS7 {
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-right-width: 1px;
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  margin-bottom: 15px;
+  margin-top: 10px;
 }
 
 .IS8 {
@@ -1809,11 +1857,22 @@ exports[`14. secondary two no pic and two - medium 1`] = `
   flex-shrink: 1;
   -webkit-flex-basis: 0%;
   flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS9 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
   -ms-flex-negative: 1;
@@ -1822,7 +1881,22 @@ exports[`14. secondary two no pic and two - medium 1`] = `
   -webkit-box-direction: normal;
 }
 
-.IS9 {
+.IS10 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  margin-right: 20px;
+  margin-left: 20px;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS11 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -1834,10 +1908,10 @@ exports[`14. secondary two no pic and two - medium 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS9"
+  className="css-view-1dbjc4n IS11"
 >
   <div
-    className="css-view-1dbjc4n IS8"
+    className="css-view-1dbjc4n IS10"
   >
     <div
       className="css-view-1dbjc4n IS4"
@@ -1846,7 +1920,7 @@ exports[`14. secondary two no pic and two - medium 1`] = `
         className="css-view-1dbjc4n IS1"
       >
         <TileAE
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="secondary1"
         />
       </div>
@@ -1857,7 +1931,7 @@ exports[`14. secondary two no pic and two - medium 1`] = `
         className="css-view-1dbjc4n IS3"
       >
         <TileAE
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="secondary2"
         />
       </div>
@@ -1866,19 +1940,27 @@ exports[`14. secondary two no pic and two - medium 1`] = `
       className="css-view-1dbjc4n IS5"
     />
     <div
-      className="css-view-1dbjc4n IS7"
+      className="css-view-1dbjc4n IS9"
     >
-      <TileG
-        breakpoint="wide"
-        tileName="support1"
-      />
       <div
         className="css-view-1dbjc4n IS6"
+      >
+        <TileG
+          breakpoint="medium"
+          tileName="support1"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS7"
       />
-      <TileG
-        breakpoint="wide"
-        tileName="support2"
-      />
+      <div
+        className="css-view-1dbjc4n IS8"
+      >
+        <TileG
+          breakpoint="medium"
+          tileName="support2"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -2102,8 +2184,8 @@ exports[`15. list two and six no pic - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-right: 10px;
-  margin-left: 10px;
+  margin-right: 20px;
+  margin-left: 20px;
   margin-top: 5px;
   margin-bottom: 5px;
   -ms-flex-positive: 1;
@@ -2135,7 +2217,7 @@ exports[`15. list two and six no pic - medium 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileAS
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="lead1"
       />
     </div>
@@ -2146,7 +2228,7 @@ exports[`15. list two and six no pic - medium 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAS
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="lead2"
       />
     </div>
@@ -2163,7 +2245,7 @@ exports[`15. list two and six no pic - medium 1`] = `
           className="css-view-1dbjc4n IS5"
         >
           <TileL
-            breakpoint="wide"
+            breakpoint="medium"
             tileName="support1"
           />
         </div>
@@ -2174,7 +2256,7 @@ exports[`15. list two and six no pic - medium 1`] = `
           className="css-view-1dbjc4n IS7"
         >
           <TileL
-            breakpoint="wide"
+            breakpoint="medium"
             tileName="support2"
           />
         </div>
@@ -2189,7 +2271,7 @@ exports[`15. list two and six no pic - medium 1`] = `
           className="css-view-1dbjc4n IS10"
         >
           <TileL
-            breakpoint="wide"
+            breakpoint="medium"
             tileName="support3"
           />
         </div>
@@ -2200,7 +2282,7 @@ exports[`15. list two and six no pic - medium 1`] = `
           className="css-view-1dbjc4n IS12"
         >
           <TileL
-            breakpoint="wide"
+            breakpoint="medium"
             tileName="support4"
           />
         </div>
@@ -2215,7 +2297,7 @@ exports[`15. list two and six no pic - medium 1`] = `
           className="css-view-1dbjc4n IS15"
         >
           <TileL
-            breakpoint="wide"
+            breakpoint="medium"
             tileName="support5"
           />
         </div>
@@ -2226,7 +2308,7 @@ exports[`15. list two and six no pic - medium 1`] = `
           className="css-view-1dbjc4n IS17"
         >
           <TileL
-            breakpoint="wide"
+            breakpoint="medium"
             tileName="support6"
           />
         </div>
@@ -2260,8 +2342,8 @@ exports[`16. puzzle - medium 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  padding-right: 10px;
-  padding-left: 10px;
+  padding-right: 20px;
+  padding-left: 20px;
   padding-top: 15px;
   -ms-flex-positive: 1;
   -webkit-box-flex: 1;
@@ -2292,7 +2374,7 @@ exports[`16. puzzle - medium 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileAK
-        breakpoint="wide"
+        breakpoint="medium"
         id="0"
         image={
           Object {
@@ -2315,7 +2397,7 @@ exports[`16. puzzle - medium 1`] = `
       className="css-view-1dbjc4n IS2"
     >
       <TileAK
-        breakpoint="wide"
+        breakpoint="medium"
         id="1"
         image={
           Object {
@@ -2338,7 +2420,7 @@ exports[`16. puzzle - medium 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAK
-        breakpoint="wide"
+        breakpoint="medium"
         id="2"
         image={
           Object {
@@ -4771,6 +4853,23 @@ exports[`33. comment lead and cartoon - huge 1`] = `
 .IS5 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS6 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -4780,29 +4879,33 @@ exports[`33. comment lead and cartoon - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS5"
+  className="css-view-1dbjc4n IS6"
 >
   <div
-    className="css-view-1dbjc4n IS4"
+    className="css-view-1dbjc4n IS5"
   >
     <div
-      className="css-view-1dbjc4n IS1"
+      className="css-view-1dbjc4n IS4"
     >
-      <TileAH
-        breakpoint="wide"
-        tileName="lead"
+      <div
+        className="css-view-1dbjc4n IS1"
+      >
+        <TileAH
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS2"
       />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS3"
-    >
-      <TileAI
-        breakpoint="wide"
-        tileName="cartoon"
-      />
+      <div
+        className="css-view-1dbjc4n IS3"
+      >
+        <TileAI
+          breakpoint="huge"
+          tileName="cartoon"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -4952,6 +5055,23 @@ exports[`34. daily universal register - huge 1`] = `
 .IS12 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS13 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -4961,68 +5081,72 @@ exports[`34. daily universal register - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS12"
+  className="css-view-1dbjc4n IS13"
 >
   <div
-    className="css-view-1dbjc4n IS11"
+    className="css-view-1dbjc4n IS12"
   >
-    <Image
-      aspectRatio={1}
-      className="IS1"
-      uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-    />
     <div
-      className="css-text-901oao IS2"
+      className="css-view-1dbjc4n IS11"
     >
-      Daily Universal Register
-    </div>
-    <div
-      className="css-view-1dbjc4n IS10"
-    >
-      <div
-        className="css-view-1dbjc4n IS5"
-      >
-        <TileS
-          breakpoint="wide"
-        />
-        <div
-          className="css-view-1dbjc4n IS3"
-        />
-        <TileS
-          breakpoint="wide"
-          logo={
-            <Logo
-              className="IS4"
-              imageUri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
-              ratio={1}
-              type="nature notes"
-            />
-          }
-        />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS6"
+      <Image
+        aspectRatio={1}
+        className="IS1"
+        uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
       />
       <div
-        className="css-view-1dbjc4n IS9"
+        className="css-text-901oao IS2"
       >
-        <TileS
-          breakpoint="wide"
+        Daily Universal Register
+      </div>
+      <div
+        className="css-view-1dbjc4n IS10"
+      >
+        <div
+          className="css-view-1dbjc4n IS5"
+        >
+          <TileS
+            breakpoint="huge"
+          />
+          <div
+            className="css-view-1dbjc4n IS3"
+          />
+          <TileS
+            breakpoint="huge"
+            logo={
+              <Logo
+                className="IS4"
+                imageUri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
+                ratio={1}
+                type="nature notes"
+              />
+            }
+          />
+        </div>
+        <div
+          className="css-view-1dbjc4n IS6"
         />
         <div
-          className="css-view-1dbjc4n IS7"
-        />
-        <TileS
-          breakpoint="wide"
-          logo={
-            <Logo
-              className="IS8"
-              imageUri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
-              ratio={1}
-              type="birthdays"
-            />
-          }
-        />
+          className="css-view-1dbjc4n IS9"
+        >
+          <TileS
+            breakpoint="huge"
+          />
+          <div
+            className="css-view-1dbjc4n IS7"
+          />
+          <TileS
+            breakpoint="huge"
+            logo={
+              <Logo
+                className="IS8"
+                imageUri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
+                ratio={1}
+                type="birthdays"
+              />
+            }
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -5076,46 +5200,21 @@ exports[`35. lead one and one - huge 1`] = `
 .IS5 {
   -webkit-align-self: center;
   align-self: center;
-  max-width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-  width: 1366px;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
   -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
 }
-</style>
 
-<div
-  className="css-view-1dbjc4n IS5"
->
-  <div
-    className="css-view-1dbjc4n IS4"
-  >
-    <div
-      className="css-view-1dbjc4n IS1"
-    >
-      <TileZ
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS3"
-    >
-      <TileAF
-        breakpoint="wide"
-        tileName="support"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`36. lead one full width - huge 1`] = `
-<style>
-.IS1 {
+.IS6 {
   -webkit-align-self: center;
   align-self: center;
   max-width: 100%;
@@ -5127,12 +5226,79 @@ exports[`36. lead one full width - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS1"
+  className="css-view-1dbjc4n IS6"
 >
-  <TileR
-    breakpoint="wide"
-    tileName="lead"
-  />
+  <div
+    className="css-view-1dbjc4n IS5"
+  >
+    <div
+      className="css-view-1dbjc4n IS4"
+    >
+      <div
+        className="css-view-1dbjc4n IS1"
+      >
+        <TileZ
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS2"
+      />
+      <div
+        className="css-view-1dbjc4n IS3"
+      >
+        <TileAF
+          breakpoint="huge"
+          tileName="support"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`36. lead one full width - huge 1`] = `
+<style>
+.IS1 {
+  -webkit-align-self: center;
+  align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS2 {
+  -webkit-align-self: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 0px;
+  padding-left: 0px;
+  width: 1366px;
+  -ms-flex-item-align: center;
+}
+</style>
+
+<div
+  className="css-view-1dbjc4n IS2"
+>
+  <div
+    className="css-view-1dbjc4n IS1"
+  >
+    <TileR
+      breakpoint="huge"
+      tileName="lead"
+    />
+  </div>
 </div>
 `;
 
@@ -5215,6 +5381,23 @@ exports[`37. lead two no pic and two - huge 1`] = `
 .IS8 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS9 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -5224,47 +5407,51 @@ exports[`37. lead two no pic and two - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS8"
+  className="css-view-1dbjc4n IS9"
 >
   <div
-    className="css-view-1dbjc4n IS7"
+    className="css-view-1dbjc4n IS8"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS7"
     >
-      <TileX
-        breakpoint="wide"
-        tileName="lead1"
+      <div
+        className="css-view-1dbjc4n IS2"
+      >
+        <TileX
+          breakpoint="huge"
+          tileName="lead1"
+        />
+        <div
+          className="css-view-1dbjc4n IS1"
+        />
+        <TileY
+          breakpoint="huge"
+          tileName="lead2"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS3"
       />
       <div
-        className="css-view-1dbjc4n IS1"
+        className="css-view-1dbjc4n IS4"
+      >
+        <TileE
+          breakpoint="huge"
+          tileName="support1"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS5"
       />
-      <TileY
-        breakpoint="wide"
-        tileName="lead2"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS3"
-    />
-    <div
-      className="css-view-1dbjc4n IS4"
-    >
-      <TileE
-        breakpoint="wide"
-        tileName="support1"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS5"
-    />
-    <div
-      className="css-view-1dbjc4n IS6"
-    >
-      <TileAL
-        breakpoint="wide"
-        tileName="support2"
-      />
+      <div
+        className="css-view-1dbjc4n IS6"
+      >
+        <TileAL
+          breakpoint="huge"
+          tileName="support2"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -5372,6 +5559,23 @@ exports[`38. leaders slice - huge 1`] = `
 .IS12 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS13 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -5381,61 +5585,65 @@ exports[`38. leaders slice - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS12"
+  className="css-view-1dbjc4n IS13"
 >
   <div
-    className="css-view-1dbjc4n IS11"
+    className="css-view-1dbjc4n IS12"
   >
     <div
-      className="css-view-1dbjc4n IS4"
+      className="css-view-1dbjc4n IS11"
     >
-      <Image
-        aspectRatio={5.74}
-        className="IS1"
-        uri="https://www.thetimes.co.uk/d/img/leaders-masthead-d17db00289.png"
-      />
       <div
-        className="css-view-1dbjc4n IS3"
+        className="css-view-1dbjc4n IS4"
       >
+        <Image
+          aspectRatio={5.74}
+          className="IS1"
+          uri="https://www.thetimes.co.uk/d/img/leaders-masthead-d17db00289.png"
+        />
         <div
-          className="css-text-901oao IS2"
+          className="css-view-1dbjc4n IS3"
         >
-           Leading Articles 
+          <div
+            className="css-text-901oao IS2"
+          >
+             Leading Articles 
+          </div>
         </div>
       </div>
-    </div>
-    <div
-      className="css-view-1dbjc4n IS10"
-    >
       <div
-        className="css-view-1dbjc4n IS5"
+        className="css-view-1dbjc4n IS10"
       >
-        <TileM
-          breakpoint="wide"
-          tileName="leader2"
+        <div
+          className="css-view-1dbjc4n IS5"
+        >
+          <TileM
+            breakpoint="huge"
+            tileName="leader2"
+          />
+        </div>
+        <div
+          className="css-view-1dbjc4n IS6"
         />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS6"
-      />
-      <div
-        className="css-view-1dbjc4n IS7"
-      >
-        <TileM
-          breakpoint="wide"
-          tileName="leader1"
+        <div
+          className="css-view-1dbjc4n IS7"
+        >
+          <TileM
+            breakpoint="huge"
+            tileName="leader1"
+          />
+        </div>
+        <div
+          className="css-view-1dbjc4n IS8"
         />
-      </div>
-      <div
-        className="css-view-1dbjc4n IS8"
-      />
-      <div
-        className="css-view-1dbjc4n IS9"
-      >
-        <TileM
-          breakpoint="wide"
-          tileName="leader3"
-        />
+        <div
+          className="css-view-1dbjc4n IS9"
+        >
+          <TileM
+            breakpoint="huge"
+            tileName="leader3"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -5620,6 +5828,23 @@ exports[`39. secondary one and four - huge 1`] = `
 .IS17 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS18 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -5629,86 +5854,90 @@ exports[`39. secondary one and four - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS17"
+  className="css-view-1dbjc4n IS18"
 >
   <div
-    className="css-view-1dbjc4n IS16"
+    className="css-view-1dbjc4n IS17"
   >
     <div
-      className="css-view-1dbjc4n IS1"
-    >
-      <TheTimesLogo
-        height={37}
-        width={35}
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS15"
+      className="css-view-1dbjc4n IS16"
     >
       <div
-        className="css-view-1dbjc4n IS3"
+        className="css-view-1dbjc4n IS1"
       >
-        <TileN
-          breakpoint="wide"
-          tileName="secondary"
+        <TheTimesLogo
+          height={37}
+          width={35}
         />
       </div>
       <div
-        className="css-view-1dbjc4n IS4"
+        className="css-view-1dbjc4n IS2"
       />
       <div
-        className="css-view-1dbjc4n IS14"
+        className="css-view-1dbjc4n IS15"
       >
         <div
-          className="css-view-1dbjc4n IS8"
+          className="css-view-1dbjc4n IS3"
         >
-          <div
-            className="css-view-1dbjc4n IS5"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support1"
-            />
-          </div>
-          <div
-            className="css-view-1dbjc4n IS6"
+          <TileN
+            breakpoint="huge"
+            tileName="secondary"
           />
-          <div
-            className="css-view-1dbjc4n IS7"
-          >
-            <TileO
-              breakpoint="wide"
-              tileName="support2"
-            />
-          </div>
         </div>
         <div
-          className="css-view-1dbjc4n IS9"
+          className="css-view-1dbjc4n IS4"
         />
         <div
-          className="css-view-1dbjc4n IS13"
+          className="css-view-1dbjc4n IS14"
         >
           <div
-            className="css-view-1dbjc4n IS10"
+            className="css-view-1dbjc4n IS8"
           >
-            <TileO
-              breakpoint="wide"
-              tileName="support3"
+            <div
+              className="css-view-1dbjc4n IS5"
+            >
+              <TileO
+                breakpoint="huge"
+                tileName="support1"
+              />
+            </div>
+            <div
+              className="css-view-1dbjc4n IS6"
             />
+            <div
+              className="css-view-1dbjc4n IS7"
+            >
+              <TileO
+                breakpoint="huge"
+                tileName="support2"
+              />
+            </div>
           </div>
           <div
-            className="css-view-1dbjc4n IS11"
+            className="css-view-1dbjc4n IS9"
           />
           <div
-            className="css-view-1dbjc4n IS12"
+            className="css-view-1dbjc4n IS13"
           >
-            <TileO
-              breakpoint="wide"
-              tileName="support4"
+            <div
+              className="css-view-1dbjc4n IS10"
+            >
+              <TileO
+                breakpoint="huge"
+                tileName="support3"
+              />
+            </div>
+            <div
+              className="css-view-1dbjc4n IS11"
             />
+            <div
+              className="css-view-1dbjc4n IS12"
+            >
+              <TileO
+                breakpoint="huge"
+                tileName="support4"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -5722,6 +5951,23 @@ exports[`40. secondary one - huge 1`] = `
 .IS1 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS2 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -5731,12 +5977,16 @@ exports[`40. secondary one - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS1"
+  className="css-view-1dbjc4n IS2"
 >
-  <TileW
-    breakpoint="wide"
-    tileName="secondary"
-  />
+  <div
+    className="css-view-1dbjc4n IS1"
+  >
+    <TileW
+      breakpoint="huge"
+      tileName="secondary"
+    />
+  </div>
 </div>
 `;
 
@@ -5866,6 +6116,23 @@ exports[`41. secondary four - huge 1`] = `
 .IS9 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS10 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -5875,65 +6142,69 @@ exports[`41. secondary four - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS9"
+  className="css-view-1dbjc4n IS10"
 >
   <div
-    className="css-view-1dbjc4n IS8"
+    className="css-view-1dbjc4n IS9"
   >
     <div
-      className="css-view-1dbjc4n IS4"
+      className="css-view-1dbjc4n IS8"
     >
       <div
-        className="css-view-1dbjc4n IS1"
+        className="css-view-1dbjc4n IS4"
       >
-        <TileAR
-          breakpoint="wide"
-          tileName="secondary1"
+        <div
+          className="css-view-1dbjc4n IS1"
+        >
+          <TileAR
+            breakpoint="huge"
+            tileName="secondary1"
+          />
+        </div>
+        <div
+          className="css-view-1dbjc4n IS2"
         />
+        <div
+          className="css-view-1dbjc4n IS3"
+        >
+          <TileAR
+            breakpoint="huge"
+            tileName="secondary2"
+          />
+        </div>
       </div>
       <div
-        className="css-view-1dbjc4n IS2"
+        className="css-view-1dbjc4n IS5"
       />
       <div
-        className="css-view-1dbjc4n IS3"
+        className="css-view-1dbjc4n IS7"
       >
-        <TileAR
-          breakpoint="wide"
-          tileName="secondary2"
+        <TileB
+          additionalHeadlineStyles={
+            Object {
+              "fontSize": 22,
+              "lineHeight": 22,
+              "marginBottom": "5px",
+            }
+          }
+          breakpoint="huge"
+          tileName="secondary3"
+        />
+        <div
+          className="css-view-1dbjc4n IS6"
+        />
+        <TileB
+          additionalHeadlineStyles={
+            Object {
+              "fontSize": 22,
+              "lineHeight": 22,
+              "marginBottom": "5px",
+            }
+          }
+          breakpoint="huge"
+          tileName="secondary4"
         />
       </div>
-    </div>
-    <div
-      className="css-view-1dbjc4n IS5"
-    />
-    <div
-      className="css-view-1dbjc4n IS7"
-    >
-      <TileB
-        additionalHeadlineStyles={
-          Object {
-            "fontSize": 20,
-            "lineHeight": 20,
-            "marginBottom": "5px",
-          }
-        }
-        breakpoint="wide"
-        tileName="secondary3"
-      />
-      <div
-        className="css-view-1dbjc4n IS6"
-      />
-      <TileB
-        additionalHeadlineStyles={
-          Object {
-            "fontSize": 20,
-            "lineHeight": 20,
-            "marginBottom": "5px",
-          }
-        }
-        breakpoint="wide"
-        tileName="secondary4"
-      />
     </div>
   </div>
 </div>
@@ -5942,7 +6213,7 @@ exports[`41. secondary four - huge 1`] = `
 exports[`42. secondary one and columnist - huge 1`] = `
 <style>
 .IS1 {
-  width: 66.7%;
+  width: 58%;
 }
 
 .IS2 {
@@ -5962,7 +6233,7 @@ exports[`42. secondary one and columnist - huge 1`] = `
 .IS3 {
   padding-top: 5px;
   padding-bottom: 5px;
-  width: 33.3%;
+  width: 42%;
 }
 
 .IS4 {
@@ -5988,6 +6259,23 @@ exports[`42. secondary one and columnist - huge 1`] = `
 .IS5 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS6 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -5997,30 +6285,34 @@ exports[`42. secondary one and columnist - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS5"
+  className="css-view-1dbjc4n IS6"
 >
   <div
-    className="css-view-1dbjc4n IS4"
+    className="css-view-1dbjc4n IS5"
   >
     <div
-      className="css-view-1dbjc4n IS1"
+      className="css-view-1dbjc4n IS4"
     >
-      <TileAB
-        breakpoint="wide"
-        tileName="columnist"
+      <div
+        className="css-view-1dbjc4n IS1"
+      >
+        <TileAB
+          breakpoint="huge"
+          tileName="columnist"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS2"
       />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS3"
-    >
-      <TileB
-        breakpoint="wide"
-        tileName="secondary"
-        withMoreTeaser={true}
-      />
+      <div
+        className="css-view-1dbjc4n IS3"
+      >
+        <TileB
+          breakpoint="huge"
+          tileName="secondary"
+          withMoreTeaser={true}
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -6109,6 +6401,23 @@ exports[`43. secondary two and two - huge 1`] = `
 .IS9 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS10 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -6118,47 +6427,51 @@ exports[`43. secondary two and two - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS9"
+  className="css-view-1dbjc4n IS10"
 >
   <div
-    className="css-view-1dbjc4n IS8"
+    className="css-view-1dbjc4n IS9"
   >
     <div
-      className="css-view-1dbjc4n IS1"
+      className="css-view-1dbjc4n IS8"
     >
-      <TileAM
-        tileName="secondary1"
+      <div
+        className="css-view-1dbjc4n IS1"
+      >
+        <TileAM
+          tileName="secondary1"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS2"
       />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS3"
-    >
-      <TileAN
-        tileName="support1"
+      <div
+        className="css-view-1dbjc4n IS3"
+      >
+        <TileAN
+          tileName="support1"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS4"
       />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS4"
-    />
-    <div
-      className="css-view-1dbjc4n IS5"
-    >
-      <TileAM
-        tileName="secondary2"
+      <div
+        className="css-view-1dbjc4n IS5"
+      >
+        <TileAM
+          tileName="secondary2"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS6"
       />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS6"
-    />
-    <div
-      className="css-view-1dbjc4n IS7"
-    >
-      <TileAN
-        tileName="support2"
-      />
+      <div
+        className="css-view-1dbjc4n IS7"
+      >
+        <TileAN
+          tileName="support2"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -6255,6 +6568,23 @@ exports[`44. lead one and four slice - huge 1`] = `
 .IS8 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS9 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -6264,50 +6594,54 @@ exports[`44. lead one and four slice - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS8"
+  className="css-view-1dbjc4n IS9"
 >
   <div
-    className="css-view-1dbjc4n IS7"
+    className="css-view-1dbjc4n IS8"
   >
     <div
-      className="css-view-1dbjc4n IS1"
+      className="css-view-1dbjc4n IS7"
     >
-      <TileAC
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS6"
-    >
-      <TileAD
-        breakpoint="wide"
-        tileName="support1"
+      <div
+        className="css-view-1dbjc4n IS1"
+      >
+        <TileAC
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS2"
       />
       <div
-        className="css-view-1dbjc4n IS3"
-      />
-      <TileAD
-        breakpoint="wide"
-        tileName="support2"
-      />
-      <div
-        className="css-view-1dbjc4n IS4"
-      />
-      <TileAD
-        breakpoint="wide"
-        tileName="support3"
-      />
-      <div
-        className="css-view-1dbjc4n IS5"
-      />
-      <TileAD
-        breakpoint="wide"
-        tileName="support4"
-      />
+        className="css-view-1dbjc4n IS6"
+      >
+        <TileAD
+          breakpoint="huge"
+          tileName="support1"
+        />
+        <div
+          className="css-view-1dbjc4n IS3"
+        />
+        <TileAD
+          breakpoint="huge"
+          tileName="support2"
+        />
+        <div
+          className="css-view-1dbjc4n IS4"
+        />
+        <TileAD
+          breakpoint="huge"
+          tileName="support3"
+        />
+        <div
+          className="css-view-1dbjc4n IS5"
+        />
+        <TileAD
+          breakpoint="huge"
+          tileName="support4"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -6394,6 +6728,23 @@ exports[`45. standard slice - huge 1`] = `
 .IS6 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS7 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -6403,46 +6754,50 @@ exports[`45. standard slice - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS6"
+  className="css-view-1dbjc4n IS7"
 >
   <div
-    className="css-view-1dbjc4n IS5"
+    className="css-view-1dbjc4n IS6"
   >
     <div
-      className="css-view-1dbjc4n"
+      className="css-view-1dbjc4n IS5"
     >
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem1"
-      />
       <div
-        className="css-view-1dbjc4n IS1"
-      />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem2"
-      />
-      <div
-        className="css-view-1dbjc4n IS2"
-      />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem3"
-      />
-      <div
-        className="css-view-1dbjc4n IS3"
-      />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem4"
-      />
-      <div
-        className="css-view-1dbjc4n IS4"
-      />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem5"
-      />
+        className="css-view-1dbjc4n"
+      >
+        <TileK
+          breakpoint="huge"
+          tileName="standardItem1"
+        />
+        <div
+          className="css-view-1dbjc4n IS1"
+        />
+        <TileK
+          breakpoint="huge"
+          tileName="standardItem2"
+        />
+        <div
+          className="css-view-1dbjc4n IS2"
+        />
+        <TileK
+          breakpoint="huge"
+          tileName="standardItem3"
+        />
+        <div
+          className="css-view-1dbjc4n IS3"
+        />
+        <TileK
+          breakpoint="huge"
+          tileName="standardItem4"
+        />
+        <div
+          className="css-view-1dbjc4n IS4"
+        />
+        <TileK
+          breakpoint="huge"
+          tileName="standardItem5"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -6547,6 +6902,23 @@ exports[`46. secondary two no pic and two - huge 1`] = `
 .IS9 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS10 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -6556,51 +6928,55 @@ exports[`46. secondary two no pic and two - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS9"
+  className="css-view-1dbjc4n IS10"
 >
   <div
-    className="css-view-1dbjc4n IS8"
+    className="css-view-1dbjc4n IS9"
   >
     <div
-      className="css-view-1dbjc4n IS4"
+      className="css-view-1dbjc4n IS8"
     >
       <div
-        className="css-view-1dbjc4n IS1"
+        className="css-view-1dbjc4n IS4"
       >
-        <TileAE
-          breakpoint="wide"
-          tileName="secondary1"
+        <div
+          className="css-view-1dbjc4n IS1"
+        >
+          <TileAE
+            breakpoint="huge"
+            tileName="secondary1"
+          />
+        </div>
+        <div
+          className="css-view-1dbjc4n IS2"
         />
+        <div
+          className="css-view-1dbjc4n IS3"
+        >
+          <TileAE
+            breakpoint="huge"
+            tileName="secondary2"
+          />
+        </div>
       </div>
       <div
-        className="css-view-1dbjc4n IS2"
+        className="css-view-1dbjc4n IS5"
       />
       <div
-        className="css-view-1dbjc4n IS3"
+        className="css-view-1dbjc4n IS7"
       >
-        <TileAE
-          breakpoint="wide"
-          tileName="secondary2"
+        <TileG
+          breakpoint="huge"
+          tileName="support1"
+        />
+        <div
+          className="css-view-1dbjc4n IS6"
+        />
+        <TileG
+          breakpoint="huge"
+          tileName="support2"
         />
       </div>
-    </div>
-    <div
-      className="css-view-1dbjc4n IS5"
-    />
-    <div
-      className="css-view-1dbjc4n IS7"
-    >
-      <TileG
-        breakpoint="wide"
-        tileName="support1"
-      />
-      <div
-        className="css-view-1dbjc4n IS6"
-      />
-      <TileG
-        breakpoint="wide"
-        tileName="support2"
-      />
     </div>
   </div>
 </div>
@@ -6839,6 +7215,23 @@ exports[`47. list two and six no pic - huge 1`] = `
 .IS21 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS22 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -6848,109 +7241,113 @@ exports[`47. list two and six no pic - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS21"
+  className="css-view-1dbjc4n IS22"
 >
   <div
-    className="css-view-1dbjc4n IS20"
+    className="css-view-1dbjc4n IS21"
   >
     <div
-      className="css-view-1dbjc4n IS1"
-    >
-      <TileAS
-        breakpoint="wide"
-        tileName="lead1"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    />
-    <div
-      className="css-view-1dbjc4n IS3"
-    >
-      <TileAS
-        breakpoint="wide"
-        tileName="lead2"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS4"
-    />
-    <div
-      className="css-view-1dbjc4n IS19"
+      className="css-view-1dbjc4n IS20"
     >
       <div
-        className="css-view-1dbjc4n IS8"
+        className="css-view-1dbjc4n IS1"
       >
-        <div
-          className="css-view-1dbjc4n IS5"
-        >
-          <TileL
-            breakpoint="wide"
-            tileName="support1"
-          />
-        </div>
-        <div
-          className="css-view-1dbjc4n IS6"
+        <TileAS
+          breakpoint="huge"
+          tileName="lead1"
         />
-        <div
-          className="css-view-1dbjc4n IS7"
-        >
-          <TileL
-            breakpoint="wide"
-            tileName="support2"
-          />
-        </div>
       </div>
       <div
-        className="css-view-1dbjc4n IS9"
+        className="css-view-1dbjc4n IS2"
       />
       <div
-        className="css-view-1dbjc4n IS13"
+        className="css-view-1dbjc4n IS3"
       >
-        <div
-          className="css-view-1dbjc4n IS10"
-        >
-          <TileL
-            breakpoint="wide"
-            tileName="support3"
-          />
-        </div>
-        <div
-          className="css-view-1dbjc4n IS11"
+        <TileAS
+          breakpoint="huge"
+          tileName="lead2"
         />
-        <div
-          className="css-view-1dbjc4n IS12"
-        >
-          <TileL
-            breakpoint="wide"
-            tileName="support4"
-          />
-        </div>
       </div>
       <div
-        className="css-view-1dbjc4n IS14"
+        className="css-view-1dbjc4n IS4"
       />
       <div
-        className="css-view-1dbjc4n IS18"
+        className="css-view-1dbjc4n IS19"
       >
         <div
-          className="css-view-1dbjc4n IS15"
+          className="css-view-1dbjc4n IS8"
         >
-          <TileL
-            breakpoint="wide"
-            tileName="support5"
+          <div
+            className="css-view-1dbjc4n IS5"
+          >
+            <TileL
+              breakpoint="huge"
+              tileName="support1"
+            />
+          </div>
+          <div
+            className="css-view-1dbjc4n IS6"
           />
+          <div
+            className="css-view-1dbjc4n IS7"
+          >
+            <TileL
+              breakpoint="huge"
+              tileName="support2"
+            />
+          </div>
         </div>
         <div
-          className="css-view-1dbjc4n IS16"
+          className="css-view-1dbjc4n IS9"
         />
         <div
-          className="css-view-1dbjc4n IS17"
+          className="css-view-1dbjc4n IS13"
         >
-          <TileL
-            breakpoint="wide"
-            tileName="support6"
+          <div
+            className="css-view-1dbjc4n IS10"
+          >
+            <TileL
+              breakpoint="huge"
+              tileName="support3"
+            />
+          </div>
+          <div
+            className="css-view-1dbjc4n IS11"
           />
+          <div
+            className="css-view-1dbjc4n IS12"
+          >
+            <TileL
+              breakpoint="huge"
+              tileName="support4"
+            />
+          </div>
+        </div>
+        <div
+          className="css-view-1dbjc4n IS14"
+        />
+        <div
+          className="css-view-1dbjc4n IS18"
+        >
+          <div
+            className="css-view-1dbjc4n IS15"
+          >
+            <TileL
+              breakpoint="huge"
+              tileName="support5"
+            />
+          </div>
+          <div
+            className="css-view-1dbjc4n IS16"
+          />
+          <div
+            className="css-view-1dbjc4n IS17"
+          >
+            <TileL
+              breakpoint="huge"
+              tileName="support6"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -6996,6 +7393,23 @@ exports[`48. puzzle - huge 1`] = `
 .IS5 {
   -webkit-align-self: center;
   align-self: center;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  width: 1180px;
+  -ms-flex-item-align: center;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS6 {
+  -webkit-align-self: center;
+  align-self: center;
   max-width: 100%;
   padding-right: 0px;
   padding-left: 0px;
@@ -7005,79 +7419,83 @@ exports[`48. puzzle - huge 1`] = `
 </style>
 
 <div
-  className="css-view-1dbjc4n IS5"
+  className="css-view-1dbjc4n IS6"
 >
   <div
-    className="css-view-1dbjc4n IS4"
+    className="css-view-1dbjc4n IS5"
   >
     <div
-      className="css-view-1dbjc4n IS1"
+      className="css-view-1dbjc4n IS4"
     >
-      <TileAK
-        breakpoint="wide"
-        id="0"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+      <div
+        className="css-view-1dbjc4n IS1"
+      >
+        <TileAK
+          breakpoint="huge"
+          id="0"
+          image={
+            Object {
+              "crop11": null,
+              "crop169": null,
+              "crop23": null,
+              "crop32": Object {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+              },
+              "crop45": null,
+              "crops": Array [],
+              "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            }
           }
-        }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS2"
-    >
-      <TileAK
-        breakpoint="wide"
-        id="1"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          title="Times Concise medium No 7881"
+          url="/crossword/123"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS2"
+      >
+        <TileAK
+          breakpoint="huge"
+          id="1"
+          image={
+            Object {
+              "crop11": null,
+              "crop169": null,
+              "crop23": null,
+              "crop32": Object {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+              },
+              "crop45": null,
+              "crops": Array [],
+              "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            }
           }
-        }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </div>
-    <div
-      className="css-view-1dbjc4n IS3"
-    >
-      <TileAK
-        breakpoint="wide"
-        id="2"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          title="Times Concise medium No 7881"
+          url="/crossword/123"
+        />
+      </div>
+      <div
+        className="css-view-1dbjc4n IS3"
+      >
+        <TileAK
+          breakpoint="huge"
+          id="2"
+          image={
+            Object {
+              "crop11": null,
+              "crop169": null,
+              "crop23": null,
+              "crop32": Object {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+              },
+              "crop45": null,
+              "crops": Array [],
+              "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            }
           }
-        }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
+          title="Times Concise medium No 7881"
+          url="/crossword/123"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -5,14 +5,14 @@ exports[`1. comment lead and cartoon - medium 1`] = `
   <div>
     <div>
       <TileAH
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="lead"
       />
     </div>
     <div />
     <div>
       <TileAI
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="cartoon"
       />
     </div>
@@ -33,11 +33,11 @@ exports[`2. daily universal register - medium 1`] = `
     <div>
       <div>
         <TileS
-          breakpoint="wide"
+          breakpoint="medium"
         />
         <div />
         <TileS
-          breakpoint="wide"
+          breakpoint="medium"
           logo={
             <Logo
               imageUri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
@@ -50,11 +50,11 @@ exports[`2. daily universal register - medium 1`] = `
       <div />
       <div>
         <TileS
-          breakpoint="wide"
+          breakpoint="medium"
         />
         <div />
         <TileS
-          breakpoint="wide"
+          breakpoint="medium"
           logo={
             <Logo
               imageUri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
@@ -73,15 +73,15 @@ exports[`3. lead one and one - medium 1`] = `
 <div>
   <div>
     <div>
-      <TileZ
-        breakpoint="wide"
+      <TileU
+        breakpoint="medium"
         tileName="lead"
       />
     </div>
     <div />
     <div>
-      <TileAF
-        breakpoint="wide"
+      <TileAA
+        breakpoint="medium"
         tileName="support"
       />
     </div>
@@ -92,7 +92,7 @@ exports[`3. lead one and one - medium 1`] = `
 exports[`4. lead one full width - medium 1`] = `
 <div>
   <TileR
-    breakpoint="wide"
+    breakpoint="medium"
     tileName="lead"
   />
 </div>
@@ -103,26 +103,24 @@ exports[`5. lead two no pic and two - medium 1`] = `
   <div>
     <div>
       <TileX
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="lead1"
       />
       <div />
       <TileY
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="lead2"
       />
     </div>
     <div />
     <div>
       <TileE
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="support1"
       />
-    </div>
-    <div />
-    <div>
-      <TileAL
-        breakpoint="wide"
+      <div />
+      <TileD
+        breakpoint="medium"
         tileName="support2"
       />
     </div>
@@ -147,21 +145,21 @@ exports[`6. leaders slice - medium 1`] = `
     <div>
       <div>
         <TileM
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="leader2"
         />
       </div>
       <div />
       <div>
         <TileM
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="leader1"
         />
       </div>
       <div />
       <div>
         <TileM
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="leader3"
         />
       </div>
@@ -183,7 +181,7 @@ exports[`7. secondary one and four - medium 1`] = `
     <div>
       <div>
         <TileN
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="secondary"
         />
       </div>
@@ -192,14 +190,14 @@ exports[`7. secondary one and four - medium 1`] = `
         <div>
           <div>
             <TileO
-              breakpoint="wide"
+              breakpoint="medium"
               tileName="support1"
             />
           </div>
           <div />
           <div>
             <TileO
-              breakpoint="wide"
+              breakpoint="medium"
               tileName="support2"
             />
           </div>
@@ -208,14 +206,14 @@ exports[`7. secondary one and four - medium 1`] = `
         <div>
           <div>
             <TileO
-              breakpoint="wide"
+              breakpoint="medium"
               tileName="support3"
             />
           </div>
           <div />
           <div>
             <TileO
-              breakpoint="wide"
+              breakpoint="medium"
               tileName="support4"
             />
           </div>
@@ -229,7 +227,7 @@ exports[`7. secondary one and four - medium 1`] = `
 exports[`8. secondary one - medium 1`] = `
 <div>
   <TileW
-    breakpoint="wide"
+    breakpoint="medium"
     tileName="secondary"
   />
 </div>
@@ -241,14 +239,14 @@ exports[`9. secondary four - medium 1`] = `
     <div>
       <div>
         <TileAR
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="secondary1"
         />
       </div>
       <div />
       <div>
         <TileAR
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="secondary2"
         />
       </div>
@@ -256,26 +254,12 @@ exports[`9. secondary four - medium 1`] = `
     <div />
     <div>
       <TileB
-        additionalHeadlineStyles={
-          Object {
-            "fontSize": 20,
-            "lineHeight": 20,
-            "marginBottom": "5px",
-          }
-        }
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="secondary3"
       />
       <div />
       <TileB
-        additionalHeadlineStyles={
-          Object {
-            "fontSize": 20,
-            "lineHeight": 20,
-            "marginBottom": "5px",
-          }
-        }
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="secondary4"
       />
     </div>
@@ -288,14 +272,14 @@ exports[`10. secondary one and columnist - medium 1`] = `
   <div>
     <div>
       <TileAB
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="columnist"
       />
     </div>
     <div />
     <div>
       <TileB
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="secondary"
         withMoreTeaser={true}
       />
@@ -308,27 +292,33 @@ exports[`11. secondary two and two - medium 1`] = `
 <div>
   <div>
     <div>
-      <TileAM
-        tileName="secondary1"
-      />
+      <div>
+        <TileV
+          tileName="secondary1"
+        />
+      </div>
+      <div />
+      <div>
+        <TileV
+          tileName="secondary2"
+        />
+      </div>
     </div>
     <div />
     <div>
-      <TileAN
-        tileName="support1"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAM
-        tileName="secondary2"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAN
-        tileName="support2"
-      />
+      <div>
+        <TileG
+          breakpoint="medium"
+          tileName="support1"
+        />
+      </div>
+      <div />
+      <div>
+        <TileG
+          breakpoint="medium"
+          tileName="support2"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -339,29 +329,29 @@ exports[`12. lead one and four slice - medium 1`] = `
   <div>
     <div>
       <TileAC
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="lead"
       />
     </div>
     <div />
     <div>
       <TileAD
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="support1"
       />
       <div />
       <TileAD
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="support2"
       />
       <div />
       <TileAD
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="support3"
       />
       <div />
       <TileAD
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="support4"
       />
     </div>
@@ -374,27 +364,27 @@ exports[`13. standard slice - medium 1`] = `
   <div>
     <div>
       <TileK
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="standardItem1"
       />
       <div />
       <TileK
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="standardItem2"
       />
       <div />
       <TileK
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="standardItem3"
       />
       <div />
       <TileK
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="standardItem4"
       />
       <div />
       <TileK
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="standardItem5"
       />
     </div>
@@ -408,29 +398,33 @@ exports[`14. secondary two no pic and two - medium 1`] = `
     <div>
       <div>
         <TileAE
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="secondary1"
         />
       </div>
       <div />
       <div>
         <TileAE
-          breakpoint="wide"
+          breakpoint="medium"
           tileName="secondary2"
         />
       </div>
     </div>
     <div />
     <div>
-      <TileG
-        breakpoint="wide"
-        tileName="support1"
-      />
+      <div>
+        <TileG
+          breakpoint="medium"
+          tileName="support1"
+        />
+      </div>
       <div />
-      <TileG
-        breakpoint="wide"
-        tileName="support2"
-      />
+      <div>
+        <TileG
+          breakpoint="medium"
+          tileName="support2"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -441,14 +435,14 @@ exports[`15. list two and six no pic - medium 1`] = `
   <div>
     <div>
       <TileAS
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="lead1"
       />
     </div>
     <div />
     <div>
       <TileAS
-        breakpoint="wide"
+        breakpoint="medium"
         tileName="lead2"
       />
     </div>
@@ -457,14 +451,14 @@ exports[`15. list two and six no pic - medium 1`] = `
       <div>
         <div>
           <TileL
-            breakpoint="wide"
+            breakpoint="medium"
             tileName="support1"
           />
         </div>
         <div />
         <div>
           <TileL
-            breakpoint="wide"
+            breakpoint="medium"
             tileName="support2"
           />
         </div>
@@ -473,14 +467,14 @@ exports[`15. list two and six no pic - medium 1`] = `
       <div>
         <div>
           <TileL
-            breakpoint="wide"
+            breakpoint="medium"
             tileName="support3"
           />
         </div>
         <div />
         <div>
           <TileL
-            breakpoint="wide"
+            breakpoint="medium"
             tileName="support4"
           />
         </div>
@@ -489,14 +483,14 @@ exports[`15. list two and six no pic - medium 1`] = `
       <div>
         <div>
           <TileL
-            breakpoint="wide"
+            breakpoint="medium"
             tileName="support5"
           />
         </div>
         <div />
         <div>
           <TileL
-            breakpoint="wide"
+            breakpoint="medium"
             tileName="support6"
           />
         </div>
@@ -511,7 +505,7 @@ exports[`16. puzzle - medium 1`] = `
   <div>
     <div>
       <TileAK
-        breakpoint="wide"
+        breakpoint="medium"
         id="0"
         image={
           Object {
@@ -532,7 +526,7 @@ exports[`16. puzzle - medium 1`] = `
     </div>
     <div>
       <TileAK
-        breakpoint="wide"
+        breakpoint="medium"
         id="1"
         image={
           Object {
@@ -553,7 +547,7 @@ exports[`16. puzzle - medium 1`] = `
     </div>
     <div>
       <TileAK
-        breakpoint="wide"
+        breakpoint="medium"
         id="2"
         image={
           Object {
@@ -1156,17 +1150,19 @@ exports[`33. comment lead and cartoon - huge 1`] = `
 <div>
   <div>
     <div>
-      <TileAH
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAI
-        breakpoint="wide"
-        tileName="cartoon"
-      />
+      <div>
+        <TileAH
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </div>
+      <div />
+      <div>
+        <TileAI
+          breakpoint="huge"
+          tileName="cartoon"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -1175,46 +1171,48 @@ exports[`33. comment lead and cartoon - huge 1`] = `
 exports[`34. daily universal register - huge 1`] = `
 <div>
   <div>
-    <Image
-      aspectRatio={1}
-      uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
-    />
     <div>
-      Daily Universal Register
-    </div>
-    <div>
+      <Image
+        aspectRatio={1}
+        uri="https://www.thetimes.co.uk/d/img/DUR-masthead-40fe00731f.png"
+      />
       <div>
-        <TileS
-          breakpoint="wide"
-        />
-        <div />
-        <TileS
-          breakpoint="wide"
-          logo={
-            <Logo
-              imageUri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
-              ratio={1}
-              type="nature notes"
-            />
-          }
-        />
+        Daily Universal Register
       </div>
-      <div />
       <div>
-        <TileS
-          breakpoint="wide"
-        />
+        <div>
+          <TileS
+            breakpoint="huge"
+          />
+          <div />
+          <TileS
+            breakpoint="huge"
+            logo={
+              <Logo
+                imageUri="https://www.thetimes.co.uk/d/img/DUR-nature-80d36dd1cd.png"
+                ratio={1}
+                type="nature notes"
+              />
+            }
+          />
+        </div>
         <div />
-        <TileS
-          breakpoint="wide"
-          logo={
-            <Logo
-              imageUri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
-              ratio={1}
-              type="birthdays"
-            />
-          }
-        />
+        <div>
+          <TileS
+            breakpoint="huge"
+          />
+          <div />
+          <TileS
+            breakpoint="huge"
+            logo={
+              <Logo
+                imageUri="https://www.thetimes.co.uk/d/img/DUR-birthdays-94b2272911.png"
+                ratio={1}
+                type="birthdays"
+              />
+            }
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1225,17 +1223,19 @@ exports[`35. lead one and one - huge 1`] = `
 <div>
   <div>
     <div>
-      <TileZ
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAF
-        breakpoint="wide"
-        tileName="support"
-      />
+      <div>
+        <TileZ
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </div>
+      <div />
+      <div>
+        <TileAF
+          breakpoint="huge"
+          tileName="support"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -1243,10 +1243,12 @@ exports[`35. lead one and one - huge 1`] = `
 
 exports[`36. lead one full width - huge 1`] = `
 <div>
-  <TileR
-    breakpoint="wide"
-    tileName="lead"
-  />
+  <div>
+    <TileR
+      breakpoint="huge"
+      tileName="lead"
+    />
+  </div>
 </div>
 `;
 
@@ -1254,29 +1256,31 @@ exports[`37. lead two no pic and two - huge 1`] = `
 <div>
   <div>
     <div>
-      <TileX
-        breakpoint="wide"
-        tileName="lead1"
-      />
+      <div>
+        <TileX
+          breakpoint="huge"
+          tileName="lead1"
+        />
+        <div />
+        <TileY
+          breakpoint="huge"
+          tileName="lead2"
+        />
+      </div>
       <div />
-      <TileY
-        breakpoint="wide"
-        tileName="lead2"
-      />
-    </div>
-    <div />
-    <div>
-      <TileE
-        breakpoint="wide"
-        tileName="support1"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAL
-        breakpoint="wide"
-        tileName="support2"
-      />
+      <div>
+        <TileE
+          breakpoint="huge"
+          tileName="support1"
+        />
+      </div>
+      <div />
+      <div>
+        <TileAL
+          breakpoint="huge"
+          tileName="support2"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -1286,36 +1290,38 @@ exports[`38. leaders slice - huge 1`] = `
 <div>
   <div>
     <div>
-      <Image
-        aspectRatio={5.74}
-        uri="https://www.thetimes.co.uk/d/img/leaders-masthead-d17db00289.png"
-      />
       <div>
+        <Image
+          aspectRatio={5.74}
+          uri="https://www.thetimes.co.uk/d/img/leaders-masthead-d17db00289.png"
+        />
         <div>
-           Leading Articles 
+          <div>
+             Leading Articles 
+          </div>
         </div>
       </div>
-    </div>
-    <div>
       <div>
-        <TileM
-          breakpoint="wide"
-          tileName="leader2"
-        />
-      </div>
-      <div />
-      <div>
-        <TileM
-          breakpoint="wide"
-          tileName="leader1"
-        />
-      </div>
-      <div />
-      <div>
-        <TileM
-          breakpoint="wide"
-          tileName="leader3"
-        />
+        <div>
+          <TileM
+            breakpoint="huge"
+            tileName="leader2"
+          />
+        </div>
+        <div />
+        <div>
+          <TileM
+            breakpoint="huge"
+            tileName="leader1"
+          />
+        </div>
+        <div />
+        <div>
+          <TileM
+            breakpoint="huge"
+            tileName="leader3"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1326,50 +1332,52 @@ exports[`39. secondary one and four - huge 1`] = `
 <div>
   <div>
     <div>
-      <TheTimesLogo
-        height={37}
-        width={35}
-      />
-    </div>
-    <div />
-    <div>
       <div>
-        <TileN
-          breakpoint="wide"
-          tileName="secondary"
+        <TheTimesLogo
+          height={37}
+          width={35}
         />
       </div>
       <div />
       <div>
         <div>
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support1"
-            />
-          </div>
-          <div />
-          <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support2"
-            />
-          </div>
+          <TileN
+            breakpoint="huge"
+            tileName="secondary"
+          />
         </div>
         <div />
         <div>
           <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support3"
-            />
+            <div>
+              <TileO
+                breakpoint="huge"
+                tileName="support1"
+              />
+            </div>
+            <div />
+            <div>
+              <TileO
+                breakpoint="huge"
+                tileName="support2"
+              />
+            </div>
           </div>
           <div />
           <div>
-            <TileO
-              breakpoint="wide"
-              tileName="support4"
-            />
+            <div>
+              <TileO
+                breakpoint="huge"
+                tileName="support3"
+              />
+            </div>
+            <div />
+            <div>
+              <TileO
+                breakpoint="huge"
+                tileName="support4"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1380,10 +1388,12 @@ exports[`39. secondary one and four - huge 1`] = `
 
 exports[`40. secondary one - huge 1`] = `
 <div>
-  <TileW
-    breakpoint="wide"
-    tileName="secondary"
-  />
+  <div>
+    <TileW
+      breakpoint="huge"
+      tileName="secondary"
+    />
+  </div>
 </div>
 `;
 
@@ -1392,44 +1402,46 @@ exports[`41. secondary four - huge 1`] = `
   <div>
     <div>
       <div>
-        <TileAR
-          breakpoint="wide"
-          tileName="secondary1"
-        />
+        <div>
+          <TileAR
+            breakpoint="huge"
+            tileName="secondary1"
+          />
+        </div>
+        <div />
+        <div>
+          <TileAR
+            breakpoint="huge"
+            tileName="secondary2"
+          />
+        </div>
       </div>
       <div />
       <div>
-        <TileAR
-          breakpoint="wide"
-          tileName="secondary2"
+        <TileB
+          additionalHeadlineStyles={
+            Object {
+              "fontSize": 22,
+              "lineHeight": 22,
+              "marginBottom": "5px",
+            }
+          }
+          breakpoint="huge"
+          tileName="secondary3"
+        />
+        <div />
+        <TileB
+          additionalHeadlineStyles={
+            Object {
+              "fontSize": 22,
+              "lineHeight": 22,
+              "marginBottom": "5px",
+            }
+          }
+          breakpoint="huge"
+          tileName="secondary4"
         />
       </div>
-    </div>
-    <div />
-    <div>
-      <TileB
-        additionalHeadlineStyles={
-          Object {
-            "fontSize": 20,
-            "lineHeight": 20,
-            "marginBottom": "5px",
-          }
-        }
-        breakpoint="wide"
-        tileName="secondary3"
-      />
-      <div />
-      <TileB
-        additionalHeadlineStyles={
-          Object {
-            "fontSize": 20,
-            "lineHeight": 20,
-            "marginBottom": "5px",
-          }
-        }
-        breakpoint="wide"
-        tileName="secondary4"
-      />
     </div>
   </div>
 </div>
@@ -1439,18 +1451,20 @@ exports[`42. secondary one and columnist - huge 1`] = `
 <div>
   <div>
     <div>
-      <TileAB
-        breakpoint="wide"
-        tileName="columnist"
-      />
-    </div>
-    <div />
-    <div>
-      <TileB
-        breakpoint="wide"
-        tileName="secondary"
-        withMoreTeaser={true}
-      />
+      <div>
+        <TileAB
+          breakpoint="huge"
+          tileName="columnist"
+        />
+      </div>
+      <div />
+      <div>
+        <TileB
+          breakpoint="huge"
+          tileName="secondary"
+          withMoreTeaser={true}
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -1460,27 +1474,29 @@ exports[`43. secondary two and two - huge 1`] = `
 <div>
   <div>
     <div>
-      <TileAM
-        tileName="secondary1"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAN
-        tileName="support1"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAM
-        tileName="secondary2"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAN
-        tileName="support2"
-      />
+      <div>
+        <TileAM
+          tileName="secondary1"
+        />
+      </div>
+      <div />
+      <div>
+        <TileAN
+          tileName="support1"
+        />
+      </div>
+      <div />
+      <div>
+        <TileAM
+          tileName="secondary2"
+        />
+      </div>
+      <div />
+      <div>
+        <TileAN
+          tileName="support2"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -1490,32 +1506,34 @@ exports[`44. lead one and four slice - huge 1`] = `
 <div>
   <div>
     <div>
-      <TileAC
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAD
-        breakpoint="wide"
-        tileName="support1"
-      />
+      <div>
+        <TileAC
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </div>
       <div />
-      <TileAD
-        breakpoint="wide"
-        tileName="support2"
-      />
-      <div />
-      <TileAD
-        breakpoint="wide"
-        tileName="support3"
-      />
-      <div />
-      <TileAD
-        breakpoint="wide"
-        tileName="support4"
-      />
+      <div>
+        <TileAD
+          breakpoint="huge"
+          tileName="support1"
+        />
+        <div />
+        <TileAD
+          breakpoint="huge"
+          tileName="support2"
+        />
+        <div />
+        <TileAD
+          breakpoint="huge"
+          tileName="support3"
+        />
+        <div />
+        <TileAD
+          breakpoint="huge"
+          tileName="support4"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -1525,30 +1543,32 @@ exports[`45. standard slice - huge 1`] = `
 <div>
   <div>
     <div>
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem1"
-      />
-      <div />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem2"
-      />
-      <div />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem3"
-      />
-      <div />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem4"
-      />
-      <div />
-      <TileK
-        breakpoint="wide"
-        tileName="standardItem5"
-      />
+      <div>
+        <TileK
+          breakpoint="huge"
+          tileName="standardItem1"
+        />
+        <div />
+        <TileK
+          breakpoint="huge"
+          tileName="standardItem2"
+        />
+        <div />
+        <TileK
+          breakpoint="huge"
+          tileName="standardItem3"
+        />
+        <div />
+        <TileK
+          breakpoint="huge"
+          tileName="standardItem4"
+        />
+        <div />
+        <TileK
+          breakpoint="huge"
+          tileName="standardItem5"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -1559,30 +1579,32 @@ exports[`46. secondary two no pic and two - huge 1`] = `
   <div>
     <div>
       <div>
-        <TileAE
-          breakpoint="wide"
-          tileName="secondary1"
-        />
+        <div>
+          <TileAE
+            breakpoint="huge"
+            tileName="secondary1"
+          />
+        </div>
+        <div />
+        <div>
+          <TileAE
+            breakpoint="huge"
+            tileName="secondary2"
+          />
+        </div>
       </div>
       <div />
       <div>
-        <TileAE
-          breakpoint="wide"
-          tileName="secondary2"
+        <TileG
+          breakpoint="huge"
+          tileName="support1"
+        />
+        <div />
+        <TileG
+          breakpoint="huge"
+          tileName="support2"
         />
       </div>
-    </div>
-    <div />
-    <div>
-      <TileG
-        breakpoint="wide"
-        tileName="support1"
-      />
-      <div />
-      <TileG
-        breakpoint="wide"
-        tileName="support2"
-      />
     </div>
   </div>
 </div>
@@ -1592,65 +1614,67 @@ exports[`47. list two and six no pic - huge 1`] = `
 <div>
   <div>
     <div>
-      <TileAS
-        breakpoint="wide"
-        tileName="lead1"
-      />
-    </div>
-    <div />
-    <div>
-      <TileAS
-        breakpoint="wide"
-        tileName="lead2"
-      />
-    </div>
-    <div />
-    <div>
       <div>
-        <div>
-          <TileL
-            breakpoint="wide"
-            tileName="support1"
-          />
-        </div>
-        <div />
-        <div>
-          <TileL
-            breakpoint="wide"
-            tileName="support2"
-          />
-        </div>
+        <TileAS
+          breakpoint="huge"
+          tileName="lead1"
+        />
+      </div>
+      <div />
+      <div>
+        <TileAS
+          breakpoint="huge"
+          tileName="lead2"
+        />
       </div>
       <div />
       <div>
         <div>
-          <TileL
-            breakpoint="wide"
-            tileName="support3"
-          />
+          <div>
+            <TileL
+              breakpoint="huge"
+              tileName="support1"
+            />
+          </div>
+          <div />
+          <div>
+            <TileL
+              breakpoint="huge"
+              tileName="support2"
+            />
+          </div>
         </div>
         <div />
         <div>
-          <TileL
-            breakpoint="wide"
-            tileName="support4"
-          />
-        </div>
-      </div>
-      <div />
-      <div>
-        <div>
-          <TileL
-            breakpoint="wide"
-            tileName="support5"
-          />
+          <div>
+            <TileL
+              breakpoint="huge"
+              tileName="support3"
+            />
+          </div>
+          <div />
+          <div>
+            <TileL
+              breakpoint="huge"
+              tileName="support4"
+            />
+          </div>
         </div>
         <div />
         <div>
-          <TileL
-            breakpoint="wide"
-            tileName="support6"
-          />
+          <div>
+            <TileL
+              breakpoint="huge"
+              tileName="support5"
+            />
+          </div>
+          <div />
+          <div>
+            <TileL
+              breakpoint="huge"
+              tileName="support6"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -1662,67 +1686,69 @@ exports[`48. puzzle - huge 1`] = `
 <div>
   <div>
     <div>
-      <TileAK
-        breakpoint="wide"
-        id="0"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+      <div>
+        <TileAK
+          breakpoint="huge"
+          id="0"
+          image={
+            Object {
+              "crop11": null,
+              "crop169": null,
+              "crop23": null,
+              "crop32": Object {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+              },
+              "crop45": null,
+              "crops": Array [],
+              "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            }
           }
-        }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </div>
-    <div>
-      <TileAK
-        breakpoint="wide"
-        id="1"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          title="Times Concise medium No 7881"
+          url="/crossword/123"
+        />
+      </div>
+      <div>
+        <TileAK
+          breakpoint="huge"
+          id="1"
+          image={
+            Object {
+              "crop11": null,
+              "crop169": null,
+              "crop23": null,
+              "crop32": Object {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+              },
+              "crop45": null,
+              "crops": Array [],
+              "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            }
           }
-        }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
-    </div>
-    <div>
-      <TileAK
-        breakpoint="wide"
-        id="2"
-        image={
-          Object {
-            "crop11": null,
-            "crop169": null,
-            "crop23": null,
-            "crop32": Object {
-              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
-            },
-            "crop45": null,
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          title="Times Concise medium No 7881"
+          url="/crossword/123"
+        />
+      </div>
+      <div>
+        <TileAK
+          breakpoint="huge"
+          id="2"
+          image={
+            Object {
+              "crop11": null,
+              "crop169": null,
+              "crop23": null,
+              "crop32": Object {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0",
+              },
+              "crop45": null,
+              "crops": Array [],
+              "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            }
           }
-        }
-        title="Times Concise medium No 7881"
-        url="/crossword/123"
-      />
+          title="Times Concise medium No 7881"
+          url="/crossword/123"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/packages/edition-slices/package.json
+++ b/packages/edition-slices/package.json
@@ -58,7 +58,7 @@
     "@times-components/fixture-generator": "0.25.10",
     "@times-components/jest-configurator": "2.6.7",
     "@times-components/jest-serializer": "3.2.19",
-    "@times-components/mocks": "0.0.44",
+    "@times-components/utils": "4.11.36",
     "@times-components/storybook": "4.0.36",
     "@times-components/test-utils": "2.3.6",
     "@times-components/webpack-configurator": "2.0.26",

--- a/packages/responsive/__tests__/android/__snapshots__/responsive.test.js.snap
+++ b/packages/responsive/__tests__/android/__snapshots__/responsive.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`with default values 1`] = `"{\\"editionBreakpoint\\":\\"small\\",\\"isTablet\\":false,\\"screenWidth\\":500}"`;
+exports[`width values should update on device rotation 1`] = `"{\\"editionBreakpoint\\":\\"small\\",\\"isTablet\\":false,\\"screenWidth\\":500}"`;
 
-exports[`with default values: after width update 1`] = `"{\\"editionBreakpoint\\":\\"medium\\",\\"isTablet\\":true,\\"screenWidth\\":1000}"`;
+exports[`width values should update on device rotation: after width update 1`] = `"{\\"editionBreakpoint\\":\\"medium\\",\\"isTablet\\":true,\\"screenWidth\\":1000}"`;
+
+exports[`with default values 1`] = `"{\\"editionBreakpoint\\":\\"small\\",\\"isTablet\\":false,\\"screenWidth\\":500}"`;

--- a/packages/responsive/__tests__/android/responsive.test.js
+++ b/packages/responsive/__tests__/android/responsive.test.js
@@ -1,3 +1,3 @@
-import shared from "../shared";
+import shared from "../shared.native";
 
 shared();

--- a/packages/responsive/__tests__/ios/__snapshots__/responsive.test.js.snap
+++ b/packages/responsive/__tests__/ios/__snapshots__/responsive.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`with default values 1`] = `"{\\"editionBreakpoint\\":\\"small\\",\\"isTablet\\":false,\\"screenWidth\\":500}"`;
+exports[`width values should update on device rotation 1`] = `"{\\"editionBreakpoint\\":\\"small\\",\\"isTablet\\":false,\\"screenWidth\\":500}"`;
 
-exports[`with default values: after width update 1`] = `"{\\"editionBreakpoint\\":\\"medium\\",\\"isTablet\\":true,\\"screenWidth\\":1000}"`;
+exports[`width values should update on device rotation: after width update 1`] = `"{\\"editionBreakpoint\\":\\"medium\\",\\"isTablet\\":true,\\"screenWidth\\":1000}"`;
+
+exports[`with default values 1`] = `"{\\"editionBreakpoint\\":\\"small\\",\\"isTablet\\":false,\\"screenWidth\\":500}"`;

--- a/packages/responsive/__tests__/ios/responsive.test.js
+++ b/packages/responsive/__tests__/ios/responsive.test.js
@@ -1,3 +1,3 @@
-import shared from "../shared";
+import shared from "../shared.native";
 
 shared();

--- a/packages/responsive/__tests__/shared.base.js
+++ b/packages/responsive/__tests__/shared.base.js
@@ -1,7 +1,18 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import { setDimension } from "@times-components/mocks/dimensions";
 import Responsive, { ResponsiveContext } from "../src/responsive";
+
+jest.mock("@times-components/utils", () => {
+  // eslint-disable-next-line global-require
+  const actualUtils = jest.requireActual("@times-components/utils");
+
+  return {
+    ...actualUtils,
+    getDimentions: jest.fn(() => ({ height: 700, width: 500 })),
+    addDimensionsListener: jest.fn(),
+    removeDimensionsListener: jest.fn()
+  };
+});
 
 export default () => {
   it("with default values", () => {
@@ -14,8 +25,5 @@ export default () => {
     );
 
     expect(testInstance).toMatchSnapshot();
-
-    setDimension({ height: 500, width: 1000 });
-    expect(testInstance).toMatchSnapshot("after width update");
   });
 };

--- a/packages/responsive/__tests__/shared.base.js
+++ b/packages/responsive/__tests__/shared.base.js
@@ -8,7 +8,7 @@ jest.mock("@times-components/utils", () => {
 
   return {
     ...actualUtils,
-    getDimentions: jest.fn(() => ({ height: 700, width: 500 })),
+    getDimensions: jest.fn(() => ({ height: 700, width: 500 })),
     addDimensionsListener: jest.fn(),
     removeDimensionsListener: jest.fn()
   };

--- a/packages/responsive/__tests__/shared.native.js
+++ b/packages/responsive/__tests__/shared.native.js
@@ -1,0 +1,84 @@
+/* eslint-disable global-require */
+import React from "react";
+import TestRenderer from "react-test-renderer";
+import { setDimension } from "@times-components/mocks/dimensions";
+import Responsive, { ResponsiveContext } from "../src/responsive";
+import shared from "./shared.base";
+
+export default () => {
+  shared();
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("width values should update on device rotation", () => {
+    const testInstance = TestRenderer.create(
+      <Responsive>
+        <ResponsiveContext.Consumer>
+          {context => JSON.stringify(context)}
+        </ResponsiveContext.Consumer>
+      </Responsive>
+    );
+
+    expect(testInstance).toMatchSnapshot();
+    setDimension({ height: 500, width: 1000 });
+    expect(testInstance).toMatchSnapshot("after width update");
+  });
+
+  it("addDimensionListener is called on mount", () => {
+    jest.doMock("@times-components/utils", () => {
+      const actualUtils = jest.requireActual("@times-components/utils");
+
+      return {
+        ...actualUtils,
+        __esModule: true,
+        addDimensionsListener: jest.fn().mockImplementation(() => {}),
+        removeDimensionsListener: jest.fn()
+      };
+    });
+
+    const { addDimensionsListener } = require("@times-components/utils");
+    // eslint-disable-next-line no-shadow
+    const Responsive = require("../src/responsive").default;
+
+    TestRenderer.create(
+      <Responsive>
+        <ResponsiveContext.Consumer>
+          {context => JSON.stringify(context)}
+        </ResponsiveContext.Consumer>
+      </Responsive>
+    );
+
+    expect(addDimensionsListener).toBeCalled();
+  });
+
+  it("removeDimensionListener is called on unmount", () => {
+    jest.doMock("@times-components/utils", () => {
+      const actualUtils = jest.requireActual("@times-components/utils");
+
+      return {
+        ...actualUtils,
+        __esModule: true,
+        addDimensionsListener: jest.fn(),
+        removeDimensionsListener: jest.fn().mockImplementation(() => {})
+      };
+    });
+
+    const { removeDimensionsListener } = require("@times-components/utils");
+    // eslint-disable-next-line no-shadow
+    const Responsive = require("../src/responsive").default;
+
+    const testInstance = TestRenderer.create(
+      <Responsive>
+        <ResponsiveContext.Consumer>
+          {context => JSON.stringify(context)}
+        </ResponsiveContext.Consumer>
+      </Responsive>
+    );
+
+    testInstance.unmount();
+
+    expect(removeDimensionsListener).toBeCalled();
+  });
+};

--- a/packages/responsive/__tests__/shared.web.js
+++ b/packages/responsive/__tests__/shared.web.js
@@ -1,0 +1,5 @@
+import shared from "./shared.base";
+
+export default () => {
+  shared();
+};

--- a/packages/responsive/__tests__/web/__snapshots__/responsive.web.test.js.snap
+++ b/packages/responsive/__tests__/web/__snapshots__/responsive.web.test.js.snap
@@ -1,5 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`with default values 1`] = `"{\\"editionBreakpoint\\":\\"wide\\",\\"isTablet\\":false,\\"screenWidth\\":1024}"`;
-
-exports[`with default values: after width update 1`] = `"{\\"editionBreakpoint\\":\\"wide\\",\\"isTablet\\":false,\\"screenWidth\\":1024}"`;
+exports[`with default values 1`] = `"{\\"editionBreakpoint\\":\\"small\\",\\"isTablet\\":false,\\"screenWidth\\":500}"`;

--- a/packages/responsive/__tests__/web/responsive.web.test.js
+++ b/packages/responsive/__tests__/web/responsive.web.test.js
@@ -1,3 +1,3 @@
-import shared from "../shared";
+import shared from "../shared.web";
 
 shared();

--- a/packages/responsive/package.json
+++ b/packages/responsive/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "dependencies": {
     "@times-components/styleguide": "3.28.49",
+    "@times-components/utils": "4.11.36",
     "prop-types": "15.7.2"
   },
   "devDependencies": {

--- a/packages/responsive/src/responsive.js
+++ b/packages/responsive/src/responsive.js
@@ -1,10 +1,14 @@
 import React, { Component } from "react";
-import { Dimensions } from "react-native";
 import PropTypes from "prop-types";
 import {
   getEditionBreakpoint,
   tabletWidth
 } from "@times-components/styleguide";
+import {
+  getDimentions,
+  addDimensionsListener,
+  removeDimensionsListener
+} from "@times-components/utils";
 import ResponsiveContext from "./context";
 
 const calculateState = (width, fontScale) => ({
@@ -18,16 +22,16 @@ class Responsive extends Component {
   constructor(props) {
     super(props);
     this.onDimensionChange = this.onDimensionChange.bind(this);
-    const { fontScale, width } = Dimensions.get("window");
+    const { fontScale, width } = getDimentions();
     this.state = calculateState(width, fontScale);
   }
 
   componentDidMount() {
-    Dimensions.addEventListener("change", this.onDimensionChange);
+    addDimensionsListener("change", this.onDimensionChange);
   }
 
   componentWillUnmount() {
-    Dimensions.removeEventListener("change", this.onDimensionChange);
+    removeDimensionsListener("change", this.onDimensionChange);
   }
 
   onDimensionChange({ window: { fontScale, width } }) {

--- a/packages/responsive/src/responsive.js
+++ b/packages/responsive/src/responsive.js
@@ -5,7 +5,7 @@ import {
   tabletWidth
 } from "@times-components/styleguide";
 import {
-  getDimentions,
+  getDimensions,
   addDimensionsListener,
   removeDimensionsListener
 } from "@times-components/utils";
@@ -22,7 +22,7 @@ class Responsive extends Component {
   constructor(props) {
     super(props);
     this.onDimensionChange = this.onDimensionChange.bind(this);
-    const { fontScale, width } = getDimentions();
+    const { fontScale, width } = getDimensions();
     this.state = calculateState(width, fontScale);
   }
 

--- a/packages/responsive/src/responsive.web.js
+++ b/packages/responsive/src/responsive.web.js
@@ -1,11 +1,11 @@
 import React from "react";
-import { Dimensions } from "react-native";
 import PropTypes from "prop-types";
 import { getEditionBreakpoint } from "@times-components/styleguide";
+import { getDimentions } from "@times-components/utils";
 import ResponsiveContext from "./context";
 
 const Responsive = ({ children }) => {
-  const { width } = Dimensions.get("window");
+  const { width } = getDimentions();
 
   return (
     <ResponsiveContext.Provider

--- a/packages/responsive/src/responsive.web.js
+++ b/packages/responsive/src/responsive.web.js
@@ -1,11 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { getEditionBreakpoint } from "@times-components/styleguide";
-import { getDimentions } from "@times-components/utils";
+import { getDimensions } from "@times-components/utils";
 import ResponsiveContext from "./context";
 
 const Responsive = ({ children }) => {
-  const { width } = getDimentions();
+  const { width } = getDimensions();
 
   return (
     <ResponsiveContext.Provider

--- a/packages/utils/src/dimensions-util.js
+++ b/packages/utils/src/dimensions-util.js
@@ -1,6 +1,6 @@
 import { Dimensions } from "react-native";
 
-export const getDimentions = (
+export const getDimensions = (
   width = Dimensions.get("window").width,
   height = Dimensions.get("window").height,
   fontScale = Dimensions.get("window").fontScale

--- a/packages/utils/src/dimensions-util.js
+++ b/packages/utils/src/dimensions-util.js
@@ -1,0 +1,15 @@
+import { Dimensions } from "react-native";
+
+export const getDimentions = (
+  width = Dimensions.get("window").width,
+  height = Dimensions.get("window").height,
+  fontScale = Dimensions.get("window").fontScale
+) => ({ width, height, fontScale });
+
+export const addDimensionsListener = (type, handler) => {
+  Dimensions.addEventListener(type, handler);
+};
+
+export const removeDimensionsListener = (type, handler) => {
+  Dimensions.removeEventListener(type, handler);
+};

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -1,5 +1,6 @@
 export * from "./screen";
 export * from "./strings";
+export * from "./dimensions-util";
 
 export { default as clean } from "./props";
 export { default as addMissingProtocol } from "./add-missing-protocol";

--- a/packages/utils/src/index.web.js
+++ b/packages/utils/src/index.web.js
@@ -1,5 +1,6 @@
 export * from "./screen";
 export * from "./strings";
+export * from "./dimensions-util";
 
 export { default as clean } from "./props";
 export { default as addMissingProtocol } from "./add-missing-protocol";


### PR DESCRIPTION
Part of [this ticket](https://nidigitalsolutions.jira.com/browse/REPLAT-8113)

Background:
Breakpoint information is carried around through the `Responsive` component. This component takes the screen width from RN `Dimensions` API and saves it in context. For testing purposes react native's `Dimensions` is mocked but instead of this mock the real implementation is applied when performing web tests. (This is also valid for mocking other RN components and RN API for web, could be `react-native-web` issue or some configuration/transformation issue and needs further investigation for all TC packages) Thus we are unable to mock the different breakpoints we have and the web snapshots are faulty.

This PR suggest decoupling Dimensions and Responsive components and introducing helper functions that will take care of providing the screen size information. When mocking these helper functions we will be able to accurately test all breakpoints for web

- [x] 1. Added util functions that provide the screen size
- [x] 2. Discard `Dimensions`' usage from `Responsive` component and use util functions instead
- [x] 3. Update edition slices tests with a mocked screen size
- [x] 4. Update web snaps only

Test coverage for web tests:
![Screenshot 2019-10-03 at 12 24 02](https://user-images.githubusercontent.com/16742525/66115074-c8702480-e5d8-11e9-8042-56acad0cf5f7.png)

Make sure the app works well after the update:
![Simulator Screen Shot - iPad Air 2 - 2019-10-03 at 12 22 43](https://user-images.githubusercontent.com/16742525/66115137-e6d62000-e5d8-11e9-8838-570721ce7859.png)

