### PR TITLE
fix: article list not updating correctly

### DIFF
--- a/packages/article-list/src/article-list.web.js
+++ b/packages/article-list/src/article-list.web.js
@@ -35,7 +35,7 @@ class ArticleList extends Component {
 
   shouldComponentUpdate(nextProps) {
     const { page } = this.props;
-    return page !== nextProps.page;
+    return page === nextProps.page;
   }
 
   render() {


### PR DESCRIPTION
- We had a [regression](https://github.com/newsuk/times-components/pull/2295/commits/ad0e781dac33864b4cf345f3f9a05356aa4252c7) in the `article-list` component. This fixes it.
<img width="1013" alt="Screenshot 2019-10-31 at 16 24 27" src="https://user-images.githubusercontent.com/1736782/67966013-fe65f000-fbfa-11e9-806f-0846a6186852.png">
