### PR TITLE
fix: Logo for seo

### DIFF
--- a/packages/article-in-depth/src/article-in-depth.web.js
+++ b/packages/article-in-depth/src/article-in-depth.web.js
@@ -72,10 +72,10 @@ class ArticlePage extends Component {
       analyticsStream,
       error,
       isLoading,
+      logoUrl,
       navigationMode,
       receiveChildList,
-      spotAccountId,
-      faviconUrl
+      spotAccountId
     } = this.props;
 
     if (error || isLoading) {
@@ -88,10 +88,10 @@ class ArticlePage extends Component {
         analyticsStream={analyticsStream}
         data={article}
         Header={this.renderHeader}
+        logoUrl={logoUrl}
         receiveChildList={receiveChildList}
         navigationMode={navigationMode}
         spotAccountId={spotAccountId}
-        faviconUrl={faviconUrl}
       />
     );
   }

--- a/packages/article-magazine-comment/src/article-magazine-comment.web.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.web.js
@@ -74,11 +74,11 @@ class ArticlePage extends Component {
       analyticsStream,
       error,
       isLoading,
+      logoUrl,
       navigationMode,
       receiveChildList,
       spotAccountId,
-      paidContentClassName,
-      faviconUrl
+      paidContentClassName
     } = this.props;
 
     if (error || isLoading) {
@@ -91,11 +91,11 @@ class ArticlePage extends Component {
         analyticsStream={analyticsStream}
         data={article}
         Header={this.renderHeader}
+        logoUrl={logoUrl}
         receiveChildList={receiveChildList}
         navigationMode={navigationMode}
         spotAccountId={spotAccountId}
         paidContentClassName={paidContentClassName}
-        faviconUrl={faviconUrl}
       />
     );
   }

--- a/packages/article-magazine-standard/src/article-magazine-standard.web.js
+++ b/packages/article-magazine-standard/src/article-magazine-standard.web.js
@@ -64,11 +64,11 @@ class ArticlePage extends Component {
       analyticsStream,
       error,
       isLoading,
+      logoUrl,
       navigationMode,
       receiveChildList,
       spotAccountId,
-      paidContentClassName,
-      faviconUrl
+      paidContentClassName
     } = this.props;
 
     if (error || isLoading) {
@@ -81,11 +81,11 @@ class ArticlePage extends Component {
         analyticsStream={analyticsStream}
         data={article}
         Header={this.renderHeader}
+        logoUrl={logoUrl}
         receiveChildList={receiveChildList}
         navigationMode={navigationMode}
         spotAccountId={spotAccountId}
         paidContentClassName={paidContentClassName}
-        faviconUrl={faviconUrl}
       />
     );
   }

--- a/packages/article-main-comment/src/article-main-comment.web.js
+++ b/packages/article-main-comment/src/article-main-comment.web.js
@@ -58,11 +58,11 @@ class ArticlePage extends Component {
       analyticsStream,
       error,
       isLoading,
+      logoUrl,
       navigationMode,
       receiveChildList,
       spotAccountId,
-      paidContentClassName,
-      faviconUrl
+      paidContentClassName
     } = this.props;
 
     if (error || isLoading) {
@@ -75,11 +75,11 @@ class ArticlePage extends Component {
         analyticsStream={analyticsStream}
         data={article}
         Header={this.renderHeader}
+        logoUrl={logoUrl}
         receiveChildList={receiveChildList}
         navigationMode={navigationMode}
         spotAccountId={spotAccountId}
         paidContentClassName={paidContentClassName}
-        faviconUrl={faviconUrl}
       />
     );
   }

--- a/packages/article-main-standard/src/article-main-standard.web.js
+++ b/packages/article-main-standard/src/article-main-standard.web.js
@@ -82,11 +82,11 @@ class ArticlePage extends Component {
       analyticsStream,
       error,
       isLoading,
+      logoUrl,
       navigationMode,
       receiveChildList,
       spotAccountId,
-      paidContentClassName,
-      faviconUrl
+      paidContentClassName
     } = this.props;
 
     if (error || isLoading) {
@@ -99,11 +99,11 @@ class ArticlePage extends Component {
           analyticsStream={analyticsStream}
           data={article}
           Header={this.renderHeader}
+          logoUrl={logoUrl}
           receiveChildList={receiveChildList}
           navigationMode={navigationMode}
           spotAccountId={spotAccountId}
           paidContentClassName={paidContentClassName}
-          faviconUrl={faviconUrl}
         />
       </ArticleMainStandardContainer>
     );

--- a/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/head.web.test.js.snap
@@ -67,7 +67,7 @@ exports[`Head outputs correct metadata 1`] = `
   <script
     type="application/ld+json"
   >
-    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times","logo":"https://www.thetimes.co.uk/d/img/icons/favicon.ico"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13T18:54:58.000Z","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"author":"Some byline","image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io","dateModified":"2015-03-13T18:54:58.000Z"}
+    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times","logo":"https://www.thetimes.co.uk/d/img/dual-masthead-placeholder-16x9-6a9822c61a.png"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13T18:54:58.000Z","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"author":"Some byline","image":{"@type":"ImageObject","url":"https://crop169.io?resize=685","caption":"Some Caption"},"thumbnailUrl":"https://crop169.io","dateModified":"2015-03-13T18:54:58.000Z"}
   </script>
 </Helmet>
 `;
@@ -139,7 +139,7 @@ exports[`Head outputs correct metadata for a video article 1`] = `
   <script
     type="application/ld+json"
   >
-    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times","logo":"https://www.thetimes.co.uk/d/img/icons/favicon.ico"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13T18:54:58.000Z","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"author":"Some byline","image":{"@type":"ImageObject","url":"https://video169.io?resize=685","caption":"This is video caption"},"thumbnailUrl":"https://video169.io","dateModified":"2015-03-13T18:54:58.000Z"}
+    {"@context":"http://schema.org","@type":"NewsArticle","headline":"Some Headline","publisher":{"@type":"Organization","name":"The Times","logo":"https://www.thetimes.co.uk/d/img/dual-masthead-placeholder-16x9-6a9822c61a.png"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"},"dateCreated":"2015-03-13T18:54:58.000Z","datePublished":"2015-03-13T18:54:58.000Z","isAccessibleForFree":false,"hasPart":{"@type":"WebPageElement","isAccessibleForFree":false,"cssSelector":".class-name"},"author":"Some byline","image":{"@type":"ImageObject","url":"https://video169.io?resize=685","caption":"This is video caption"},"thumbnailUrl":"https://video169.io","dateModified":"2015-03-13T18:54:58.000Z"}
   </script>
 </Helmet>
 `;

--- a/packages/article-skeleton/__tests__/web/head.web.test.js
+++ b/packages/article-skeleton/__tests__/web/head.web.test.js
@@ -43,15 +43,16 @@ const videoArticle = articleFixture({
 });
 
 const paidContentClassName = "class-name";
-const faviconUrl = "https://www.thetimes.co.uk/d/img/icons/favicon.ico";
+const logoUrl =
+  "https://www.thetimes.co.uk/d/img/dual-masthead-placeholder-16x9-6a9822c61a.png";
 
 describe("Head", () => {
   it("outputs correct metadata", () => {
     const testRenderer = TestRenderer.create(
       <Head
         article={article}
+        logoUrl={logoUrl}
         paidContentClassName={paidContentClassName}
-        faviconUrl={faviconUrl}
       />
     );
 
@@ -62,8 +63,8 @@ describe("Head", () => {
     const testRenderer = TestRenderer.create(
       <Head
         article={videoArticle}
+        logoUrl={logoUrl}
         paidContentClassName={paidContentClassName}
-        faviconUrl={faviconUrl}
       />
     );
 

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -57,10 +57,10 @@ class ArticleSkeleton extends Component {
       analyticsStream,
       data: article,
       Header,
+      logoUrl,
       receiveChildList,
       spotAccountId,
-      paidContentClassName,
-      faviconUrl
+      paidContentClassName
     } = this.props;
 
     const {
@@ -101,8 +101,8 @@ class ArticleSkeleton extends Component {
         >
           <Head
             article={article}
+            logoUrl={logoUrl}
             paidContentClassName={paidContentClassName}
-            faviconUrl={faviconUrl}
           />
           <AdComposer adConfig={adConfig}>
             <LazyLoad rootMargin={spacing(10)} threshold={0.5}>

--- a/packages/article-skeleton/src/head.web.js
+++ b/packages/article-skeleton/src/head.web.js
@@ -108,7 +108,7 @@ const getThumbnailUrlFromImage = article => {
   return get(article.leadAsset, "crop169.url", null);
 };
 
-function Head({ article, paidContentClassName, faviconUrl }) {
+function Head({ article, logoUrl, paidContentClassName }) {
   const {
     descriptionMarkup,
     headline,
@@ -147,7 +147,7 @@ function Head({ article, paidContentClassName, faviconUrl }) {
     publisher: {
       "@type": "Organization",
       name: publication,
-      logo: faviconUrl
+      logo: logoUrl
     },
     mainEntityOfPage: {
       "@type": "WebPage"
@@ -220,8 +220,8 @@ Head.propTypes = {
     shortIdentifier: PropTypes.string.isRequired,
     tiles: PropTypes.array
   }).isRequired,
-  paidContentClassName: PropTypes.string.isRequired,
-  faviconUrl: PropTypes.string.isRequired
+  logoUrl: PropTypes.string.isRequired,
+  paidContentClassName: PropTypes.string.isRequired
 };
 
 export default Head;

--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -18,6 +18,7 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
     articleId,
     enableNewskit,
     debounceTimeMs,
+    logoUrl,
     makeArticleUrl,
     makeTopicUrl,
     mapArticleToAdConfig,
@@ -25,8 +26,7 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
     spotAccountId,
     getCookieValue,
     userState,
-    paidContentClassName,
-    faviconUrl
+    paidContentClassName
   } = data;
 
   return React.createElement(
@@ -64,14 +64,14 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
               article,
               error,
               isLoading,
+              logoUrl,
               navigationMode,
               onAuthorPress: () => {},
               onRelatedArticlePress: () => {},
               onTopicPress: () => {},
               refetch,
               spotAccountId,
-              paidContentClassName,
-              faviconUrl
+              paidContentClassName
             })
           )
       )

--- a/packages/ssr/src/server/article.js
+++ b/packages/ssr/src/server/article.js
@@ -14,12 +14,12 @@ module.exports = (
     enableNewskit,
     graphqlApiUrl,
     logger,
+    logoUrl,
     makeArticleUrl,
     makeTopicUrl,
     navigationMode,
     spotAccountId,
-    paidContentClassName,
-    faviconUrl
+    paidContentClassName
   },
   userState
 ) => {
@@ -58,14 +58,14 @@ module.exports = (
       articleId,
       enableNewskit,
       debounceTimeMs: 0,
+      logoUrl,
       makeArticleUrl,
       makeTopicUrl,
       mapArticleToAdConfig: defaultAdConfig,
       navigationMode,
       spotAccountId,
       userState,
-      paidContentClassName,
-      faviconUrl
+      paidContentClassName
     },
     name: "article"
   };


### PR DESCRIPTION
- in schema.org metadata the logo field needs to use the dual masthead image not the favicon as per https://nidigitalsolutions.jira.com/browse/REPLAT-8274
- Render PR to pass `logoUrl` with new image coming