### PR TITLE
chore: Add test ids to aid ui testing

### DIFF
--- a/packages/save-and-share-bar/__tests__/web/__snapshots__/save-and-share-bar.test.js.snap
+++ b/packages/save-and-share-bar/__tests__/web/__snapshots__/save-and-share-bar.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`save and share bar component email icon when tokenising with loading state while network request is fetching data 1`] = `
-<BarItem>
+<BarItem
+  dataTestId="email-share"
+>
   <div
     aria-valuemax="1"
     aria-valuemin="0"
@@ -64,6 +66,7 @@ exports[`save and share bar component email icon when tokenising with loading st
 exports[`save and share bar component save and share bar renders correctly when logged in 1`] = `
 <div
   className="css-view-1dbjc4n"
+  data-testid="save-and-share-bar"
   style={
     Object {
       "WebkitAlignItems": "center",
@@ -128,7 +131,9 @@ exports[`save and share bar component save and share bar renders correctly when 
     >
       Share
     </div>
-    <BarItem>
+    <BarItem
+      dataTestId="email-share"
+    >
       <IconEmail
         fillColour="currentColor"
         height={16}
@@ -136,6 +141,7 @@ exports[`save and share bar component save and share bar renders correctly when 
       />
     </BarItem>
     <BarItem
+      dataTestId="share-twitter"
       target="_blank"
       url="https://twitter.com/intent/tweet?text=https://www.thetimes.co.uk/"
     >
@@ -146,6 +152,7 @@ exports[`save and share bar component save and share bar renders correctly when 
       />
     </BarItem>
     <BarItem
+      dataTestId="share-facebook"
       target="_blank"
       url="https://www.facebook.com/sharer/sharer.php?u=https://www.thetimes.co.uk/"
     >
@@ -157,6 +164,7 @@ exports[`save and share bar component save and share bar renders correctly when 
     </BarItem>
     <BarItem
       color="#696969"
+      dataTestId="copy-to-clickboard"
       hoverColor="#1D1D1B"
     >
       <IconCopyLink
@@ -168,6 +176,7 @@ exports[`save and share bar component save and share bar renders correctly when 
   </div>
   <div
     className="css-view-1dbjc4n"
+    data-testid="save-star"
     style={
       Object {
         "WebkitAlignItems": "center",
@@ -196,6 +205,7 @@ exports[`save and share bar component save and share bar renders correctly when 
 exports[`save and share bar component save and share bar renders correctly when not logged in 1`] = `
 <div
   className="css-view-1dbjc4n"
+  data-testid="save-and-share-bar"
   style={
     Object {
       "WebkitAlignItems": "center",
@@ -260,7 +270,9 @@ exports[`save and share bar component save and share bar renders correctly when 
     >
       Share
     </div>
-    <BarItem>
+    <BarItem
+      dataTestId="email-share"
+    >
       <IconEmail
         fillColour="currentColor"
         height={16}
@@ -268,6 +280,7 @@ exports[`save and share bar component save and share bar renders correctly when 
       />
     </BarItem>
     <BarItem
+      dataTestId="share-twitter"
       target="_blank"
       url="https://twitter.com/intent/tweet?text=https://www.thetimes.co.uk/"
     >
@@ -278,6 +291,7 @@ exports[`save and share bar component save and share bar renders correctly when 
       />
     </BarItem>
     <BarItem
+      dataTestId="share-facebook"
       target="_blank"
       url="https://www.facebook.com/sharer/sharer.php?u=https://www.thetimes.co.uk/"
     >
@@ -289,6 +303,7 @@ exports[`save and share bar component save and share bar renders correctly when 
     </BarItem>
     <BarItem
       color="#696969"
+      dataTestId="copy-to-clickboard"
       hoverColor="#1D1D1B"
     >
       <IconCopyLink

--- a/packages/save-and-share-bar/src/bar-item.js
+++ b/packages/save-and-share-bar/src/bar-item.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { View } from "react-native";
 import { HoverIcon } from "@times-components/utils";
 import Link from "@times-components/link";
 import PropTypes from "prop-types";
@@ -8,20 +9,24 @@ import styles from "./styles";
 const BarItem = ({
   children,
   colour = styles.svgIcon.fillColour,
+  dataTestId,
   hoverColour = styles.svgIcon.hoverFillColour,
   onPress = () => {},
   ...props
 }) => (
-  <Link onPress={onPress} responsiveLinkStyles={styles.link} {...props}>
-    <HoverIcon colour={colour} hoverColour={hoverColour}>
-      {children}
-    </HoverIcon>
-  </Link>
+  <View data-testid={dataTestId}>
+    <Link onPress={onPress} responsiveLinkStyles={styles.link} {...props}>
+      <HoverIcon colour={colour} hoverColour={hoverColour}>
+        {children}
+      </HoverIcon>
+    </Link>
+  </View>
 );
 
 BarItem.propTypes = {
   children: PropTypes.node.isRequired,
   colour: PropTypes.string,
+  dataTestId: PropTypes.string,
   hoverColour: PropTypes.string,
   onPress: PropTypes.func
 };

--- a/packages/save-and-share-bar/src/email-share.js
+++ b/packages/save-and-share-bar/src/email-share.js
@@ -63,7 +63,7 @@ class EmailShare extends Component {
     const { isLoading } = this.state;
 
     return (
-      <BarItem onPress={this.onShare}>
+      <BarItem onPress={this.onShare} dataTestId="email-share">
         {isLoading ? (
           <ActivityIndicator size="small" style={styles.activityLoader} />
         ) : (

--- a/packages/save-and-share-bar/src/save-and-share-bar.js
+++ b/packages/save-and-share-bar/src/save-and-share-bar.js
@@ -41,7 +41,7 @@ class SaveAndShareBar extends Component {
     } = this.props;
 
     return (
-      <View style={styles.container}>
+      <View style={styles.container} data-testid="save-and-share-bar">
         {sharingEnabled && (
           <View style={styles.rowItem}>
             <Text style={styles.label}>Share</Text>
@@ -68,6 +68,7 @@ class SaveAndShareBar extends Component {
             <BarItem
               onPress={onShareOnTwitter}
               target="_blank"
+              dataTestId="share-twitter"
               url={`${SharingApiUrls.twitter}?text=${articleUrl}`}
             >
               <IconTwitter
@@ -79,6 +80,7 @@ class SaveAndShareBar extends Component {
             <BarItem
               onPress={onShareOnFB}
               target="_blank"
+              dataTestId="share-facebook"
               url={`${SharingApiUrls.facebook}?u=${articleUrl}`}
             >
               <IconFacebook
@@ -91,6 +93,7 @@ class SaveAndShareBar extends Component {
               color={styles.svgIcon.save.strokeColour}
               hoverColor={styles.svgIcon.hoverFillColour}
               onPress={this.copyToClipboard}
+              dataTestId="copy-to-clickboard"
             >
               <IconCopyLink
                 fillColour="currentColor"
@@ -102,7 +105,7 @@ class SaveAndShareBar extends Component {
         )}
         {savingEnabled ? (
           <UserState state={UserState.loggedIn} serverRender={false}>
-            <View style={styles.rowItem}>
+            <View style={styles.rowItem} data-testid="save-star">
               <SaveStar
                 colour={styles.svgIcon.save.strokeColour}
                 hoverColor={styles.svgIcon.hoverFillColour}


### PR DESCRIPTION
- `save-and-share-bar` component doesn't have any class names or id in order help UI testing such as Cypress
- As part of https://github.com/newsuk/cps-content-render/pull/3101 where we need to convert some Cypress tests which were using the non-react dom structure. 