### PR TITLE
fix: missing single pixel ads

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -758,6 +758,9 @@ exports[`full article with style 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;
@@ -1521,6 +1524,9 @@ exports[`full article with style in the culture magazine 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;
@@ -2285,6 +2291,9 @@ exports[`full article with style in the style magazine 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;
@@ -3048,6 +3057,9 @@ exports[`full article with style in the sunday times magazine 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;

--- a/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -249,6 +249,21 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;
@@ -500,6 +515,21 @@ exports[`4. an article with ads 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;

--- a/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -384,5 +384,53 @@ exports[`1. a full article 1`] = `
       />
     </article>
   </main>
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
 </article>
 `;

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -732,6 +732,9 @@ exports[`full article with style 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;
@@ -1476,6 +1479,9 @@ exports[`full article with style in the culture magazine 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;
@@ -2221,6 +2227,9 @@ exports[`full article with style in the style magazine 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;
@@ -2965,6 +2974,9 @@ exports[`full article with style in the sunday times magazine 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -243,6 +243,21 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;
@@ -488,6 +503,21 @@ exports[`4. an article with ads 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;
@@ -752,6 +782,21 @@ exports[`7. an article with no author 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -400,5 +400,53 @@ exports[`1. a full article 1`] = `
       />
     </article>
   </main>
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
 </article>
 `;

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -677,6 +677,9 @@ exports[`full article with style 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;
@@ -1366,6 +1369,9 @@ exports[`full article with style in the culture magazine 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;
@@ -2056,6 +2062,9 @@ exports[`full article with style in the style magazine 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;
@@ -2745,6 +2754,9 @@ exports[`full article with style in the sunday times magazine 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -237,6 +237,21 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;
@@ -476,6 +491,21 @@ exports[`4. an article with ads 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -384,5 +384,53 @@ exports[`1. a full article 1`] = `
       />
     </article>
   </main>
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
 </article>
 `;

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -673,6 +673,9 @@ exports[`full article with style 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -229,6 +229,21 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;
@@ -460,6 +475,21 @@ exports[`4. an article with ads 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -379,5 +379,53 @@ exports[`1. a full article 1`] = `
       />
     </article>
   </main>
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
 </article>
 `;

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -784,6 +784,9 @@ exports[`full article with style 1`] = `
           <ArticleExtras />
         </article>
       </main>
+      <Ad />
+      <Ad />
+      <Ad />
     </article>
   </div>
 </div>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -289,6 +289,21 @@ exports[`1. an article 1`] = `
           />
         </article>
       </main>
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixel"
+      />
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixelteads"
+      />
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixelskin"
+      />
     </article>
   </div>
 </div>
@@ -433,6 +448,21 @@ exports[`4. an article with no headline falls back to use shortheadline 1`] = `
           />
         </article>
       </main>
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixel"
+      />
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixelteads"
+      />
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixelskin"
+      />
     </article>
   </div>
 </div>
@@ -575,6 +605,21 @@ exports[`5. an article with ads 1`] = `
           />
         </article>
       </main>
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixel"
+      />
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixelteads"
+      />
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixelskin"
+      />
     </article>
   </div>
 </div>
@@ -903,6 +948,21 @@ exports[`6. should show topics when logged in or shared 1`] = `
           />
         </article>
       </main>
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixel"
+      />
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixelteads"
+      />
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixelskin"
+      />
     </article>
   </div>
 </div>
@@ -1149,6 +1209,21 @@ exports[`7. an article with no byline 1`] = `
           />
         </article>
       </main>
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixel"
+      />
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixelteads"
+      />
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixelskin"
+      />
     </article>
   </div>
 </div>
@@ -1438,6 +1513,21 @@ exports[`8. an article with no label 1`] = `
           />
         </article>
       </main>
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixel"
+      />
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixelteads"
+      />
+      <Ad
+        contextUrl="https://url.io"
+        section="Some Section"
+        slotName="pixelskin"
+      />
     </article>
   </div>
 </div>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -413,5 +413,53 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       />
     </article>
   </main>
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
+  <svg
+    height={1}
+    viewBox="-50 0 1 1"
+    width={1}
+  >
+    <g
+      id="watermark"
+      opacity="0.07"
+    >
+      <path
+        d="53a8dae08c4e492d934bf2f094a46ab4"
+        id="shape"
+      />
+    </g>
+  </svg>
+  ADVERTISEMENT
 </article>
 `;

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
@@ -183,6 +183,9 @@ exports[`1. a primary image 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;
@@ -345,6 +348,9 @@ exports[`2. a fullwidth image 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;
@@ -539,6 +545,9 @@ exports[`3. a secondary image 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;
@@ -734,6 +743,9 @@ exports[`4. an inline image 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
@@ -78,6 +78,21 @@ exports[`1. a primary image 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;
@@ -158,6 +173,21 @@ exports[`2. a fullwidth image 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;
@@ -240,6 +270,21 @@ exports[`3. a secondary image 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;
@@ -322,6 +367,21 @@ exports[`4. an inline image 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -483,6 +483,9 @@ exports[`full article with style 1`] = `
         <ArticleExtras />
       </article>
     </main>
+    <Ad />
+    <Ad />
+    <Ad />
   </article>
 </div>
 `;

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-user-state.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-user-state.web.test.js.snap
@@ -332,6 +332,21 @@ exports[`Article with user state Render full article when user has access to ful
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;
@@ -668,6 +683,21 @@ exports[`Article with user state Render teaser article when user does not have a
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -358,6 +358,21 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;
@@ -490,6 +505,21 @@ exports[`2. an article with interactives 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;
@@ -600,6 +630,21 @@ exports[`3. an article with no content 1`] = `
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;
@@ -674,6 +719,21 @@ exports[`4. an article with a nested markup in first paragraph displays a drop c
         />
       </article>
     </main>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixel"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelteads"
+    />
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="pixelskin"
+    />
   </article>
 </div>
 `;

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -106,74 +106,76 @@ class ArticleSkeleton extends Component {
             paidContentClassName={paidContentClassName}
           />
           <AdComposer adConfig={adConfig}>
-            <LazyLoad rootMargin={spacing(10)} threshold={0.5}>
-              {({ observed, registerNode }) => (
-                <Fragment>
-                  <HeaderAdContainer key="headerAd">
-                    <Ad
-                      contextUrl={url}
-                      section={section}
-                      slotName="header"
-                      style={adStyle}
-                    />
-                  </HeaderAdContainer>
-                  <MainContainer accessibilityRole="main">
-                    <HeaderContainer>
-                      <Header width={articleWidth} />
-                      {savingEnabled || sharingEnabled ? (
-                        <UserState state={UserState.loggedInOrShared}>
-                          <MessageContext.Consumer>
-                            {({ showMessage }) => (
-                              <StickySaveAndShareBar
-                                articleId={articleId}
-                                articleHeadline={headline}
-                                articleUrl={url}
-                                onCopyLink={() =>
-                                  showMessage("Article link copied")
-                                }
-                                onSaveToMyArticles={() => {}}
-                                onShareOnEmail={() => {}}
-                                savingEnabled={savingEnabled}
-                                sharingEnabled={sharingEnabled}
-                              />
-                            )}
-                          </MessageContext.Consumer>
-                        </UserState>
-                      ) : null}
-                    </HeaderContainer>
-                    <BodyContainer accessibilityRole="article">
-                      <ArticleBody
-                        content={newContent}
+            <Fragment>
+              <LazyLoad rootMargin={spacing(10)} threshold={0.5}>
+                {({ observed, registerNode }) => (
+                  <Fragment>
+                    <HeaderAdContainer key="headerAd">
+                      <Ad
                         contextUrl={url}
-                        observed={observed}
-                        registerNode={registerNode}
                         section={section}
-                        paidContentClassName={paidContentClassName}
+                        slotName="header"
+                        style={adStyle}
                       />
-                      <ArticleExtras
-                        analyticsStream={analyticsStream}
-                        articleId={articleId}
-                        articleHeadline={headline}
-                        articleUrl={url}
-                        savingEnabled={savingEnabled}
-                        sharingEnabled={sharingEnabled}
-                        commentsEnabled={commentsEnabled}
-                        registerNode={registerNode}
-                        relatedArticleSlice={relatedArticleSlice}
-                        relatedArticlesVisible={
-                          !!observed.get("related-articles")
-                        }
-                        spotAccountId={spotAccountId}
-                        topics={topics}
-                      />
-                    </BodyContainer>
-                  </MainContainer>
-                </Fragment>
-              )}
-            </LazyLoad>
-            <Ad contextUrl={url} section={section} slotName="pixel" />
-            <Ad contextUrl={url} section={section} slotName="pixelteads" />
-            <Ad contextUrl={url} section={section} slotName="pixelskin" />
+                    </HeaderAdContainer>
+                    <MainContainer accessibilityRole="main">
+                      <HeaderContainer>
+                        <Header width={articleWidth} />
+                        {savingEnabled || sharingEnabled ? (
+                          <UserState state={UserState.loggedInOrShared}>
+                            <MessageContext.Consumer>
+                              {({ showMessage }) => (
+                                <StickySaveAndShareBar
+                                  articleId={articleId}
+                                  articleHeadline={headline}
+                                  articleUrl={url}
+                                  onCopyLink={() =>
+                                    showMessage("Article link copied")
+                                  }
+                                  onSaveToMyArticles={() => {}}
+                                  onShareOnEmail={() => {}}
+                                  savingEnabled={savingEnabled}
+                                  sharingEnabled={sharingEnabled}
+                                />
+                              )}
+                            </MessageContext.Consumer>
+                          </UserState>
+                        ) : null}
+                      </HeaderContainer>
+                      <BodyContainer accessibilityRole="article">
+                        <ArticleBody
+                          content={newContent}
+                          contextUrl={url}
+                          observed={observed}
+                          registerNode={registerNode}
+                          section={section}
+                          paidContentClassName={paidContentClassName}
+                        />
+                        <ArticleExtras
+                          analyticsStream={analyticsStream}
+                          articleId={articleId}
+                          articleHeadline={headline}
+                          articleUrl={url}
+                          savingEnabled={savingEnabled}
+                          sharingEnabled={sharingEnabled}
+                          commentsEnabled={commentsEnabled}
+                          registerNode={registerNode}
+                          relatedArticleSlice={relatedArticleSlice}
+                          relatedArticlesVisible={
+                            !!observed.get("related-articles")
+                          }
+                          spotAccountId={spotAccountId}
+                          topics={topics}
+                        />
+                      </BodyContainer>
+                    </MainContainer>
+                  </Fragment>
+                )}
+              </LazyLoad>
+              <Ad contextUrl={url} section={section} slotName="pixel" />
+              <Ad contextUrl={url} section={section} slotName="pixelteads" />
+              <Ad contextUrl={url} section={section} slotName="pixelskin" />
+            </Fragment>
           </AdComposer>
         </article>
       </StickyProvider>

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -171,6 +171,9 @@ class ArticleSkeleton extends Component {
                 </Fragment>
               )}
             </LazyLoad>
+            <Ad contextUrl={url} section={section} slotName="pixel" />
+            <Ad contextUrl={url} section={section} slotName="pixelteads" />
+            <Ad contextUrl={url} section={section} slotName="pixelskin" />
           </AdComposer>
         </article>
       </StickyProvider>


### PR DESCRIPTION
- At some point during refactoring article templates the single pixel ads were mistakenly removed. 
- Here you can see where they were when they were in the `article` package: https://github.com/newsuk/times-components/blob/31c87a989bed5bb1242eab1ac2640f373f64dcf3/packages/article/src/article.web.js#L107
- This PR re-instates them to fix https://nidigitalsolutions.jira.com/browse/REPLAT-1407