### PR TITLE
Fix/replat 11034 clicks on authors not tracked

### DIFF
--- a/packages/article-byline/__tests__/shared.base.js
+++ b/packages/article-byline/__tests__/shared.base.js
@@ -98,6 +98,8 @@ export default Component => {
             />
           );
 
+          console.log("WRAPPER ===>", onAuthorPressMock);
+
           wrapper
             .at(0)
             .dive()

--- a/packages/article-byline/__tests__/shared.base.js
+++ b/packages/article-byline/__tests__/shared.base.js
@@ -1,9 +1,11 @@
 import React from "react";
 import { View } from "react-native";
 import TestRenderer from "react-test-renderer";
+import { shallow } from "enzyme";
 import { iterator } from "@times-components/test-utils";
 import ArticleByline from "../src/article-byline";
 import authorsFixture from "../fixtures/authors.json";
+import ArticleBylineWithLinks from "../src/article-byline-with-links";
 
 export default Component => {
   const renderArticleByline = props =>
@@ -83,6 +85,25 @@ export default Component => {
       }
     }
   ];
+
+  if (Component.displayName === "ArticleBylineWithLinks") {
+    tests.push({
+      name: "handle an empty onPress event",
+      test: () => {
+        const wrapper = shallow(
+          <ArticleBylineWithLinks ast={authorsFixture.singleAuthor} />
+        );
+
+        expect(() =>
+          wrapper
+            .at(0)
+            .dive()
+            .find("AuthorComponent")
+            .simulate("press")
+        ).not.toThrow();
+      }
+    });
+  }
 
   iterator(tests);
 };

--- a/packages/article-byline/__tests__/shared.base.js
+++ b/packages/article-byline/__tests__/shared.base.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { View } from "react-native";
 import TestRenderer from "react-test-renderer";
-import { shallow } from "enzyme";
 import { iterator } from "@times-components/test-utils";
 import ArticleByline from "../src/article-byline";
 import authorsFixture from "../fixtures/authors.json";
@@ -84,49 +83,6 @@ export default Component => {
       }
     }
   ];
-
-  if (Component.displayName === "ArticleBylineWithLinks") {
-    tests.push(
-      {
-        name: "handle the onPress event",
-        test: () => {
-          const onAuthorPressMock = jest.fn();
-          const wrapper = shallow(
-            <Component
-              ast={authorsFixture.singleAuthor}
-              onAuthorPress={onAuthorPressMock}
-            />
-          );
-
-          console.log("WRAPPER ===>", onAuthorPressMock);
-
-          wrapper
-            .at(0)
-            .dive()
-            .find("Text")
-            .simulate("press");
-
-          expect(onAuthorPressMock).toHaveBeenCalled();
-        }
-      },
-      {
-        name: "handle an empty onPress event",
-        test: () => {
-          const wrapper = shallow(
-            <Component ast={authorsFixture.singleAuthor} />
-          );
-
-          expect(() =>
-            wrapper
-              .at(0)
-              .dive()
-              .find("Text")
-              .simulate("press")
-          ).not.toThrow();
-        }
-      }
-    );
-  }
 
   iterator(tests);
 };

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -67,6 +67,7 @@
     "@times-components/markup": "3.4.17",
     "@times-components/markup-forest": "1.7.30",
     "@times-components/styleguide": "3.33.14",
+    "@times-components/tracking": "2.5.17",
     "prop-types": "15.7.2"
   },
   "resolutions": {

--- a/packages/article-byline/src/article-byline-opinion.js
+++ b/packages/article-byline/src/article-byline-opinion.js
@@ -5,14 +5,14 @@ import renderByline from "./render-byline";
 import { propTypes, defaultProps } from "./article-byline-prop-types";
 import styles from "./styles";
 
-const renderAuthorComponent = ({ children, key, className }) => (
+const AuthorComponent = ({ children, key, className }) => (
   <Text className={className} key={key} style={styles.opinion}>
     {children}
   </Text>
 );
 
 const ArticleBylineOpinion = ({ ast, ...props }) =>
-  renderByline(renderAuthorComponent, ast, styles.opinion, props);
+  renderByline(AuthorComponent, ast, styles.opinion, props);
 
 ArticleBylineOpinion.displayName = "ArticleBylineOpinion";
 

--- a/packages/article-byline/src/article-byline-opinion.js
+++ b/packages/article-byline/src/article-byline-opinion.js
@@ -1,10 +1,11 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Text } from "react-native";
 import renderByline from "./render-byline";
 import { propTypes, defaultProps } from "./article-byline-prop-types";
 import styles from "./styles";
 
-const renderAuthorComponent = (children, key, attributes, { className }) => (
+const renderAuthorComponent = ({ children, key, className }) => (
   <Text className={className} key={key} style={styles.opinion}>
     {children}
   </Text>

--- a/packages/article-byline/src/article-byline-prop-types.js
+++ b/packages/article-byline/src/article-byline-prop-types.js
@@ -3,7 +3,11 @@ import PropTypes from "prop-types";
 export const propTypes = {
   ast: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   onAuthorPress: PropTypes.func,
-  capitalize: PropTypes.bool
+  capitalize: PropTypes.bool,
+  children: PropTypes.array,
+  key: PropTypes.string,
+  attributes: PropTypes.array,
+  slug: PropTypes.string
 };
 
 export const defaultProps = {

--- a/packages/article-byline/src/article-byline-with-links.js
+++ b/packages/article-byline/src/article-byline-with-links.js
@@ -7,12 +7,7 @@ import { propTypes, defaultProps } from "./article-byline-prop-types";
 import styles from "./styles";
 import withTrackEvents from "../tracking/with-track-events";
 
-const renderAuthorComponent = ({
-  slug,
-  className,
-  onAuthorPress,
-  children
-}) => {
+const AuthorComponent = ({ slug, className, onAuthorPress, children }) => {
   const url = `/profile/${slug}`;
   const name = children[0];
 
@@ -32,7 +27,7 @@ const renderAuthorComponent = ({
 
 const ArticleBylineWithLinks = ({ ast, centered, ...props }) =>
   renderByline(
-    withTrackEvents(renderAuthorComponent),
+    withTrackEvents(AuthorComponent),
     ast,
     // TODO: revert platform switch after design signoff
     centered && Platform.OS === "web"

--- a/packages/article-byline/src/article-byline-with-links.js
+++ b/packages/article-byline/src/article-byline-with-links.js
@@ -1,25 +1,27 @@
+/* eslint-disable react/prop-types, no-sequences, no-unused-expressions */
 import React from "react";
 import { Platform } from "react-native";
 import { TextLink } from "@times-components/link";
 import renderByline from "./render-byline";
 import { propTypes, defaultProps } from "./article-byline-prop-types";
 import styles from "./styles";
-import withTrackEvents from '../tracking/with-track-events';
+import withTrackEvents from "../tracking/with-track-events";
 
-const renderAuthorComponent = (
-  children,
-  key,
-  attributes,
-  { onPress, className }
-) => {
-  const slug = attributes.slug;
+const renderAuthorComponent = ({
+  slug,
+  className,
+  onAuthorPress,
+  children
+}) => {
   const url = `/profile/${slug}`;
+  const name = children[0];
 
   return (
     <TextLink
       className={className}
-      key={key}
-      onPress={(e) => {onPress(e, {slug, url})}}
+      onPress={e => {
+        onAuthorPress(e), { name, slug };
+      }}
       style={styles.link}
       url={url}
     >
@@ -28,11 +30,9 @@ const renderAuthorComponent = (
   );
 };
 
-
-
 const ArticleBylineWithLinks = ({ ast, centered, ...props }) =>
   renderByline(
-    renderAuthorComponent,
+    withTrackEvents(renderAuthorComponent),
     ast,
     // TODO: revert platform switch after design signoff
     centered && Platform.OS === "web"
@@ -46,4 +46,4 @@ ArticleBylineWithLinks.displayName = "ArticleBylineWithLinks";
 ArticleBylineWithLinks.propTypes = propTypes;
 ArticleBylineWithLinks.defaultProps = defaultProps;
 
-export default withTrackEvents(ArticleBylineWithLinks);
+export default ArticleBylineWithLinks;

--- a/packages/article-byline/src/article-byline-with-links.js
+++ b/packages/article-byline/src/article-byline-with-links.js
@@ -4,6 +4,7 @@ import { TextLink } from "@times-components/link";
 import renderByline from "./render-byline";
 import { propTypes, defaultProps } from "./article-byline-prop-types";
 import styles from "./styles";
+import withTrackEvents from '../tracking/with-track-events';
 
 const renderAuthorComponent = (
   children,
@@ -12,11 +13,17 @@ const renderAuthorComponent = (
   { onAuthorPress, className }
 ) => {
   const url = `/profile/${attributes.slug}`;
+  const onPress = (e) => {
+    console.log('=====> trigger onpress', attributes.slug, url);
+    onAuthorPress(e, { slug: attributes.slug, url })
+  }
+
+
   return (
     <TextLink
       className={className}
       key={key}
-      onPress={e => onAuthorPress(e, { slug: attributes.slug, url })}
+      onPress={onPress}
       style={styles.link}
       url={url}
     >
@@ -24,6 +31,8 @@ const renderAuthorComponent = (
     </TextLink>
   );
 };
+
+
 
 const ArticleBylineWithLinks = ({ ast, centered, ...props }) =>
   renderByline(
@@ -41,4 +50,4 @@ ArticleBylineWithLinks.displayName = "ArticleBylineWithLinks";
 ArticleBylineWithLinks.propTypes = propTypes;
 ArticleBylineWithLinks.defaultProps = defaultProps;
 
-export default ArticleBylineWithLinks;
+export default withTrackEvents(ArticleBylineWithLinks);

--- a/packages/article-byline/src/article-byline-with-links.js
+++ b/packages/article-byline/src/article-byline-with-links.js
@@ -10,20 +10,16 @@ const renderAuthorComponent = (
   children,
   key,
   attributes,
-  { onAuthorPress, className }
+  { onPress, className }
 ) => {
-  const url = `/profile/${attributes.slug}`;
-  const onPress = (e) => {
-    console.log('=====> trigger onpress', attributes.slug, url);
-    onAuthorPress(e, { slug: attributes.slug, url })
-  }
-
+  const slug = attributes.slug;
+  const url = `/profile/${slug}`;
 
   return (
     <TextLink
       className={className}
       key={key}
-      onPress={onPress}
+      onPress={(e) => {onPress(e, {slug, url})}}
       style={styles.link}
       url={url}
     >

--- a/packages/article-byline/src/article-byline.js
+++ b/packages/article-byline/src/article-byline.js
@@ -5,7 +5,7 @@ import renderByline from "./render-byline";
 import { propTypes, defaultProps } from "./article-byline-prop-types";
 import styles from "./styles";
 
-const renderAuthorComponent = ({ children, key, className, bylineStyle }) => (
+const AuthorComponent = ({ children, key, className, bylineStyle }) => (
   <Text
     className={className}
     key={key}
@@ -16,7 +16,7 @@ const renderAuthorComponent = ({ children, key, className, bylineStyle }) => (
 );
 
 const ArticleByline = ({ ast, ...props }) =>
-  renderByline(renderAuthorComponent, ast, styles.nonLinkText, props);
+  renderByline(AuthorComponent, ast, styles.nonLinkText, props);
 
 ArticleByline.displayName = "ArticleByline";
 

--- a/packages/article-byline/src/article-byline.js
+++ b/packages/article-byline/src/article-byline.js
@@ -1,15 +1,11 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Text } from "react-native";
 import renderByline from "./render-byline";
 import { propTypes, defaultProps } from "./article-byline-prop-types";
 import styles from "./styles";
 
-const renderAuthorComponent = (
-  children,
-  key,
-  attributes,
-  { className, bylineStyle }
-) => (
+const renderAuthorComponent = ({ children, key, className, bylineStyle }) => (
   <Text
     className={className}
     key={key}

--- a/packages/article-byline/src/render-byline.js
+++ b/packages/article-byline/src/render-byline.js
@@ -4,10 +4,14 @@ import { Text } from "react-native";
 import renderTrees from "@times-components/markup-forest";
 import renderers from "@times-components/markup";
 
-const bylineRenderers = (renderAuthorComponent, textStyle, props = {}) => ({
+const bylineRenderers = (Component, textStyle, props = {}) => ({
   ...renderers,
   author(key, attributes, children) {
-    return renderAuthorComponent(children, key, attributes, props);
+    return (
+      <Component key={key} name={children[0]} {...attributes} {...props}>
+        {children}
+      </Component>
+    );
   },
 
   inline(key, attributes, children) {
@@ -20,15 +24,12 @@ const bylineRenderers = (renderAuthorComponent, textStyle, props = {}) => ({
   }
 });
 
-const renderByline = (renderAuthorComponent, ast, textStyle, props = {}) => {
+const renderByline = (Component, ast, textStyle, props = {}) => {
   const bylineAst = ast.map(
     bylineObj =>
       bylineObj.byline && bylineObj.byline.length > 0 ? bylineObj.byline[0] : {}
   );
-  return renderTrees(
-    bylineAst,
-    bylineRenderers(renderAuthorComponent, textStyle, props)
-  );
+  return renderTrees(bylineAst, bylineRenderers(Component, textStyle, props));
 };
 
 export default renderByline;

--- a/packages/article-byline/tracking/with-track-events.js
+++ b/packages/article-byline/tracking/with-track-events.js
@@ -1,0 +1,16 @@
+import { withTrackEvents } from "@times-components/tracking";
+
+export default Component =>
+  withTrackEvents(Component, {
+    analyticsEvents: [
+      {
+        actionName: "Pressed",
+        eventName: "onAuthorPress",
+        getAttrs: ({ slug, url }) => ({
+          slug,
+          url
+        }),
+        trackingName: "ArticlePressAuthor"
+      }
+    ]
+  });

--- a/packages/article-byline/tracking/with-track-events.js
+++ b/packages/article-byline/tracking/with-track-events.js
@@ -5,7 +5,7 @@ export default Component =>
     analyticsEvents: [
       {
         actionName: "Pressed",
-        eventName: "onAuthorPress",
+        eventName: "onPress",
         getAttrs: ({ slug, url }) => ({
           slug,
           url

--- a/packages/article-byline/tracking/with-track-events.js
+++ b/packages/article-byline/tracking/with-track-events.js
@@ -5,10 +5,10 @@ export default Component =>
     analyticsEvents: [
       {
         actionName: "Pressed",
-        eventName: "onPress",
-        getAttrs: ({ slug, url }) => ({
-          slug,
-          url
+        eventName: "onAuthorPress",
+        getAttrs: ({ name, slug }) => ({
+          name,
+          slug
         }),
         trackingName: "ArticlePressAuthor"
       }


### PR DESCRIPTION
This issue is for the following [issue](https://nidigitalsolutions.jira.com/browse/REPLAT-11034).
Adding an analytics action for the byline with author link.
<img width="1083" alt="Screenshot at Dec 17 17-15-14" src="https://user-images.githubusercontent.com/8719799/71008425-41b7e780-20f1-11ea-8a79-65098fb7cb99.png">
<img width="585" alt="Screenshot at Dec 17 17-14-33" src="https://user-images.githubusercontent.com/8719799/71008438-47153200-20f1-11ea-9bef-20ed06e6596d.png">
Sending name and slug properties, depending on the author name.
