### PR TITLE
fix: section slice keys were entirely based on index

### DIFF
--- a/packages/section/src/utils.js
+++ b/packages/section/src/utils.js
@@ -39,10 +39,16 @@ const buildSliceData = memoizeOne(data =>
     }
 
     const currentSlice = newSlices[idx];
+    let generatedId = currentSlice.id;
+    Object.keys(currentSlice).forEach(key => {
+      if (currentSlice[key].article) {
+        generatedId += currentSlice[key].article.id;
+      }
+    });
 
     newSlices[idx] = {
       ...currentSlice,
-      elementId: `${currentSlice.id}.${idx}`
+      elementId: `${generatedId}.${idx}`
     };
 
     return newSlices;


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Not all slices have an id property, resulting in slices having the key 'undefined.0', 'undefined.1' etc. This means that when the slices are rendered after an update while the app is open and they are in the same position but with different articles the update does not work properly. This commit just generates a key that is unique per index and child article content so that updates work properly.
