### PR TITLE
fix: (REPLAT-10284) nested and styled line-breaks

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -1287,7 +1287,203 @@ exports[`7. breaks up malformed huge paragraphs 1`] = `
 </View>
 `;
 
-exports[`8. renders content 1`] = `
+exports[`8. breaks up nested malformed markup 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView
+    initialNumToRender={3}
+    maxToRenderPerBatch={10}
+    nestedScrollEnabled={true}
+    onEndReachedThreshold={2}
+    removeClippedSubviews={true}
+    scrollEventThrottle={50}
+    showsVerticalScrollIndicator={false}
+    updateCellsBatchingPeriod={50}
+    windowSize={3}
+  >
+    <View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+              ]
+            }
+          >
+            <View>
+              <Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "italic",
+                      "fontWeight": "normal",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  Telegraph 
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "normal",
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  When Thatcher joined the campaign trail for the 2001 general election...
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+              ]
+            }
+          >
+            <View>
+              <Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "normal",
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  test break bold
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "normal",
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "height": 0,
+          }
+        }
+      />
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`9. renders content 1`] = `
 <View
   style={
     Object {

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -1287,7 +1287,203 @@ exports[`7. breaks up malformed huge paragraphs 1`] = `
 </View>
 `;
 
-exports[`8. renders content 1`] = `
+exports[`8. breaks up nested malformed markup 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView
+    initialNumToRender={3}
+    maxToRenderPerBatch={10}
+    nestedScrollEnabled={true}
+    onEndReachedThreshold={2}
+    removeClippedSubviews={true}
+    scrollEventThrottle={50}
+    showsVerticalScrollIndicator={false}
+    updateCellsBatchingPeriod={50}
+    windowSize={3}
+  >
+    <View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+              ]
+            }
+          >
+            <View>
+              <Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "italic",
+                      "fontWeight": "normal",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  Telegraph 
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "normal",
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  When Thatcher joined the campaign trail for the 2001 general election...
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+              ]
+            }
+          >
+            <View>
+              <Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "normal",
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  test break bold
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "normal",
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "height": 0,
+          }
+        }
+      />
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`9. renders content 1`] = `
 <View
   style={
     Object {

--- a/packages/article-skeleton/__tests__/shared.native.js
+++ b/packages/article-skeleton/__tests__/shared.native.js
@@ -17,6 +17,7 @@ import ArticleSkeleton from "../src/article-skeleton";
 import articleFixture, {
   testFixture,
   nestedContent,
+  styledNestedContent,
   longContent
 } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";
@@ -167,6 +168,16 @@ export default () => {
       test() {
         const testInstance = TestRenderer.create(
           renderArticleContent(nestedContent)
+        );
+
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "breaks up nested malformed markup",
+      test() {
+        const testInstance = TestRenderer.create(
+          renderArticleContent(styledNestedContent)
         );
 
         expect(testInstance.toJSON()).toMatchSnapshot();

--- a/packages/article-skeleton/fixtures/full-article.js
+++ b/packages/article-skeleton/fixtures/full-article.js
@@ -671,6 +671,31 @@ export const nestedContent = [
   }
 ];
 
+export const styledNestedContent = [
+  {
+    name: "paragraph",
+    children: []
+      .concat(
+        ...longContent.filter(n => n.name === "paragraph").map(p => [
+          {
+            name: "bold",
+            children: [
+              { name: "break" },
+              { name: "break" },
+              {
+                name: "text",
+                attributes: { value: "test break bold" },
+                children: []
+              }
+            ]
+          },
+          ...p.children
+        ])
+      )
+      .slice(2)
+  }
+];
+
 const defaultBrightcovePolicyKey =
   "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U";
 

--- a/packages/article-skeleton/src/body-utils.js
+++ b/packages/article-skeleton/src/body-utils.js
@@ -1,4 +1,26 @@
+/* eslint-disable no-plusplus */
 import memoize from "memoize-one";
+
+// Handle the case where jounralist nest paragraph breaks inside styling markup
+const liftBreaks = paragraph => {
+  const children = paragraph.children.slice();
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    const breaks = (child.children || []).filter(c => c.name === "break");
+    children.splice(
+      i,
+      1,
+      ...breaks.concat({
+        ...child,
+        children: (child.children || []).filter(c => c.name !== "break")
+      })
+    );
+  }
+  return {
+    ...paragraph,
+    children
+  };
+};
 
 // Handle the case where journalists put everything in one paragraph
 const splitHuge = paragraph => {
@@ -36,7 +58,7 @@ const split = content =>
   [].concat(
     ...content.map(node => {
       if (node.name === "paragraph") {
-        return splitHuge(node);
+        return splitHuge(liftBreaks(node));
       }
       return [node];
     })


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
(╯°□°)╯︵ ┻━┻
This adds a function that lifts line breaks out of styling nodes so that paragraph chunking works properly. These things keep popping up, we should probably consider adding markup validation somewhere up the stack or we will end up implementing a full HTML renderer. :(
BEFORE:
![Screenshot_1572903919](https://user-images.githubusercontent.com/615608/68160812-78c0a800-ff4c-11e9-9945-7bb1132a0058.png)

AFTER:
![Screenshot_1572903757](https://user-images.githubusercontent.com/615608/68160820-7a8a6b80-ff4c-11e9-89d6-d412ff0d9611.png)