### PR TITLE
chore: edition-slices web snapshots update

### DIFF
--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -372,7 +372,6 @@ exports[`3. lead one and one - medium 1`] = `
       className="css-view-1dbjc4n IS1"
     >
       <TileU
-        breakpoint="medium"
         tileName="lead"
       />
     </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -74,7 +74,6 @@ exports[`3. lead one and one - medium 1`] = `
   <div>
     <div>
       <TileU
-        breakpoint="medium"
         tileName="lead"
       />
     </div>


### PR DESCRIPTION
[The latest tests](https://app.bitrise.io/build/5e83ae434d3d41a6#?tab=log) on master are failing. 
Updating the snapshots on master branch in order to unblock tests in all open the PRs.
Snaps updated in [this commit](https://github.com/newsuk/times-components/commit/d685fe69fee2a6b84ef579a8917a376c9399c8f3) were overridden by the [next commit.](https://github.com/newsuk/times-components/commit/4087b7f79eec707ea47158667c6d0a640153632c)