### PR TITLE
chore: update ad readme

### DIFF
--- a/packages/ad/README.md
+++ b/packages/ad/README.md
@@ -8,7 +8,7 @@ select and serve targeted ads. GPT is an ad tagging
 key details (targeting parameters) such as ad unit name, ad size, and custom
 targeting, builds the request, and displays the ad on web pages.
 
-When an ad is still loading or the app is offline, the ad component will show a
+When an advert is still loading or the app is offline, the ad component will show a
 placeholder image.
 
 ## DFP setup


### PR DESCRIPTION
Update the ad readme as previous squashed commit for ad stuff was not conventional.
This will force the repo to re-publish