### PR TITLE
fix: remove dateUpdated from schema REPLAT-8272

### DIFF
--- a/packages/article-skeleton/src/head.web.js
+++ b/packages/article-skeleton/src/head.web.js
@@ -169,10 +169,6 @@ function Head({ article, paidContentClassName, faviconUrl }) {
     dateModified
   };
 
-  if (updatedTime) {
-    jsonLD.dateUpdated = updatedTime;
-  }
-
   return (
     <Context.Consumer>
       {({ makeArticleUrl }) => {

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "dependencies": {
-    "@times-components/styleguide": "3.28.49"
+    "@times-components/styleguide": "3.28.50"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "dependencies": {
-    "@times-components/styleguide": "3.28.49"
+    "@times-components/styleguide": "3.28.50"
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -41,7 +41,7 @@
     "@times-components/eslint-config-thetimes": "0.8.15",
     "@times-components/jest-configurator": "2.6.7",
     "@times-components/jest-serializer": "3.2.19",
-    "@times-components/storybook": "4.0.36",
+    "@times-components/storybook": "4.0.37",
     "@times-components/test-utils": "2.3.6",
     "babel-jest": "24.8.0",
     "babel-loader": "8.0.5",
@@ -59,7 +59,7 @@
     "webpack-cli": "3.3.1"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.28.49",
+    "@times-components/styleguide": "3.28.50",
     "@times-components/svgs": "2.7.25",
     "prop-types": "15.7.2"
   },


### PR DESCRIPTION
<!--
Thank you for your PR!

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Removing dateUpdated from jsonLD schema as we don't need it. Further details in JIRA comments

JIRA:
https://nidigitalsolutions.jira.com/browse/REPLAT-8272
