### PR TITLE
fix: bookmarks of null on a preview article

### DIFF
--- a/packages/save-star-web/src/save-api.js
+++ b/packages/save-star-web/src/save-api.js
@@ -53,33 +53,36 @@ function onUnsaveMutationUpdate(
 function SaveAPI({ articleId, children }) {
   return (
     <ArticleBookmarked id={articleId} debounceTimeMs={0}>
-      {({ isLoading, article: { isBookmarked = false } = {} }) => (
-        <Mutation mutation={saveBookmarks} update={onSaveMutationUpdate}>
-          {(save, { loading: saveMutationLoading }) => (
-            <Mutation
-              mutation={unsaveBookmarks}
-              update={onUnsaveMutationUpdate}
-            >
-              {(unsave, { loading: unsaveMutationLoading }) =>
-                children({
-                  savedStatus: isBookmarked,
-                  async toggleSaved() {
-                    const args = { variables: { id: articleId } };
+      {({ isLoading, article }) => {
+        const isSaved = article && Boolean(article.isBookmarked);
+        return (
+          <Mutation mutation={saveBookmarks} update={onSaveMutationUpdate}>
+            {(save, { loading: saveMutationLoading }) => (
+              <Mutation
+                mutation={unsaveBookmarks}
+                update={onUnsaveMutationUpdate}
+              >
+                {(unsave, { loading: unsaveMutationLoading }) =>
+                  children({
+                    savedStatus: isSaved,
+                    async toggleSaved() {
+                      const args = { variables: { id: articleId } };
 
-                    if (isBookmarked) {
-                      await unsave(args);
-                    } else {
-                      await save(args);
-                    }
-                  },
-                  isLoading:
-                    isLoading || saveMutationLoading || unsaveMutationLoading
-                })
-              }
-            </Mutation>
-          )}
-        </Mutation>
-      )}
+                      if (isSaved) {
+                        await unsave(args);
+                      } else {
+                        await save(args);
+                      }
+                    },
+                    isLoading:
+                      isLoading || saveMutationLoading || unsaveMutationLoading
+                  })
+                }
+              </Mutation>
+            )}
+          </Mutation>
+        );
+      }}
     </ArticleBookmarked>
   );
 }


### PR DESCRIPTION
Bookmarks on a draft article are currently causing error on the CI tests. 
Adding guard for the cases when article.isBookmarked is null or undefined...
