### PR TITLE
fix: REPLAT-9907 pagination fix on topic and author pages

### DIFF
--- a/packages/ssr/src/client/author-profile.js
+++ b/packages/ssr/src/client/author-profile.js
@@ -27,7 +27,8 @@ if (window.nuk && window.nuk.ssr && window.nuk.authorProfile) {
 
   const clientOptions = {
     rootTag,
-    useGET: true
+    useGET: true,
+    skipAuthorization: true
   };
 
   runClient(authorProfile, clientOptions, data);

--- a/packages/ssr/src/client/topic.js
+++ b/packages/ssr/src/client/topic.js
@@ -29,6 +29,7 @@ if (window.nuk && window.nuk.ssr && window.nuk.topicPage) {
   const clientOptions = {
     rootTag,
     useGET: true,
+    skipAuthorization: true,
     headers: useNewTopicDataSource
       ? {
           "x-new-topic-data-source": true

--- a/packages/ssr/src/lib/run-client.js
+++ b/packages/ssr/src/lib/run-client.js
@@ -29,7 +29,11 @@ const makeClient = options => {
     networkInterfaceOptions.useGETForQueries = true;
   }
 
-  if (typeof window !== "undefined" && window.nuk) {
+  if (
+    typeof window !== "undefined" &&
+    window.nuk &&
+    !options.skipAuthorization
+  ) {
     const acsTnlCookie = window.nuk.getCookieValue("acs_tnl");
     const sacsTnlCookie = window.nuk.getCookieValue("sacs_tnl");
     networkInterfaceOptions.headers.Authorization = `Cookie acs_tnl=${acsTnlCookie};sacs_tnl=${sacsTnlCookie}`;
@@ -58,7 +62,8 @@ module.exports = (component, clientOptions, data) => {
     initialState: window.__APOLLO_STATE__,
     uri: window.nuk.graphqlapi.url,
     useGET: clientOptions.useGET,
-    headers: clientOptions.headers
+    headers: clientOptions.headers,
+    skipAuthorization: clientOptions.skipAuthorization
   });
 
   const reporterOptions = {


### PR DESCRIPTION
[Story.](https://nidigitalsolutions.jira.com/browse/REPLAT-9907)

Authorization skipped for topics and journalist pages.
Both of the pages are public and doesn't require authentication.
Sending the cookie `asc_tnl` no matter the value returns an authentication error.

Result:
![profile-pagination](https://user-images.githubusercontent.com/8720661/67937342-15461b80-fbd6-11e9-9d01-a3e244e7afd2.gif)



The second bug - updating the component after the data is fetched will be covered in another PR. More information can be found in the comments in JIRA and in the video below:
![topics-pagination-issue](https://user-images.githubusercontent.com/8720661/67937346-18410c00-fbd6-11e9-883d-2b9add16ee76.gif)
