### PR TITLE
feat: add customMPU ad slot

### DIFF
--- a/packages/ad/ad.showcase.js
+++ b/packages/ad/ad.showcase.js
@@ -34,7 +34,8 @@ const slotNames = [
   "header",
   "pixel",
   "pixelteads",
-  "pixelskin"
+  "pixelskin",
+  "customMPU"
 ];
 
 const articleContextURL =

--- a/packages/ad/src/utils/generate-config.js
+++ b/packages/ad/src/utils/generate-config.js
@@ -24,7 +24,8 @@ const slotPositions = {
   header: 1,
   pixel: 2,
   pixelskin: 2,
-  pixelteads: 2
+  pixelteads: 2,
+  customMPU: 3,
 };
 
 const sizeMap = {
@@ -38,7 +39,8 @@ const sizeMap = {
   "native-inline-ad": sizes.native,
   pixel: sizes.pixel,
   pixelskin: sizes.pixel,
-  pixelteads: sizes.pixel
+  pixelteads: sizes.pixel,
+  customMPU: sizes.customMPU,
 };
 
 const getAdSizes = (adSizeMap, width) => {

--- a/packages/ad/src/utils/generate-config.js
+++ b/packages/ad/src/utils/generate-config.js
@@ -25,7 +25,7 @@ const slotPositions = {
   pixel: 2,
   pixelskin: 2,
   pixelteads: 2,
-  customMPU: 3,
+  customMPU: 3
 };
 
 const sizeMap = {
@@ -40,7 +40,7 @@ const sizeMap = {
   pixel: sizes.pixel,
   pixelskin: sizes.pixel,
   pixelteads: sizes.pixel,
-  customMPU: sizes.customMPU,
+  customMPU: sizes.customMPU
 };
 
 const getAdSizes = (adSizeMap, width) => {

--- a/packages/ad/src/utils/sizes.js
+++ b/packages/ad/src/utils/sizes.js
@@ -48,6 +48,18 @@ const sizes = {
       width: 1024
     }
   ],
+  customMPU: [
+    {
+      height: 0,
+      sizes: [],
+      width: 0
+    },
+    {
+      height: 250,
+      sizes: [[300, 250]],
+      width: 300
+    }
+  ],
   native: [
     {
       height: 250,


### PR DESCRIPTION
Add a configuration for a new add slot named customMPU.

Request context: 
Current ad slots increase in width in relation to the overall device width. This request adds a new ad slot which displays at 300px on all device widths.

https://nidigitalsolutions.jira.com/browse/TCC-135?atlOrigin=eyJpIjoiYzljMzIzZmNiZGU5NDk3M2I1Mjc1MTAxNWJhNGYwMGEiLCJwIjoiaiJ9
