### PR TITLE
Remove react dependencies from Podspec file (no longer required)

### DIFF
--- a/TimesComponents.podspec
+++ b/TimesComponents.podspec
@@ -64,39 +64,4 @@ Pod::Spec.new do |s|
     'TimesComponents' => ['assets/js/index.ios.bundle', 'assets/res/*']
   }
   
-  # React, and the subspecs we have to use
-  s.dependency 'React/Core', react_native_version
-  s.dependency 'React/CxxBridge', react_native_version
-  s.dependency 'React/RCTAnimation', react_native_version
-  s.dependency 'React/RCTCameraRoll', react_native_version
-  s.dependency 'React/RCTImage', react_native_version
-  s.dependency 'React/RCTLinkingIOS', react_native_version
-  s.dependency 'React/RCTNetwork', react_native_version
-  s.dependency 'React/RCTText', react_native_version
-  s.dependency 'React/RCTGeolocation', react_native_version
-  s.dependency 'React/RCTActionSheet', react_native_version
-  s.dependency 'React/RCTWebSocket', react_native_version
-  s.dependency 'React/DevSupport', react_native_version
-  s.dependency 'React/ART', react_native_version
-
-  # React's Dependencies
-  react_podspecs = [
-    'node_modules/react-native/ReactCommon/yoga/yoga.podspec',
-    'node_modules/react-native/third-party-podspecs/DoubleConversion.podspec',
-    'node_modules/react-native/third-party-podspecs/Folly.podspec',
-    'node_modules/react-native/third-party-podspecs/glog.podspec'
-  ]
-
-  # Native dependencies if any, which come from node_modules
-  dep_podspecs = [
-    'node_modules/react-native-webview/react-native-webview.podspec'
-  ]
-
-  # Ties the exact versions so host apps don't need to guess the version
-  # or have a potential mismatch
-  podspecs = react_podspecs + dep_podspecs
-  podspecs.each do |podspec_path|
-    spec = Pod::Specification.from_file podspec_path
-    s.dependency spec.name, "#{spec.version}"
-  end
 end

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -67,7 +67,7 @@
     "@times-components/gradient": "3.2.17",
     "@times-components/link": "3.6.1",
     "@times-components/responsive": "0.5.21",
-    "@times-components/responsive-image": "0.4.4",
+    "@times-components/responsive-image": "0.4.3",
     "@times-components/styleguide": "3.33.14",
     "@times-components/svgs": "2.7.28",
     "@times-components/utils": "6.0.1",

--- a/packages/responsive-image/package.json
+++ b/packages/responsive-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@times-components/responsive-image",
-  "version": "0.4.4",
+  "version": "0.4.3",
   "description": "A responsive-image for react native",
   "main": "src/index.tsx",
   "typings": "build/index.d.ts",


### PR DESCRIPTION
See: https://nidigitalsolutions.jira.com/browse/REPLAT-11696

We were unable to update Times Components on the iOS app via the normal process (described [here](https://github.com/newsuk/nu-digital-projectd-times-smartphone-ios/blob/develop/README.md)) because this `podspec` file was incorrect.

We need to remove the dependencies from this podspec file (they are no longer required) so that the Times Components library can be installed successfully on iOS.

