### PR TITLE
fix: scroll to top on content load

### DIFF
--- a/packages/ad/src/ad.js
+++ b/packages/ad/src/ad.js
@@ -141,6 +141,10 @@ class Ad extends Component {
   }
 
   render() {
+    const { adConfig: propAdConfig } = this.props;
+    if (propAdConfig) {
+      return this.renderAd(propAdConfig);
+    }
     return (
       <Subscriber channel="adConfig">
         {adConfig => this.renderAd(adConfig)}

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
@@ -10,6 +10,7 @@ exports[`1. article with header 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-images.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-images.android.test.js.snap
@@ -10,6 +10,7 @@ exports[`1. a primary image 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -84,6 +85,7 @@ exports[`2. a fullwidth image 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -158,6 +160,7 @@ exports[`3. a secondary image 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -232,6 +235,7 @@ exports[`4. an inline image 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -22,6 +22,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -360,6 +361,7 @@ exports[`2. an article with interactives 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -518,6 +520,7 @@ exports[`3. an article with no content 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -636,6 +639,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -1273,6 +1277,7 @@ exports[`8. breaks up malformed huge paragraphs 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -1506,6 +1511,7 @@ exports[`9. breaks up nested malformed markup 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -1739,6 +1745,7 @@ exports[`10. renders content 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-header-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-header-with-style.ios.test.js.snap
@@ -10,6 +10,7 @@ exports[`1. article with header 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-images.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-images.ios.test.js.snap
@@ -10,6 +10,7 @@ exports[`1. a primary image 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -84,6 +85,7 @@ exports[`2. a fullwidth image 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -158,6 +160,7 @@ exports[`3. a secondary image 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -232,6 +235,7 @@ exports[`4. an inline image 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -22,6 +22,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -360,6 +361,7 @@ exports[`2. an article with interactives 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -518,6 +520,7 @@ exports[`3. an article with no content 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -636,6 +639,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -1273,6 +1277,7 @@ exports[`8. breaks up malformed huge paragraphs 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -1506,6 +1511,7 @@ exports[`9. breaks up nested malformed markup 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}
@@ -1739,6 +1745,7 @@ exports[`10. renders content 1`] = `
         />
       </Gutter>
     }
+    extraData={true}
     initialNumToRender={2}
     maxToRenderPerBatch={10}
     nestedScrollEnabled={true}

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -25,6 +25,7 @@ export default ({
   onVideoPress,
   onImagePress,
   isTablet,
+  adConfig,
   dropcapsDisabled,
   dropCapFont = "dropCap",
   scale
@@ -175,7 +176,14 @@ export default ({
       );
     },
     ad(key, attributes) {
-      return <Ad key={key} slotName="native-inline-ad" {...attributes} />;
+      return (
+        <Ad
+          key={key}
+          adConfig={adConfig}
+          slotName="native-inline-ad"
+          {...attributes}
+        />
+      );
     },
     image(
       key,

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -1,10 +1,9 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useState, useMemo } from "react";
 import { View, FlatList, ActivityIndicator, Platform } from "react-native";
 import PropTypes from "prop-types";
 import { screenWidth } from "@times-components/utils";
 import { withTrackScrollDepth } from "@times-components/tracking";
 import { Viewport } from "@skele/components";
-import { AdComposer } from "@times-components/ad";
 import { render } from "@times-components/markup-forest";
 import ArticleExtras from "@times-components/article-extras";
 import {
@@ -32,9 +31,8 @@ const isDropcapsDisabled = ({ template, dropcapsDisabled }) => {
   return !templateWithDropCaps.includes(template);
 };
 
-const ArticleSkeleton = props => {
+const ArticleWithContent = props => {
   const {
-    adConfig,
     Header,
     data,
     analyticsStream,
@@ -45,6 +43,8 @@ const ArticleSkeleton = props => {
     isTablet,
     onViewed
   } = props;
+
+  const { id, url, content } = data;
 
   const onViewableItemsChanged = useCallback(
     info => {
@@ -72,88 +72,132 @@ const ArticleSkeleton = props => {
     setLoading(false);
   }, []);
 
-  if (!data) {
-    return null;
-  }
-
-  const { id, url, content } = data;
-
-  if (!content) {
-    return null;
-  }
-
-  const header = (
-    <Gutter>
-      <Header width={Math.min(maxWidth, screenWidth())} />
-    </Gutter>
+  const header = useMemo(
+    () => (
+      <Gutter>
+        <Header width={Math.min(maxWidth, screenWidth())} />
+      </Gutter>
+    ),
+    []
   );
 
-  const footer = (
-    <Gutter>
-      <ArticleExtras
-        analyticsStream={analyticsStream}
-        articleId={id}
-        articleUrl={url}
-        onCommentGuidelinesPress={onCommentGuidelinesPress}
-        onCommentsPress={onCommentsPress}
-        onRelatedArticlePress={onRelatedArticlePress}
-        onTopicPress={onTopicPress}
-      />
-    </Gutter>
+  const footer = useMemo(
+    () => (
+      <Gutter>
+        <ArticleExtras
+          analyticsStream={analyticsStream}
+          articleId={id}
+          articleUrl={url}
+          onCommentGuidelinesPress={onCommentGuidelinesPress}
+          onCommentsPress={onCommentsPress}
+          onRelatedArticlePress={onRelatedArticlePress}
+          onTopicPress={onTopicPress}
+        />
+      </Gutter>
+    ),
+    [
+      analyticsStream,
+      id,
+      onCommentGuidelinesPress,
+      onCommentsPress,
+      onRelatedArticlePress,
+      onTopicPress,
+      url
+    ]
   );
 
   const dropcapsDisabled = isDropcapsDisabled(data);
   const renderChild = render(renderers({ dropcapsDisabled, ...props }));
   // eslint-disable-next-line react/prop-types
-  const Child = ({ item, index }) => (
-    <Gutter style={{ overflow: "hidden" }}>
-      <ErrorBoundary>
-        {item.name === "footer"
-          ? footer
-          : renderChild(item, index.toString(), index)}
-      </ErrorBoundary>
-    </Gutter>
+  const Child = useCallback(
+    ({ item, index }) => (
+      <Gutter style={{ overflow: "hidden" }}>
+        <ErrorBoundary>
+          {item.name === "footer"
+            ? footer
+            : renderChild(item, index.toString(), index)}
+        </ErrorBoundary>
+      </Gutter>
+    ),
+    [footer, renderChild]
   );
 
-  const fixedContent = [...fixup(isTablet, content), { name: "footer" }];
+  const fixedContent = useMemo(
+    () => [...fixup(isTablet, content), { name: "footer" }],
+    [content, isTablet]
+  );
 
   // FIXME: remove this when ios memory leaks are resolved
-  const Scroller = scrollprops =>
-    Platform.select({
-      ios: (
-        <FlatList
-          {...scrollprops}
-          data={scrollprops.data.map((item, index) => Child({ item, index }))}
-          renderItem={({ item }) => item}
-        />
-      ),
-      android: <FlatList {...scrollprops} />
-    });
+  const Scroller = React.useCallback(
+    scrollprops =>
+      Platform.select({
+        ios: (
+          <FlatList
+            {...scrollprops}
+            data={scrollprops.data.map((item, index) => Child({ item, index }))}
+            renderItem={({ item }) => item}
+          />
+        ),
+        android: <FlatList {...scrollprops} />
+      }),
+    [Child]
+  );
 
   return (
-    <AdComposer adConfig={adConfig}>
-      <View style={styles.articleContainer}>
-        <Viewport.Tracker>
-          <Scroller
-            data={fixedContent}
-            ListEmptyComponent={Loading}
-            ListHeaderComponent={header}
-            ListFooterComponent={Loading}
-            onEndReached={onEndReached}
-            showsVerticalScrollIndicator={false}
-            renderItem={Child}
-            onViewableItemsChanged={onViewableItemsChanged}
-            removeClippedSubviews
-            keyExtractor={(item, index) => index.toString()}
-            initialNumToRender={2}
-            windowSize={3}
-            nestedScrollEnabled
-            testID="flat-list-article"
-          />
-        </Viewport.Tracker>
-      </View>
-    </AdComposer>
+    <View style={styles.articleContainer}>
+      <Viewport.Tracker>
+        <Scroller
+          data={fixedContent}
+          extraData={loading}
+          ListEmptyComponent={Loading}
+          ListHeaderComponent={header}
+          ListFooterComponent={Loading}
+          onEndReached={onEndReached}
+          showsVerticalScrollIndicator={false}
+          renderItem={Child}
+          onViewableItemsChanged={onViewableItemsChanged}
+          removeClippedSubviews
+          keyExtractor={(item, index) => index.toString()}
+          initialNumToRender={2}
+          windowSize={3}
+          nestedScrollEnabled
+          testID="flat-list-article"
+        />
+      </Viewport.Tracker>
+    </View>
   );
+};
+
+ArticleWithContent.propTypes = {
+  ...articleSkeletonPropTypes,
+  interactiveConfig: PropTypes.shape({}),
+  onCommentGuidelinesPress: PropTypes.func.isRequired,
+  onCommentsPress: PropTypes.func.isRequired,
+  onLinkPress: PropTypes.func.isRequired,
+  onRelatedArticlePress: PropTypes.func.isRequired,
+  onTwitterLinkPress: PropTypes.func.isRequired,
+  onVideoPress: PropTypes.func.isRequired,
+  onImagePress: PropTypes.func.isRequired
+};
+ArticleWithContent.defaultProps = {
+  ...articleSkeletonDefaultProps,
+  interactiveConfig: {}
+};
+
+const ArticleSkeleton = props => {
+  const { data } = props;
+
+  if (!data) {
+    return null;
+  }
+
+  const { content } = data;
+
+  if (!content) {
+    return null;
+  }
+
+  return <ArticleWithContent {...props} />;
 };
 
 ArticleSkeleton.displayName = "ArticleSkeleton";


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
A state update for removing the loading spinner was causing the article content to rerender, this PR makes generous use of useMemo and useCallback to make sure that rerender only occurs when the data itself changes.