### PR TITLE
feat: REPLAT-9308 lead 2 no pic 2 tiles swapped for 1024 and 1366

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1664,11 +1664,11 @@ exports[`21. lead two no pic and two - wide 1`] = `
     <View
       style={
         Object {
-          "width": "42%",
+          "width": "16%",
         }
       }
     >
-      <TileE />
+      <TileAL />
     </View>
     <View
       style={
@@ -1683,11 +1683,11 @@ exports[`21. lead two no pic and two - wide 1`] = `
     <View
       style={
         Object {
-          "width": "16%",
+          "width": "42%",
         }
       }
     >
-      <TileAL />
+      <TileE />
     </View>
   </View>
 </View>
@@ -3071,11 +3071,11 @@ exports[`37. lead two no pic and two - huge 1`] = `
       <View
         style={
           Object {
-            "width": "42%",
+            "width": "16%",
           }
         }
       >
-        <TileE />
+        <TileAL />
       </View>
       <View
         style={
@@ -3090,11 +3090,11 @@ exports[`37. lead two no pic and two - huge 1`] = `
       <View
         style={
           Object {
-            "width": "16%",
+            "width": "42%",
           }
         }
       >
-        <TileAL />
+        <TileE />
       </View>
     </View>
   </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -695,16 +695,16 @@ exports[`21. lead two no pic and two - wide 1`] = `
     </View>
     <View />
     <View>
-      <TileE
+      <TileAL
         breakpoint="wide"
-        tileName="support1"
+        tileName="support2"
       />
     </View>
     <View />
     <View>
-      <TileAL
+      <TileE
         breakpoint="wide"
-        tileName="support2"
+        tileName="support1"
       />
     </View>
   </View>
@@ -1288,16 +1288,16 @@ exports[`37. lead two no pic and two - huge 1`] = `
       </View>
       <View />
       <View>
-        <TileE
+        <TileAL
           breakpoint="huge"
-          tileName="support1"
+          tileName="support2"
         />
       </View>
       <View />
       <View>
-        <TileAL
+        <TileE
           breakpoint="huge"
-          tileName="support2"
+          tileName="support1"
         />
       </View>
     </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1664,11 +1664,11 @@ exports[`21. lead two no pic and two - wide 1`] = `
     <View
       style={
         Object {
-          "width": "42%",
+          "width": "16%",
         }
       }
     >
-      <TileE />
+      <TileAL />
     </View>
     <View
       style={
@@ -1683,11 +1683,11 @@ exports[`21. lead two no pic and two - wide 1`] = `
     <View
       style={
         Object {
-          "width": "16%",
+          "width": "42%",
         }
       }
     >
-      <TileAL />
+      <TileE />
     </View>
   </View>
 </View>
@@ -3071,11 +3071,11 @@ exports[`37. lead two no pic and two - huge 1`] = `
       <View
         style={
           Object {
-            "width": "42%",
+            "width": "16%",
           }
         }
       >
-        <TileE />
+        <TileAL />
       </View>
       <View
         style={
@@ -3090,11 +3090,11 @@ exports[`37. lead two no pic and two - huge 1`] = `
       <View
         style={
           Object {
-            "width": "16%",
+            "width": "42%",
           }
         }
       >
-        <TileAL />
+        <TileE />
       </View>
     </View>
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -695,16 +695,16 @@ exports[`21. lead two no pic and two - wide 1`] = `
     </View>
     <View />
     <View>
-      <TileE
+      <TileAL
         breakpoint="wide"
-        tileName="support1"
+        tileName="support2"
       />
     </View>
     <View />
     <View>
-      <TileAL
+      <TileE
         breakpoint="wide"
-        tileName="support2"
+        tileName="support1"
       />
     </View>
   </View>
@@ -1288,16 +1288,16 @@ exports[`37. lead two no pic and two - huge 1`] = `
       </View>
       <View />
       <View>
-        <TileE
+        <TileAL
           breakpoint="huge"
-          tileName="support1"
+          tileName="support2"
         />
       </View>
       <View />
       <View>
-        <TileAL
+        <TileE
           breakpoint="huge"
-          tileName="support2"
+          tileName="support1"
         />
       </View>
     </View>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2891,7 +2891,7 @@ exports[`21. lead two no pic and two - wide 1`] = `
 }
 
 .IS4 {
-  width: 42%;
+  width: 16%;
 }
 
 .IS5 {
@@ -2909,7 +2909,7 @@ exports[`21. lead two no pic and two - wide 1`] = `
 }
 
 .IS6 {
-  width: 16%;
+  width: 42%;
 }
 
 .IS7 {
@@ -2970,9 +2970,9 @@ exports[`21. lead two no pic and two - wide 1`] = `
     <div
       className="css-view-1dbjc4n IS4"
     >
-      <TileE
+      <TileAL
         breakpoint="wide"
-        tileName="support1"
+        tileName="support2"
       />
     </div>
     <div
@@ -2981,9 +2981,9 @@ exports[`21. lead two no pic and two - wide 1`] = `
     <div
       className="css-view-1dbjc4n IS6"
     >
-      <TileAL
+      <TileE
         breakpoint="wide"
-        tileName="support2"
+        tileName="support1"
       />
     </div>
   </div>
@@ -5336,7 +5336,7 @@ exports[`37. lead two no pic and two - huge 1`] = `
 }
 
 .IS4 {
-  width: 42%;
+  width: 16%;
 }
 
 .IS5 {
@@ -5354,7 +5354,7 @@ exports[`37. lead two no pic and two - huge 1`] = `
 }
 
 .IS6 {
-  width: 16%;
+  width: 42%;
 }
 
 .IS7 {
@@ -5435,9 +5435,9 @@ exports[`37. lead two no pic and two - huge 1`] = `
       <div
         className="css-view-1dbjc4n IS4"
       >
-        <TileE
+        <TileAL
           breakpoint="huge"
-          tileName="support1"
+          tileName="support2"
         />
       </div>
       <div
@@ -5446,9 +5446,9 @@ exports[`37. lead two no pic and two - huge 1`] = `
       <div
         className="css-view-1dbjc4n IS6"
       >
-        <TileAL
+        <TileE
           breakpoint="huge"
-          tileName="support2"
+          tileName="support1"
         />
       </div>
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -683,16 +683,16 @@ exports[`21. lead two no pic and two - wide 1`] = `
     </div>
     <div />
     <div>
-      <TileE
+      <TileAL
         breakpoint="wide"
-        tileName="support1"
+        tileName="support2"
       />
     </div>
     <div />
     <div>
-      <TileAL
+      <TileE
         breakpoint="wide"
-        tileName="support2"
+        tileName="support1"
       />
     </div>
   </div>
@@ -1268,16 +1268,16 @@ exports[`37. lead two no pic and two - huge 1`] = `
       </div>
       <div />
       <div>
-        <TileE
+        <TileAL
           breakpoint="huge"
-          tileName="support1"
+          tileName="support2"
         />
       </div>
       <div />
       <div>
-        <TileAL
+        <TileE
           breakpoint="huge"
-          tileName="support2"
+          tileName="support1"
         />
       </div>
     </div>

--- a/packages/slice-layout/__tests__/android/__snapshots__/l2np2-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/l2np2-with-style.android.test.js.snap
@@ -165,12 +165,12 @@ exports[`3. lead two no pic and two - wide 1`] = `
   <View
     style={
       Object {
-        "width": "42%",
+        "width": "16%",
       }
     }
   >
     <Text>
-      support-1
+      support-2
     </Text>
   </View>
   <View
@@ -186,12 +186,12 @@ exports[`3. lead two no pic and two - wide 1`] = `
   <View
     style={
       Object {
-        "width": "16%",
+        "width": "42%",
       }
     }
   >
     <Text>
-      support-2
+      support-1
     </Text>
   </View>
 </View>
@@ -244,12 +244,12 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "width": "42%",
+        "width": "16%",
       }
     }
   >
     <Text>
-      support-1
+      support-2
     </Text>
   </View>
   <View
@@ -265,12 +265,12 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "width": "16%",
+        "width": "42%",
       }
     }
   >
     <Text>
-      support-2
+      support-1
     </Text>
   </View>
 </View>

--- a/packages/slice-layout/__tests__/android/__snapshots__/l2np2.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/l2np2.android.test.js.snap
@@ -58,13 +58,13 @@ exports[`3. lead two no pic and two - wide 1`] = `
   <View />
   <View>
     <Text>
-      support-1
+      support-2
     </Text>
   </View>
   <View />
   <View>
     <Text>
-      support-2
+      support-1
     </Text>
   </View>
 </View>
@@ -84,13 +84,13 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View />
   <View>
     <Text>
-      support-1
+      support-2
     </Text>
   </View>
   <View />
   <View>
     <Text>
-      support-2
+      support-1
     </Text>
   </View>
 </View>

--- a/packages/slice-layout/__tests__/ios/__snapshots__/l2np2-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/l2np2-with-style.ios.test.js.snap
@@ -165,12 +165,12 @@ exports[`3. lead two no pic and two - wide 1`] = `
   <View
     style={
       Object {
-        "width": "42%",
+        "width": "16%",
       }
     }
   >
     <Text>
-      support-1
+      support-2
     </Text>
   </View>
   <View
@@ -186,12 +186,12 @@ exports[`3. lead two no pic and two - wide 1`] = `
   <View
     style={
       Object {
-        "width": "16%",
+        "width": "42%",
       }
     }
   >
     <Text>
-      support-2
+      support-1
     </Text>
   </View>
 </View>
@@ -244,12 +244,12 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "width": "42%",
+        "width": "16%",
       }
     }
   >
     <Text>
-      support-1
+      support-2
     </Text>
   </View>
   <View
@@ -265,12 +265,12 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View
     style={
       Object {
-        "width": "16%",
+        "width": "42%",
       }
     }
   >
     <Text>
-      support-2
+      support-1
     </Text>
   </View>
 </View>

--- a/packages/slice-layout/__tests__/ios/__snapshots__/l2np2.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/l2np2.ios.test.js.snap
@@ -58,13 +58,13 @@ exports[`3. lead two no pic and two - wide 1`] = `
   <View />
   <View>
     <Text>
-      support-1
+      support-2
     </Text>
   </View>
   <View />
   <View>
     <Text>
-      support-2
+      support-1
     </Text>
   </View>
 </View>
@@ -84,13 +84,13 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <View />
   <View>
     <Text>
-      support-1
+      support-2
     </Text>
   </View>
   <View />
   <View>
     <Text>
-      support-2
+      support-1
     </Text>
   </View>
 </View>

--- a/packages/slice-layout/__tests__/web/__snapshots__/l2np2-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/l2np2-with-style.web.test.js.snap
@@ -285,14 +285,14 @@ exports[`3. lead two no pic and two - wide 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "42%",
+        "width": "16%",
       }
     }
   >
     <div
       className="css-text-901oao"
     >
-      support-1
+      support-2
     </div>
   </div>
   <div
@@ -317,14 +317,14 @@ exports[`3. lead two no pic and two - wide 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "16%",
+        "width": "42%",
       }
     }
   >
     <div
       className="css-text-901oao"
     >
-      support-2
+      support-1
     </div>
   </div>
 </div>
@@ -414,14 +414,14 @@ exports[`4. lead two no pic and two - huge 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "42%",
+        "width": "16%",
       }
     }
   >
     <div
       className="css-text-901oao"
     >
-      support-1
+      support-2
     </div>
   </div>
   <div
@@ -446,14 +446,14 @@ exports[`4. lead two no pic and two - huge 1`] = `
     className="css-view-1dbjc4n"
     style={
       Object {
-        "width": "16%",
+        "width": "42%",
       }
     }
   >
     <div
       className="css-text-901oao"
     >
-      support-2
+      support-1
     </div>
   </div>
 </div>

--- a/packages/slice-layout/__tests__/web/__snapshots__/l2np2.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/l2np2.web.test.js.snap
@@ -58,13 +58,13 @@ exports[`3. lead two no pic and two - wide 1`] = `
   <div />
   <div>
     <div>
-      support-1
+      support-2
     </div>
   </div>
   <div />
   <div>
     <div>
-      support-2
+      support-1
     </div>
   </div>
 </div>
@@ -84,13 +84,13 @@ exports[`4. lead two no pic and two - huge 1`] = `
   <div />
   <div>
     <div>
-      support-1
+      support-2
     </div>
   </div>
   <div />
   <div>
     <div>
-      support-2
+      support-1
     </div>
   </div>
 </div>

--- a/packages/slice-layout/src/templates/leadtwonopicandtwo/index.js
+++ b/packages/slice-layout/src/templates/leadtwonopicandtwo/index.js
@@ -23,9 +23,9 @@ const LeadTwoNoPicAndTwoSlice = ({
       <View style={styles.container}>
         <VerticalLayout style={styles.column} tiles={[lead1, lead2]} />
         <ItemColSeparator style={styles.colSeparatorStyle} />
-        <View style={styles.column}>{support1}</View>
-        <ItemColSeparator style={styles.colSeparatorStyle} />
         <View style={styles.middleTile}>{support2}</View>
+        <ItemColSeparator style={styles.colSeparatorStyle} />
+        <View style={styles.column}>{support1}</View>
       </View>
     );
   }


### PR DESCRIPTION
[Story.](https://nidigitalsolutions.jira.com/browse/REPLAT-9308)
[Design.](https://app.zeplin.io/project/5d2849a2b4a4605645afb4be/screen/5d516aab9df85c9b3c22473b)
Lead 2 no pic 2 slice design changes:
Large image tile (support1) moved to right for wide and huge viewports.

Before:
![image](https://user-images.githubusercontent.com/8720661/66135502-bb682b00-e602-11e9-8090-8ff8f3b2a73b.png)

After:
![image](https://user-images.githubusercontent.com/8720661/66135468-aee3d280-e602-11e9-85d7-b4c90ae09bdc.png)
