### PR TITLE
fix: remove display:none css styling

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -83,7 +83,15 @@ exports[`full article with style 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -300,20 +308,6 @@ exports[`full article with style 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 
@@ -848,7 +842,15 @@ exports[`full article with style in the culture magazine 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -1065,20 +1067,6 @@ exports[`full article with style in the culture magazine 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 
@@ -1614,7 +1602,15 @@ exports[`full article with style in the style magazine 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -1831,20 +1827,6 @@ exports[`full article with style in the style magazine 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 
@@ -2381,7 +2363,15 @@ exports[`full article with style in the sunday times magazine 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -2598,20 +2588,6 @@ exports[`full article with style in the sunday times magazine 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -68,7 +68,15 @@ exports[`full article with style 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -274,20 +282,6 @@ exports[`full article with style 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 
@@ -807,7 +801,15 @@ exports[`full article with style in the culture magazine 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -1013,20 +1015,6 @@ exports[`full article with style in the culture magazine 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 
@@ -1554,7 +1542,15 @@ exports[`full article with style in the style magazine 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -1760,20 +1756,6 @@ exports[`full article with style in the style magazine 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 
@@ -2302,7 +2284,15 @@ exports[`full article with style in the sunday times magazine 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -2508,20 +2498,6 @@ exports[`full article with style in the sunday times magazine 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -68,7 +68,15 @@ exports[`full article with style 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -267,20 +275,6 @@ exports[`full article with style 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 
@@ -752,7 +746,15 @@ exports[`full article with style in the culture magazine 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -951,20 +953,6 @@ exports[`full article with style in the culture magazine 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 
@@ -1444,7 +1432,15 @@ exports[`full article with style in the style magazine 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -1643,20 +1639,6 @@ exports[`full article with style in the style magazine 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 
@@ -2137,7 +2119,15 @@ exports[`full article with style in the sunday times magazine 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -2336,20 +2326,6 @@ exports[`full article with style in the sunday times magazine 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -68,7 +68,15 @@ exports[`full article with style 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -268,20 +276,6 @@ exports[`full article with style 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -92,7 +92,15 @@ exports[`full article with style 1`] = `
 }
 
 .c1 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c3 {
@@ -318,20 +326,6 @@ exports[`full article with style 1`] = `
   .c2 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
@@ -10,7 +10,15 @@ exports[`1. a primary image 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -92,20 +100,6 @@ exports[`1. a primary image 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 
@@ -192,7 +186,15 @@ exports[`1. a primary image 1`] = `
 
 exports[`2. a fullwidth image 1`] = `
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -261,20 +263,6 @@ exports[`2. a fullwidth image 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 
@@ -370,7 +358,15 @@ exports[`3. a secondary image 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -454,20 +450,6 @@ exports[`3. a secondary image 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 
@@ -568,7 +550,15 @@ exports[`4. an inline image 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -652,20 +642,6 @@ exports[`4. an inline image 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -89,7 +89,15 @@ exports[`full article with style 1`] = `
 }
 
 .c0 {
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-top-color: #DBDBDB;
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .c2 {
@@ -265,20 +273,6 @@ exports[`full article with style 1`] = `
   .c1 {
     padding-top: 20px;
     margin: 0 auto;
-  }
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }
 

--- a/packages/article-skeleton/src/styles/responsive.web.js
+++ b/packages/article-skeleton/src/styles/responsive.web.js
@@ -11,16 +11,12 @@ export const MainContainer = styled(View)`
 `;
 
 export const HeaderAdContainer = styled(View)`
-  display: none;
-
-  @media (min-width: ${breakpoints.medium}px) {
-    display: flex;
-    border-top-color: ${colours.functional.keyline};
-    border-bottom-color: ${colours.functional.keyline};
-    border-bottom-width: 1px;
-    padding-top: ${spacing(2)};
-    padding-bottom: ${spacing(2)};
-  }
+  display: flex;
+  border-top-color: ${colours.functional.keyline};
+  border-bottom-color: ${colours.functional.keyline};
+  border-bottom-width: 1px;
+  padding-top: ${spacing(2)};
+  padding-bottom: ${spacing(2)};
 `;
 
 export const HeaderContainer = styled(View)`


### PR DESCRIPTION
Removes the display none styling which was stopping the header ad from being displayed on mobile web.

Have tested locally and everything works.

Header Ad container is only used in web so shouldn't cause an issue in the Native world