### PR TITLE
Fix: Replat-9642 no click tracking on related articles

### DIFF
--- a/packages/related-articles/src/related-article-item.web.js
+++ b/packages/related-articles/src/related-article-item.web.js
@@ -18,4 +18,4 @@ const RelatedArticleItemWeb = props => (
   </RelatedArticleItem>
 );
 
-export default relatedArticlesItemTrackingEvents(RelatedArticleItemWeb)
+export default relatedArticlesItemTrackingEvents(RelatedArticleItemWeb);

--- a/packages/related-articles/src/related-article-item.web.js
+++ b/packages/related-articles/src/related-article-item.web.js
@@ -9,7 +9,6 @@ const RelatedArticleItemWeb = props => (
     {({ article, card }) => (
       <Context.Consumer>
         {({ makeArticleUrl }) => (
-          // I need to add some on press stuff here:
           <Link linkStyle={{ padding: 10 }} url={makeArticleUrl(article)}>
             {card}
           </Link>

--- a/packages/related-articles/src/related-article-item.web.js
+++ b/packages/related-articles/src/related-article-item.web.js
@@ -2,12 +2,14 @@ import React from "react";
 import Context from "@times-components/context";
 import Link from "@times-components/link";
 import RelatedArticleItem from "./related-article-item.base";
+import relatedArticlesItemTrackingEvents from "./related-articles-item-tracking-events";
 
-export default props => (
+const RelatedArticleItemWeb = props => (
   <RelatedArticleItem {...props}>
     {({ article, card }) => (
       <Context.Consumer>
         {({ makeArticleUrl }) => (
+          // I need to add some on press stuff here:
           <Link linkStyle={{ padding: 10 }} url={makeArticleUrl(article)}>
             {card}
           </Link>
@@ -16,3 +18,5 @@ export default props => (
     )}
   </RelatedArticleItem>
 );
+
+export default relatedArticlesItemTrackingEvents(RelatedArticleItemWeb)


### PR DESCRIPTION
[Replat-9642](https://nidigitalsolutions.jira.com/browse/REPLAT-9642)

After having a look at the Related Article Item web it looks like a HOC was created to handle the analytics events but never implemented for the web version. 
After wrapping the component the events seem to be firing properly