### PR TITLE
:fix: added aria-label to svgs

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -117,7 +117,7 @@ exports[`1. a full article 1`] = `
       target={null}
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-email"
         height={16}
         role="img"
         viewBox="0 0 22 16"
@@ -138,7 +138,7 @@ exports[`1. a full article 1`] = `
       target="_blank"
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-twitter"
         height={16}
         role="img"
         viewBox="-354.2 -279.4 750 600"
@@ -157,7 +157,7 @@ exports[`1. a full article 1`] = `
       target="_blank"
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-facebook"
         height={18}
         role="img"
         viewBox="14 10 10.592460632324219 20.397258758544922"
@@ -178,7 +178,7 @@ exports[`1. a full article 1`] = `
       target={null}
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-copy-link"
         height={16}
         role="img"
         viewBox="0 0 15 15"
@@ -238,7 +238,7 @@ exports[`1. a full article 1`] = `
         AName
         , a text
         <svg
-          aria-label="[title]"
+          aria-label="icon-twitter"
           height={10}
           role="img"
           viewBox="-354.2 -279.4 750 600"
@@ -291,7 +291,7 @@ exports[`1. a full article 1`] = `
         target={null}
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-email"
           height={16}
           role="img"
           viewBox="0 0 22 16"
@@ -312,7 +312,7 @@ exports[`1. a full article 1`] = `
         target="_blank"
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-twitter"
           height={16}
           role="img"
           viewBox="-354.2 -279.4 750 600"
@@ -331,7 +331,7 @@ exports[`1. a full article 1`] = `
         target="_blank"
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-facebook"
           height={18}
           role="img"
           viewBox="14 10 10.592460632324219 20.397258758544922"
@@ -352,7 +352,7 @@ exports[`1. a full article 1`] = `
         target={null}
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-copy-link"
           height={16}
           role="img"
           viewBox="0 0 15 15"

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -133,7 +133,7 @@ exports[`1. a full article 1`] = `
       target={null}
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-email"
         height={16}
         role="img"
         viewBox="0 0 22 16"
@@ -154,7 +154,7 @@ exports[`1. a full article 1`] = `
       target="_blank"
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-twitter"
         height={16}
         role="img"
         viewBox="-354.2 -279.4 750 600"
@@ -173,7 +173,7 @@ exports[`1. a full article 1`] = `
       target="_blank"
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-facebook"
         height={18}
         role="img"
         viewBox="14 10 10.592460632324219 20.397258758544922"
@@ -194,7 +194,7 @@ exports[`1. a full article 1`] = `
       target={null}
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-copy-link"
         height={16}
         role="img"
         viewBox="0 0 15 15"
@@ -254,7 +254,7 @@ exports[`1. a full article 1`] = `
         AName
         , a text
         <svg
-          aria-label="[title]"
+          aria-label="icon-twitter"
           height={10}
           role="img"
           viewBox="-354.2 -279.4 750 600"
@@ -307,7 +307,7 @@ exports[`1. a full article 1`] = `
         target={null}
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-email"
           height={16}
           role="img"
           viewBox="0 0 22 16"
@@ -328,7 +328,7 @@ exports[`1. a full article 1`] = `
         target="_blank"
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-twitter"
           height={16}
           role="img"
           viewBox="-354.2 -279.4 750 600"
@@ -347,7 +347,7 @@ exports[`1. a full article 1`] = `
         target="_blank"
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-facebook"
           height={18}
           role="img"
           viewBox="14 10 10.592460632324219 20.397258758544922"
@@ -368,7 +368,7 @@ exports[`1. a full article 1`] = `
         target={null}
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-copy-link"
           height={16}
           role="img"
           viewBox="0 0 15 15"

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -117,7 +117,7 @@ exports[`1. a full article 1`] = `
       target={null}
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-email"
         height={16}
         role="img"
         viewBox="0 0 22 16"
@@ -138,7 +138,7 @@ exports[`1. a full article 1`] = `
       target="_blank"
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-twitter"
         height={16}
         role="img"
         viewBox="-354.2 -279.4 750 600"
@@ -157,7 +157,7 @@ exports[`1. a full article 1`] = `
       target="_blank"
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-facebook"
         height={18}
         role="img"
         viewBox="14 10 10.592460632324219 20.397258758544922"
@@ -178,7 +178,7 @@ exports[`1. a full article 1`] = `
       target={null}
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-copy-link"
         height={16}
         role="img"
         viewBox="0 0 15 15"
@@ -238,7 +238,7 @@ exports[`1. a full article 1`] = `
         AName
         , a text
         <svg
-          aria-label="[title]"
+          aria-label="icon-twitter"
           height={10}
           role="img"
           viewBox="-354.2 -279.4 750 600"
@@ -291,7 +291,7 @@ exports[`1. a full article 1`] = `
         target={null}
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-email"
           height={16}
           role="img"
           viewBox="0 0 22 16"
@@ -312,7 +312,7 @@ exports[`1. a full article 1`] = `
         target="_blank"
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-twitter"
           height={16}
           role="img"
           viewBox="-354.2 -279.4 750 600"
@@ -331,7 +331,7 @@ exports[`1. a full article 1`] = `
         target="_blank"
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-facebook"
           height={18}
           role="img"
           viewBox="14 10 10.592460632324219 20.397258758544922"
@@ -352,7 +352,7 @@ exports[`1. a full article 1`] = `
         target={null}
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-copy-link"
           height={16}
           role="img"
           viewBox="0 0 15 15"

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -112,7 +112,7 @@ exports[`1. a full article 1`] = `
       target={null}
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-email"
         height={16}
         role="img"
         viewBox="0 0 22 16"
@@ -133,7 +133,7 @@ exports[`1. a full article 1`] = `
       target="_blank"
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-twitter"
         height={16}
         role="img"
         viewBox="-354.2 -279.4 750 600"
@@ -152,7 +152,7 @@ exports[`1. a full article 1`] = `
       target="_blank"
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-facebook"
         height={18}
         role="img"
         viewBox="14 10 10.592460632324219 20.397258758544922"
@@ -173,7 +173,7 @@ exports[`1. a full article 1`] = `
       target={null}
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-copy-link"
         height={16}
         role="img"
         viewBox="0 0 15 15"
@@ -233,7 +233,7 @@ exports[`1. a full article 1`] = `
         AName
         , a text
         <svg
-          aria-label="[title]"
+          aria-label="icon-twitter"
           height={10}
           role="img"
           viewBox="-354.2 -279.4 750 600"
@@ -286,7 +286,7 @@ exports[`1. a full article 1`] = `
         target={null}
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-email"
           height={16}
           role="img"
           viewBox="0 0 22 16"
@@ -307,7 +307,7 @@ exports[`1. a full article 1`] = `
         target="_blank"
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-twitter"
           height={16}
           role="img"
           viewBox="-354.2 -279.4 750 600"
@@ -326,7 +326,7 @@ exports[`1. a full article 1`] = `
         target="_blank"
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-facebook"
           height={18}
           role="img"
           viewBox="14 10 10.592460632324219 20.397258758544922"
@@ -347,7 +347,7 @@ exports[`1. a full article 1`] = `
         target={null}
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-copy-link"
           height={16}
           role="img"
           viewBox="0 0 15 15"

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -146,7 +146,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       target={null}
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-email"
         height={16}
         role="img"
         viewBox="0 0 22 16"
@@ -167,7 +167,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       target="_blank"
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-twitter"
         height={16}
         role="img"
         viewBox="-354.2 -279.4 750 600"
@@ -186,7 +186,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       target="_blank"
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-facebook"
         height={18}
         role="img"
         viewBox="14 10 10.592460632324219 20.397258758544922"
@@ -207,7 +207,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       target={null}
     >
       <svg
-        aria-label="[title]"
+        aria-label="icon-copy-link"
         height={16}
         role="img"
         viewBox="0 0 15 15"
@@ -267,7 +267,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
         AName
         , a text
         <svg
-          aria-label="[title]"
+          aria-label="icon-twitter"
           height={10}
           role="img"
           viewBox="-354.2 -279.4 750 600"
@@ -320,7 +320,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
         target={null}
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-email"
           height={16}
           role="img"
           viewBox="0 0 22 16"
@@ -341,7 +341,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
         target="_blank"
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-twitter"
           height={16}
           role="img"
           viewBox="-354.2 -279.4 750 600"
@@ -360,7 +360,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
         target="_blank"
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-facebook"
           height={18}
           role="img"
           viewBox="14 10 10.592460632324219 20.397258758544922"
@@ -381,7 +381,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
         target={null}
       >
         <svg
-          aria-label="[title]"
+          aria-label="icon-copy-link"
           height={16}
           role="img"
           viewBox="0 0 15 15"

--- a/packages/icons/__tests__/android/__snapshots__/icons-dim.android.test.js.snap
+++ b/packages/icons/__tests__/android/__snapshots__/icons-dim.android.test.js.snap
@@ -3,6 +3,7 @@
 exports[`1. iconemail sets a width when height is set 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-email"
   bbHeight={50}
   bbWidth={68.75}
   focusable={false}
@@ -31,6 +32,7 @@ exports[`1. iconemail sets a width when height is set 1`] = `
 exports[`2. iconfacebook sets a width when height is set 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-facebook"
   bbHeight={50}
   bbWidth={25}
   focusable={false}
@@ -59,6 +61,7 @@ exports[`2. iconfacebook sets a width when height is set 1`] = `
 exports[`3. iconforwardarrow sets a width when height is set 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-forward-arrow"
   bbHeight={12}
   bbWidth={7}
   focusable={false}
@@ -85,6 +88,7 @@ exports[`3. iconforwardarrow sets a width when height is set 1`] = `
 exports[`4. iconstar sets a width when height is set 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-save-star"
   bbHeight={50}
   bbWidth={50}
   focusable={false}
@@ -113,6 +117,7 @@ exports[`4. iconstar sets a width when height is set 1`] = `
 exports[`5. iconcopylink sets a width when height is set 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-copy-link"
   bbHeight={50}
   bbWidth={15}
   focusable={false}
@@ -141,6 +146,7 @@ exports[`5. iconcopylink sets a width when height is set 1`] = `
 exports[`6. iconsavebookmark sets a width when height is set 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-save-bookmark"
   bbHeight={50}
   bbWidth={12}
   focusable={false}
@@ -169,6 +175,7 @@ exports[`6. iconsavebookmark sets a width when height is set 1`] = `
 exports[`7. icontwitter sets a width when height is set 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-twitter"
   bbHeight={50}
   bbWidth={62.5}
   focusable={false}
@@ -197,6 +204,7 @@ exports[`7. icontwitter sets a width when height is set 1`] = `
 exports[`8. iconvideo sets a width when height is set 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-video"
   bbHeight={50}
   bbWidth={85}
   focusable={false}
@@ -225,6 +233,7 @@ exports[`8. iconvideo sets a width when height is set 1`] = `
 exports[`9. iconvideo360player sets a width when height is set 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-video-360-player"
   bbHeight={50}
   bbWidth={54}
   focusable={false}
@@ -253,6 +262,7 @@ exports[`9. iconvideo360player sets a width when height is set 1`] = `
 exports[`10. thestlogo sets a width when height is set 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="logo-the-sunday-times"
   bbHeight={50}
   bbWidth={50}
   focusable={false}
@@ -281,6 +291,7 @@ exports[`10. thestlogo sets a width when height is set 1`] = `
 exports[`11. thetimeslogo sets a width when height is set 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="logo-the-times"
   bbHeight={50}
   bbWidth={50}
   focusable={false}
@@ -309,6 +320,7 @@ exports[`11. thetimeslogo sets a width when height is set 1`] = `
 exports[`12. closeicon sets a width when height is set 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-close"
   bbHeight={50}
   bbWidth={28}
   focusable={false}

--- a/packages/icons/__tests__/android/__snapshots__/icons.android.test.js.snap
+++ b/packages/icons/__tests__/android/__snapshots__/icons.android.test.js.snap
@@ -3,6 +3,7 @@
 exports[`1. iconemail renders 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-email"
   bbWidth={20}
   focusable={false}
   meetOrSlice={0}
@@ -154,6 +155,7 @@ exports[`1. iconemail renders 1`] = `
 exports[`2. iconfacebook renders 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-facebook"
   bbWidth={20}
   focusable={false}
   meetOrSlice={0}
@@ -305,6 +307,7 @@ exports[`2. iconfacebook renders 1`] = `
 exports[`3. iconforwardarrow renders 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-forward-arrow"
   bbHeight={12}
   bbWidth={7}
   focusable={false}
@@ -458,6 +461,7 @@ exports[`3. iconforwardarrow renders 1`] = `
 exports[`4. iconstar renders 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-save-star"
   bbWidth={20}
   focusable={false}
   meetOrSlice={0}
@@ -567,6 +571,7 @@ exports[`4. iconstar renders 1`] = `
 exports[`5. iconcopylink renders 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-copy-link"
   bbHeight={15}
   bbWidth={20}
   focusable={false}
@@ -681,6 +686,7 @@ exports[`5. iconcopylink renders 1`] = `
 exports[`6. iconsavebookmark renders 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-save-bookmark"
   bbHeight={16}
   bbWidth={20}
   focusable={false}
@@ -795,6 +801,7 @@ exports[`6. iconsavebookmark renders 1`] = `
 exports[`7. icontwitter renders 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-twitter"
   bbWidth={20}
   focusable={false}
   meetOrSlice={0}
@@ -904,6 +911,7 @@ exports[`7. icontwitter renders 1`] = `
 exports[`8. iconvideo renders 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-video"
   bbWidth={20}
   focusable={false}
   meetOrSlice={0}
@@ -1058,6 +1066,7 @@ exports[`8. iconvideo renders 1`] = `
 exports[`9. iconvideo360player renders 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-video-360-player"
   bbWidth={20}
   focusable={false}
   meetOrSlice={0}
@@ -1167,6 +1176,7 @@ exports[`9. iconvideo360player renders 1`] = `
 exports[`10. thestlogo renders 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="logo-the-sunday-times"
   bbWidth={20}
   focusable={false}
   meetOrSlice={0}
@@ -1276,6 +1286,7 @@ exports[`10. thestlogo renders 1`] = `
 exports[`11. thetimeslogo renders 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="logo-the-times"
   bbWidth={20}
   focusable={false}
   meetOrSlice={0}
@@ -1385,6 +1396,7 @@ exports[`11. thetimeslogo renders 1`] = `
 exports[`12. closeicon renders 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
+  aria-label="icon-close"
   bbHeight={28}
   bbWidth={20}
   focusable={false}

--- a/packages/icons/__tests__/web/__snapshots__/icons-dim.web.test.js.snap
+++ b/packages/icons/__tests__/web/__snapshots__/icons-dim.web.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`1. iconemail sets a width when height is set 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-email"
   height={50}
   role="img"
   width={68.75}
@@ -11,7 +11,7 @@ exports[`1. iconemail sets a width when height is set 1`] = `
 
 exports[`2. iconfacebook sets a width when height is set 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-facebook"
   height={50}
   role="img"
   width={25}
@@ -20,6 +20,7 @@ exports[`2. iconfacebook sets a width when height is set 1`] = `
 
 exports[`3. iconforwardarrow sets a width when height is set 1`] = `
 <svg
+  aria-label="icon-forward-arrow"
   height={12}
   width={7}
 />
@@ -27,7 +28,7 @@ exports[`3. iconforwardarrow sets a width when height is set 1`] = `
 
 exports[`4. iconstar sets a width when height is set 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-save-star"
   height={50}
   role="img"
   width={50}
@@ -36,7 +37,7 @@ exports[`4. iconstar sets a width when height is set 1`] = `
 
 exports[`5. iconcopylink sets a width when height is set 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-copy-link"
   height={50}
   role="img"
   width={15}
@@ -45,7 +46,7 @@ exports[`5. iconcopylink sets a width when height is set 1`] = `
 
 exports[`6. iconsavebookmark sets a width when height is set 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-save-bookmark"
   height={50}
   role="img"
   width={12}
@@ -54,7 +55,7 @@ exports[`6. iconsavebookmark sets a width when height is set 1`] = `
 
 exports[`7. icontwitter sets a width when height is set 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-twitter"
   height={50}
   role="img"
   width={62.5}
@@ -63,7 +64,7 @@ exports[`7. icontwitter sets a width when height is set 1`] = `
 
 exports[`8. iconvideo sets a width when height is set 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-video"
   height={50}
   role="img"
   width={85}
@@ -72,7 +73,7 @@ exports[`8. iconvideo sets a width when height is set 1`] = `
 
 exports[`9. iconvideo360player sets a width when height is set 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-video-360-player"
   height={50}
   role="img"
   width={54}
@@ -81,7 +82,7 @@ exports[`9. iconvideo360player sets a width when height is set 1`] = `
 
 exports[`10. thestlogo sets a width when height is set 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="logo-the-sunday-times"
   height={50}
   role="img"
   width={50}
@@ -90,7 +91,7 @@ exports[`10. thestlogo sets a width when height is set 1`] = `
 
 exports[`11. thetimeslogo sets a width when height is set 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="logo-the-times"
   height={50}
   role="img"
   width={50}
@@ -99,7 +100,7 @@ exports[`11. thetimeslogo sets a width when height is set 1`] = `
 
 exports[`12. closeicon sets a width when height is set 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-close"
   height={50}
   role="img"
   width={28}

--- a/packages/icons/__tests__/web/__snapshots__/icons.web.test.js.snap
+++ b/packages/icons/__tests__/web/__snapshots__/icons.web.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`1. iconemail renders 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-email"
   role="img"
   viewBox="b4de9ef077a0a2ad684a1d8e6916ebc4"
   width={20}
@@ -23,7 +23,7 @@ exports[`1. iconemail renders 1`] = `
 
 exports[`2. iconfacebook renders 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-facebook"
   role="img"
   viewBox="bd9a71c8a3142edf7cab6a62a2277378"
   width={20}
@@ -44,6 +44,7 @@ exports[`2. iconfacebook renders 1`] = `
 
 exports[`3. iconforwardarrow renders 1`] = `
 <svg
+  aria-label="icon-forward-arrow"
   height={12}
   viewBox="5c14eb9241a8569e247b0186d9e66a8a"
   width={7}
@@ -60,7 +61,7 @@ exports[`3. iconforwardarrow renders 1`] = `
 
 exports[`4. iconstar renders 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-save-star"
   role="img"
   viewBox="951cf65ef61fef616e498a37f3f5a9b1"
   width={20}
@@ -77,7 +78,7 @@ exports[`4. iconstar renders 1`] = `
 
 exports[`5. iconcopylink renders 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-copy-link"
   height={15}
   role="img"
   viewBox="7798bdae936d01418f5704cad29092ad"
@@ -95,7 +96,7 @@ exports[`5. iconcopylink renders 1`] = `
 
 exports[`6. iconsavebookmark renders 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-save-bookmark"
   height={16}
   role="img"
   viewBox="192c9a888d6def500471679101ad9f5c"
@@ -113,7 +114,7 @@ exports[`6. iconsavebookmark renders 1`] = `
 
 exports[`7. icontwitter renders 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-twitter"
   role="img"
   viewBox="f0ca3b77f62fa9136cdfd9a3f847d07b"
   width={20}
@@ -130,7 +131,7 @@ exports[`7. icontwitter renders 1`] = `
 
 exports[`8. iconvideo renders 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-video"
   role="img"
   viewBox="32c562c1b3cee8479f67d0cbd8edef4d"
   width={20}
@@ -154,7 +155,7 @@ exports[`8. iconvideo renders 1`] = `
 
 exports[`9. iconvideo360player renders 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-video-360-player"
   role="img"
   viewBox="544726bb051c5bacf72288529e947083"
   width={20}
@@ -171,7 +172,7 @@ exports[`9. iconvideo360player renders 1`] = `
 
 exports[`10. thestlogo renders 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="logo-the-sunday-times"
   role="img"
   viewBox="432b2b997b72ed04860614d58bfe21fa"
   width={20}
@@ -188,7 +189,7 @@ exports[`10. thestlogo renders 1`] = `
 
 exports[`11. thetimeslogo renders 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="logo-the-times"
   role="img"
   viewBox="064d9dc888226a281482b4aa9646de05"
   width={20}
@@ -205,7 +206,7 @@ exports[`11. thetimeslogo renders 1`] = `
 
 exports[`12. closeicon renders 1`] = `
 <svg
-  aria-label="[title]"
+  aria-label="icon-close"
   height={28}
   role="img"
   viewBox="a20267b134584c37a6dc39235d4a5519"

--- a/packages/icons/src/icons/close.js
+++ b/packages/icons/src/icons/close.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 
 const IconClose = ({ height, width }) => (
   <Svg
+    aria-label="icon-close"
     role="img"
     viewBox="0 0 28 28"
     {...clean({

--- a/packages/icons/src/icons/copy-link.js
+++ b/packages/icons/src/icons/copy-link.js
@@ -13,6 +13,7 @@ const IconCopyLink = ({
   width
 }) => (
   <Svg
+    aria-label="icon-copy-link"
     role="img"
     viewBox="0 0 15 15"
     {...clean({

--- a/packages/icons/src/icons/email.js
+++ b/packages/icons/src/icons/email.js
@@ -15,6 +15,7 @@ const IconEmail = ({
   width
 }) => (
   <Svg
+    aria-label="icon-email"
     role="img"
     viewBox={viewBox}
     {...clean({

--- a/packages/icons/src/icons/facebook.js
+++ b/packages/icons/src/icons/facebook.js
@@ -15,6 +15,7 @@ const IconFacebook = ({
   width
 }) => (
   <Svg
+    aria-label="icon-facebook"
     role="img"
     viewBox={viewBox}
     {...clean({

--- a/packages/icons/src/icons/forward-arrow.js
+++ b/packages/icons/src/icons/forward-arrow.js
@@ -4,7 +4,12 @@ import Svg, { G, Path } from "@times-components/svgs";
 import propTypes from "./prop-types";
 
 const ForwardArrow = ({ fillColour }) => (
-  <Svg height={12} viewBox="42 12 60 120" width={7}>
+  <Svg
+    aria-label="icon-forward-arrow"
+    height={12}
+    viewBox="42 12 60 120"
+    width={7}
+  >
     <G fill={fillColour}>
       <Path d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z" />
     </G>

--- a/packages/icons/src/icons/save-bookmark.js
+++ b/packages/icons/src/icons/save-bookmark.js
@@ -13,6 +13,7 @@ const IconSaveBookmark = ({
   width
 }) => (
   <Svg
+    aria-label="icon-save-bookmark"
     role="img"
     viewBox="0 0 12 16"
     {...clean({

--- a/packages/icons/src/icons/star.js
+++ b/packages/icons/src/icons/star.js
@@ -13,6 +13,7 @@ const IconStar = ({
   width
 }) => (
   <Svg
+    aria-label="icon-save-star"
     role="img"
     viewBox="0 0 18 18"
     {...clean({

--- a/packages/icons/src/icons/thesundaytimes-logo.js
+++ b/packages/icons/src/icons/thesundaytimes-logo.js
@@ -12,6 +12,7 @@ const TheSTLogo = ({
   width
 }) => (
   <Svg
+    aria-label="logo-the-sunday-times"
     role="img"
     viewBox="0 0 29 20"
     {...clean({

--- a/packages/icons/src/icons/thetimes-logo.js
+++ b/packages/icons/src/icons/thetimes-logo.js
@@ -12,6 +12,7 @@ const TheTimesLogo = ({
   width
 }) => (
   <Svg
+    aria-label="logo-the-times"
     role="img"
     viewBox="0 0 20 20"
     {...clean({

--- a/packages/icons/src/icons/twitter.js
+++ b/packages/icons/src/icons/twitter.js
@@ -14,6 +14,7 @@ const IconTwitter = ({
   width
 }) => (
   <Svg
+    aria-label="icon-twitter"
     role="img"
     viewBox="-354.2 -279.4 750 600"
     {...clean({

--- a/packages/icons/src/icons/video-360-player.js
+++ b/packages/icons/src/icons/video-360-player.js
@@ -14,6 +14,7 @@ const IconVideo360Player = ({
   width
 }) => (
   <Svg
+    aria-label="icon-video-360-player"
     role="img"
     viewBox="0 0 108 100"
     {...clean({

--- a/packages/icons/src/icons/video.js
+++ b/packages/icons/src/icons/video.js
@@ -15,6 +15,7 @@ const IconVideo = ({
   width
 }) => (
   <Svg
+    aria-label="icon-video"
     role="img"
     viewBox={viewBox}
     {...clean({

--- a/packages/message-bar/__tests__/android/__snapshots__/message-bar.test.js.snap
+++ b/packages/message-bar/__tests__/android/__snapshots__/message-bar.test.js.snap
@@ -13,6 +13,7 @@ exports[`1. renders correctly 1`] = `
         >
           <RNSVGSvgView
             align="xMidYMid"
+            aria-label="icon-close"
             bbHeight="28"
             bbWidth="28"
             focusable={false}

--- a/packages/message-bar/__tests__/web/__snapshots__/message-bar.test.js.snap
+++ b/packages/message-bar/__tests__/web/__snapshots__/message-bar.test.js.snap
@@ -12,7 +12,7 @@ exports[`1. renders correctly 1`] = `
           tabIndex="0"
         >
           <svg
-            aria-label="[title]"
+            aria-label="icon-close"
             height="28"
             role="img"
             viewBox="0 0 28 28"

--- a/packages/pagination/__tests__/web/__snapshots__/pagination.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination.web.test.js.snap
@@ -77,6 +77,7 @@ exports[`1. renders results, previous and next 1`] = `
                     </span>
                   </div>
                   <svg
+                    aria-label="icon-next-page"
                     height={12}
                     viewBox="42 12 60 120"
                     width={7}
@@ -170,6 +171,7 @@ exports[`2. renders with no results 1`] = `
                     </span>
                   </div>
                   <svg
+                    aria-label="icon-next-page"
                     height={12}
                     viewBox="42 12 60 120"
                     width={7}
@@ -366,6 +368,7 @@ exports[`6. renders next and not previous 1`] = `
                     </span>
                   </div>
                   <svg
+                    aria-label="icon-next-page"
                     height={12}
                     viewBox="42 12 60 120"
                     width={7}

--- a/packages/pagination/src/pagination-icons.web.js
+++ b/packages/pagination/src/pagination-icons.web.js
@@ -57,6 +57,7 @@ export const NextPageIcon = () => (
       <PageLabel direction="Next" />
     </Text>
     <Svg
+      aria-label="icon-next-page"
       height={12}
       style={{ marginTop: spacing(-0.5) }}
       viewBox="42 12 60 120"

--- a/packages/save-star-web/__tests__/web/__snapshots__/save-star-web.test.js.snap
+++ b/packages/save-star-web/__tests__/web/__snapshots__/save-star-web.test.js.snap
@@ -47,7 +47,7 @@ Array [
   >
     <div>
       <svg
-        aria-label="[title]"
+        aria-label="icon-save-star"
         height={18}
         role="img"
         viewBox="0 0 18 18"
@@ -78,7 +78,7 @@ Array [
   >
     <div>
       <svg
-        aria-label="[title]"
+        aria-label="icon-save-star"
         height={18}
         role="img"
         viewBox="0 0 18 18"

--- a/packages/video/__tests__/android/__snapshots__/video.android.test.js.snap
+++ b/packages/video/__tests__/android/__snapshots__/video.android.test.js.snap
@@ -13,6 +13,7 @@ exports[`1. video 1`] = `
   <View>
     <View>
       <Svg
+        aria-label="icon-play"
         height={70}
         viewBox="0 0 100 100"
         width={70}
@@ -54,6 +55,7 @@ exports[`2. video without a poster image 1`] = `
   <View>
     <View>
       <Svg
+        aria-label="icon-play"
         height={70}
         viewBox="0 0 100 100"
         width={70}
@@ -106,6 +108,7 @@ exports[`3. sky sports video 1`] = `
   <View>
     <View>
       <Svg
+        aria-label="icon-play"
         height={70}
         viewBox="0 0 100 100"
         width={70}
@@ -150,6 +153,7 @@ exports[`4. 360 video 1`] = `
   <View>
     <View>
       <Svg
+        aria-label="icon-play"
         height={70}
         viewBox="0 0 100 100"
         width={70}

--- a/packages/video/__tests__/ios/__snapshots__/video.ios.test.js.snap
+++ b/packages/video/__tests__/ios/__snapshots__/video.ios.test.js.snap
@@ -14,6 +14,7 @@ exports[`1. video 1`] = `
     <View>
       <View>
         <Svg
+          aria-label="icon-play"
           height={70}
           viewBox="0 0 100 100"
           width={70}
@@ -57,6 +58,7 @@ exports[`2. video without a poster image 1`] = `
     <View>
       <View>
         <Svg
+          aria-label="icon-play"
           height={70}
           viewBox="0 0 100 100"
           width={70}
@@ -113,6 +115,7 @@ exports[`3. sky sports video 1`] = `
     <View>
       <View>
         <Svg
+          aria-label="icon-play"
           height={70}
           viewBox="0 0 100 100"
           width={70}
@@ -159,6 +162,7 @@ exports[`4. 360 video 1`] = `
     <View>
       <View>
         <Svg
+          aria-label="icon-play"
           height={70}
           viewBox="0 0 100 100"
           width={70}

--- a/packages/video/src/play-icon.native.js
+++ b/packages/video/src/play-icon.native.js
@@ -4,7 +4,7 @@ import Svg, { Polygon, Rect } from "@times-components/svgs";
 
 const PlayIcon = () => (
   <View>
-    <Svg height={70} viewBox="0 0 100 100" width={70}>
+    <Svg aria-label="icon-play" height={70} viewBox="0 0 100 100" width={70}>
       <Rect
         fill="#000000"
         fillOpacity="0.4"

--- a/packages/watermark/__tests__/web/__snapshots__/watermark.web.test.js.snap
+++ b/packages/watermark/__tests__/web/__snapshots__/watermark.web.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`1. watermark 1`] = `
 <Svg
+  aria-label="watermark"
   height={250}
   viewBox="0 0 300 250"
   width={300}

--- a/packages/watermark/src/watermark.web.js
+++ b/packages/watermark/src/watermark.web.js
@@ -4,7 +4,7 @@ import Svg, { G, Path } from "@times-components/svgs";
 import { colours } from "@times-components/styleguide";
 
 const Watermark = ({ height, viewBox, width }) => (
-  <Svg height={height} viewBox={viewBox} width={width}>
+  <Svg aria-label="watermark" height={height} viewBox={viewBox} width={width}>
     <G
       fill="none"
       fillRule="evenodd"


### PR DESCRIPTION
This PR is for the following [issue](https://nidigitalsolutions.jira.com/browse/REPLAT-10513).
We used to have '[title]' as a placeholder on aria-labels or no aria-labels at all.
Here are screenshots:
<img width="673" alt="Screenshot at Dec 19 16-46-04" src="https://user-images.githubusercontent.com/8719799/71184493-81620900-2282-11ea-8b62-9270d52fc8db.png">
<img width="761" alt="Screenshot at Dec 19 17-05-52" src="https://user-images.githubusercontent.com/8719799/71184509-8757ea00-2282-11ea-86a7-6395d5c88e93.png">

