### PR TITLE
feat: REPLAT-9113 moving flags for tablet beneath the headline or standfirst text

### DIFF
--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
@@ -694,3 +694,177 @@ exports[`18. article summary content component without white space height 1`] = 
   </Text>
 </Text>
 `;
+
+exports[`19. article summary component with a single paragraph and flag on tablet 1`] = `
+<View>
+  <View>
+    <ArticleLabel
+      color="#333333"
+      title="Camilla Long"
+    />
+  </View>
+  <Text
+    accessibilityRole="header"
+    aria-level="3"
+  >
+    Test Headline
+  </Text>
+  <ArticleFlags
+    flags={
+      Array [
+        Object {
+          "expiryTime": "2020-03-13T12:00:00.000Z",
+          "type": "UPDATED",
+        },
+        Object {
+          "expiryTime": "2019-03-14T12:00:00.000Z",
+          "type": "EXCLUSIVE",
+        },
+      ]
+    }
+  />
+  <Text>
+    <Text>
+      
+      Test paragraph
+      ...
+    </Text>
+  </Text>
+  <Text>
+    <DatePublication
+      date="2017-11-17T00:01:00.000Z"
+      publication="TIMES"
+    />
+  </Text>
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {
+              "slug": "camilla-long",
+            },
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Camilla Long",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "author",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": ", Environment Editor",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
+</View>
+`;
+
+exports[`20. article summary component with a strapline and flag on tablet 1`] = `
+<View>
+  <View>
+    <ArticleLabel
+      color="#333333"
+      title="Camilla Long"
+    />
+  </View>
+  <Text
+    accessibilityRole="header"
+    aria-level="3"
+  >
+    Test Headline
+  </Text>
+  <Text
+    accessibilityRole="header"
+    aria-level="4"
+  >
+    Test Strapline
+  </Text>
+  <ArticleFlags
+    flags={
+      Array [
+        Object {
+          "expiryTime": "2020-03-13T12:00:00.000Z",
+          "type": "UPDATED",
+        },
+        Object {
+          "expiryTime": "2019-03-14T12:00:00.000Z",
+          "type": "EXCLUSIVE",
+        },
+      ]
+    }
+  />
+  <Text>
+    <Text>
+      
+      Test paragraph
+      ...
+    </Text>
+  </Text>
+  <Text>
+    <DatePublication
+      date="2017-11-17T00:01:00.000Z"
+      publication="TIMES"
+    />
+  </Text>
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "byline": Array [
+              Object {
+                "attributes": Object {
+                  "slug": "camilla-long",
+                },
+                "children": Array [
+                  Object {
+                    "attributes": Object {
+                      "value": "Camilla Long",
+                    },
+                    "children": Array [],
+                    "name": "text",
+                  },
+                ],
+                "name": "author",
+              },
+            ],
+          },
+          Object {
+            "byline": Array [
+              Object {
+                "attributes": Object {},
+                "children": Array [
+                  Object {
+                    "attributes": Object {
+                      "value": ", Environment Editor",
+                    },
+                    "children": Array [],
+                    "name": "text",
+                  },
+                ],
+                "name": "inline",
+              },
+            ],
+          },
+        ]
+      }
+    />
+  </Text>
+</View>
+`;

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
@@ -694,3 +694,177 @@ exports[`18. article summary content component without white space height 1`] = 
   </Text>
 </Text>
 `;
+
+exports[`19. article summary component with a single paragraph and flag on tablet 1`] = `
+<View>
+  <View>
+    <ArticleLabel
+      color="#333333"
+      title="Camilla Long"
+    />
+  </View>
+  <Text
+    accessibilityRole="header"
+    aria-level="3"
+  >
+    Test Headline
+  </Text>
+  <ArticleFlags
+    flags={
+      Array [
+        Object {
+          "expiryTime": "2020-03-13T12:00:00.000Z",
+          "type": "UPDATED",
+        },
+        Object {
+          "expiryTime": "2019-03-14T12:00:00.000Z",
+          "type": "EXCLUSIVE",
+        },
+      ]
+    }
+  />
+  <Text>
+    <Text>
+      
+      Test paragraph
+      ...
+    </Text>
+  </Text>
+  <Text>
+    <DatePublication
+      date="2017-11-17T00:01:00.000Z"
+      publication="TIMES"
+    />
+  </Text>
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {
+              "slug": "camilla-long",
+            },
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Camilla Long",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "author",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": ", Environment Editor",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
+</View>
+`;
+
+exports[`20. article summary component with a strapline and flag on tablet 1`] = `
+<View>
+  <View>
+    <ArticleLabel
+      color="#333333"
+      title="Camilla Long"
+    />
+  </View>
+  <Text
+    accessibilityRole="header"
+    aria-level="3"
+  >
+    Test Headline
+  </Text>
+  <Text
+    accessibilityRole="header"
+    aria-level="4"
+  >
+    Test Strapline
+  </Text>
+  <ArticleFlags
+    flags={
+      Array [
+        Object {
+          "expiryTime": "2020-03-13T12:00:00.000Z",
+          "type": "UPDATED",
+        },
+        Object {
+          "expiryTime": "2019-03-14T12:00:00.000Z",
+          "type": "EXCLUSIVE",
+        },
+      ]
+    }
+  />
+  <Text>
+    <Text>
+      
+      Test paragraph
+      ...
+    </Text>
+  </Text>
+  <Text>
+    <DatePublication
+      date="2017-11-17T00:01:00.000Z"
+      publication="TIMES"
+    />
+  </Text>
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "byline": Array [
+              Object {
+                "attributes": Object {
+                  "slug": "camilla-long",
+                },
+                "children": Array [
+                  Object {
+                    "attributes": Object {
+                      "value": "Camilla Long",
+                    },
+                    "children": Array [],
+                    "name": "text",
+                  },
+                ],
+                "name": "author",
+              },
+            ],
+          },
+          Object {
+            "byline": Array [
+              Object {
+                "attributes": Object {},
+                "children": Array [
+                  Object {
+                    "attributes": Object {
+                      "value": ", Environment Editor",
+                    },
+                    "children": Array [],
+                    "name": "text",
+                  },
+                ],
+                "name": "inline",
+              },
+            ],
+          },
+        ]
+      }
+    />
+  </Text>
+</View>
+`;

--- a/packages/article-summary/__tests__/shared.base.js
+++ b/packages/article-summary/__tests__/shared.base.js
@@ -58,6 +58,7 @@ export default () => {
       name: "paragraph"
     }
   ];
+  const isTablet = true;
 
   const tests = [
     {
@@ -298,6 +299,42 @@ export default () => {
       test: () => {
         const testInstance = TestRenderer.create(
           <ArticleSummaryContent ast={defaultContent} whiteSpaceHeight={0} />
+        );
+
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name:
+        "article summary component with a single paragraph and flag on tablet",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...defaultFixture({
+              flags,
+              headline,
+              paragraph
+            })}
+            isTablet={isTablet}
+          />
+        );
+
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article summary component with a strapline and flag on tablet",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...straplineFixture({
+              flags,
+              headline,
+              paragraph,
+              strapline
+            })}
+            isTablet={isTablet}
+          />
         );
 
         expect(testInstance.toJSON()).toMatchSnapshot();

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
@@ -850,3 +850,204 @@ exports[`18. article summary content component without white space height 1`] = 
   </span>
 </div>
 `;
+
+exports[`19. article summary component with a single paragraph and flag on tablet 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <div
+    className="css-view-1dbjc4n r-marginBottom-p1pxzi"
+  >
+    <ArticleLabel
+      color="#333333"
+      title="Camilla Long"
+    />
+  </div>
+  <h3
+    aria-level="3"
+    className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw r-marginBottom-d0pm55"
+    role="heading"
+  >
+    Test Headline
+  </h3>
+  <ArticleFlags
+    flags={
+      Array [
+        Object {
+          "expiryTime": "2020-03-13T12:00:00.000Z",
+          "type": "UPDATED",
+        },
+        Object {
+          "expiryTime": "2019-03-14T12:00:00.000Z",
+          "type": "EXCLUSIVE",
+        },
+      ]
+    }
+  />
+  <div
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+  >
+    <span
+      className="css-text-901oao css-textHasAncestor-16my406"
+    >
+      
+      Test paragraph
+      ...
+    </span>
+  </div>
+  <div
+    className="css-text-901oao r-color-1khp51w r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-marginBottom-d0pm55"
+  >
+    <DatePublication
+      date="2017-11-17T00:01:00.000Z"
+      publication="TIMES"
+    />
+  </div>
+  <div
+    className="css-text-901oao"
+  >
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {
+              "slug": "camilla-long",
+            },
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Camilla Long",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "author",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": ", Environment Editor",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`20. article summary component with a strapline and flag on tablet 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <div
+    className="css-view-1dbjc4n r-marginBottom-p1pxzi"
+  >
+    <ArticleLabel
+      color="#333333"
+      title="Camilla Long"
+    />
+  </div>
+  <h3
+    aria-level="3"
+    className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw r-marginBottom-d0pm55"
+    role="heading"
+  >
+    Test Headline
+  </h3>
+  <h4
+    aria-level="4"
+    className="css-reset-4rbku5 css-text-901oao r-color-1khp51w r-fontFamily-4h8ur4 r-fontSize-1b6yd1w r-lineHeight-10yl4k r-paddingBottom-1mi0q7o"
+    role="heading"
+  >
+    Test Strapline
+  </h4>
+  <ArticleFlags
+    flags={
+      Array [
+        Object {
+          "expiryTime": "2020-03-13T12:00:00.000Z",
+          "type": "UPDATED",
+        },
+        Object {
+          "expiryTime": "2019-03-14T12:00:00.000Z",
+          "type": "EXCLUSIVE",
+        },
+      ]
+    }
+  />
+  <div
+    className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r"
+  >
+    <span
+      className="css-text-901oao css-textHasAncestor-16my406"
+    >
+      
+      Test paragraph
+      ...
+    </span>
+  </div>
+  <div
+    className="css-text-901oao r-color-1khp51w r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-marginBottom-d0pm55"
+  >
+    <DatePublication
+      date="2017-11-17T00:01:00.000Z"
+      publication="TIMES"
+    />
+  </div>
+  <div
+    className="css-text-901oao"
+  >
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "byline": Array [
+              Object {
+                "attributes": Object {
+                  "slug": "camilla-long",
+                },
+                "children": Array [
+                  Object {
+                    "attributes": Object {
+                      "value": "Camilla Long",
+                    },
+                    "children": Array [],
+                    "name": "text",
+                  },
+                ],
+                "name": "author",
+              },
+            ],
+          },
+          Object {
+            "byline": Array [
+              Object {
+                "attributes": Object {},
+                "children": Array [
+                  Object {
+                    "attributes": Object {
+                      "value": ", Environment Editor",
+                    },
+                    "children": Array [],
+                    "name": "text",
+                  },
+                ],
+                "name": "inline",
+              },
+            ],
+          },
+        ]
+      }
+    />
+  </div>
+</div>
+`;

--- a/packages/article-summary/article-summary.showcase.js
+++ b/packages/article-summary/article-summary.showcase.js
@@ -12,12 +12,18 @@ import reviewFixture from "./fixtures/review";
 import straplineFixture from "./fixtures/strapline";
 
 const story = m => <View style={{ padding: 20 }}>{m}</View>;
+const isTablet = true;
 
 export default {
   children: [
     {
       component: () => story(<ArticleSummary {...defaultFixture()} />),
       name: "Default",
+      type: "story"
+    },
+    {
+      component: () => story(<ArticleSummary {...defaultFixture()} isTablet={isTablet} />),
+      name: "Default on tablet",
       type: "story"
     },
     {

--- a/packages/article-summary/article-summary.showcase.js
+++ b/packages/article-summary/article-summary.showcase.js
@@ -22,7 +22,8 @@ export default {
       type: "story"
     },
     {
-      component: () => story(<ArticleSummary {...defaultFixture()} isTablet={isTablet} />),
+      component: () =>
+        story(<ArticleSummary {...defaultFixture()} isTablet={isTablet} />),
       name: "Default on tablet",
       type: "story"
     },

--- a/packages/article-summary/src/article-summary.js
+++ b/packages/article-summary/src/article-summary.js
@@ -60,11 +60,14 @@ function ArticleSummary(props) {
     labelProps,
     style,
     strapline,
-    saveStar
+    saveStar,
+    isTablet
   } = props;
 
   const { isOpinionByline = false } = bylineProps || {};
   const byline = bylineProps ? <Byline {...bylineProps} /> : null;
+  const tabletFlags = isTablet && flags;
+  const mobileFlags = !isTablet && flags;
 
   return (
     <View style={style}>
@@ -72,8 +75,9 @@ function ArticleSummary(props) {
       {isOpinionByline && byline}
       {headline}
       {strapline}
+      {tabletFlags}
       {content}
-      {flags}
+      {mobileFlags}
       {saveStar}
       {datePublicationProps ? (
         <Text style={styles.metaText} testID="datePublication">

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
@@ -619,6 +619,21 @@ exports[`5. standard 1`] = `
                   "name": "paragraph",
                 },
               ],
+              "summary800": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
               "synonyms": Object {
                 "edges": Array [],
                 "nodes": Array [],
@@ -1030,6 +1045,21 @@ exports[`5. standard 1`] = `
                     Object {
                       "attributes": Object {
                         "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary800": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
                       },
                       "children": Array [],
                       "name": "text",
@@ -1457,6 +1487,21 @@ exports[`5. standard 1`] = `
                   "name": "paragraph",
                 },
               ],
+              "summary800": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
               "synonyms": Object {
                 "edges": Array [],
                 "nodes": Array [],
@@ -1876,6 +1921,21 @@ exports[`5. standard 1`] = `
                   "name": "paragraph",
                 },
               ],
+              "summary800": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
               "synonyms": Object {
                 "edges": Array [],
                 "nodes": Array [],
@@ -2287,6 +2347,21 @@ exports[`5. standard 1`] = `
                     Object {
                       "attributes": Object {
                         "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary800": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
                       },
                       "children": Array [],
                       "name": "text",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -84,7 +84,6 @@ exports[`3. lead one and one - medium 1`] = `
     <View />
     <View>
       <TileAA
-        breakpoint="medium"
         tileName="support"
       />
     </View>
@@ -845,7 +844,6 @@ exports[`25. secondary four - wide 1`] = `
           Object {
             "fontSize": 20,
             "lineHeight": 20,
-            "marginBottom": 5,
           }
         }
         breakpoint="wide"
@@ -857,7 +855,6 @@ exports[`25. secondary four - wide 1`] = `
           Object {
             "fontSize": 20,
             "lineHeight": 20,
-            "marginBottom": 5,
           }
         }
         breakpoint="wide"
@@ -1446,7 +1443,6 @@ exports[`41. secondary four - huge 1`] = `
             Object {
               "fontSize": 22,
               "lineHeight": 22,
-              "marginBottom": 5,
             }
           }
           breakpoint="huge"
@@ -1458,7 +1454,6 @@ exports[`41. secondary four - huge 1`] = `
             Object {
               "fontSize": 22,
               "lineHeight": 22,
-              "marginBottom": 5,
             }
           }
           breakpoint="huge"

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-aa.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-aa.test.js.snap
@@ -1,71 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile aа huge 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 15,
-    }
-  }
-  url="/article/123"
->
-  <View
-    style={
-      Object {
-        "flex": 1,
-      }
-    }
-  >
-    <View>
-      <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
-            }
-          }
-        >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
-          />
-        </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 28,
-              "fontWeight": "400",
-              "lineHeight": 28,
-              "marginBottom": 10,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-      </View>
-    </View>
-  </View>
-</Link>
-`;
-
-exports[`tile aа medium 1`] = `
+exports[`tile aа without breakpoint 1`] = `
 <Link
   linkStyle={
     Object {
@@ -108,141 +43,31 @@ exports[`tile aа medium 1`] = `
               "fontSize": 20,
               "fontWeight": "400",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
         </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-      </View>
-    </View>
-  </View>
-</Link>
-`;
-
-exports[`tile aа wide 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 15,
-    }
-  }
-  url="/article/123"
->
-  <View
-    style={
-      Object {
-        "flex": 1,
-      }
-    }
-  >
-    <View>
-      <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
-            }
-          }
-        >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
-          />
-        </View>
         <Text
-          accessibilityRole="header"
-          aria-level="3"
+          numberOfLines={2}
           style={
             Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 28,
-              "fontWeight": "400",
-              "lineHeight": 28,
-              "marginBottom": 10,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-      </View>
-    </View>
-  </View>
-</Link>
-`;
-
-exports[`tile aа without breakpoint should be like medium 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 15,
-    }
-  }
-  url="/article/123"
->
-  <View
-    style={
-      Object {
-        "flex": 1,
-      }
-    }
-  >
-    <View>
-      <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
-            }
-          }
-        >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
-          />
-        </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 20,
-              "fontWeight": "400",
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >
-          This is tile headline
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ab.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ab.test.js.snap
@@ -52,11 +52,31 @@ exports[`tile ab huge 1`] = `
                 "fontSize": 45,
                 "fontWeight": "400",
                 "lineHeight": 45,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -137,11 +157,31 @@ exports[`tile ab medium 1`] = `
                 "fontSize": 30,
                 "fontWeight": "400",
                 "lineHeight": 30,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -222,11 +262,31 @@ exports[`tile ab wide 1`] = `
                 "fontSize": 40,
                 "fontWeight": "400",
                 "lineHeight": 40,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -307,11 +367,31 @@ exports[`tile ab without breakpoint should be like medium 1`] = `
                 "fontSize": 30,
                 "fontWeight": "400",
                 "lineHeight": 30,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ad.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ad.test.js.snap
@@ -43,7 +43,7 @@ exports[`tile ad huge 1`] = `
               "fontSize": 22,
               "fontWeight": "400",
               "lineHeight": 22,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
@@ -59,6 +59,7 @@ exports[`tile ad huge 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >
@@ -127,7 +128,7 @@ exports[`tile ad medium 1`] = `
               "fontSize": 20,
               "fontWeight": "400",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
@@ -192,7 +193,7 @@ exports[`tile ad wide 1`] = `
               "fontSize": 20,
               "fontWeight": "400",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
@@ -208,6 +209,7 @@ exports[`tile ad wide 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >
@@ -276,7 +278,7 @@ exports[`tile ad without breakpoint should be like medium 1`] = `
               "fontSize": 20,
               "fontWeight": "400",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ae.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ae.test.js.snap
@@ -44,11 +44,31 @@ exports[`tile ae huge 1`] = `
               "fontSize": 35,
               "fontWeight": "400",
               "lineHeight": 35,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={5}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={
@@ -110,11 +130,31 @@ exports[`tile ae medium 1`] = `
               "fontSize": 30,
               "fontWeight": "400",
               "lineHeight": 30,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={5}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={
@@ -176,11 +216,31 @@ exports[`tile ae wide 1`] = `
               "fontSize": 30,
               "fontWeight": "400",
               "lineHeight": 30,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={5}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={
@@ -242,11 +302,31 @@ exports[`tile ae without breakpoint should be like medium 1`] = `
               "fontSize": 30,
               "fontWeight": "400",
               "lineHeight": 30,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={5}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-af.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-af.test.js.snap
@@ -1,6 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile af without breakpoint 1`] = `
+exports[`tile af huge 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingVertical": 15,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "400",
+              "lineHeight": 22,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile af wide 1`] = `
 <Link
   linkStyle={
     Object {
@@ -43,11 +128,116 @@ exports[`tile af without breakpoint 1`] = `
               "fontSize": 20,
               "fontWeight": "400",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile af without breakpoint should be like wide 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingVertical": 15,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 20,
+              "fontWeight": "400",
+              "lineHeight": 20,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ah.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ah.test.js.snap
@@ -59,7 +59,8 @@ exports[`tile ah huge 1`] = `
           "fontWeight": "400",
           "lineHeight": 45,
           "marginBottom": 0,
-          "paddingVertical": 10,
+          "paddingBottom": 10,
+          "paddingTop": 5,
           "textAlign": "center",
         }
       }
@@ -75,7 +76,7 @@ exports[`tile ah huge 1`] = `
           "fontFamily": "TimesDigitalW04-Regular",
           "fontSize": 14,
           "lineHeight": 20,
-          "paddingBottom": 5,
+          "paddingBottom": 0,
           "textAlign": "center",
         }
       }
@@ -155,7 +156,8 @@ exports[`tile ah medium 1`] = `
           "fontWeight": "400",
           "lineHeight": 30,
           "marginBottom": 0,
-          "paddingVertical": 10,
+          "paddingBottom": 10,
+          "paddingTop": 5,
           "textAlign": "center",
         }
       }
@@ -171,7 +173,7 @@ exports[`tile ah medium 1`] = `
           "fontFamily": "TimesDigitalW04-Regular",
           "fontSize": 14,
           "lineHeight": 20,
-          "paddingBottom": 5,
+          "paddingBottom": 0,
           "textAlign": "center",
         }
       }
@@ -251,7 +253,8 @@ exports[`tile ah wide 1`] = `
           "fontWeight": "400",
           "lineHeight": 40,
           "marginBottom": 0,
-          "paddingVertical": 10,
+          "paddingBottom": 10,
+          "paddingTop": 5,
           "textAlign": "center",
         }
       }
@@ -267,7 +270,7 @@ exports[`tile ah wide 1`] = `
           "fontFamily": "TimesDigitalW04-Regular",
           "fontSize": 14,
           "lineHeight": 20,
-          "paddingBottom": 5,
+          "paddingBottom": 0,
           "textAlign": "center",
         }
       }
@@ -347,7 +350,8 @@ exports[`tile ah without breakpoint should be like medium 1`] = `
           "fontWeight": "400",
           "lineHeight": 30,
           "marginBottom": 0,
-          "paddingVertical": 10,
+          "paddingBottom": 10,
+          "paddingTop": 5,
           "textAlign": "center",
         }
       }
@@ -363,7 +367,7 @@ exports[`tile ah without breakpoint should be like medium 1`] = `
           "fontFamily": "TimesDigitalW04-Regular",
           "fontSize": 14,
           "lineHeight": 20,
-          "paddingBottom": 5,
+          "paddingBottom": 0,
           "textAlign": "center",
         }
       }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-al.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-al.test.js.snap
@@ -1,6 +1,102 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile al without breakpoint 1`] = `
+exports[`tile al huge 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingVertical": 15,
+    }
+  }
+  url="/article/123"
+>
+  <Image
+    aspectRatio={1.5}
+    fill={true}
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+  />
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "400",
+              "lineHeight": 22,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile al wide 1`] = `
 <Link
   linkStyle={
     Object {
@@ -54,11 +150,31 @@ exports[`tile al without breakpoint 1`] = `
               "fontSize": 20,
               "fontWeight": "400",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-am.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-am.test.js.snap
@@ -60,6 +60,25 @@ exports[`tile am without breakpoint 1`] = `
         >
           This is tile headline
         </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
+        </Text>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ar.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ar.test.js.snap
@@ -1,6 +1,105 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile ar without breakpoint 1`] = `
+exports[`tile ar huge 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingVertical": 15,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      fill={true}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "400",
+              "lineHeight": 22,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile ar medium 1`] = `
 <Link
   linkStyle={
     Object {
@@ -57,7 +156,7 @@ exports[`tile ar without breakpoint 1`] = `
               "fontSize": 20,
               "fontWeight": "400",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
@@ -73,6 +172,205 @@ exports[`tile ar without breakpoint 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile ar wide 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingVertical": 15,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      fill={true}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 20,
+              "fontWeight": "400",
+              "lineHeight": 20,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile ar without breakpoint should be like medium 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingVertical": 15,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      fill={true}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 20,
+              "fontWeight": "400",
+              "lineHeight": 20,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-as.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-as.test.js.snap
@@ -55,7 +55,7 @@ exports[`tile as huge 1`] = `
           "fontSize": 22,
           "fontWeight": "400",
           "lineHeight": 22,
-          "marginBottom": 5,
+          "marginBottom": 0,
         }
       }
     >
@@ -70,6 +70,7 @@ exports[`tile as huge 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >
@@ -148,7 +149,7 @@ exports[`tile as medium 1`] = `
           "fontSize": 18,
           "fontWeight": "400",
           "lineHeight": 18,
-          "marginBottom": 5,
+          "marginBottom": 0,
         }
       }
     >
@@ -163,6 +164,7 @@ exports[`tile as medium 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >
@@ -241,7 +243,7 @@ exports[`tile as wide 1`] = `
           "fontSize": 20,
           "fontWeight": "400",
           "lineHeight": 20,
-          "marginBottom": 5,
+          "marginBottom": 0,
         }
       }
     >
@@ -256,6 +258,7 @@ exports[`tile as wide 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-b.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-b.test.js.snap
@@ -42,7 +42,7 @@ exports[`tile b huge 1`] = `
               "fontSize": 35,
               "fontWeight": "400",
               "lineHeight": 35,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
@@ -58,6 +58,7 @@ exports[`tile b huge 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >
@@ -125,7 +126,7 @@ exports[`tile b medium 1`] = `
               "fontSize": 20,
               "fontWeight": "400",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
@@ -141,6 +142,7 @@ exports[`tile b medium 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >
@@ -291,7 +293,7 @@ exports[`tile b wide 1`] = `
               "fontSize": 30,
               "fontWeight": "400",
               "lineHeight": 30,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
@@ -307,6 +309,7 @@ exports[`tile b wide 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >
@@ -374,11 +377,31 @@ exports[`tile b with more teaser 1`] = `
               "fontSize": 20,
               "fontWeight": "400",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g.test.js.snap
@@ -1,5 +1,102 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`tile g huge 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "flexDirection": "row",
+      "padding": 10,
+      "paddingHorizontal": 10,
+      "paddingVertical": 10,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "column",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <Image
+        aspectRatio={1}
+        fill={true}
+        resizeMode="cover"
+        rounded={true}
+        style={
+          Object {
+            "overflow": "hidden",
+            "width": 97,
+          }
+        }
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "justifyContent": "center",
+            "paddingLeft": 10,
+            "width": "70%",
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "400",
+              "lineHeight": 22,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
 exports[`tile g medium 1`] = `
 <Link
   linkStyle={
@@ -192,7 +289,7 @@ exports[`tile g small 1`] = `
 </Link>
 `;
 
-exports[`tile g without breakpoint should be like small 1`] = `
+exports[`tile g wide 1`] = `
 <Link
   linkStyle={
     Object {
@@ -200,7 +297,7 @@ exports[`tile g without breakpoint should be like small 1`] = `
       "flexDirection": "row",
       "padding": 10,
       "paddingHorizontal": 10,
-      "paddingVertical": 15,
+      "paddingVertical": 10,
     }
   }
   url="/article/123"
@@ -267,6 +364,103 @@ exports[`tile g without breakpoint should be like small 1`] = `
               "fontSize": 20,
               "fontWeight": "400",
               "lineHeight": 20,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile g without breakpoint should be like small 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "flexDirection": "row",
+      "padding": 10,
+      "paddingHorizontal": 10,
+      "paddingVertical": 10,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "column",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <Image
+        aspectRatio={1}
+        fill={true}
+        resizeMode="cover"
+        rounded={true}
+        style={
+          Object {
+            "overflow": "hidden",
+            "width": 97,
+          }
+        }
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "justifyContent": "center",
+            "paddingLeft": 10,
+            "width": "70%",
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "marginBottom": 5,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "400",
+              "lineHeight": 22,
               "marginBottom": 0,
             }
           }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-w.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-w.test.js.snap
@@ -53,11 +53,31 @@ exports[`tile w huge 1`] = `
                 "fontSize": 45,
                 "fontWeight": "400",
                 "lineHeight": 45,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -139,11 +159,31 @@ exports[`tile w medium 1`] = `
                 "fontSize": 30,
                 "fontWeight": "400",
                 "lineHeight": 30,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -225,11 +265,31 @@ exports[`tile w wide 1`] = `
                 "fontSize": 40,
                 "fontWeight": "400",
                 "lineHeight": 40,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -311,11 +371,31 @@ exports[`tile w without breakpoint should be like medium 1`] = `
                 "fontSize": 30,
                 "fontWeight": "400",
                 "lineHeight": 30,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-x.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-x.test.js.snap
@@ -43,7 +43,7 @@ exports[`tile x huge 1`] = `
               "fontSize": 45,
               "fontWeight": "400",
               "lineHeight": 45,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
@@ -58,11 +58,32 @@ exports[`tile x huge 1`] = `
               "fontFamily": "TimesModern-Regular",
               "fontSize": 24,
               "lineHeight": 26,
-              "paddingBottom": 10,
+              "paddingBottom": 0,
+              "paddingTop": 10,
             }
           }
         >
           Three Conservative MPs resign
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={
@@ -123,7 +144,7 @@ exports[`tile x medium 1`] = `
               "fontSize": 40,
               "fontWeight": "400",
               "lineHeight": 40,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
@@ -138,11 +159,32 @@ exports[`tile x medium 1`] = `
               "fontFamily": "TimesModern-Regular",
               "fontSize": 24,
               "lineHeight": 26,
-              "paddingBottom": 10,
+              "paddingBottom": 0,
+              "paddingTop": 10,
             }
           }
         >
           Three Conservative MPs resign
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={
@@ -203,7 +245,7 @@ exports[`tile x wide 1`] = `
               "fontSize": 40,
               "fontWeight": "400",
               "lineHeight": 40,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
@@ -218,11 +260,32 @@ exports[`tile x wide 1`] = `
               "fontFamily": "TimesModern-Regular",
               "fontSize": 24,
               "lineHeight": 26,
-              "paddingBottom": 10,
+              "paddingBottom": 0,
+              "paddingTop": 10,
             }
           }
         >
           Three Conservative MPs resign
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-y.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-y.test.js.snap
@@ -35,7 +35,7 @@ exports[`tile y huge 1`] = `
           "fontSize": 35,
           "fontWeight": "400",
           "lineHeight": 35,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >
@@ -50,6 +50,7 @@ exports[`tile y huge 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >
@@ -108,7 +109,7 @@ exports[`tile y medium 1`] = `
           "fontSize": 30,
           "fontWeight": "400",
           "lineHeight": 30,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >
@@ -123,6 +124,7 @@ exports[`tile y medium 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >
@@ -181,7 +183,7 @@ exports[`tile y wide 1`] = `
           "fontSize": 30,
           "fontWeight": "400",
           "lineHeight": 30,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >
@@ -196,6 +198,7 @@ exports[`tile y wide 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >
@@ -254,7 +257,7 @@ exports[`tile y without breakpoint should be like medium 1`] = `
           "fontSize": 30,
           "fontWeight": "400",
           "lineHeight": 30,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >
@@ -269,6 +272,7 @@ exports[`tile y without breakpoint should be like medium 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-z.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-z.test.js.snap
@@ -53,11 +53,31 @@ exports[`tile z huge 1`] = `
                 "fontSize": 45,
                 "fontWeight": "400",
                 "lineHeight": 45,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -139,11 +159,31 @@ exports[`tile z wide 1`] = `
                 "fontSize": 40,
                 "fontWeight": "400",
                 "lineHeight": 40,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -225,11 +265,31 @@ exports[`tile z without breakpoint should be like wide 1`] = `
                 "fontSize": 40,
                 "fontWeight": "400",
                 "lineHeight": 40,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
@@ -619,6 +619,21 @@ exports[`5. standard 1`] = `
                   "name": "paragraph",
                 },
               ],
+              "summary800": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
               "synonyms": Object {
                 "edges": Array [],
                 "nodes": Array [],
@@ -1030,6 +1045,21 @@ exports[`5. standard 1`] = `
                     Object {
                       "attributes": Object {
                         "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary800": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
                       },
                       "children": Array [],
                       "name": "text",
@@ -1457,6 +1487,21 @@ exports[`5. standard 1`] = `
                   "name": "paragraph",
                 },
               ],
+              "summary800": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
               "synonyms": Object {
                 "edges": Array [],
                 "nodes": Array [],
@@ -1876,6 +1921,21 @@ exports[`5. standard 1`] = `
                   "name": "paragraph",
                 },
               ],
+              "summary800": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
               "synonyms": Object {
                 "edges": Array [],
                 "nodes": Array [],
@@ -2287,6 +2347,21 @@ exports[`5. standard 1`] = `
                     Object {
                       "attributes": Object {
                         "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary800": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
                       },
                       "children": Array [],
                       "name": "text",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -84,7 +84,6 @@ exports[`3. lead one and one - medium 1`] = `
     <View />
     <View>
       <TileAA
-        breakpoint="medium"
         tileName="support"
       />
     </View>
@@ -845,7 +844,6 @@ exports[`25. secondary four - wide 1`] = `
           Object {
             "fontSize": 20,
             "lineHeight": 20,
-            "marginBottom": 5,
           }
         }
         breakpoint="wide"
@@ -857,7 +855,6 @@ exports[`25. secondary four - wide 1`] = `
           Object {
             "fontSize": 20,
             "lineHeight": 20,
-            "marginBottom": 5,
           }
         }
         breakpoint="wide"
@@ -1446,7 +1443,6 @@ exports[`41. secondary four - huge 1`] = `
             Object {
               "fontSize": 22,
               "lineHeight": 22,
-              "marginBottom": 5,
             }
           }
           breakpoint="huge"
@@ -1458,7 +1454,6 @@ exports[`41. secondary four - huge 1`] = `
             Object {
               "fontSize": 22,
               "lineHeight": 22,
-              "marginBottom": 5,
             }
           }
           breakpoint="huge"

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-aa.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-aa.test.js.snap
@@ -1,71 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile aа huge 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 15,
-    }
-  }
-  url="/article/123"
->
-  <View
-    style={
-      Object {
-        "flex": 1,
-      }
-    }
-  >
-    <View>
-      <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 0,
-            }
-          }
-        >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
-          />
-        </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 28,
-              "fontWeight": "900",
-              "lineHeight": 28,
-              "marginBottom": 10,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-      </View>
-    </View>
-  </View>
-</Link>
-`;
-
-exports[`tile aа medium 1`] = `
+exports[`tile aа without breakpoint 1`] = `
 <Link
   linkStyle={
     Object {
@@ -108,141 +43,31 @@ exports[`tile aа medium 1`] = `
               "fontSize": 20,
               "fontWeight": "900",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
         </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-      </View>
-    </View>
-  </View>
-</Link>
-`;
-
-exports[`tile aа wide 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 15,
-    }
-  }
-  url="/article/123"
->
-  <View
-    style={
-      Object {
-        "flex": 1,
-      }
-    }
-  >
-    <View>
-      <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 0,
-            }
-          }
-        >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
-          />
-        </View>
         <Text
-          accessibilityRole="header"
-          aria-level="3"
+          numberOfLines={2}
           style={
             Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 28,
-              "fontWeight": "900",
-              "lineHeight": 28,
-              "marginBottom": 10,
-            }
-          }
-        >
-          This is tile headline
-        </Text>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-      </View>
-    </View>
-  </View>
-</Link>
-`;
-
-exports[`tile aа without breakpoint should be like medium 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 15,
-    }
-  }
-  url="/article/123"
->
-  <View
-    style={
-      Object {
-        "flex": 1,
-      }
-    }
-  >
-    <View>
-      <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 0,
-            }
-          }
-        >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
-          />
-        </View>
-        <Text
-          accessibilityRole="header"
-          aria-level="3"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 20,
-              "fontWeight": "900",
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >
-          This is tile headline
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ab.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ab.test.js.snap
@@ -52,11 +52,31 @@ exports[`tile ab huge 1`] = `
                 "fontSize": 45,
                 "fontWeight": "900",
                 "lineHeight": 45,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -137,11 +157,31 @@ exports[`tile ab medium 1`] = `
                 "fontSize": 30,
                 "fontWeight": "900",
                 "lineHeight": 30,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -222,11 +262,31 @@ exports[`tile ab wide 1`] = `
                 "fontSize": 40,
                 "fontWeight": "900",
                 "lineHeight": 40,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -307,11 +367,31 @@ exports[`tile ab without breakpoint should be like medium 1`] = `
                 "fontSize": 30,
                 "fontWeight": "900",
                 "lineHeight": 30,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ad.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ad.test.js.snap
@@ -43,7 +43,7 @@ exports[`tile ad huge 1`] = `
               "fontSize": 22,
               "fontWeight": "900",
               "lineHeight": 22,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
@@ -59,6 +59,7 @@ exports[`tile ad huge 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >
@@ -127,7 +128,7 @@ exports[`tile ad medium 1`] = `
               "fontSize": 20,
               "fontWeight": "900",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
@@ -192,7 +193,7 @@ exports[`tile ad wide 1`] = `
               "fontSize": 20,
               "fontWeight": "900",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
@@ -208,6 +209,7 @@ exports[`tile ad wide 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >
@@ -276,7 +278,7 @@ exports[`tile ad without breakpoint should be like medium 1`] = `
               "fontSize": 20,
               "fontWeight": "900",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ae.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ae.test.js.snap
@@ -44,11 +44,31 @@ exports[`tile ae huge 1`] = `
               "fontSize": 35,
               "fontWeight": "900",
               "lineHeight": 35,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={5}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={
@@ -110,11 +130,31 @@ exports[`tile ae medium 1`] = `
               "fontSize": 30,
               "fontWeight": "900",
               "lineHeight": 30,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={5}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={
@@ -176,11 +216,31 @@ exports[`tile ae wide 1`] = `
               "fontSize": 30,
               "fontWeight": "900",
               "lineHeight": 30,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={5}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={
@@ -242,11 +302,31 @@ exports[`tile ae without breakpoint should be like medium 1`] = `
               "fontSize": 30,
               "fontWeight": "900",
               "lineHeight": 30,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={5}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-af.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-af.test.js.snap
@@ -1,6 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile af without breakpoint 1`] = `
+exports[`tile af huge 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingVertical": 15,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "900",
+              "lineHeight": 22,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile af wide 1`] = `
 <Link
   linkStyle={
     Object {
@@ -43,11 +128,116 @@ exports[`tile af without breakpoint 1`] = `
               "fontSize": 20,
               "fontWeight": "900",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile af without breakpoint should be like wide 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingVertical": 15,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 20,
+              "fontWeight": "900",
+              "lineHeight": 20,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ah.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ah.test.js.snap
@@ -59,7 +59,8 @@ exports[`tile ah huge 1`] = `
           "fontWeight": "900",
           "lineHeight": 45,
           "marginBottom": 0,
-          "paddingVertical": 10,
+          "paddingBottom": 10,
+          "paddingTop": 5,
           "textAlign": "center",
         }
       }
@@ -75,7 +76,7 @@ exports[`tile ah huge 1`] = `
           "fontFamily": "TimesDigitalW04-Regular",
           "fontSize": 14,
           "lineHeight": 20,
-          "paddingBottom": 5,
+          "paddingBottom": 0,
           "textAlign": "center",
         }
       }
@@ -155,7 +156,8 @@ exports[`tile ah medium 1`] = `
           "fontWeight": "900",
           "lineHeight": 30,
           "marginBottom": 0,
-          "paddingVertical": 10,
+          "paddingBottom": 10,
+          "paddingTop": 5,
           "textAlign": "center",
         }
       }
@@ -171,7 +173,7 @@ exports[`tile ah medium 1`] = `
           "fontFamily": "TimesDigitalW04-Regular",
           "fontSize": 14,
           "lineHeight": 20,
-          "paddingBottom": 5,
+          "paddingBottom": 0,
           "textAlign": "center",
         }
       }
@@ -251,7 +253,8 @@ exports[`tile ah wide 1`] = `
           "fontWeight": "900",
           "lineHeight": 40,
           "marginBottom": 0,
-          "paddingVertical": 10,
+          "paddingBottom": 10,
+          "paddingTop": 5,
           "textAlign": "center",
         }
       }
@@ -267,7 +270,7 @@ exports[`tile ah wide 1`] = `
           "fontFamily": "TimesDigitalW04-Regular",
           "fontSize": 14,
           "lineHeight": 20,
-          "paddingBottom": 5,
+          "paddingBottom": 0,
           "textAlign": "center",
         }
       }
@@ -347,7 +350,8 @@ exports[`tile ah without breakpoint should be like medium 1`] = `
           "fontWeight": "900",
           "lineHeight": 30,
           "marginBottom": 0,
-          "paddingVertical": 10,
+          "paddingBottom": 10,
+          "paddingTop": 5,
           "textAlign": "center",
         }
       }
@@ -363,7 +367,7 @@ exports[`tile ah without breakpoint should be like medium 1`] = `
           "fontFamily": "TimesDigitalW04-Regular",
           "fontSize": 14,
           "lineHeight": 20,
-          "paddingBottom": 5,
+          "paddingBottom": 0,
           "textAlign": "center",
         }
       }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-al.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-al.test.js.snap
@@ -1,6 +1,102 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile al without breakpoint 1`] = `
+exports[`tile al huge 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingVertical": 15,
+    }
+  }
+  url="/article/123"
+>
+  <Image
+    aspectRatio={1.5}
+    fill={true}
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+  />
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "900",
+              "lineHeight": 22,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile al wide 1`] = `
 <Link
   linkStyle={
     Object {
@@ -54,11 +150,31 @@ exports[`tile al without breakpoint 1`] = `
               "fontSize": 20,
               "fontWeight": "900",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-am.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-am.test.js.snap
@@ -60,6 +60,25 @@ exports[`tile am without breakpoint 1`] = `
         >
           This is tile headline
         </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
+        </Text>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ar.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ar.test.js.snap
@@ -1,6 +1,105 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile ar without breakpoint 1`] = `
+exports[`tile ar huge 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingVertical": 15,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      fill={true}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "900",
+              "lineHeight": 22,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile ar medium 1`] = `
 <Link
   linkStyle={
     Object {
@@ -57,7 +156,7 @@ exports[`tile ar without breakpoint 1`] = `
               "fontSize": 20,
               "fontWeight": "900",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
@@ -73,6 +172,205 @@ exports[`tile ar without breakpoint 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile ar wide 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingVertical": 15,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      fill={true}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 20,
+              "fontWeight": "900",
+              "lineHeight": 20,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </Text>
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile ar without breakpoint should be like medium 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": 10,
+      "paddingVertical": 15,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      fill={true}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 20,
+              "fontWeight": "900",
+              "lineHeight": 20,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-as.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-as.test.js.snap
@@ -55,7 +55,7 @@ exports[`tile as huge 1`] = `
           "fontSize": 22,
           "fontWeight": "900",
           "lineHeight": 22,
-          "marginBottom": 5,
+          "marginBottom": 0,
         }
       }
     >
@@ -70,6 +70,7 @@ exports[`tile as huge 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >
@@ -148,7 +149,7 @@ exports[`tile as medium 1`] = `
           "fontSize": 18,
           "fontWeight": "900",
           "lineHeight": 18,
-          "marginBottom": 5,
+          "marginBottom": 0,
         }
       }
     >
@@ -163,6 +164,7 @@ exports[`tile as medium 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >
@@ -241,7 +243,7 @@ exports[`tile as wide 1`] = `
           "fontSize": 20,
           "fontWeight": "900",
           "lineHeight": 20,
-          "marginBottom": 5,
+          "marginBottom": 0,
         }
       }
     >
@@ -256,6 +258,7 @@ exports[`tile as wide 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-b.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-b.test.js.snap
@@ -42,7 +42,7 @@ exports[`tile b huge 1`] = `
               "fontSize": 35,
               "fontWeight": "900",
               "lineHeight": 35,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
@@ -58,6 +58,7 @@ exports[`tile b huge 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >
@@ -125,7 +126,7 @@ exports[`tile b medium 1`] = `
               "fontSize": 20,
               "fontWeight": "900",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
@@ -141,6 +142,7 @@ exports[`tile b medium 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >
@@ -291,7 +293,7 @@ exports[`tile b wide 1`] = `
               "fontSize": 30,
               "fontWeight": "900",
               "lineHeight": 30,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
@@ -307,6 +309,7 @@ exports[`tile b wide 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 0,
+              "marginTop": 10,
             }
           }
         >
@@ -374,11 +377,31 @@ exports[`tile b with more teaser 1`] = `
               "fontSize": 20,
               "fontWeight": "900",
               "lineHeight": 20,
-              "marginBottom": 5,
+              "marginBottom": 0,
             }
           }
         >
           This is tile headline
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g.test.js.snap
@@ -1,5 +1,102 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`tile g huge 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "flexDirection": "row",
+      "padding": 10,
+      "paddingHorizontal": 10,
+      "paddingVertical": 10,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "column",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <Image
+        aspectRatio={1}
+        fill={true}
+        resizeMode="cover"
+        rounded={true}
+        style={
+          Object {
+            "overflow": "hidden",
+            "width": 97,
+          }
+        }
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "justifyContent": "center",
+            "paddingLeft": 10,
+            "width": "70%",
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "900",
+              "lineHeight": 22,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
 exports[`tile g medium 1`] = `
 <Link
   linkStyle={
@@ -192,7 +289,7 @@ exports[`tile g small 1`] = `
 </Link>
 `;
 
-exports[`tile g without breakpoint should be like small 1`] = `
+exports[`tile g wide 1`] = `
 <Link
   linkStyle={
     Object {
@@ -200,7 +297,7 @@ exports[`tile g without breakpoint should be like small 1`] = `
       "flexDirection": "row",
       "padding": 10,
       "paddingHorizontal": 10,
-      "paddingVertical": 15,
+      "paddingVertical": 10,
     }
   }
   url="/article/123"
@@ -267,6 +364,103 @@ exports[`tile g without breakpoint should be like small 1`] = `
               "fontSize": 20,
               "fontWeight": "900",
               "lineHeight": 20,
+              "marginBottom": 0,
+            }
+          }
+        >
+          This is tile headline
+        </Text>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`tile g without breakpoint should be like small 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "flexDirection": "row",
+      "padding": 10,
+      "paddingHorizontal": 10,
+      "paddingVertical": 10,
+    }
+  }
+  url="/article/123"
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "column",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <Image
+        aspectRatio={1}
+        fill={true}
+        resizeMode="cover"
+        rounded={true}
+        style={
+          Object {
+            "overflow": "hidden",
+            "width": 97,
+          }
+        }
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "justifyContent": "center",
+            "paddingLeft": 10,
+            "width": "70%",
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "marginBottom": 0,
+            }
+          }
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </View>
+        <Text
+          accessibilityRole="header"
+          aria-level="3"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 22,
+              "fontWeight": "900",
+              "lineHeight": 22,
               "marginBottom": 0,
             }
           }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-w.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-w.test.js.snap
@@ -53,11 +53,31 @@ exports[`tile w huge 1`] = `
                 "fontSize": 45,
                 "fontWeight": "900",
                 "lineHeight": 45,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -139,11 +159,31 @@ exports[`tile w medium 1`] = `
                 "fontSize": 30,
                 "fontWeight": "900",
                 "lineHeight": 30,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -225,11 +265,31 @@ exports[`tile w wide 1`] = `
                 "fontSize": 40,
                 "fontWeight": "900",
                 "lineHeight": 40,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -311,11 +371,31 @@ exports[`tile w without breakpoint should be like medium 1`] = `
                 "fontSize": 30,
                 "fontWeight": "900",
                 "lineHeight": 30,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-x.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-x.test.js.snap
@@ -43,7 +43,7 @@ exports[`tile x huge 1`] = `
               "fontSize": 45,
               "fontWeight": "900",
               "lineHeight": 45,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
@@ -58,11 +58,32 @@ exports[`tile x huge 1`] = `
               "fontFamily": "TimesModern-Regular",
               "fontSize": 24,
               "lineHeight": 26,
-              "paddingBottom": 10,
+              "paddingBottom": 0,
+              "paddingTop": 10,
             }
           }
         >
           Three Conservative MPs resign
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={
@@ -123,7 +144,7 @@ exports[`tile x medium 1`] = `
               "fontSize": 40,
               "fontWeight": "900",
               "lineHeight": 40,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
@@ -138,11 +159,32 @@ exports[`tile x medium 1`] = `
               "fontFamily": "TimesModern-Regular",
               "fontSize": 24,
               "lineHeight": 26,
-              "paddingBottom": 10,
+              "paddingBottom": 0,
+              "paddingTop": 10,
             }
           }
         >
           Three Conservative MPs resign
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={
@@ -203,7 +245,7 @@ exports[`tile x wide 1`] = `
               "fontSize": 40,
               "fontWeight": "900",
               "lineHeight": 40,
-              "marginBottom": 10,
+              "marginBottom": 0,
             }
           }
         >
@@ -218,11 +260,32 @@ exports[`tile x wide 1`] = `
               "fontFamily": "TimesModern-Regular",
               "fontSize": 24,
               "lineHeight": 26,
-              "paddingBottom": 10,
+              "paddingBottom": 0,
+              "paddingTop": 10,
             }
           }
         >
           Three Conservative MPs resign
+        </Text>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "#696969",
+              "flexWrap": "wrap",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 14,
+              "lineHeight": 20,
+              "marginBottom": 0,
+              "marginTop": 10,
+            }
+          }
+        >
+          <Text>
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </Text>
         </Text>
         <ArticleFlags
           flags={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-y.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-y.test.js.snap
@@ -35,7 +35,7 @@ exports[`tile y huge 1`] = `
           "fontSize": 35,
           "fontWeight": "900",
           "lineHeight": 35,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >
@@ -50,6 +50,7 @@ exports[`tile y huge 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >
@@ -108,7 +109,7 @@ exports[`tile y medium 1`] = `
           "fontSize": 30,
           "fontWeight": "900",
           "lineHeight": 30,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >
@@ -123,6 +124,7 @@ exports[`tile y medium 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >
@@ -181,7 +183,7 @@ exports[`tile y wide 1`] = `
           "fontSize": 30,
           "fontWeight": "900",
           "lineHeight": 30,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >
@@ -196,6 +198,7 @@ exports[`tile y wide 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >
@@ -254,7 +257,7 @@ exports[`tile y without breakpoint should be like medium 1`] = `
           "fontSize": 30,
           "fontWeight": "900",
           "lineHeight": 30,
-          "marginBottom": 10,
+          "marginBottom": 0,
         }
       }
     >
@@ -269,6 +272,7 @@ exports[`tile y without breakpoint should be like medium 1`] = `
           "fontSize": 14,
           "lineHeight": 20,
           "marginBottom": 0,
+          "marginTop": 10,
         }
       }
     >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-z.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-z.test.js.snap
@@ -53,11 +53,31 @@ exports[`tile z huge 1`] = `
                 "fontSize": 45,
                 "fontWeight": "900",
                 "lineHeight": 45,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -139,11 +159,31 @@ exports[`tile z wide 1`] = `
                 "fontSize": 40,
                 "fontWeight": "900",
                 "lineHeight": 40,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={
@@ -225,11 +265,31 @@ exports[`tile z without breakpoint should be like wide 1`] = `
                 "fontSize": 40,
                 "fontWeight": "900",
                 "lineHeight": 40,
-                "marginBottom": 10,
+                "marginBottom": 0,
               }
             }
           >
             This is tile headline
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#696969",
+                "flexWrap": "wrap",
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 14,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginTop": 10,
+              }
+            }
+          >
+            <Text>
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </Text>
           </Text>
           <ArticleFlags
             flags={

--- a/packages/edition-slices/__tests__/tile-aa/shared-tile-aa.base.js
+++ b/packages/edition-slices/__tests__/tile-aa/shared-tile-aa.base.js
@@ -1,23 +1,10 @@
 import "../mocks-tiles";
-import { editionBreakpoints } from "@times-components/styleguide";
 import { testTile } from "../shared-tile-utils";
 import { TileAA } from "../../src/tiles";
 
 export default () => {
   describe("tile aа", () => {
-    it("medium", () => {
-      testTile(TileAA, editionBreakpoints.medium);
-    });
-
-    it("wide", () => {
-      testTile(TileAA, editionBreakpoints.wide);
-    });
-
-    it("huge", () => {
-      testTile(TileAA, editionBreakpoints.huge);
-    });
-
-    it("without breakpoint should be like medium", () => {
+    it("without breakpoint", () => {
       testTile(TileAA);
     });
   });

--- a/packages/edition-slices/__tests__/tile-af/shared-tile-af.base.js
+++ b/packages/edition-slices/__tests__/tile-af/shared-tile-af.base.js
@@ -1,10 +1,19 @@
 import "../mocks-tiles";
+import { editionBreakpoints } from "@times-components/styleguide";
 import { testTile } from "../shared-tile-utils";
 import { TileAF } from "../../src/tiles";
 
 export default () => {
   describe("tile af", () => {
-    it("without breakpoint", () => {
+    it("wide", () => {
+      testTile(TileAF, editionBreakpoints.wide);
+    });
+
+    it("huge", () => {
+      testTile(TileAF, editionBreakpoints.huge);
+    });
+
+    it("without breakpoint should be like wide", () => {
       testTile(TileAF);
     });
   });

--- a/packages/edition-slices/__tests__/tile-al/shared-tile-al.base.js
+++ b/packages/edition-slices/__tests__/tile-al/shared-tile-al.base.js
@@ -1,11 +1,15 @@
 import "../mocks-tiles";
+import { editionBreakpoints } from "@times-components/styleguide";
 import { testTile } from "../shared-tile-utils";
 import { TileAL } from "../../src/tiles";
 
 export default () => {
   describe("tile al", () => {
-    it("without breakpoint", () => {
-      testTile(TileAL);
+    it("wide", () => {
+      testTile(TileAL, editionBreakpoints.wide);
+    });
+    it("huge", () => {
+      testTile(TileAL, editionBreakpoints.huge);
     });
   });
 };

--- a/packages/edition-slices/__tests__/tile-ar/shared-tile-ar.base.js
+++ b/packages/edition-slices/__tests__/tile-ar/shared-tile-ar.base.js
@@ -1,10 +1,23 @@
 import "../mocks-tiles";
+import { editionBreakpoints } from "@times-components/styleguide";
 import { testTile } from "../shared-tile-utils";
 import { TileAR } from "../../src/tiles";
 
 export default () => {
   describe("tile ar", () => {
-    it("without breakpoint", () => {
+    it("medium", () => {
+      testTile(TileAR, editionBreakpoints.medium);
+    });
+
+    it("wide", () => {
+      testTile(TileAR, editionBreakpoints.wide);
+    });
+
+    it("huge", () => {
+      testTile(TileAR, editionBreakpoints.huge);
+    });
+
+    it("without breakpoint should be like medium", () => {
       testTile(TileAR);
     });
   });

--- a/packages/edition-slices/__tests__/tile-g/shared-tile-g.base.js
+++ b/packages/edition-slices/__tests__/tile-g/shared-tile-g.base.js
@@ -13,6 +13,14 @@ export default () => {
       testTile(TileG, editionBreakpoints.medium);
     });
 
+    it("wide", () => {
+      testTile(TileG, editionBreakpoints.wide);
+    });
+
+    it("huge", () => {
+      testTile(TileG, editionBreakpoints.huge);
+    });
+
     it("without breakpoint should be like small", () => {
       testTile(TileG);
     });

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -382,7 +382,6 @@ exports[`3. lead one and one - medium 1`] = `
       className="css-view-1dbjc4n IS3"
     >
       <TileAA
-        breakpoint="medium"
         tileName="support"
       />
     </div>
@@ -3634,7 +3633,6 @@ exports[`25. secondary four - wide 1`] = `
           Object {
             "fontSize": 20,
             "lineHeight": 20,
-            "marginBottom": "5px",
           }
         }
         breakpoint="wide"
@@ -3648,7 +3646,6 @@ exports[`25. secondary four - wide 1`] = `
           Object {
             "fontSize": 20,
             "lineHeight": 20,
-            "marginBottom": "5px",
           }
         }
         breakpoint="wide"
@@ -6183,7 +6180,6 @@ exports[`41. secondary four - huge 1`] = `
             Object {
               "fontSize": 22,
               "lineHeight": 22,
-              "marginBottom": "5px",
             }
           }
           breakpoint="huge"
@@ -6197,7 +6193,6 @@ exports[`41. secondary four - huge 1`] = `
             Object {
               "fontSize": 22,
               "lineHeight": 22,
-              "marginBottom": "5px",
             }
           }
           breakpoint="huge"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tablet-slices.test.js.snap
@@ -80,7 +80,6 @@ exports[`3. lead one and one - medium 1`] = `
     <div />
     <div>
       <TileAA
-        breakpoint="medium"
         tileName="support"
       />
     </div>
@@ -829,7 +828,6 @@ exports[`25. secondary four - wide 1`] = `
           Object {
             "fontSize": 20,
             "lineHeight": 20,
-            "marginBottom": "5px",
           }
         }
         breakpoint="wide"
@@ -841,7 +839,6 @@ exports[`25. secondary four - wide 1`] = `
           Object {
             "fontSize": 20,
             "lineHeight": 20,
-            "marginBottom": "5px",
           }
         }
         breakpoint="wide"
@@ -1422,7 +1419,6 @@ exports[`41. secondary four - huge 1`] = `
             Object {
               "fontSize": 22,
               "lineHeight": 22,
-              "marginBottom": "5px",
             }
           }
           breakpoint="huge"
@@ -1434,7 +1430,6 @@ exports[`41. secondary four - huge 1`] = `
             Object {
               "fontSize": 22,
               "lineHeight": 22,
-              "marginBottom": "5px",
             }
           }
           breakpoint="huge"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-aa.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-aa.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile aа huge 1`] = `
+exports[`tile aа without breakpoint 1`] = `
 <style>
 .S1 {
   margin-bottom: 0px;
@@ -10,90 +10,19 @@ exports[`tile aа huge 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
 }
 
-.IS1 {
-  font-size: 28px;
-  line-height: 28px;
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
   margin-bottom: 10px;
-}
-
-.IS2 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-</style>
-
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingVertical": "15px",
-    }
-  }
-  url="/article/123"
->
-  <div
-    className="css-view-1dbjc4n IS2"
-  >
-    <div
-      className="css-view-1dbjc4n"
-    >
-      <div
-        className="css-view-1dbjc4n"
-      >
-        <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-        >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
-          />
-        </div>
-        <h3
-          aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-      </div>
-    </div>
-  </div>
-</Link>
-`;
-
-exports[`tile aа medium 1`] = `
-<style>
-.S1 {
-  margin-bottom: 0px;
-}
-
-.S2 {
-  color: rgba(51,51,51,1.00);
-  font-family: TimesModern-Bold;
-  font-weight: 400;
-  margin-bottom: 5px;
 }
 
 .IS1 {
@@ -102,6 +31,11 @@ exports[`tile aа medium 1`] = `
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -126,7 +60,7 @@ exports[`tile aа medium 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n IS3"
   >
     <div
       className="css-view-1dbjc4n"
@@ -145,177 +79,22 @@ exports[`tile aа medium 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
         </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-      </div>
-    </div>
-  </div>
-</Link>
-`;
-
-exports[`tile aа wide 1`] = `
-<style>
-.S1 {
-  margin-bottom: 0px;
-}
-
-.S2 {
-  color: rgba(51,51,51,1.00);
-  font-family: TimesModern-Bold;
-  font-weight: 400;
-}
-
-.IS1 {
-  font-size: 28px;
-  line-height: 28px;
-  margin-bottom: 10px;
-}
-
-.IS2 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-</style>
-
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingVertical": "15px",
-    }
-  }
-  url="/article/123"
->
-  <div
-    className="css-view-1dbjc4n IS2"
-  >
-    <div
-      className="css-view-1dbjc4n"
-    >
-      <div
-        className="css-view-1dbjc4n"
-      >
         <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
         >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
-          />
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
         </div>
-        <h3
-          aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
-        <ArticleFlags
-          flags={
-            Array [
-              Object {
-                "expiryTime": "2030-03-14T12:00:00.000Z",
-                "type": "EXCLUSIVE",
-              },
-            ]
-          }
-        />
-      </div>
-    </div>
-  </div>
-</Link>
-`;
-
-exports[`tile aа without breakpoint should be like medium 1`] = `
-<style>
-.S1 {
-  margin-bottom: 0px;
-}
-
-.S2 {
-  color: rgba(51,51,51,1.00);
-  font-family: TimesModern-Bold;
-  font-weight: 400;
-  margin-bottom: 5px;
-}
-
-.IS1 {
-  font-size: 20px;
-  line-height: 20px;
-}
-
-.IS2 {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
-  -webkit-flex-basis: 0%;
-  flex-basis: 0%;
-  -ms-flex-positive: 1;
-  -webkit-box-flex: 1;
-  -ms-flex-negative: 1;
-  -ms-flex-preferred-size: 0%;
-}
-</style>
-
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingHorizontal": "10px",
-      "paddingVertical": "15px",
-    }
-  }
-  url="/article/123"
->
-  <div
-    className="css-view-1dbjc4n IS2"
-  >
-    <div
-      className="css-view-1dbjc4n"
-    >
-      <div
-        className="css-view-1dbjc4n"
-      >
-        <div
-          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
-        >
-          <ArticleLabel
-            color="#005B8D"
-            isVideo={false}
-            title="label"
-          />
-        </div>
-        <h3
-          aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
-          role="heading"
-        >
-          This is tile headline
-        </h3>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-ab.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-ab.test.js.snap
@@ -10,15 +10,32 @@ exports[`tile ab huge 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 45px;
   line-height: 45px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -31,7 +48,7 @@ exports[`tile ab huge 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   -webkit-flex-grow: 0.74;
   flex-grow: 0.74;
   -webkit-flex-shrink: 1;
@@ -45,7 +62,7 @@ exports[`tile ab huge 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS4 {
+.IS5 {
   flex: 0.26;
 }
 </style>
@@ -62,10 +79,10 @@ exports[`tile ab huge 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
@@ -84,11 +101,22 @@ exports[`tile ab huge 1`] = `
           </div>
           <h3
             aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
             role="heading"
           >
             This is tile headline
           </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </span>
+          </div>
           <ArticleFlags
             flags={
               Array [
@@ -105,7 +133,7 @@ exports[`tile ab huge 1`] = `
   </div>
   <Image
     aspectRatio={0.6666666666666666}
-    className="IS4"
+    className="IS5"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />
@@ -122,15 +150,32 @@ exports[`tile ab medium 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 30px;
   line-height: 30px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -143,7 +188,7 @@ exports[`tile ab medium 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   -webkit-flex-grow: 0.56;
   flex-grow: 0.56;
   -webkit-flex-shrink: 1;
@@ -157,7 +202,7 @@ exports[`tile ab medium 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS4 {
+.IS5 {
   flex: 0.44;
 }
 </style>
@@ -174,10 +219,10 @@ exports[`tile ab medium 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
@@ -196,11 +241,22 @@ exports[`tile ab medium 1`] = `
           </div>
           <h3
             aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
             role="heading"
           >
             This is tile headline
           </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </span>
+          </div>
           <ArticleFlags
             flags={
               Array [
@@ -217,7 +273,7 @@ exports[`tile ab medium 1`] = `
   </div>
   <Image
     aspectRatio={0.6666666666666666}
-    className="IS4"
+    className="IS5"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />
@@ -234,15 +290,32 @@ exports[`tile ab wide 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 40px;
   line-height: 40px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -255,7 +328,7 @@ exports[`tile ab wide 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -269,7 +342,7 @@ exports[`tile ab wide 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS4 {
+.IS5 {
   flex: 1;
 }
 </style>
@@ -286,10 +359,10 @@ exports[`tile ab wide 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
@@ -308,11 +381,22 @@ exports[`tile ab wide 1`] = `
           </div>
           <h3
             aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
             role="heading"
           >
             This is tile headline
           </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </span>
+          </div>
           <ArticleFlags
             flags={
               Array [
@@ -329,7 +413,7 @@ exports[`tile ab wide 1`] = `
   </div>
   <Image
     aspectRatio={0.6666666666666666}
-    className="IS4"
+    className="IS5"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />
@@ -346,15 +430,32 @@ exports[`tile ab without breakpoint should be like medium 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 30px;
   line-height: 30px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -367,7 +468,7 @@ exports[`tile ab without breakpoint should be like medium 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   -webkit-flex-grow: 0.56;
   flex-grow: 0.56;
   -webkit-flex-shrink: 1;
@@ -381,7 +482,7 @@ exports[`tile ab without breakpoint should be like medium 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS4 {
+.IS5 {
   flex: 0.44;
 }
 </style>
@@ -398,10 +499,10 @@ exports[`tile ab without breakpoint should be like medium 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
@@ -420,11 +521,22 @@ exports[`tile ab without breakpoint should be like medium 1`] = `
           </div>
           <h3
             aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
             role="heading"
           >
             This is tile headline
           </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </span>
+          </div>
           <ArticleFlags
             flags={
               Array [
@@ -441,7 +553,7 @@ exports[`tile ab without breakpoint should be like medium 1`] = `
   </div>
   <Image
     aspectRatio={0.6666666666666666}
-    className="IS4"
+    className="IS5"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
   />

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-ad.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-ad.test.js.snap
@@ -11,7 +11,7 @@ exports[`tile ad huge 1`] = `
   font-family: TimesModern-Bold;
   font-size: 22px;
   font-weight: 400;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -32,6 +32,7 @@ exports[`tile ad huge 1`] = `
 
 .IS2 {
   -webkit-line-clamp: 2;
+  margin-top: 10px;
 }
 
 .IS3 {
@@ -78,7 +79,7 @@ exports[`tile ad huge 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
@@ -120,7 +121,7 @@ exports[`tile ad medium 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
 }
 
 .IS1 {
@@ -172,7 +173,7 @@ exports[`tile ad medium 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
@@ -203,7 +204,7 @@ exports[`tile ad wide 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -225,6 +226,7 @@ exports[`tile ad wide 1`] = `
 
 .IS2 {
   -webkit-line-clamp: 2;
+  margin-top: 10px;
 }
 
 .IS3 {
@@ -271,7 +273,7 @@ exports[`tile ad wide 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
@@ -314,7 +316,7 @@ exports[`tile ad without breakpoint should be like medium 1`] = `
   font-family: TimesModern-Bold;
   font-weight: 400;
   line-height: 20px;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
 }
 
 .IS1 {
@@ -365,7 +367,7 @@ exports[`tile ad without breakpoint should be like medium 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-ae.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-ae.test.js.snap
@@ -10,15 +10,32 @@ exports[`tile ae huge 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 35px;
   line-height: 35px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 5;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -44,7 +61,7 @@ exports[`tile ae huge 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n IS3"
   >
     <div
       className="css-view-1dbjc4n"
@@ -63,11 +80,22 @@ exports[`tile ae huge 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
         </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
         <ArticleFlags
           flags={
             Array [
@@ -94,15 +122,32 @@ exports[`tile ae medium 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 30px;
   line-height: 30px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 5;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -128,7 +173,7 @@ exports[`tile ae medium 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n IS3"
   >
     <div
       className="css-view-1dbjc4n"
@@ -147,11 +192,22 @@ exports[`tile ae medium 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
         </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
         <ArticleFlags
           flags={
             Array [
@@ -178,15 +234,32 @@ exports[`tile ae wide 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 30px;
   line-height: 30px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 5;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -212,7 +285,7 @@ exports[`tile ae wide 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n IS3"
   >
     <div
       className="css-view-1dbjc4n"
@@ -231,11 +304,22 @@ exports[`tile ae wide 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
         </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
         <ArticleFlags
           flags={
             Array [
@@ -262,15 +346,32 @@ exports[`tile ae without breakpoint should be like medium 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 30px;
   line-height: 30px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 5;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -296,7 +397,7 @@ exports[`tile ae without breakpoint should be like medium 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n IS3"
   >
     <div
       className="css-view-1dbjc4n"
@@ -315,11 +416,22 @@ exports[`tile ae without breakpoint should be like medium 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
         </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-af.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-af.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile af without breakpoint 1`] = `
+exports[`tile af huge 1`] = `
 <style>
 .S1 {
   margin-bottom: 0px;
@@ -9,16 +9,33 @@ exports[`tile af without breakpoint 1`] = `
 .S2 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
+  font-size: 22px;
   font-weight: 400;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
-  font-size: 20px;
-  line-height: 20px;
+  line-height: 22px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -43,7 +60,7 @@ exports[`tile af without breakpoint 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n IS3"
   >
     <div
       className="css-view-1dbjc4n"
@@ -62,11 +79,244 @@ exports[`tile af without breakpoint 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
         </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </div>
+    </div>
+  </div>
+</Link>
+`;
+
+exports[`tile af wide 1`] = `
+<style>
+.S1 {
+  margin-bottom: 0px;
+}
+
+.S2 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.IS1 {
+  font-size: 20px;
+  line-height: 20px;
+}
+
+.IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+</style>
+
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": "10px",
+      "paddingVertical": "15px",
+    }
+  }
+  url="/article/123"
+>
+  <div
+    className="css-view-1dbjc4n IS3"
+  >
+    <div
+      className="css-view-1dbjc4n"
+    >
+      <div
+        className="css-view-1dbjc4n"
+      >
+        <div
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </div>
+    </div>
+  </div>
+</Link>
+`;
+
+exports[`tile af without breakpoint should be like wide 1`] = `
+<style>
+.S1 {
+  margin-bottom: 0px;
+}
+
+.S2 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-weight: 400;
+  line-height: 20px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.IS1 {
+  font-size: 20px;
+}
+
+.IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+</style>
+
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": "10px",
+      "paddingVertical": "15px",
+    }
+  }
+  url="/article/123"
+>
+  <div
+    className="css-view-1dbjc4n IS3"
+  >
+    <div
+      className="css-view-1dbjc4n"
+    >
+      <div
+        className="css-view-1dbjc4n"
+      >
+        <div
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-p1pxzi IS1 S2"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-ah.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-ah.test.js.snap
@@ -26,8 +26,7 @@ exports[`tile ah huge 1`] = `
   color: rgba(29,29,27,1.00);
   font-size: 45px;
   line-height: 45px;
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-top: 5px;
   text-align: center;
 }
 
@@ -35,7 +34,7 @@ exports[`tile ah huge 1`] = `
   font-family: TimesDigitalW04-Regular;
   font-size: 14px;
   line-height: 20px;
-  padding-bottom: 5px;
+  padding-bottom: 0px;
   text-align: center;
 }
 
@@ -82,7 +81,7 @@ exports[`tile ah huge 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi r-paddingBottom-1mi0q7o IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -134,8 +133,8 @@ exports[`tile ah medium 1`] = `
   color: rgba(29,29,27,1.00);
   font-size: 30px;
   line-height: 30px;
-  padding-top: 10px;
   padding-bottom: 10px;
+  padding-top: 5px;
   text-align: center;
 }
 
@@ -143,7 +142,7 @@ exports[`tile ah medium 1`] = `
   font-family: TimesDigitalW04-Regular;
   font-size: 14px;
   line-height: 20px;
-  padding-bottom: 5px;
+  padding-bottom: 0px;
   text-align: center;
 }
 
@@ -242,8 +241,7 @@ exports[`tile ah wide 1`] = `
   color: rgba(29,29,27,1.00);
   font-size: 40px;
   line-height: 40px;
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-top: 5px;
   text-align: center;
 }
 
@@ -251,7 +249,7 @@ exports[`tile ah wide 1`] = `
   font-family: TimesDigitalW04-Regular;
   font-size: 14px;
   line-height: 20px;
-  padding-bottom: 5px;
+  padding-bottom: 0px;
   text-align: center;
 }
 
@@ -298,7 +296,7 @@ exports[`tile ah wide 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi r-paddingBottom-1mi0q7o IS2 S2"
       role="heading"
     >
       This is tile headline
@@ -350,8 +348,7 @@ exports[`tile ah without breakpoint should be like medium 1`] = `
   color: rgba(29,29,27,1.00);
   font-size: 30px;
   line-height: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-top: 5px;
   text-align: center;
 }
 
@@ -359,7 +356,7 @@ exports[`tile ah without breakpoint should be like medium 1`] = `
   font-family: TimesDigitalW04-Regular;
   font-size: 14px;
   line-height: 20px;
-  padding-bottom: 5px;
+  padding-bottom: 0px;
   text-align: center;
 }
 
@@ -406,7 +403,7 @@ exports[`tile ah without breakpoint should be like medium 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi r-paddingBottom-1mi0q7o IS2 S2"
       role="heading"
     >
       This is tile headline

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-al.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-al.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile al without breakpoint 1`] = `
+exports[`tile al huge 1`] = `
 <style>
 .S1 {
   margin-bottom: 0px;
@@ -9,8 +9,21 @@ exports[`tile al without breakpoint 1`] = `
 .S2 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
+  font-size: 22px;
   font-weight: 400;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -19,11 +32,15 @@ exports[`tile al without breakpoint 1`] = `
 }
 
 .IS2 {
-  font-size: 20px;
-  line-height: 20px;
+  line-height: 22px;
 }
 
 .IS3 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -54,7 +71,7 @@ exports[`tile al without breakpoint 1`] = `
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
       className="css-view-1dbjc4n"
@@ -73,11 +90,144 @@ exports[`tile al without breakpoint 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
           role="heading"
         >
           This is tile headline
         </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </div>
+    </div>
+  </div>
+</Link>
+`;
+
+exports[`tile al wide 1`] = `
+<style>
+.S1 {
+  margin-bottom: 0px;
+}
+
+.S2 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.IS1 {
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.IS2 {
+  font-size: 20px;
+  line-height: 20px;
+}
+
+.IS3 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+</style>
+
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": "10px",
+      "paddingVertical": "15px",
+    }
+  }
+  url="/article/123"
+>
+  <Image
+    aspectRatio={1.5}
+    className="IS1"
+    fill={true}
+    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+  />
+  <div
+    className="css-view-1dbjc4n IS4"
+  >
+    <div
+      className="css-view-1dbjc4n"
+    >
+      <div
+        className="css-view-1dbjc4n"
+      >
+        <div
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-am.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-am.test.js.snap
@@ -13,6 +13,18 @@ exports[`tile am without breakpoint 1`] = `
   margin-bottom: 5px;
 }
 
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
 .IS1 {
   margin-bottom: 10px;
   width: 100%;
@@ -25,6 +37,10 @@ exports[`tile am without breakpoint 1`] = `
 }
 
 .IS3 {
+  -webkit-line-clamp: 2;
+}
+
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -54,7 +70,7 @@ exports[`tile am without breakpoint 1`] = `
     uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
       className="css-view-1dbjc4n"
@@ -78,6 +94,17 @@ exports[`tile am without breakpoint 1`] = `
         >
           This is tile headline
         </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-ar.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-ar.test.js.snap
@@ -1,6 +1,134 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tile ar without breakpoint 1`] = `
+exports[`tile ar huge 1`] = `
+<style>
+.S1 {
+  margin-bottom: 10px;
+}
+
+.S2 {
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S4 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.IS1 {
+  width: 100%;
+}
+
+.IS2 {
+  line-height: 22px;
+}
+
+.IS3 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+</style>
+
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": "10px",
+      "paddingVertical": "15px",
+    }
+  }
+  url="/article/123"
+>
+  <div
+    className="css-view-1dbjc4n r-marginBottom-15d164r IS1 S1"
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      fill={true}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </div>
+  <div
+    className="css-view-1dbjc4n IS4"
+  >
+    <div
+      className="css-view-1dbjc4n"
+    >
+      <div
+        className="css-view-1dbjc4n"
+      >
+        <div
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S3"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S4"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </span>
+        </div>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </div>
+    </div>
+  </div>
+</Link>
+`;
+
+exports[`tile ar medium 1`] = `
 <style>
 .S1 {
   margin-bottom: 0px;
@@ -10,7 +138,7 @@ exports[`tile ar without breakpoint 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -37,6 +165,7 @@ exports[`tile ar without breakpoint 1`] = `
 
 .IS3 {
   -webkit-line-clamp: 2;
+  margin-top: 10px;
 }
 
 .IS4 {
@@ -92,13 +221,269 @@ exports[`tile ar without breakpoint 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
           role="heading"
         >
           This is tile headline
         </h3>
         <div
           className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </span>
+        </div>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </div>
+    </div>
+  </div>
+</Link>
+`;
+
+exports[`tile ar wide 1`] = `
+<style>
+.S1 {
+  margin-bottom: 10px;
+}
+
+.S2 {
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-weight: 400;
+  line-height: 20px;
+  margin-bottom: 0px;
+}
+
+.S4 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.IS1 {
+  width: 100%;
+}
+
+.IS2 {
+  font-size: 20px;
+}
+
+.IS3 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+</style>
+
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": "10px",
+      "paddingVertical": "15px",
+    }
+  }
+  url="/article/123"
+>
+  <div
+    className="css-view-1dbjc4n r-marginBottom-15d164r IS1 S1"
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      fill={true}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </div>
+  <div
+    className="css-view-1dbjc4n IS4"
+  >
+    <div
+      className="css-view-1dbjc4n"
+    >
+      <div
+        className="css-view-1dbjc4n"
+      >
+        <div
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-p1pxzi IS2 S3"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S4"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+            ...
+          </span>
+        </div>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </div>
+    </div>
+  </div>
+</Link>
+`;
+
+exports[`tile ar without breakpoint should be like medium 1`] = `
+<style>
+.S1 {
+  margin-bottom: 10px;
+}
+
+.S2 {
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-weight: 400;
+  line-height: 20px;
+  margin-bottom: 0px;
+}
+
+.S4 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.IS1 {
+  width: 100%;
+}
+
+.IS2 {
+  font-size: 20px;
+}
+
+.IS3 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+</style>
+
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingHorizontal": "10px",
+      "paddingVertical": "15px",
+    }
+  }
+  url="/article/123"
+>
+  <div
+    className="css-view-1dbjc4n r-marginBottom-15d164r IS1 S1"
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      fill={true}
+      uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    />
+  </div>
+  <div
+    className="css-view-1dbjc4n IS4"
+  >
+    <div
+      className="css-view-1dbjc4n"
+    >
+      <div
+        className="css-view-1dbjc4n"
+      >
+        <div
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-p1pxzi IS2 S3"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S4"
         >
           <span
             className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-as.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-as.test.js.snap
@@ -15,7 +15,7 @@ exports[`tile as huge 1`] = `
   font-family: TimesModern-Bold;
   font-size: 22px;
   font-weight: 400;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
 }
 
 .S4 {
@@ -39,6 +39,10 @@ exports[`tile as huge 1`] = `
 }
 
 .IS3 {
+  margin-top: 10px;
+}
+
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -72,7 +76,7 @@ exports[`tile as huge 1`] = `
     />
   </div>
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
@@ -85,13 +89,13 @@ exports[`tile as huge 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S3"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S3"
       role="heading"
     >
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S4"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S4"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -125,7 +129,7 @@ exports[`tile as medium 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -151,6 +155,10 @@ exports[`tile as medium 1`] = `
 }
 
 .IS3 {
+  margin-top: 10px;
+}
+
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -184,7 +192,7 @@ exports[`tile as medium 1`] = `
     />
   </div>
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
@@ -197,13 +205,13 @@ exports[`tile as medium 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-d0pm55 IS2 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
       role="heading"
     >
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S3"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -242,7 +250,7 @@ exports[`tile as wide 1`] = `
   font-family: TimesModern-Bold;
   font-weight: 400;
   line-height: 20px;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
 }
 
 .S4 {
@@ -266,6 +274,10 @@ exports[`tile as wide 1`] = `
 }
 
 .IS3 {
+  margin-top: 10px;
+}
+
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -299,7 +311,7 @@ exports[`tile as wide 1`] = `
     />
   </div>
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
       className="css-view-1dbjc4n r-marginBottom-p1pxzi S2"
@@ -312,13 +324,13 @@ exports[`tile as wide 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS2 S3"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-p1pxzi IS2 S3"
       role="heading"
     >
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S4"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S4"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-b.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-b.test.js.snap
@@ -10,7 +10,7 @@ exports[`tile b huge 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 10px;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -32,6 +32,7 @@ exports[`tile b huge 1`] = `
 
 .IS2 {
   -webkit-line-clamp: 2;
+  margin-top: 10px;
 }
 
 .IS3 {
@@ -77,7 +78,7 @@ exports[`tile b huge 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
@@ -120,7 +121,7 @@ exports[`tile b medium 1`] = `
   font-family: TimesModern-Bold;
   font-weight: 400;
   line-height: 20px;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -141,6 +142,7 @@ exports[`tile b medium 1`] = `
 
 .IS2 {
   -webkit-line-clamp: 2;
+  margin-top: 10px;
 }
 
 .IS3 {
@@ -186,7 +188,7 @@ exports[`tile b medium 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
@@ -337,7 +339,7 @@ exports[`tile b wide 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 10px;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -359,6 +361,7 @@ exports[`tile b wide 1`] = `
 
 .IS2 {
   -webkit-line-clamp: 2;
+  margin-top: 10px;
 }
 
 .IS3 {
@@ -404,7 +407,7 @@ exports[`tile b wide 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
@@ -447,7 +450,19 @@ exports[`tile b with more teaser 1`] = `
   font-family: TimesModern-Bold;
   font-weight: 400;
   line-height: 20px;
-  margin-bottom: 5px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
@@ -455,6 +470,11 @@ exports[`tile b with more teaser 1`] = `
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -478,7 +498,7 @@ exports[`tile b with more teaser 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS2"
+    className="css-view-1dbjc4n IS3"
   >
     <div
       className="css-view-1dbjc4n"
@@ -497,11 +517,22 @@ exports[`tile b with more teaser 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-d0pm55 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-lineHeight-rjixqe r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
         </h3>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-g.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-g.test.js.snap
@@ -1,5 +1,145 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`tile g huge 1`] = `
+<style>
+.S1 {
+  margin-bottom: 0px;
+}
+
+.S2 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.IS1 {
+  overflow: hidden;
+  width: 97;
+}
+
+.IS2 {
+  line-height: 22px;
+}
+
+.IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -webkit-justify-content: center;
+  justify-content: center;
+  padding-left: 10px;
+  width: 70%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+}
+
+.IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+
+.IS5 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+}
+</style>
+
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "flexDirection": "row",
+      "padding": "10px",
+      "paddingHorizontal": "10px",
+      "paddingVertical": "10px",
+    }
+  }
+  url="/article/123"
+>
+  <div
+    className="css-view-1dbjc4n IS5"
+  >
+    <div
+      className="css-view-1dbjc4n IS4"
+    >
+      <Image
+        aspectRatio={1}
+        className="IS1"
+        fill={true}
+        resizeMode="cover"
+        rounded={true}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+      <div
+        className="css-view-1dbjc4n IS3"
+      >
+        <div
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </div>
+    </div>
+  </div>
+</Link>
+`;
+
 exports[`tile g medium 1`] = `
 <style>
 .S1 {
@@ -278,7 +418,7 @@ exports[`tile g small 1`] = `
 </Link>
 `;
 
-exports[`tile g without breakpoint should be like small 1`] = `
+exports[`tile g wide 1`] = `
 <style>
 .S1 {
   margin-bottom: 0px;
@@ -364,7 +504,7 @@ exports[`tile g without breakpoint should be like small 1`] = `
       "flexDirection": "row",
       "padding": "10px",
       "paddingHorizontal": "10px",
-      "paddingVertical": "15px",
+      "paddingVertical": "10px",
     }
   }
   url="/article/123"
@@ -398,6 +538,146 @@ exports[`tile g without breakpoint should be like small 1`] = `
         <h3
           aria-level="3"
           className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
+          role="heading"
+        >
+          This is tile headline
+        </h3>
+        <ArticleFlags
+          flags={
+            Array [
+              Object {
+                "expiryTime": "2030-03-14T12:00:00.000Z",
+                "type": "EXCLUSIVE",
+              },
+            ]
+          }
+        />
+      </div>
+    </div>
+  </div>
+</Link>
+`;
+
+exports[`tile g without breakpoint should be like small 1`] = `
+<style>
+.S1 {
+  margin-bottom: 0px;
+}
+
+.S2 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.IS1 {
+  overflow: hidden;
+  width: 97;
+}
+
+.IS2 {
+  line-height: 22px;
+}
+
+.IS3 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -webkit-justify-content: center;
+  justify-content: center;
+  padding-left: 10px;
+  width: 70%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+}
+
+.IS4 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+
+.IS5 {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+}
+</style>
+
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "flexDirection": "row",
+      "padding": "10px",
+      "paddingHorizontal": "10px",
+      "paddingVertical": "10px",
+    }
+  }
+  url="/article/123"
+>
+  <div
+    className="css-view-1dbjc4n IS5"
+  >
+    <div
+      className="css-view-1dbjc4n IS4"
+    >
+      <Image
+        aspectRatio={1}
+        className="IS1"
+        fill={true}
+        resizeMode="cover"
+        rounded={true}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+      <div
+        className="css-view-1dbjc4n IS3"
+      >
+        <div
+          className="css-view-1dbjc4n r-marginBottom-p1pxzi S1"
+        >
+          <ArticleLabel
+            color="#005B8D"
+            isVideo={false}
+            title="label"
+          />
+        </div>
+        <h3
+          aria-level="3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-marginBottom-p1pxzi IS2 S2"
           role="heading"
         >
           This is tile headline

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-w.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-w.test.js.snap
@@ -10,15 +10,32 @@ exports[`tile w huge 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 45px;
   line-height: 45px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -31,7 +48,7 @@ exports[`tile w huge 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -45,7 +62,7 @@ exports[`tile w huge 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS4 {
+.IS5 {
   flex: 1;
 }
 </style>
@@ -63,10 +80,10 @@ exports[`tile w huge 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
@@ -85,11 +102,22 @@ exports[`tile w huge 1`] = `
           </div>
           <h3
             aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
             role="heading"
           >
             This is tile headline
           </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </span>
+          </div>
           <ArticleFlags
             flags={
               Array [
@@ -106,7 +134,7 @@ exports[`tile w huge 1`] = `
   </div>
   <Image
     aspectRatio={1.5}
-    className="IS4"
+    className="IS5"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
@@ -123,15 +151,32 @@ exports[`tile w medium 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 30px;
   line-height: 30px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -144,7 +189,7 @@ exports[`tile w medium 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -158,7 +203,7 @@ exports[`tile w medium 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS4 {
+.IS5 {
   flex: 1;
 }
 </style>
@@ -176,10 +221,10 @@ exports[`tile w medium 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
@@ -198,11 +243,22 @@ exports[`tile w medium 1`] = `
           </div>
           <h3
             aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
             role="heading"
           >
             This is tile headline
           </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </span>
+          </div>
           <ArticleFlags
             flags={
               Array [
@@ -219,7 +275,7 @@ exports[`tile w medium 1`] = `
   </div>
   <Image
     aspectRatio={1.5}
-    className="IS4"
+    className="IS5"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
@@ -236,15 +292,32 @@ exports[`tile w wide 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 40px;
   line-height: 40px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -257,7 +330,7 @@ exports[`tile w wide 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -271,7 +344,7 @@ exports[`tile w wide 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS4 {
+.IS5 {
   flex: 1;
 }
 </style>
@@ -289,10 +362,10 @@ exports[`tile w wide 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
@@ -311,11 +384,22 @@ exports[`tile w wide 1`] = `
           </div>
           <h3
             aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
             role="heading"
           >
             This is tile headline
           </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </span>
+          </div>
           <ArticleFlags
             flags={
               Array [
@@ -332,7 +416,7 @@ exports[`tile w wide 1`] = `
   </div>
   <Image
     aspectRatio={1.5}
-    className="IS4"
+    className="IS5"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
@@ -349,15 +433,32 @@ exports[`tile w without breakpoint should be like medium 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 30px;
   line-height: 30px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -370,7 +471,7 @@ exports[`tile w without breakpoint should be like medium 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -384,7 +485,7 @@ exports[`tile w without breakpoint should be like medium 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS4 {
+.IS5 {
   flex: 1;
 }
 </style>
@@ -402,10 +503,10 @@ exports[`tile w without breakpoint should be like medium 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
@@ -424,11 +525,22 @@ exports[`tile w without breakpoint should be like medium 1`] = `
           </div>
           <h3
             aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
             role="heading"
           >
             This is tile headline
           </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </span>
+          </div>
           <ArticleFlags
             flags={
               Array [
@@ -445,7 +557,7 @@ exports[`tile w without breakpoint should be like medium 1`] = `
   </div>
   <Image
     aspectRatio={1.5}
-    className="IS4"
+    className="IS5"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-x.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-x.test.js.snap
@@ -10,6 +10,7 @@ exports[`tile x huge 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -17,18 +18,36 @@ exports[`tile x huge 1`] = `
   font-family: TimesModern-Regular;
 }
 
+.S4 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
 .IS1 {
   font-size: 45px;
   line-height: 45px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
   font-size: 24px;
   line-height: 26px;
+  padding-bottom: 0px;
+  padding-top: 10px;
 }
 
 .IS3 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -53,7 +72,7 @@ exports[`tile x huge 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
       className="css-view-1dbjc4n"
@@ -72,18 +91,29 @@ exports[`tile x huge 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
         </h3>
         <h4
           aria-level="4"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-4h8ur4 r-paddingBottom-1mi0q7o IS2 S3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-4h8ur4 IS2 S3"
           role="heading"
         >
           Three Conservative MPs resign
         </h4>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S4"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
         <ArticleFlags
           flags={
             Array [
@@ -110,6 +140,7 @@ exports[`tile x medium 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -117,18 +148,36 @@ exports[`tile x medium 1`] = `
   font-family: TimesModern-Regular;
 }
 
+.S4 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
 .IS1 {
   font-size: 40px;
   line-height: 40px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
   font-size: 24px;
   line-height: 26px;
+  padding-bottom: 0px;
+  padding-top: 10px;
 }
 
 .IS3 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -153,7 +202,7 @@ exports[`tile x medium 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
       className="css-view-1dbjc4n"
@@ -172,18 +221,29 @@ exports[`tile x medium 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
         </h3>
         <h4
           aria-level="4"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-4h8ur4 r-paddingBottom-1mi0q7o IS2 S3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-4h8ur4 IS2 S3"
           role="heading"
         >
           Three Conservative MPs resign
         </h4>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S4"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
         <ArticleFlags
           flags={
             Array [
@@ -210,6 +270,7 @@ exports[`tile x wide 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -217,18 +278,36 @@ exports[`tile x wide 1`] = `
   font-family: TimesModern-Regular;
 }
 
+.S4 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
 .IS1 {
   font-size: 40px;
   line-height: 40px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
   font-size: 24px;
   line-height: 26px;
+  padding-bottom: 0px;
+  padding-top: 10px;
 }
 
 .IS3 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -253,7 +332,7 @@ exports[`tile x wide 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
       className="css-view-1dbjc4n"
@@ -272,18 +351,29 @@ exports[`tile x wide 1`] = `
         </div>
         <h3
           aria-level="3"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
           role="heading"
         >
           This is tile headline
         </h3>
         <h4
           aria-level="4"
-          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-4h8ur4 r-paddingBottom-1mi0q7o IS2 S3"
+          className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-4h8ur4 IS2 S3"
           role="heading"
         >
           Three Conservative MPs resign
         </h4>
+        <div
+          className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS3 S4"
+        >
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+          >
+            
+            Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+            ...
+          </span>
+        </div>
         <ArticleFlags
           flags={
             Array [

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-y.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-y.test.js.snap
@@ -10,7 +10,7 @@ exports[`tile y huge 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 10px;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -28,6 +28,10 @@ exports[`tile y huge 1`] = `
 .IS1 {
   font-size: 35px;
   line-height: 35px;
+}
+
+.IS2 {
+  margin-top: 10px;
 }
 </style>
 
@@ -55,13 +59,13 @@ exports[`tile y huge 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
       role="heading"
     >
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -95,6 +99,7 @@ exports[`tile y medium 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -112,7 +117,10 @@ exports[`tile y medium 1`] = `
 .IS1 {
   font-size: 30px;
   line-height: 30px;
-  margin-bottom: 10px;
+}
+
+.IS2 {
+  margin-top: 10px;
 }
 </style>
 
@@ -140,13 +148,13 @@ exports[`tile y medium 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
       role="heading"
     >
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -180,7 +188,7 @@ exports[`tile y wide 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 10px;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -198,6 +206,10 @@ exports[`tile y wide 1`] = `
 .IS1 {
   font-size: 30px;
   line-height: 30px;
+}
+
+.IS2 {
+  margin-top: 10px;
 }
 </style>
 
@@ -225,13 +237,13 @@ exports[`tile y wide 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
       role="heading"
     >
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
@@ -265,7 +277,7 @@ exports[`tile y without breakpoint should be like medium 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
-  margin-bottom: 10px;
+  margin-bottom: 0px;
 }
 
 .S3 {
@@ -283,6 +295,10 @@ exports[`tile y without breakpoint should be like medium 1`] = `
 .IS1 {
   font-size: 30px;
   line-height: 30px;
+}
+
+.IS2 {
+  margin-top: 10px;
 }
 </style>
 
@@ -310,13 +326,13 @@ exports[`tile y without breakpoint should be like medium 1`] = `
     </div>
     <h3
       aria-level="3"
-      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-15d164r IS1 S2"
+      className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
       role="heading"
     >
       This is tile headline
     </h3>
     <div
-      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r S3"
+      className="css-text-901oao r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tile-z.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tile-z.test.js.snap
@@ -10,15 +10,32 @@ exports[`tile z huge 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 45px;
   line-height: 45px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -31,7 +48,7 @@ exports[`tile z huge 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -46,7 +63,7 @@ exports[`tile z huge 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS4 {
+.IS5 {
   width: 59%;
 }
 </style>
@@ -63,10 +80,10 @@ exports[`tile z huge 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
@@ -85,11 +102,22 @@ exports[`tile z huge 1`] = `
           </div>
           <h3
             aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
             role="heading"
           >
             This is tile headline
           </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </span>
+          </div>
           <ArticleFlags
             flags={
               Array [
@@ -106,7 +134,7 @@ exports[`tile z huge 1`] = `
   </div>
   <Image
     aspectRatio={1.5}
-    className="IS4"
+    className="IS5"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
@@ -123,15 +151,32 @@ exports[`tile z wide 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 40px;
   line-height: 40px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -144,7 +189,7 @@ exports[`tile z wide 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -159,7 +204,7 @@ exports[`tile z wide 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS4 {
+.IS5 {
   width: 59%;
 }
 </style>
@@ -176,10 +221,10 @@ exports[`tile z wide 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
@@ -198,11 +243,22 @@ exports[`tile z wide 1`] = `
           </div>
           <h3
             aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
             role="heading"
           >
             This is tile headline
           </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </span>
+          </div>
           <ArticleFlags
             flags={
               Array [
@@ -219,7 +275,7 @@ exports[`tile z wide 1`] = `
   </div>
   <Image
     aspectRatio={1.5}
-    className="IS4"
+    className="IS5"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
@@ -236,15 +292,32 @@ exports[`tile z without breakpoint should be like wide 1`] = `
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
   font-weight: 400;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 
 .IS1 {
   font-size: 40px;
   line-height: 40px;
-  margin-bottom: 10px;
 }
 
 .IS2 {
+  -webkit-line-clamp: 2;
+  margin-top: 10px;
+}
+
+.IS3 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -257,7 +330,7 @@ exports[`tile z without breakpoint should be like wide 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS3 {
+.IS4 {
   -webkit-flex-grow: 1;
   flex-grow: 1;
   -webkit-flex-shrink: 1;
@@ -272,7 +345,7 @@ exports[`tile z without breakpoint should be like wide 1`] = `
   -ms-flex-preferred-size: 0%;
 }
 
-.IS4 {
+.IS5 {
   width: 59%;
 }
 </style>
@@ -289,10 +362,10 @@ exports[`tile z without breakpoint should be like wide 1`] = `
   url="/article/123"
 >
   <div
-    className="css-view-1dbjc4n IS3"
+    className="css-view-1dbjc4n IS4"
   >
     <div
-      className="css-view-1dbjc4n IS2"
+      className="css-view-1dbjc4n IS3"
     >
       <div
         className="css-view-1dbjc4n"
@@ -311,11 +384,22 @@ exports[`tile z without breakpoint should be like wide 1`] = `
           </div>
           <h3
             aria-level="3"
-            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 IS1 S2"
+            className="css-reset-4rbku5 css-text-901oao r-color-1khnkhu r-fontFamily-iirzy8 r-fontWeight-16dba41 r-marginBottom-p1pxzi IS1 S2"
             role="heading"
           >
             This is tile headline
           </h3>
+          <div
+            className="css-text-901oao css-textMultiLine-cens5h r-color-1khp51w r-flexWrap-1w6e6rj r-fontFamily-1feecvn r-fontSize-1b43r93 r-lineHeight-rjixqe r-marginBottom-15d164r IS2 S3"
+          >
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+            >
+              
+              Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit
+              ...
+            </span>
+          </div>
           <ArticleFlags
             flags={
               Array [
@@ -332,7 +416,7 @@ exports[`tile z without breakpoint should be like wide 1`] = `
   </div>
   <Image
     aspectRatio={1.5}
-    className="IS4"
+    className="IS5"
     fill={true}
     uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />

--- a/packages/edition-slices/src/slices/leadoneandone/index.js
+++ b/packages/edition-slices/src/slices/leadoneandone/index.js
@@ -35,14 +35,7 @@ class LeadOneAndOne extends Component {
       <LeadOneAndOneSlice
         breakpoint={breakpoint}
         lead={<TileU onPress={onPress} tile={lead} tileName="lead" />}
-        support={
-          <TileAA
-            breakpoint={breakpoint}
-            onPress={onPress}
-            tile={support}
-            tileName="support"
-          />
-        }
+        support={<TileAA onPress={onPress} tile={support} tileName="support" />}
       />
     );
   }

--- a/packages/edition-slices/src/slices/secondaryfour/styles.js
+++ b/packages/edition-slices/src/slices/secondaryfour/styles.js
@@ -1,15 +1,13 @@
-import { editionBreakpoints, spacing } from "@times-components/styleguide";
+import { editionBreakpoints } from "@times-components/styleguide";
 
 const wideBreakpointHeadlineStyles = {
   fontSize: 20,
-  lineHeight: 20,
-  marginBottom: spacing(1)
+  lineHeight: 20
 };
 
 const hugeBreakpointHeadlineStyles = {
   fontSize: 22,
-  lineHeight: 22,
-  marginBottom: spacing(1)
+  lineHeight: 22
 };
 
 const styleResolver = {

--- a/packages/edition-slices/src/slices/secondarytwonopicandtwo/index.js
+++ b/packages/edition-slices/src/slices/secondarytwonopicandtwo/index.js
@@ -86,7 +86,6 @@ class SecondaryTwoNoPicAndTwo extends Component {
       <ResponsiveSlice
         renderSmall={this.renderSmall}
         renderMedium={this.renderMedium}
-        renderWide={this.renderMedium}
       />
     );
   }

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -7,6 +7,7 @@ import ArticleSummary, {
 } from "@times-components/article-summary";
 import { ArticleFlags } from "@times-components/article-flag";
 import { colours } from "@times-components/styleguide";
+import { ResponsiveContext } from "@times-components/responsive";
 import PositionedTileStar from "./positioned-tile-star";
 
 class TileSummary extends Component {
@@ -44,7 +45,12 @@ class TileSummary extends Component {
       flagColour
     } = this.props;
 
-    return <ArticleFlags {...flagColour} flags={expirableFlags} />;
+    return <ArticleFlags {...flagColour} flags={
+        [{
+            expiryTime:"2019-12-28T11:00:00.000Z",
+            type:"NEW" 
+        }]  
+      } />;
   }
 
   renderSaveStar() {
@@ -107,25 +113,30 @@ class TileSummary extends Component {
       withStar,
       labelColour
     } = this.props;
-
     return (
-      <ArticleSummary
-        bylineProps={bylines ? { ast: bylines, bylineStyle } : null}
-        content={summary ? this.renderContent() : undefined}
-        flags={this.renderFlags()}
-        headline={this.renderHeadline()}
-        label={label}
-        labelProps={{
-          color:
-            labelColour ||
-            (colours.section[section] || colours.section.default),
-          isVideo: hasVideo,
-          title: label
-        }}
-        strapline={strapline ? this.renderStrapline() : undefined}
-        saveStar={withStar && this.renderSaveStar()}
-        style={style}
-      />
+      <ResponsiveContext.Consumer>
+        {({ isTablet }) => {
+        return (
+          <ArticleSummary
+            bylineProps={bylines ? { ast: bylines, bylineStyle } : null}
+            content={summary ? this.renderContent() : undefined}
+            flags={this.renderFlags()}
+            headline={this.renderHeadline()}
+            label={label}
+            labelProps={{
+              color:
+                labelColour ||
+                (colours.section[section] || colours.section.default),
+              isVideo: hasVideo,
+              title: label
+            }}
+            strapline={strapline ? this.renderStrapline() : undefined}
+            saveStar={withStar && this.renderSaveStar()}
+            style={style}
+            isTablet={isTablet}
+          />
+        )}}
+      </ResponsiveContext.Consumer>
     );
   }
 }

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -45,12 +45,7 @@ class TileSummary extends Component {
       flagColour
     } = this.props;
 
-    return <ArticleFlags {...flagColour} flags={
-        [{
-            expiryTime:"2019-12-28T11:00:00.000Z",
-            type:"NEW" 
-        }]  
-      } />;
+    return <ArticleFlags {...flagColour} flags={expirableFlags} />;
   }
 
   renderSaveStar() {
@@ -115,8 +110,7 @@ class TileSummary extends Component {
     } = this.props;
     return (
       <ResponsiveContext.Consumer>
-        {({ isTablet }) => {
-        return (
+        {({ isTablet }) => (
           <ArticleSummary
             bylineProps={bylines ? { ast: bylines, bylineStyle } : null}
             content={summary ? this.renderContent() : undefined}
@@ -135,7 +129,7 @@ class TileSummary extends Component {
             style={style}
             isTablet={isTablet}
           />
-        )}}
+        )}
       </ResponsiveContext.Consumer>
     );
   }

--- a/packages/edition-slices/src/tiles/tile-aa/index.js
+++ b/packages/edition-slices/src/tiles/tile-aa/index.js
@@ -1,41 +1,36 @@
 /* eslint-disable react/require-default-props */
 import React from "react";
 import PropTypes from "prop-types";
-import { editionBreakpoints } from "@times-components/styleguide";
 import {
   getTileSummary,
   TileLink,
   TileSummary,
   withTileTracking
 } from "../shared";
-import styleFactory from "./styles";
+import styles from "./styles";
 import WithoutWhiteSpace from "../shared/without-white-space";
 import PositionedTileStar from "../shared/positioned-tile-star";
 
-const TileAA = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
-  const styles = styleFactory(breakpoint);
-
-  return (
-    <TileLink onPress={onPress} style={styles.container} tile={tile}>
-      <WithoutWhiteSpace
-        style={styles.summaryContainer}
-        render={whiteSpaceHeight => (
-          <TileSummary
-            headlineStyle={styles.headline}
-            summary={getTileSummary(tile, 800)}
-            tile={tile}
-            whiteSpaceHeight={whiteSpaceHeight}
-            withStar={false}
-          />
-        )}
-      />
-      <PositionedTileStar articleId={tile.article.id} />
-    </TileLink>
-  );
-};
+const TileAA = ({ onPress, tile }) => (
+  <TileLink onPress={onPress} style={styles.container} tile={tile}>
+    <WithoutWhiteSpace
+      style={styles.summaryContainer}
+      render={whiteSpaceHeight => (
+        <TileSummary
+          headlineStyle={styles.headline}
+          summary={getTileSummary(tile, 800)}
+          summaryStyle={styles.summary}
+          tile={tile}
+          whiteSpaceHeight={whiteSpaceHeight}
+          withStar={false}
+        />
+      )}
+    />
+    <PositionedTileStar articleId={tile.article.id} />
+  </TileLink>
+);
 
 TileAA.propTypes = {
-  breakpoint: PropTypes.string,
   onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired
 };

--- a/packages/edition-slices/src/tiles/tile-aa/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-aa/styles/index.js
@@ -1,31 +1,24 @@
 import {
   fonts,
   spacing,
-  editionBreakpoints
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
-const mediumBreakpointStyles = {
+const styles = {
   container: {
     flex: 1,
     paddingVertical: spacing(3),
     paddingHorizontal: spacing(2)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: 20,
     lineHeight: 20
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 };
-const wideBreakpointStyles = {
-  ...mediumBreakpointStyles,
-  headline: {
-    fontFamily: fonts.headline,
-    fontSize: 28,
-    lineHeight: 28,
-    marginBottom: spacing(2)
-  }
-};
-export default breakpoint =>
-  breakpoint === editionBreakpoints.medium
-    ? mediumBreakpointStyles
-    : wideBreakpointStyles;
+
+export default styles;

--- a/packages/edition-slices/src/tiles/tile-ab/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/index.js
@@ -31,6 +31,7 @@ const TileAB = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
             <TileSummary
               headlineStyle={styles.headline}
               summary={getTileSummary(tile, 800)}
+              summaryStyle={styles.summary}
               tile={tile}
               whiteSpaceHeight={whiteSpaceHeight}
               withStar={false}

--- a/packages/edition-slices/src/tiles/tile-ab/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/styles/index.js
@@ -1,7 +1,8 @@
 import {
   fonts,
   spacing,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const mediumBreakpointStyles = {
@@ -12,10 +13,10 @@ const mediumBreakpointStyles = {
     paddingVertical: spacing(3)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: 30,
-    lineHeight: 30,
-    marginBottom: spacing(2)
+    lineHeight: 30
   },
   imageContainer: {
     flex: 0.44
@@ -23,6 +24,9 @@ const mediumBreakpointStyles = {
   summaryContainer: {
     flex: 0.56,
     paddingRight: spacing(4)
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-ad/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/index.js
@@ -22,6 +22,7 @@ const TileAD = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
           <TileSummary
             headlineStyle={styles.headline}
             summary={showSummary ? getTileSummary(tile, 300) : null}
+            summaryStyle={styles.summary}
             tile={tile}
             whiteSpaceHeight={whiteSpaceHeight}
           />

--- a/packages/edition-slices/src/tiles/tile-ad/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ad/styles/index.js
@@ -1,7 +1,8 @@
 import {
   fonts,
   spacing,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const fontSizeResolver = {
@@ -17,12 +18,15 @@ export default breakpoint => ({
     padding: spacing(2)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: fontSizeResolver[breakpoint],
-    lineHeight: fontSizeResolver[breakpoint],
-    marginBottom: spacing(1)
+    lineHeight: fontSizeResolver[breakpoint]
   },
   summaryContainer: {
     width: "100%"
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 });

--- a/packages/edition-slices/src/tiles/tile-ae/index.js
+++ b/packages/edition-slices/src/tiles/tile-ae/index.js
@@ -21,6 +21,7 @@ const TileAE = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
           <TileSummary
             headlineStyle={styles.headline}
             summary={getTileSummary(tile, 800)}
+            summaryStyle={styles.summary}
             tile={tile}
             whiteSpaceHeight={whiteSpaceHeight}
             withStar={false}

--- a/packages/edition-slices/src/tiles/tile-ae/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ae/styles/index.js
@@ -1,7 +1,8 @@
 import {
   fonts,
   spacing,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const headlineFontResolver = {
@@ -18,9 +19,12 @@ export default breakpoint => ({
     paddingTop: spacing(3)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: headlineFontResolver[breakpoint],
-    lineHeight: headlineFontResolver[breakpoint],
-    marginBottom: spacing(2)
+    lineHeight: headlineFontResolver[breakpoint]
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 });

--- a/packages/edition-slices/src/tiles/tile-af/index.js
+++ b/packages/edition-slices/src/tiles/tile-af/index.js
@@ -23,6 +23,7 @@ const TileAF = ({ onPress, tile, breakpoint = editionBreakpoints.wide }) => {
           <TileSummary
             headlineStyle={styles.headline}
             summary={getTileSummary(tile, 800)}
+            summaryStyle={styles.summary}
             tile={tile}
             whiteSpaceHeight={whiteSpaceHeight}
             withStar={false}

--- a/packages/edition-slices/src/tiles/tile-af/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-af/styles/index.js
@@ -1,7 +1,8 @@
 import {
   fonts,
   spacing,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const fontSizeResolver = {
@@ -16,8 +17,12 @@ export default breakpoint => ({
     paddingHorizontal: spacing(2)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: fontSizeResolver[breakpoint],
     lineHeight: fontSizeResolver[breakpoint]
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 });

--- a/packages/edition-slices/src/tiles/tile-ah/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/styles/index.js
@@ -3,7 +3,8 @@ import {
   fonts,
   fontSizes,
   spacing,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const headlineFontSizeResolver = {
@@ -27,13 +28,14 @@ const styles = breakpoint => ({
     paddingRight: keylinePadding[breakpoint]
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     color: colours.functional.brandColour,
     fontFamily: fonts.headline,
     fontSize: headlineFontSizeResolver[breakpoint],
     lineHeight: headlineFontSizeResolver[breakpoint],
-    paddingVertical: spacing(2),
     textAlign: "center",
-    marginBottom: 0
+    paddingBottom: spacing(2),
+    paddingTop: spacing(1)
   },
   imageContainer: {
     overflow: "hidden",
@@ -46,7 +48,7 @@ const styles = breakpoint => ({
     fontSize: fontSizes.meta,
     lineHeight: 20,
     textAlign: "center",
-    paddingBottom: spacing(1)
+    paddingBottom: 0
   },
   summaryContainer: {
     paddingTop: spacing(1),

--- a/packages/edition-slices/src/tiles/tile-al/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/index.js
@@ -39,6 +39,7 @@ const TileAL = ({ onPress, tile, breakpoint = editionBreakpoints.wide }) => {
           <TileSummary
             headlineStyle={styles.headline}
             summary={getTileSummary(tile, 800)}
+            summaryStyle={styles.summary}
             tile={tile}
             whiteSpaceHeight={whiteSpaceHeight}
             withStar={false}

--- a/packages/edition-slices/src/tiles/tile-al/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/styles/index.js
@@ -1,7 +1,8 @@
 import {
   fonts,
   spacing,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const fontSizeResolver = {
@@ -16,6 +17,7 @@ export default breakpoint => ({
     paddingVertical: spacing(3)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: fontSizeResolver[breakpoint],
     lineHeight: fontSizeResolver[breakpoint]
@@ -23,5 +25,8 @@ export default breakpoint => ({
   imageContainer: {
     width: "100%",
     marginBottom: spacing(2)
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 });

--- a/packages/edition-slices/src/tiles/tile-ar/index.js
+++ b/packages/edition-slices/src/tiles/tile-ar/index.js
@@ -41,6 +41,7 @@ const TileAR = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
           <TileSummary
             headlineStyle={styles.headline}
             summary={getTileSummary(tile, 125)}
+            summaryStyle={styles.summary}
             tile={tile}
             whiteSpaceHeight={whiteSpaceHeight}
             withStar={false}

--- a/packages/edition-slices/src/tiles/tile-ar/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-ar/styles/index.js
@@ -1,7 +1,8 @@
 import {
   fonts,
   spacing,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const fontSizeResolver = {
@@ -17,6 +18,7 @@ export default breakpoint => ({
     paddingHorizontal: spacing(2)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: fontSizeResolver[breakpoint],
     lineHeight: fontSizeResolver[breakpoint]
@@ -24,5 +26,8 @@ export default breakpoint => ({
   imageContainer: {
     marginBottom: spacing(2),
     width: "100%"
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 });

--- a/packages/edition-slices/src/tiles/tile-as/index.js
+++ b/packages/edition-slices/src/tiles/tile-as/index.js
@@ -35,6 +35,7 @@ const TileAS = ({ onPress, tile, breakpoint }) => {
       <TileSummary
         headlineStyle={styles.headline}
         summary={getTileSummary(tile, 125)}
+        summaryStyle={styles.summary}
         style={styles.summaryContainer}
         tile={tile}
       />

--- a/packages/edition-slices/src/tiles/tile-as/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-as/styles/index.js
@@ -1,7 +1,8 @@
 import {
   fonts,
   spacing,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const headlineFontSize = {
@@ -17,6 +18,7 @@ export default breakpoint => ({
     paddingHorizontal: spacing(2)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: headlineFontSize[breakpoint],
     lineHeight: headlineFontSize[breakpoint]
@@ -27,5 +29,8 @@ export default breakpoint => ({
   imageContainer: {
     marginBottom: spacing(2),
     width: "100%"
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 });

--- a/packages/edition-slices/src/tiles/tile-b/index.js
+++ b/packages/edition-slices/src/tiles/tile-b/index.js
@@ -33,6 +33,7 @@ const TileB = ({
           <TileSummary
             headlineStyle={headLineStyles}
             summary={getTileSummary(tile, withMoreTeaser ? 800 : 125)}
+            summaryStyle={styles.summary}
             tile={tile}
             whiteSpaceHeight={whiteSpaceHeight}
             withStar={false}

--- a/packages/edition-slices/src/tiles/tile-b/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-b/styles/index.js
@@ -1,7 +1,8 @@
 import {
   fonts,
   spacing,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const sharedStyles = {
@@ -9,6 +10,7 @@ const sharedStyles = {
     flex: 1
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline
   }
 };
@@ -21,7 +23,8 @@ const smallBreakpointStyles = {
   headline: {
     ...sharedStyles.headline,
     fontSize: 25,
-    lineHeight: 25
+    lineHeight: 25,
+    marginBottom: spacing(1)
   }
 };
 
@@ -34,6 +37,9 @@ const mediumBreakpointStyles = {
     ...sharedStyles.headline,
     fontSize: 20,
     lineHeight: 20
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 };
 
@@ -44,9 +50,11 @@ const wideBreakpointStyles = {
   },
   headline: {
     ...sharedStyles.headline,
-    marginBottom: spacing(2),
     fontSize: 30,
     lineHeight: 30
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-g/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g/styles/index.js
@@ -2,7 +2,8 @@ import {
   fonts,
   fontFactory,
   spacing,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const defaultStyles = {
@@ -49,10 +50,10 @@ const mediumBreakpointStyles = {
     paddingVertical: spacing(3)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: 20,
-    lineHeight: 20,
-    marginBottom: 0
+    lineHeight: 20
   },
   imageContainer: {
     overflow: "hidden",

--- a/packages/edition-slices/src/tiles/tile-w/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/index.js
@@ -31,6 +31,7 @@ const TileW = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
             <TileSummary
               headlineStyle={styles.headline}
               summary={getTileSummary(tile, 800)}
+              summaryStyle={styles.summary}
               tile={tile}
               whiteSpaceHeight={whiteSpaceHeight}
               withStar={false}

--- a/packages/edition-slices/src/tiles/tile-w/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/styles/index.js
@@ -1,4 +1,8 @@
-import { spacing, fonts } from "@times-components/styleguide";
+import {
+  spacing,
+  fonts,
+  globalSpacingStyles
+} from "@times-components/styleguide";
 
 const mediumBreakpointStyles = {
   container: {
@@ -9,10 +13,10 @@ const mediumBreakpointStyles = {
     paddingVertical: spacing(3)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: 30,
-    lineHeight: 30,
-    marginBottom: spacing(2)
+    lineHeight: 30
   },
   summaryContainer: {
     flex: 1,
@@ -20,6 +24,9 @@ const mediumBreakpointStyles = {
   },
   imageContainer: {
     flex: 1
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-x/index.js
+++ b/packages/edition-slices/src/tiles/tile-x/index.js
@@ -24,6 +24,7 @@ const TileX = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
             strapline={getTileStrapline(tile)}
             straplineStyle={styles.strapline}
             summary={getTileSummary(tile, 800)}
+            summaryStyle={styles.summary}
             tile={tile}
             whiteSpaceHeight={whiteSpaceHeight}
             withStar={false}

--- a/packages/edition-slices/src/tiles/tile-x/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-x/styles/index.js
@@ -2,7 +2,8 @@ import {
   colours,
   fonts,
   spacing,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const fontSizeResolver = {
@@ -18,15 +19,20 @@ export default breakpoint => ({
     paddingTop: spacing(3)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: fontSizeResolver[breakpoint],
-    lineHeight: fontSizeResolver[breakpoint],
-    marginBottom: spacing(2)
+    lineHeight: fontSizeResolver[breakpoint]
   },
   strapline: {
     fontFamily: fonts.headlineRegular,
     color: colours.functional.primary,
     fontSize: 24,
-    lineHeight: 26
+    lineHeight: 26,
+    paddingTop: spacing(2),
+    paddingBottom: 0
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 });

--- a/packages/edition-slices/src/tiles/tile-y/index.js
+++ b/packages/edition-slices/src/tiles/tile-y/index.js
@@ -18,6 +18,7 @@ const TileY = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
       <TileSummary
         headlineStyle={styles.headline}
         summary={getTileSummary(tile, 300)}
+        summaryStyle={styles.summary}
         tile={tile}
       />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-y/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-y/styles/index.js
@@ -1,7 +1,8 @@
 import {
   fonts,
   spacing,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const fontSizeResolver = {
@@ -17,9 +18,12 @@ export default breakpoint => ({
     paddingBottom: spacing(3)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: fontSizeResolver[breakpoint],
-    lineHeight: fontSizeResolver[breakpoint],
-    marginBottom: spacing(2)
+    lineHeight: fontSizeResolver[breakpoint]
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 });

--- a/packages/edition-slices/src/tiles/tile-z/index.js
+++ b/packages/edition-slices/src/tiles/tile-z/index.js
@@ -31,6 +31,7 @@ const TileZ = ({ onPress, tile, breakpoint = editionBreakpoints.wide }) => {
             <TileSummary
               headlineStyle={styles.headline}
               summary={getTileSummary(tile, 800)}
+              summaryStyle={styles.summary}
               tile={tile}
               whiteSpaceHeight={whiteSpaceHeight}
               withStar={false}

--- a/packages/edition-slices/src/tiles/tile-z/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-z/styles/index.js
@@ -1,7 +1,8 @@
 import {
   spacing,
   fonts,
-  editionBreakpoints
+  editionBreakpoints,
+  globalSpacingStyles
 } from "@times-components/styleguide";
 
 const fontSizeResolver = {
@@ -17,10 +18,10 @@ export default breakpoint => ({
     paddingVertical: spacing(3)
   },
   headline: {
+    ...globalSpacingStyles.tabletHeadline,
     fontFamily: fonts.headline,
     fontSize: fontSizeResolver[breakpoint],
-    lineHeight: fontSizeResolver[breakpoint],
-    marginBottom: spacing(2)
+    lineHeight: fontSizeResolver[breakpoint]
   },
   summaryContainer: {
     flex: 1,
@@ -29,5 +30,8 @@ export default breakpoint => ({
   },
   imageContainer: {
     width: "59%"
+  },
+  summary: {
+    ...globalSpacingStyles.tabletTeaser
   }
 });

--- a/packages/fixture-generator/src/mock-article.ts
+++ b/packages/fixture-generator/src/mock-article.ts
@@ -22,6 +22,7 @@ interface TimesArticle extends Article {
   summary175: Markup | null;
   summary225: Markup | null;
   summary300: Markup | null;
+  summary800: Markup | null;
 }
 
 class MockArticle {
@@ -74,6 +75,7 @@ class MockArticle {
       summary175: new MockMarkup().addSummary("summary175").get(),
       summary225: new MockMarkup().addSummary("summary225").get(),
       summary300: new MockMarkup().addSummary("summary300").get(),
+      summary800: new MockMarkup().addSummary("summary800").get(),
       synonyms: {
         edges: [],
         nodes: [],

--- a/packages/fixture-generator/src/mock-markup.ts
+++ b/packages/fixture-generator/src/mock-markup.ts
@@ -169,6 +169,20 @@ const markupTypes: Markup = {
         children: []
       }
     ]
+  },
+  summary800: {
+    name: "paragraph",
+    attributes: {},
+    children: [
+      {
+        name: "text",
+        attributes: {
+          value:
+            "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit"
+        },
+        children: []
+      }
+    ]
   }
 };
 

--- a/packages/styleguide/src/spacing/base.js
+++ b/packages/styleguide/src/spacing/base.js
@@ -3,3 +3,12 @@ const spacingBase = 5;
 export default function(multiple) {
   return spacingBase * multiple;
 }
+
+export const globalSpacingStyles = {
+  tabletHeadline: {
+      marginBottom: 0
+  },
+  tabletTeaser: {
+      marginTop: spacingBase * 2
+  }
+};

--- a/packages/styleguide/src/spacing/base.js
+++ b/packages/styleguide/src/spacing/base.js
@@ -6,9 +6,9 @@ export default function(multiple) {
 
 export const globalSpacingStyles = {
   tabletHeadline: {
-      marginBottom: 0
+    marginBottom: 0
   },
   tabletTeaser: {
-      marginTop: spacingBase * 2
+    marginTop: spacingBase * 2
   }
 };

--- a/packages/styleguide/src/spacing/index.js
+++ b/packages/styleguide/src/spacing/index.js
@@ -1,12 +1,4 @@
-import spacing from "./base";
+import spacing, { globalSpacingStyles } from "./base";
 
-export const globalSpacingStyles = {
-    tabletHeadline: {
-        marginBottom: 0
-    },
-    tabletTeaser: {
-        marginTop: spacing(2)
-    }
-};
-
+export { globalSpacingStyles };
 export default spacing;

--- a/packages/styleguide/src/spacing/index.js
+++ b/packages/styleguide/src/spacing/index.js
@@ -1,3 +1,12 @@
 import spacing from "./base";
 
+export const globalSpacingStyles = {
+    tabletHeadline: {
+        marginBottom: 0
+    },
+    tabletTeaser: {
+        marginTop: spacing(2)
+    }
+};
+
 export default spacing;

--- a/packages/styleguide/src/spacing/index.web.js
+++ b/packages/styleguide/src/spacing/index.web.js
@@ -1,5 +1,6 @@
-import spacing from "./base";
+import spacing, { globalSpacingStyles } from "./base";
 
 export default function(multiple) {
   return `${spacing(multiple)}px`;
 }
+export { globalSpacingStyles };

--- a/packages/styleguide/src/styleguide.js
+++ b/packages/styleguide/src/styleguide.js
@@ -17,7 +17,7 @@ import timesFontFactory from "./fonts/font-factory";
 import themeFactory from "./theme/theme-factory";
 
 import scales from "./scales";
-import spacing from "./spacing";
+import spacing, { globalSpacingStyles } from "./spacing";
 
 const colours = {
   functional: functionalColours,
@@ -53,6 +53,7 @@ export {
   lineHeight,
   scales,
   spacing,
+  globalSpacingStyles,
   tabletRowPadding,
   tabletWidth,
   tabletWidthMax,


### PR DESCRIPTION
[Story.](https://nidigitalsolutions.jira.com/browse/REPLAT-9113) 
Flags moved for medium, wide and huge breakpoints.

Summary800 added in fixture generator.
Tiles snaps updated based on usage.
Global variables for tablet spacing added.

Result:
![lead-1-and-1-768](https://user-images.githubusercontent.com/8720661/67394619-2f1ba900-f5ad-11e9-86c5-81ebd49d85a0.png)
![lead-1-and-4-1366](https://user-images.githubusercontent.com/8720661/67394621-2fb43f80-f5ad-11e9-8dc6-7403438ca906.png)
![cartoon-1024-styling](https://user-images.githubusercontent.com/8720661/67394622-2fb43f80-f5ad-11e9-9655-f466a2f91264.png)
![lead-2-no-pic-and-2-768](https://user-images.githubusercontent.com/8720661/67394623-2fb43f80-f5ad-11e9-909b-e8c41ff0f47a.png)
![lead-2-no-pic-and-2-1024](https://user-images.githubusercontent.com/8720661/67394624-304cd600-f5ad-11e9-8098-113ec37e7957.png)

![secondary-4](https://user-images.githubusercontent.com/8720661/67553169-3bbb1100-f715-11e9-99f9-d6bdc5a1bd92.png)
![secondary-1-and-columnist](https://user-images.githubusercontent.com/8720661/67553170-3bbb1100-f715-11e9-85a7-174151ba1df1.png)

![secondary-2-no-pic-and-2](https://user-images.githubusercontent.com/8720661/67557799-6d84a580-f71e-11e9-907a-70e8319565c3.png)


![secondary-two](https://user-images.githubusercontent.com/8720661/67582792-0d5c2680-f753-11e9-9c2a-0176b51a6434.png)
![list-2-and-6-no-pic](https://user-images.githubusercontent.com/8720661/67582793-0d5c2680-f753-11e9-846e-9122c9a19bba.png)
