### PR TITLE
fix: unnecessary rerender in article

### DIFF
--- a/packages/article-skeleton/.eslintrc.json
+++ b/packages/article-skeleton/.eslintrc.json
@@ -2,5 +2,8 @@
   "extends": ["@times-components/thetimes"],
   "globals": {
     "window": true
+  },
+  "rules": {
+    "react-hooks/exhaustive-deps": false
   }
 }

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -59,18 +59,17 @@ const ArticleWithContent = props => {
 
   const [loading, setLoading] = useState(true);
   const Loading = useCallback(
-    () =>
-      loading ? (
-        <Gutter>
-          <ActivityIndicator size="large" />
-        </Gutter>
-      ) : null,
+    () => (
+      <Gutter>
+        <ActivityIndicator size="large" animating={loading} />
+      </Gutter>
+    ),
     [loading]
   );
 
-  const onEndReached = useCallback(() => {
+  const onEndReached = () => {
     setLoading(false);
-  }, []);
+  };
 
   const header = useMemo(
     () => (
@@ -95,15 +94,7 @@ const ArticleWithContent = props => {
         />
       </Gutter>
     ),
-    [
-      analyticsStream,
-      id,
-      onCommentGuidelinesPress,
-      onCommentsPress,
-      onRelatedArticlePress,
-      onTopicPress,
-      url
-    ]
+    []
   );
 
   const dropcapsDisabled = isDropcapsDisabled(data);
@@ -119,7 +110,7 @@ const ArticleWithContent = props => {
         </ErrorBoundary>
       </Gutter>
     ),
-    [footer, renderChild]
+    [footer]
   );
 
   const fixedContent = useMemo(


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Prettifier was adding deps that caused rerenders, we actually don't care about those props.