### PR TITLE
fix: paragraph heights not correct

### DIFF
--- a/packages/article-paragraph/src/article-paragraph.js
+++ b/packages/article-paragraph/src/article-paragraph.js
@@ -14,7 +14,7 @@ const BodyParagraph = props => (
           styles.articleMainContentRow,
           styles.articleTextElement,
           isTablet && styles.articleMainContentRowTablet
-        ]}
+        ].concat(props.height ? [{ height: props.height }] : [])}
       >
         <View>{props.children}</View>
       </View>
@@ -23,7 +23,12 @@ const BodyParagraph = props => (
 );
 
 BodyParagraph.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  height: PropTypes.number
+};
+
+BodyParagraph.defaultProps = {
+  height: null
 };
 
 export default BodyParagraph;

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -51,6 +51,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           <View
             style={
               Object {
+                "height": 84,
                 "marginBottom": 20,
                 "paddingLeft": 10,
                 "paddingRight": 10,
@@ -389,6 +390,7 @@ exports[`4. an article with a nested markup in first paragraph displays a drop c
           <View
             style={
               Object {
+                "height": 84,
                 "marginBottom": 20,
                 "paddingLeft": 10,
                 "paddingRight": 10,

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -51,6 +51,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           <View
             style={
               Object {
+                "height": 84,
                 "marginBottom": 20,
                 "paddingLeft": 10,
                 "paddingRight": 10,
@@ -389,6 +390,7 @@ exports[`4. an article with a nested markup in first paragraph displays a drop c
           <View
             style={
               Object {
+                "height": 84,
                 "marginBottom": 20,
                 "paddingLeft": 10,
                 "paddingRight": 10,

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -136,7 +136,7 @@ const Paragraph = ({
 
   const container = new TextContainer(
     isTablet ? contentWidth : screenWidth() - spacing(4),
-    10000,
+    5000,
     0,
     0,
     dropCap ? [dropCap.exclusion] : []


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
A change in the previous PR that removed height from article-paragraph caused a regression. This restores it without adding undefined to the snapshots like it was before
BEFORE:
![Screenshot_1571836100](https://user-images.githubusercontent.com/615608/67395906-a3028500-f59e-11e9-97b1-b44f94611c6f.png)
AFTER:
![Screenshot_1571836076](https://user-images.githubusercontent.com/615608/67395924-a8f86600-f59e-11e9-838a-7274953ca47d.png)

