### PR TITLE
Fix/replat 7221 header ads missing firefox

### DIFF
--- a/packages/ad/__tests__/utils/ad-init-apstag.js
+++ b/packages/ad/__tests__/utils/ad-init-apstag.js
@@ -37,11 +37,9 @@ export default () => {
     const init = adInit(merge(initOptions, amazonInitExtension));
     jest.spyOn(init.apstag, "process");
     jest.spyOn(init.apstag, "init");
-    jest.spyOn(init.apstag, "bid");
     init.init();
     expect(init.apstag.process).toHaveBeenCalled();
     expect(init.apstag.init).toHaveBeenCalled();
-    expect(init.apstag.bid).toHaveBeenCalled();
   });
 
   it("does not set up Amazon bidding if no Amazon bidder config is present", () => {

--- a/packages/ad/src/utils/ad-init.js
+++ b/packages/ad/src/utils/ad-init.js
@@ -328,8 +328,8 @@ export default ({ el, data, platform, eventCallback, window }) => {
       process() {
         if (isWeb) {
           this.init();
-            return this.bid();
-          }
+          return this.bid();
+        }
 
         const msg = "[Prebid] INFO: no prebid on native";
         eventCallback("warn", msg);
@@ -422,7 +422,7 @@ export default ({ el, data, platform, eventCallback, window }) => {
         eventCallback("log", apstagConfig);
         apstag.init(apstagConfig, () => {
           eventCallback("warn", "[Amazon] INFO: initialised");
-          return this.bid()
+          return this.bid();
         });
       }
     },

--- a/packages/ad/src/utils/ad-init.js
+++ b/packages/ad/src/utils/ad-init.js
@@ -328,8 +328,8 @@ export default ({ el, data, platform, eventCallback, window }) => {
       process() {
         if (isWeb) {
           this.init();
-          return this.bid();
-        }
+            return this.bid();
+          }
 
         const msg = "[Prebid] INFO: no prebid on native";
         eventCallback("warn", msg);
@@ -402,8 +402,7 @@ export default ({ el, data, platform, eventCallback, window }) => {
 
       process() {
         if (amazonAccountID) {
-          this.init();
-          return this.bid();
+          return this.init();
         }
 
         const msg = "[Amazon] INFO: amazonAccountID undefined";
@@ -420,9 +419,11 @@ export default ({ el, data, platform, eventCallback, window }) => {
           },
           pubID: amazonAccountID
         };
-        eventCallback("warn", "[Amazon] INFO: initialised");
         eventCallback("log", apstagConfig);
-        apstag.init(apstagConfig);
+        apstag.init(apstagConfig, () => {
+          eventCallback("warn", "[Amazon] INFO: initialised");
+          return this.bid()
+        });
       }
     },
 


### PR DESCRIPTION
Firefox and Safari header ads weren't loading for React articles. 
Asynchronous promises with the Amazon ads were causing issues.

Tested running local copy of Times Components in Render