### PR TITLE
fix: invalid callback change

### DIFF
--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -54,7 +54,7 @@ const ArticleWithContent = props => {
         .filter(viewableItem => viewableItem.isViewable)
         .map(viewableItem => onViewed(viewableItem.item, data));
     },
-    [data, onViewed]
+    []
   );
 
   const [loading, setLoading] = useState(true);

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -46,16 +46,13 @@ const ArticleWithContent = props => {
 
   const { id, url, content } = data;
 
-  const onViewableItemsChanged = useCallback(
-    info => {
-      if (!onViewed || !info.changed || !info.changed.length) return [];
+  const onViewableItemsChanged = useCallback(info => {
+    if (!onViewed || !info.changed || !info.changed.length) return [];
 
-      return info.changed
-        .filter(viewableItem => viewableItem.isViewable)
-        .map(viewableItem => onViewed(viewableItem.item, data));
-    },
-    []
-  );
+    return info.changed
+      .filter(viewableItem => viewableItem.isViewable)
+      .map(viewableItem => onViewed(viewableItem.item, data));
+  }, []);
 
   const [loading, setLoading] = useState(true);
   const Loading = useCallback(


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
We no longer rebuild article components after the first render, there is an arrow function callback somewhere up the tree causing a prop change of a callback that cannot be changed. Avoid changing the function as it is actually always the same just a different instance.