### PR TITLE
fix: revert comment article bylines

### DIFF
--- a/packages/article-main-comment/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -35,7 +35,6 @@ exports[`1. article main comment - tablet 1`] = `
           }
         }
       />
-      <ArticleByline />
       <View
         style={
           Object {
@@ -100,6 +99,16 @@ exports[`1. article main comment - tablet 1`] = `
           }
         }
       >
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "flexWrap": "wrap",
+            }
+          }
+        >
+          <ArticleBylineWithLinks />
+        </View>
         <View
           style={
             Object {

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -31,7 +31,6 @@ exports[`phone full article with style 1`] = `
           }
         }
       />
-      <ArticleByline />
       <View
         style={
           Object {
@@ -102,6 +101,16 @@ exports[`phone full article with style 1`] = `
             }
           }
         >
+          <ArticleBylineWithLinks />
+        </View>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "flexWrap": "wrap",
+            }
+          }
+        >
           <Text
             style={
               Object {
@@ -153,7 +162,6 @@ exports[`tablet full article with style 1`] = `
           }
         }
       />
-      <ArticleByline />
       <View
         style={
           Object {
@@ -216,6 +224,16 @@ exports[`tablet full article with style 1`] = `
           }
         }
       >
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "flexWrap": "wrap",
+            }
+          }
+        >
+          <ArticleBylineWithLinks />
+        </View>
         <View
           style={
             Object {

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -13,51 +13,42 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         rounded={true}
         uri="https://image.io"
       />
-      <ArticleByline
-        ast={
-          Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Some byline",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "image": Object {
-                "crop": Object {
-                  "ratio": "1:1",
-                  "url": "https://image.io",
-                },
-                "id": "36f9b2e8-0d41-464a-9e95-921bdb6895be",
-              },
-            },
-          ]
-        }
-        bylineStyle={
-          Object {
-            "color": "#850029",
-            "fontFamily": "GillSansMTStd-Medium",
-            "fontSize": 12,
-            "letterSpacing": 0.6,
-            "lineHeight": 12,
-            "marginBottom": 5,
-            "textTransform": "uppercase",
-          }
-        }
-      />
       <Text>
         Some Short Headline
       </Text>
       <View>
+        <View>
+          <ArticleBylineWithLinks
+            ast={
+              Array [
+                Object {
+                  "byline": Array [
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Some byline",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "inline",
+                    },
+                  ],
+                  "image": Object {
+                    "crop": Object {
+                      "ratio": "1:1",
+                      "url": "https://image.io",
+                    },
+                    "id": "36f9b2e8-0d41-464a-9e95-921bdb6895be",
+                  },
+                },
+              ]
+            }
+          />
+        </View>
         <View>
           <Text>
             Friday March 13 2015, 6.54pm, The Times
@@ -78,51 +69,42 @@ exports[`4. an article with ads 1`] = `
         rounded={true}
         uri="https://image.io"
       />
-      <ArticleByline
-        ast={
-          Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Some byline",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "image": Object {
-                "crop": Object {
-                  "ratio": "1:1",
-                  "url": "https://image.io",
-                },
-                "id": "36f9b2e8-0d41-464a-9e95-921bdb6895be",
-              },
-            },
-          ]
-        }
-        bylineStyle={
-          Object {
-            "color": "#850029",
-            "fontFamily": "GillSansMTStd-Medium",
-            "fontSize": 12,
-            "letterSpacing": 0.6,
-            "lineHeight": 12,
-            "marginBottom": 5,
-            "textTransform": "uppercase",
-          }
-        }
-      />
       <Text>
         Some Headline
       </Text>
       <View>
+        <View>
+          <ArticleBylineWithLinks
+            ast={
+              Array [
+                Object {
+                  "byline": Array [
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Some byline",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "inline",
+                    },
+                  ],
+                  "image": Object {
+                    "crop": Object {
+                      "ratio": "1:1",
+                      "url": "https://image.io",
+                    },
+                    "id": "36f9b2e8-0d41-464a-9e95-921bdb6895be",
+                  },
+                },
+              ]
+            }
+          />
+        </View>
         <View>
           <Text>
             Friday March 13 2015, 6.54pm, The Times

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -35,7 +35,6 @@ exports[`1. article main comment - tablet 1`] = `
           }
         }
       />
-      <ArticleByline />
       <View
         style={
           Object {
@@ -100,6 +99,16 @@ exports[`1. article main comment - tablet 1`] = `
           }
         }
       >
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "flexWrap": "wrap",
+            }
+          }
+        >
+          <ArticleBylineWithLinks />
+        </View>
         <View
           style={
             Object {

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -31,7 +31,6 @@ exports[`phone full article with style 1`] = `
           }
         }
       />
-      <ArticleByline />
       <View
         style={
           Object {
@@ -102,6 +101,16 @@ exports[`phone full article with style 1`] = `
             }
           }
         >
+          <ArticleBylineWithLinks />
+        </View>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "flexWrap": "wrap",
+            }
+          }
+        >
           <Text
             style={
               Object {
@@ -153,7 +162,6 @@ exports[`tablet full article with style 1`] = `
           }
         }
       />
-      <ArticleByline />
       <View
         style={
           Object {
@@ -216,6 +224,16 @@ exports[`tablet full article with style 1`] = `
           }
         }
       >
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "flexWrap": "wrap",
+            }
+          }
+        >
+          <ArticleBylineWithLinks />
+        </View>
         <View
           style={
             Object {

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -13,51 +13,42 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         rounded={true}
         uri="https://image.io"
       />
-      <ArticleByline
-        ast={
-          Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Some byline",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "image": Object {
-                "crop": Object {
-                  "ratio": "1:1",
-                  "url": "https://image.io",
-                },
-                "id": "36f9b2e8-0d41-464a-9e95-921bdb6895be",
-              },
-            },
-          ]
-        }
-        bylineStyle={
-          Object {
-            "color": "#850029",
-            "fontFamily": "GillSansMTStd-Medium",
-            "fontSize": 12,
-            "letterSpacing": 0.6,
-            "lineHeight": 12,
-            "marginBottom": 5,
-            "textTransform": "uppercase",
-          }
-        }
-      />
       <Text>
         Some Short Headline
       </Text>
       <View>
+        <View>
+          <ArticleBylineWithLinks
+            ast={
+              Array [
+                Object {
+                  "byline": Array [
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Some byline",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "inline",
+                    },
+                  ],
+                  "image": Object {
+                    "crop": Object {
+                      "ratio": "1:1",
+                      "url": "https://image.io",
+                    },
+                    "id": "36f9b2e8-0d41-464a-9e95-921bdb6895be",
+                  },
+                },
+              ]
+            }
+          />
+        </View>
         <View>
           <Text>
             Friday March 13 2015, 6.54pm, The Times
@@ -78,51 +69,42 @@ exports[`4. an article with ads 1`] = `
         rounded={true}
         uri="https://image.io"
       />
-      <ArticleByline
-        ast={
-          Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Some byline",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "image": Object {
-                "crop": Object {
-                  "ratio": "1:1",
-                  "url": "https://image.io",
-                },
-                "id": "36f9b2e8-0d41-464a-9e95-921bdb6895be",
-              },
-            },
-          ]
-        }
-        bylineStyle={
-          Object {
-            "color": "#850029",
-            "fontFamily": "GillSansMTStd-Medium",
-            "fontSize": 12,
-            "letterSpacing": 0.6,
-            "lineHeight": 12,
-            "marginBottom": 5,
-            "textTransform": "uppercase",
-          }
-        }
-      />
       <Text>
         Some Headline
       </Text>
       <View>
+        <View>
+          <ArticleBylineWithLinks
+            ast={
+              Array [
+                Object {
+                  "byline": Array [
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Some byline",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "inline",
+                    },
+                  ],
+                  "image": Object {
+                    "crop": Object {
+                      "ratio": "1:1",
+                      "url": "https://image.io",
+                    },
+                    "id": "36f9b2e8-0d41-464a-9e95-921bdb6895be",
+                  },
+                },
+              ]
+            }
+          />
+        </View>
         <View>
           <Text>
             Friday March 13 2015, 6.54pm, The Times

--- a/packages/article-main-comment/src/article-header/article-header.js
+++ b/packages/article-main-comment/src/article-header/article-header.js
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 import { ArticleFlags, getActiveFlags } from "@times-components/article-flag";
 import { ModalImage } from "@times-components/image";
 import { ResponsiveContext } from "@times-components/responsive";
-import Byline from "@times-components/article-byline";
 import Label from "../article-label/article-label";
 import Meta from "../article-meta/article-meta";
 import Standfirst from "../article-standfirst/article-standfirst";
@@ -36,7 +35,6 @@ const ArticleHeader = ({
             uri={authorImage}
             rounded
           />
-          <Byline ast={bylines} bylineStyle={styles.bylineOpinion} />
           <Label isVideo={hasVideo} label={label} />
           <Text
             style={[
@@ -53,6 +51,7 @@ const ArticleHeader = ({
           )}
           <Standfirst standfirst={standfirst} />
           <Meta
+            bylines={bylines}
             hasStandfirst={standfirst}
             isTablet={isTablet}
             onAuthorPress={onAuthorPress}


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Reverts the change to add bylines under author images in comment articles until we have the ability to detect the article position and only do this for the hero article.
