### PR TITLE
fix: fixed the margin below the fullstandard image

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -676,10 +676,10 @@ exports[`full article with style 1`] = `
           Some content
         </p>
         <div
-          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c20 css-view-1dbjc4n"
+          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c20 css-view-1dbjc4n"
         >
           <div
-            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c21 css-view-1dbjc4n"
+            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c21 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -737,14 +737,14 @@ exports[`full article with style 1`] = `
         />
         <div>
           <div
-            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-6 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c24 responsiveweb__InlineImg-sc-16nqyj8-7 c24 css-view-1dbjc4n"
+            className="c24 responsiveweb__InlineImg-sc-16nqyj8-8 c24 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
@@ -1436,10 +1436,10 @@ exports[`full article with style in the culture magazine 1`] = `
           Some content
         </p>
         <div
-          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c20 css-view-1dbjc4n"
+          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c20 css-view-1dbjc4n"
         >
           <div
-            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c21 css-view-1dbjc4n"
+            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c21 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -1497,14 +1497,14 @@ exports[`full article with style in the culture magazine 1`] = `
         />
         <div>
           <div
-            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-6 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c24 responsiveweb__InlineImg-sc-16nqyj8-7 c24 css-view-1dbjc4n"
+            className="c24 responsiveweb__InlineImg-sc-16nqyj8-8 c24 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
@@ -2197,10 +2197,10 @@ exports[`full article with style in the style magazine 1`] = `
           Some content
         </p>
         <div
-          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c20 css-view-1dbjc4n"
+          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c20 css-view-1dbjc4n"
         >
           <div
-            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c21 css-view-1dbjc4n"
+            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c21 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -2258,14 +2258,14 @@ exports[`full article with style in the style magazine 1`] = `
         />
         <div>
           <div
-            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-6 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c24 responsiveweb__InlineImg-sc-16nqyj8-7 c24 css-view-1dbjc4n"
+            className="c24 responsiveweb__InlineImg-sc-16nqyj8-8 c24 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
@@ -2957,10 +2957,10 @@ exports[`full article with style in the sunday times magazine 1`] = `
           Some content
         </p>
         <div
-          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c20 css-view-1dbjc4n"
+          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c20 css-view-1dbjc4n"
         >
           <div
-            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c21 css-view-1dbjc4n"
+            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c21 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -3018,14 +3018,14 @@ exports[`full article with style in the sunday times magazine 1`] = `
         />
         <div>
           <div
-            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-6 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c24 responsiveweb__InlineImg-sc-16nqyj8-7 c24 css-view-1dbjc4n"
+            className="c24 responsiveweb__InlineImg-sc-16nqyj8-8 c24 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -662,10 +662,10 @@ exports[`full article with style 1`] = `
           Some content
         </p>
         <div
-          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c20 css-view-1dbjc4n"
+          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c20 css-view-1dbjc4n"
         >
           <div
-            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c21 css-view-1dbjc4n"
+            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c21 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -711,14 +711,14 @@ exports[`full article with style 1`] = `
         />
         <div>
           <div
-            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-6 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c24 responsiveweb__InlineImg-sc-16nqyj8-7 c24 css-view-1dbjc4n"
+            className="c24 responsiveweb__InlineImg-sc-16nqyj8-8 c24 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
@@ -1403,10 +1403,10 @@ exports[`full article with style in the culture magazine 1`] = `
           Some content
         </p>
         <div
-          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c20 css-view-1dbjc4n"
+          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c20 css-view-1dbjc4n"
         >
           <div
-            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c21 css-view-1dbjc4n"
+            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c21 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -1452,14 +1452,14 @@ exports[`full article with style in the culture magazine 1`] = `
         />
         <div>
           <div
-            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-6 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c24 responsiveweb__InlineImg-sc-16nqyj8-7 c24 css-view-1dbjc4n"
+            className="c24 responsiveweb__InlineImg-sc-16nqyj8-8 c24 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
@@ -2145,10 +2145,10 @@ exports[`full article with style in the style magazine 1`] = `
           Some content
         </p>
         <div
-          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c20 css-view-1dbjc4n"
+          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c20 css-view-1dbjc4n"
         >
           <div
-            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c21 css-view-1dbjc4n"
+            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c21 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -2194,14 +2194,14 @@ exports[`full article with style in the style magazine 1`] = `
         />
         <div>
           <div
-            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-6 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c24 responsiveweb__InlineImg-sc-16nqyj8-7 c24 css-view-1dbjc4n"
+            className="c24 responsiveweb__InlineImg-sc-16nqyj8-8 c24 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
@@ -2886,10 +2886,10 @@ exports[`full article with style in the sunday times magazine 1`] = `
           Some content
         </p>
         <div
-          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c20 css-view-1dbjc4n"
+          className="c20 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c20 css-view-1dbjc4n"
         >
           <div
-            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c21 css-view-1dbjc4n"
+            className="c21 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c21 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -2935,14 +2935,14 @@ exports[`full article with style in the sunday times magazine 1`] = `
         />
         <div>
           <div
-            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-6 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__SecondaryImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c24 responsiveweb__InlineImg-sc-16nqyj8-7 c24 css-view-1dbjc4n"
+            className="c24 responsiveweb__InlineImg-sc-16nqyj8-8 c24 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -607,10 +607,10 @@ exports[`full article with style 1`] = `
           Some content
         </p>
         <div
-          className="c19 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c19 css-view-1dbjc4n"
+          className="c19 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c19 css-view-1dbjc4n"
         >
           <div
-            className="c20 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c20 css-view-1dbjc4n"
+            className="c20 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c20 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -656,14 +656,14 @@ exports[`full article with style 1`] = `
         />
         <div>
           <div
-            className="c22 responsiveweb__SecondaryImg-sc-16nqyj8-6 c22 css-view-1dbjc4n"
+            className="c22 responsiveweb__SecondaryImg-sc-16nqyj8-7 c22 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c23 responsiveweb__InlineImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__InlineImg-sc-16nqyj8-8 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
@@ -1293,10 +1293,10 @@ exports[`full article with style in the culture magazine 1`] = `
           Some content
         </p>
         <div
-          className="c19 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c19 css-view-1dbjc4n"
+          className="c19 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c19 css-view-1dbjc4n"
         >
           <div
-            className="c20 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c20 css-view-1dbjc4n"
+            className="c20 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c20 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -1342,14 +1342,14 @@ exports[`full article with style in the culture magazine 1`] = `
         />
         <div>
           <div
-            className="c22 responsiveweb__SecondaryImg-sc-16nqyj8-6 c22 css-view-1dbjc4n"
+            className="c22 responsiveweb__SecondaryImg-sc-16nqyj8-7 c22 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c23 responsiveweb__InlineImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__InlineImg-sc-16nqyj8-8 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
@@ -1980,10 +1980,10 @@ exports[`full article with style in the style magazine 1`] = `
           Some content
         </p>
         <div
-          className="c19 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c19 css-view-1dbjc4n"
+          className="c19 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c19 css-view-1dbjc4n"
         >
           <div
-            className="c20 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c20 css-view-1dbjc4n"
+            className="c20 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c20 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -2029,14 +2029,14 @@ exports[`full article with style in the style magazine 1`] = `
         />
         <div>
           <div
-            className="c22 responsiveweb__SecondaryImg-sc-16nqyj8-6 c22 css-view-1dbjc4n"
+            className="c22 responsiveweb__SecondaryImg-sc-16nqyj8-7 c22 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c23 responsiveweb__InlineImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__InlineImg-sc-16nqyj8-8 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
@@ -2666,10 +2666,10 @@ exports[`full article with style in the sunday times magazine 1`] = `
           Some content
         </p>
         <div
-          className="c19 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c19 css-view-1dbjc4n"
+          className="c19 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c19 css-view-1dbjc4n"
         >
           <div
-            className="c20 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c20 css-view-1dbjc4n"
+            className="c20 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c20 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -2715,14 +2715,14 @@ exports[`full article with style in the sunday times magazine 1`] = `
         />
         <div>
           <div
-            className="c22 responsiveweb__SecondaryImg-sc-16nqyj8-6 c22 css-view-1dbjc4n"
+            className="c22 responsiveweb__SecondaryImg-sc-16nqyj8-7 c22 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c23 responsiveweb__InlineImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__InlineImg-sc-16nqyj8-8 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -603,10 +603,10 @@ exports[`full article with style 1`] = `
           Some content
         </p>
         <div
-          className="c19 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c19 css-view-1dbjc4n"
+          className="c19 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c19 css-view-1dbjc4n"
         >
           <div
-            className="c20 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c20 css-view-1dbjc4n"
+            className="c20 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c20 css-view-1dbjc4n"
           >
             <PullQuote>
               The pull quote content
@@ -652,14 +652,14 @@ exports[`full article with style 1`] = `
         />
         <div>
           <div
-            className="c22 responsiveweb__SecondaryImg-sc-16nqyj8-6 c22 css-view-1dbjc4n"
+            className="c22 responsiveweb__SecondaryImg-sc-16nqyj8-7 c22 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c23 responsiveweb__InlineImg-sc-16nqyj8-7 c23 css-view-1dbjc4n"
+            className="c23 responsiveweb__InlineImg-sc-16nqyj8-8 c23 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -702,10 +702,10 @@ exports[`full article with style 1`] = `
             Some content
           </p>
           <div
-            className="c21 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c21 css-view-1dbjc4n"
+            className="c21 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c21 css-view-1dbjc4n"
           >
             <div
-              className="c22 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c22 css-view-1dbjc4n"
+              className="c22 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c22 css-view-1dbjc4n"
             >
               <PullQuote>
                 The pull quote content
@@ -763,14 +763,14 @@ exports[`full article with style 1`] = `
           />
           <div>
             <div
-              className="c24 responsiveweb__SecondaryImg-sc-16nqyj8-6 c24 css-view-1dbjc4n"
+              className="c24 responsiveweb__SecondaryImg-sc-16nqyj8-7 c24 css-view-1dbjc4n"
             >
               <ArticleImage />
             </div>
           </div>
           <div>
             <div
-              className="c25 responsiveweb__InlineImg-sc-16nqyj8-7 c25 css-view-1dbjc4n"
+              className="c25 responsiveweb__InlineImg-sc-16nqyj8-8 c25 css-view-1dbjc4n"
             >
               <ArticleImage />
             </div>

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
@@ -185,6 +185,10 @@ exports[`1. a primary image 1`] = `
 `;
 
 exports[`2. a fullwidth image 1`] = `
+.c8 {
+  padding-bottom: 20px;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -331,7 +335,11 @@ exports[`2. a fullwidth image 1`] = `
         className="c7 responsiveweb__BodyContainer-sc-1exejum-3 c7 css-view-1dbjc4n"
       >
         <div>
-          <ArticleImage />
+          <div
+            className="c8 responsiveweb__FullWidthImg-sc-16nqyj8-6 c8 css-view-1dbjc4n"
+          >
+            <ArticleImage />
+          </div>
         </div>
         <ArticleExtras />
       </article>
@@ -519,7 +527,7 @@ exports[`3. a secondary image 1`] = `
       >
         <div>
           <div
-            className="c8 responsiveweb__SecondaryImg-sc-16nqyj8-6 c8 css-view-1dbjc4n"
+            className="c8 responsiveweb__SecondaryImg-sc-16nqyj8-7 c8 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
@@ -711,7 +719,7 @@ exports[`4. an inline image 1`] = `
       >
         <div>
           <div
-            className="c8 responsiveweb__InlineImg-sc-16nqyj8-7 c8 css-view-1dbjc4n"
+            className="c8 responsiveweb__InlineImg-sc-16nqyj8-8 c8 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
@@ -143,23 +143,25 @@ exports[`2. a fullwidth image 1`] = `
         <div
           id="0"
         >
-          <ArticleImage
-            captionOptions={
-              Object {
-                "caption": "A Caption",
-                "credits": "Some Credits",
+          <div>
+            <ArticleImage
+              captionOptions={
+                Object {
+                  "caption": "A Caption",
+                  "credits": "Some Credits",
+                }
               }
-            }
-            imageOptions={
-              Object {
-                "display": "fullwidth",
-                "highResSize": null,
-                "lowResSize": 100,
-                "ratio": "3:2",
-                "uri": "https://image-2.io",
+              imageOptions={
+                Object {
+                  "display": "fullwidth",
+                  "highResSize": null,
+                  "lowResSize": 100,
+                  "ratio": "3:2",
+                  "uri": "https://image-2.io",
+                }
               }
-            }
-          />
+            />
+          </div>
         </div>
         <ArticleExtras
           articleHeadline="Some Headline"

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -404,14 +404,14 @@ exports[`full article with style 1`] = `
         </div>
         <div>
           <div
-            className="c13 responsiveweb__SecondaryImg-sc-16nqyj8-6 c13 css-view-1dbjc4n"
+            className="c13 responsiveweb__SecondaryImg-sc-16nqyj8-7 c13 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
         </div>
         <div>
           <div
-            className="c14 responsiveweb__InlineImg-sc-16nqyj8-7 c14 css-view-1dbjc4n"
+            className="c14 responsiveweb__InlineImg-sc-16nqyj8-8 c14 css-view-1dbjc4n"
           >
             <ArticleImage />
           </div>
@@ -428,10 +428,10 @@ exports[`full article with style 1`] = `
             Some content
           </p>
           <div
-            className="c15 responsiveweb__PullQuoteContainer-sc-16nqyj8-9 c15 css-view-1dbjc4n"
+            className="c15 responsiveweb__PullQuoteContainer-sc-16nqyj8-10 c15 css-view-1dbjc4n"
           >
             <div
-              className="c16 responsiveweb__PullQuoteResp-sc-16nqyj8-8 c16 css-view-1dbjc4n"
+              className="c16 responsiveweb__PullQuoteResp-sc-16nqyj8-9 c16 css-view-1dbjc4n"
             >
               <PullQuote>
                 The pull quote content

--- a/packages/article-skeleton/src/article-body/article-body.web.js
+++ b/packages/article-skeleton/src/article-body/article-body.web.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import Ad from "@times-components/ad";
 import LazyLoad from "@times-components/lazy-load";
@@ -21,6 +21,7 @@ import {
   PrimaryImg,
   SecondaryImg,
   InlineImg,
+  FullWidthImg,
   InteractiveContainer,
   PullQuoteContainer,
   PullQuoteResp
@@ -34,7 +35,7 @@ export const responsiveDisplayWrapper = displayType => {
     case "inline":
       return InlineImg;
     case "fullwidth":
-      return Fragment;
+      return FullWidthImg;
     default:
       return PrimaryImg;
   }

--- a/packages/article-skeleton/src/styles/article-body/responsive.web.js
+++ b/packages/article-skeleton/src/styles/article-body/responsive.web.js
@@ -106,6 +106,10 @@ export const PrimaryImg = styled(View)`
   }
 `;
 
+export const FullWidthImg = styled(View)`
+  padding-bottom: ${spacing(4)};
+`;
+
 export const SecondaryImg = styled(View)`
   width: 100%;
   flex-direction: row;

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "dependencies": {
-    "@times-components/styleguide": "3.33.5"
+    "@times-components/styleguide": "3.33.6"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "dependencies": {
-    "@times-components/styleguide": "3.33.5"
+    "@times-components/styleguide": "3.33.6"
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",

--- a/packages/responsive-image/package.json
+++ b/packages/responsive-image/package.json
@@ -48,7 +48,7 @@
     "node": ">=8.9"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.33.5",
+    "@times-components/styleguide": "3.33.6",
     "memoize-one": "5.1.1",
     "react": "16.9.0",
     "react-native": "0.61.1",

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -41,7 +41,7 @@
     "@times-components/eslint-config-thetimes": "0.8.16",
     "@times-components/jest-configurator": "2.6.10",
     "@times-components/jest-serializer": "3.2.22",
-    "@times-components/storybook": "4.1.15",
+    "@times-components/storybook": "4.1.16",
     "@times-components/test-utils": "2.3.8",
     "babel-jest": "24.8.0",
     "babel-loader": "8.0.5",
@@ -59,7 +59,7 @@
     "webpack-cli": "3.3.1"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.33.5",
+    "@times-components/styleguide": "3.33.6",
     "@times-components/svgs": "2.7.28",
     "prop-types": "15.7.2"
   },


### PR DESCRIPTION
This PR is for this [issue](https://nidigitalsolutions.jira.com/browse/REPLAT-11030).
<img width="1181" alt="Screenshot at Dec 06 10-46-29" src="https://user-images.githubusercontent.com/8719799/70309280-d54a0800-1815-11ea-97fc-391e5e23884e.png">
Note the red line - the space there used to be non-existent.
