### PR TITLE
fix: REPLAT-11287 inline ad web styling

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -540,6 +540,7 @@ exports[`full article with style 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 
@@ -1300,6 +1301,7 @@ exports[`full article with style in the culture magazine 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 
@@ -2061,6 +2063,7 @@ exports[`full article with style in the style magazine 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 
@@ -2821,6 +2824,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -512,6 +512,7 @@ exports[`full article with style 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 
@@ -1253,6 +1254,7 @@ exports[`full article with style in the culture magazine 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 
@@ -1995,6 +1997,7 @@ exports[`full article with style in the style magazine 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 
@@ -2736,6 +2739,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -479,6 +479,7 @@ exports[`full article with style 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 
@@ -1165,6 +1166,7 @@ exports[`full article with style in the culture magazine 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 
@@ -1852,6 +1854,7 @@ exports[`full article with style in the style magazine 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 
@@ -2538,6 +2541,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -473,6 +473,7 @@ exports[`full article with style 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -515,6 +515,7 @@ exports[`full article with style 1`] = `
   padding-horizontal: 10px;
   padding-vertical: 10px;
   margin-top: 30px;
+  width: 100%;
 }
 </style>
 

--- a/packages/article-skeleton/src/styles/article-body/index.web.js
+++ b/packages/article-skeleton/src/styles/article-body/index.web.js
@@ -10,7 +10,8 @@ const webStyles = {
   ad: {
     ...sharedStyles.ad,
     marginBottom: spacing(6),
-    marginTop: spacing(6)
+    marginTop: spacing(6),
+    width: "100%"
   },
   articleTextElement: {
     ...sharedStyles.articleTextElement,


### PR DESCRIPTION
Inline Ad was miss aligned.

Before:
![image](https://user-images.githubusercontent.com/8720661/72082034-3890f380-3308-11ea-88c3-a35a3c35aa05.png)


After:
![image](https://user-images.githubusercontent.com/8720661/72082062-45154c00-3308-11ea-9dfd-956a9ab39bf1.png)
