### PR TITLE
fix: fixed save-button position when share is disabled

### DIFF
--- a/packages/save-and-share-bar/__tests__/web/__snapshots__/save-and-share-bar.test.js.snap
+++ b/packages/save-and-share-bar/__tests__/web/__snapshots__/save-and-share-bar.test.js.snap
@@ -187,6 +187,7 @@ exports[`save and share bar component save and share bar renders correctly when 
         "alignItems": "center",
         "flexDirection": "row",
         "height": "40px",
+        "marginLeft": "auto",
         "msFlexAlign": "center",
         "msFlexDirection": "row",
       }

--- a/packages/save-and-share-bar/src/save-and-share-bar.js
+++ b/packages/save-and-share-bar/src/save-and-share-bar.js
@@ -105,7 +105,7 @@ class SaveAndShareBar extends Component {
         )}
         {savingEnabled ? (
           <UserState state={UserState.loggedIn} serverRender={false}>
-            <View style={styles.rowItem} data-testid="save-star">
+            <View style={styles.rowItemRight} data-testid="save-star">
               <SaveStar
                 colour={styles.svgIcon.save.strokeColour}
                 hoverColor={styles.svgIcon.hoverFillColour}

--- a/packages/save-and-share-bar/src/styles/index.js
+++ b/packages/save-and-share-bar/src/styles/index.js
@@ -31,7 +31,7 @@ const styles = {
       margin-left: ${spacing(1)};
       cursor: pointer;
       border-radius: ${ICON_SIZE}px;
-      
+
       &, > * {
         display: flex;
         align-items: center;
@@ -52,6 +52,12 @@ const styles = {
     alignItems: "center",
     flexDirection: "row",
     height: ICON_SIZE
+  },
+  rowItemRight: {
+    alignItems: "center",
+    flexDirection: "row",
+    height: ICON_SIZE,
+    marginLeft: "auto"
   },
   svgIcon: {
     fb: {


### PR DESCRIPTION
This PR fixes the following [issue](https://nidigitalsolutions.jira.com/secure/RapidBoard.jspa?rapidView=1117&view=planning&selectedIssue=REPLAT-10793).
<img width="723" alt="Screenshot 2019-12-02 at 15 41 16" src="https://user-images.githubusercontent.com/8719799/69964092-5786b380-151a-11ea-984e-e409a72188ef.png">

