### PR TITLE
fix(REPLAT-11399): fix bylines that were breaking out of container

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -177,6 +177,10 @@ exports[`full article with style 1`] = `
   order: 2;
 }
 
+.c11 {
+  width: 100%;
+}
+
 .c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -934,6 +938,10 @@ exports[`full article with style in the culture magazine 1`] = `
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
+}
+
+.c11 {
+  width: 100%;
 }
 
 .c10 {
@@ -1696,6 +1704,10 @@ exports[`full article with style in the style magazine 1`] = `
   order: 2;
 }
 
+.c11 {
+  width: 100%;
+}
+
 .c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2455,6 +2467,10 @@ exports[`full article with style in the sunday times magazine 1`] = `
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
+}
+
+.c11 {
+  width: 100%;
 }
 
 .c10 {

--- a/packages/article-in-depth/src/styles/responsive.web.js
+++ b/packages/article-in-depth/src/styles/responsive.web.js
@@ -57,6 +57,8 @@ export const LabelContainer = styled(View)`
 `;
 
 export const Meta = styled(View)`
+  width: 100%;
+
   @media (min-width: ${breakpoints.medium}px) {
     margin-top: 0;
   }

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -169,6 +169,10 @@ exports[`full article with style 1`] = `
   order: 2;
 }
 
+.c9 {
+  width: 100%;
+}
+
 .c8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -900,6 +904,10 @@ exports[`full article with style in the culture magazine 1`] = `
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
+}
+
+.c9 {
+  width: 100%;
 }
 
 .c8 {
@@ -1643,6 +1651,10 @@ exports[`full article with style in the style magazine 1`] = `
   order: 2;
 }
 
+.c9 {
+  width: 100%;
+}
+
 .c8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2383,6 +2395,10 @@ exports[`full article with style in the sunday times magazine 1`] = `
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
+}
+
+.c9 {
+  width: 100%;
 }
 
 .c8 {

--- a/packages/article-magazine-comment/src/styles/responsive.web.js
+++ b/packages/article-magazine-comment/src/styles/responsive.web.js
@@ -72,6 +72,8 @@ export const LabelContainer = styled(View)`
 `;
 
 export const Meta = styled(View)`
+  width: 100%;
+
   @media (min-width: ${breakpoints.medium}px) {
     margin-top: 0;
   }

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -162,6 +162,10 @@ exports[`full article with style 1`] = `
   order: 2;
 }
 
+.c8 {
+  width: 100%;
+}
+
 .c7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -838,6 +842,10 @@ exports[`full article with style in the culture magazine 1`] = `
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
+}
+
+.c8 {
+  width: 100%;
 }
 
 .c7 {
@@ -1526,6 +1534,10 @@ exports[`full article with style in the style magazine 1`] = `
   order: 2;
 }
 
+.c8 {
+  width: 100%;
+}
+
 .c7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2211,6 +2223,10 @@ exports[`full article with style in the sunday times magazine 1`] = `
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
+}
+
+.c8 {
+  width: 100%;
 }
 
 .c7 {

--- a/packages/article-magazine-standard/src/styles/responsive.web.js
+++ b/packages/article-magazine-standard/src/styles/responsive.web.js
@@ -59,6 +59,8 @@ export const LabelContainer = styled(View)`
 `;
 
 export const Meta = styled(View)`
+  width: 100%;
+
   @media (min-width: ${breakpoints.medium}px) {
     margin-top: 0;
   }

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -169,6 +169,10 @@ exports[`full article with style 1`] = `
   order: 2;
 }
 
+.c9 {
+  width: 100%;
+}
+
 .c8 {
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/packages/article-main-comment/src/styles/responsive.web.js
+++ b/packages/article-main-comment/src/styles/responsive.web.js
@@ -69,6 +69,8 @@ export const LabelContainer = styled(View)`
 `;
 
 export const Meta = styled(View)`
+  width: 100%;
+
   @media (min-width: ${breakpoints.medium}px) {
     margin-top: 0;
   }


### PR DESCRIPTION
- https://nidigitalsolutions.jira.com/browse/REPLAT-11399
- Fix bylines that were breaking out of container

## Before

<img width="1265" alt="Screenshot 2019-12-20 at 14 41 45" src="https://user-images.githubusercontent.com/1736782/71263399-b8472600-2339-11ea-862b-02d5ece3bb27.png">


## After

<img width="1452" alt="Screenshot 2019-12-20 at 14 41 30" src="https://user-images.githubusercontent.com/1736782/71263390-b41b0880-2339-11ea-94ac-e1f7b5b02426.png">