### PR TITLE
fix: REPLAT-9346 android app fails to bundle because of fonts

### DIFF
--- a/fonts.js
+++ b/fonts.js
@@ -1,24 +1,24 @@
 /* eslint-disable global-require */
 const fonts = {
   "CenturyGothic-Bold": () =>
-    require("./dist/public/fonts/CenturyGothic-Bold.js").default,
-  "Flama-Bold": () => require("./dist/public/fonts/Flama-Bold.js").default,
+    require("./dist/public/fonts/CenturyGothic-Bold-metrics.js").default,
+  "Flama-Bold": () => require("./dist/public/fonts/Flama-Bold-metrics.js").default,
   "GillSansMTStd-Medium": () =>
-    require("./dist/public/fonts/GillSansMTStd-Medium.js").default,
+    require("./dist/public/fonts/GillSansMTStd-Medium-metrics.js").default,
   "Tiempos-Headline-Bold": () =>
-    require("./dist/public/fonts/Tiempos-Headline-Bold.js").default,
+    require("./dist/public/fonts/Tiempos-Headline-Bold-metrics.js").default,
   "TimesDigitalW04-Bold": () =>
-    require("./dist/public/fonts/TimesDigitalW04_bold.js").default,
+    require("./dist/public/fonts/TimesDigitalW04_bold-metrics.js").default,
   "TimesDigitalW04-Italic": () =>
-    require("./dist/public/fonts/TimesDigitalW04_italic.js").default,
+    require("./dist/public/fonts/TimesDigitalW04_italic-metrics.js").default,
   "TimesModern-Bold": () =>
-    require("./dist/public/fonts/TimesModern-Bold.js").default,
+    require("./dist/public/fonts/TimesModern-Bold-metrics.js").default,
   "TimesDigitalW04-Regular": () =>
-    require("./dist/public/fonts/TimesDigitalW04-Regular.js").default,
+    require("./dist/public/fonts/TimesDigitalW04-Regular-metrics.js").default,
   "TimesDigitalW04-Normal": () =>
-    require("./dist/public/fonts/TimesDigitalW04.js").default,
+    require("./dist/public/fonts/TimesDigitalW04-metrics.js").default,
   "TimesModern-Regular": () =>
-    require("./dist/public/fonts/TimesModern-Regular.js").default
+    require("./dist/public/fonts/TimesModern-Regular-metrics.js").default
 };
 
 const ttf = {};


### PR DESCRIPTION
https://github.com/newsuk/times-components/commit/35cee66496828bf12ad3b1a6913097fd628577ce#diff-c55d5a77a3267bfe3cf57c7c402e52cd
Broke android-app build because it can't bundle fonts it can't find