### PR TITLE
fix: revert cookie pagination fix

### DIFF
--- a/packages/ssr/src/lib/run-client.js
+++ b/packages/ssr/src/lib/run-client.js
@@ -32,9 +32,7 @@ const makeClient = options => {
   if (typeof window !== "undefined" && window.nuk) {
     const acsTnlCookie = window.nuk.getCookieValue("acs_tnl");
     const sacsTnlCookie = window.nuk.getCookieValue("sacs_tnl");
-    if (acsTnlCookie && sacsTnlCookie) {
-      networkInterfaceOptions.headers.Authorization = `Cookie acs_tnl=${acsTnlCookie};sacs_tnl=${sacsTnlCookie}`;
-    }
+    networkInterfaceOptions.headers.Authorization = `Cookie acs_tnl=${acsTnlCookie};sacs_tnl=${sacsTnlCookie}`;
   }
 
   return new ApolloClient({


### PR DESCRIPTION
Reverts PR-2351:

`sacsTnlCookie` will always be null as secure cookies cannot be accessed by the client. This breaks the Save and Share Bar