### PR TITLE
chore: add id comments container

### DIFF
--- a/packages/article-comments/__tests__/web/__snapshots__/shared-with-style.web.test.js.snap
+++ b/packages/article-comments/__tests__/web/__snapshots__/shared-with-style.web.test.js.snap
@@ -83,6 +83,7 @@ exports[`enabled comments 1`] = `
 
 <div
   className="c0"
+  id="comments-container"
 >
   <div />
 </div>

--- a/packages/article-comments/__tests__/web/__snapshots__/shared.web.test.js.snap
+++ b/packages/article-comments/__tests__/web/__snapshots__/shared.web.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render comments label, when comments are loaded 1`] = `
-<div>
+<div
+  id="comments-container"
+>
   <p>
     Comments are subject to our community guidelines, which can be viewed
      
@@ -39,19 +41,25 @@ exports[`disabled comments 1`] = `
 `;
 
 exports[`enabled comments 1`] = `
-<div>
+<div
+  id="comments-container"
+>
   <div />
 </div>
 `;
 
 exports[`single comment 1`] = `
-<div>
+<div
+  id="comments-container"
+>
   <div />
 </div>
 `;
 
 exports[`zero comments 1`] = `
-<div>
+<div
+  id="comments-container"
+>
   <div />
 </div>
 `;

--- a/packages/article-comments/src/comments.web.js
+++ b/packages/article-comments/src/comments.web.js
@@ -97,6 +97,7 @@ class Comments extends Component {
 
     return (
       <CommentContainer
+        id="comments-container"
         onCommentStart={onCommentStart}
         onCommentPost={onCommentPost}
       >


### PR DESCRIPTION
- In order to abstract from changing DOM structure in spot IM commenting 
- Currently visual tests are trying to hide/ignore/waitfor classnames in spot IM commenting but they often change.