### PR TITLE
fix: ios crop urls are wrong

### DIFF
--- a/packages/responsive-image/src/index.tsx
+++ b/packages/responsive-image/src/index.tsx
@@ -44,17 +44,13 @@ const ResponsiveImage = (props: ResponsiveImageProps) => {
 
   const url: Url = new Url(uri, true);
   if (!uri.includes('data:')) {
-    url.query.rel_width = Math.floor(relativeWidth).toString();
-    url.query.rel_height = Math.floor(relativeHeight).toString();
+    url.query.rel_width = relativeWidth.toString();
+    url.query.rel_height = relativeHeight.toString();
     if (relativeVerticalOffset) {
-      url.query.rel_vertical_offset = Math.floor(
-        relativeVerticalOffset
-      ).toString();
+      url.query.rel_vertical_offset = relativeVerticalOffset.toString();
     }
     if (relativeHorizontalOffset) {
-      url.query.rel_horizontal_offset = Math.floor(
-        relativeHorizontalOffset
-      ).toString();
+      url.query.rel_horizontal_offset = relativeHorizontalOffset.toString();
     }
     url.query.offline = 'true';
   }


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
The cropping logic was adjusted to fix android but it turns out android was doing the wrong thing and ios was correct :(