### PR TITLE
fix: do not show lead asset when no crop returned from tpa

### DIFF
--- a/packages/utils/__tests__/get-lead-asset.test.js
+++ b/packages/utils/__tests__/get-lead-asset.test.js
@@ -46,6 +46,24 @@ describe("getLeadAsset should", () => {
     expect(getLeadAsset({ leadAsset: null })).toEqual(defaultAsset);
   });
 
+  it("return default values if no crops provided", () => {
+    const leadAssetNoCrop = {
+      caption: null,
+      credits: null,
+      crop11: null,
+      crop23: null,
+      crop32: null,
+      crop45: null,
+      crop169: null,
+      crop1251: null,
+      id: "ab0b986f-d503-4c53-9ed3-b524c73a9936",
+      isVideo: false,
+      title: "no crop"
+    };
+
+    expect(getLeadAsset(leadAssetNoCrop)).toEqual(defaultAsset);
+  });
+
   it("return image lead asset values", () => {
     const testLeadAssetResult = {
       aspectRatio: "16:9",

--- a/packages/utils/src/get-lead-asset.js
+++ b/packages/utils/src/get-lead-asset.js
@@ -17,6 +17,8 @@ export default function getLeadAsset({ leadAsset }) {
     ? getStandardTemplateCrop(leadAsset.posterImage)
     : getStandardTemplateCrop(leadAsset);
 
+  if (!displayImage) return defaultAsset;
+
   const aspectRatio = displayImage.ratio;
 
   return {


### PR DESCRIPTION
- Fixes: https://nidigitalsolutions.jira.com/browse/REPLAT-11021
- For articles (generally old) which do not have any of the supported crops we currently show a 500 error  as the code is trying to get the `ratio` of null.
 see thetimes.co.uk/article/should-the-world-be-run-on-fergie-time-vvgp8nmd6kz?react=1
- This PR handles that and results in showing no image in this case

<img width="1347" alt="Screenshot 2019-12-04 at 15 43 29" src="https://user-images.githubusercontent.com/1736782/70157488-95681100-16ad-11ea-8c87-fb478610daaf.png">
