### PR TITLE
fix: only add acs and sacs cookies if they exist

### DIFF
--- a/packages/ssr/src/lib/run-client.js
+++ b/packages/ssr/src/lib/run-client.js
@@ -32,8 +32,9 @@ const makeClient = options => {
   if (typeof window !== "undefined" && window.nuk) {
     const acsTnlCookie = window.nuk.getCookieValue("acs_tnl");
     const sacsTnlCookie = window.nuk.getCookieValue("sacs_tnl");
-
-    networkInterfaceOptions.headers.Authorization = `Cookie acs_tnl=${acsTnlCookie};sacs_tnl=${sacsTnlCookie}`;
+    if (acsTnlCookie && sacsTnlCookie) {
+      networkInterfaceOptions.headers.Authorization = `Cookie acs_tnl=${acsTnlCookie};sacs_tnl=${sacsTnlCookie}`;
+    }
   }
 
   return new ApolloClient({


### PR DESCRIPTION
[REPLAT-9907](https://nidigitalsolutions.jira.com/browse/REPLAT-9907)

Pagination broken for topics and journalist pages.
When making requests to the graphql endpoint client side, the requests were failing because we were sending `acs_tnl` and `sacs_tnl` cookies with the value of `null
<img width="824" alt="Screenshot 2019-10-24 at 17 12 23" src="https://user-images.githubusercontent.com/17279130/67569221-29959e80-f726-11e9-84e3-5b344aaf69d9.png">
`
Those cookies are only available when logged in but the topics and author pages are available when not logged in.
These cookies will only be added now if they have a `truthy` value

This has been tested by running a local version of TC in render