### PR TITLE
fix: REPLAT-8723 load offline images from react cache before tarball

### DIFF
--- a/packages/responsive-image/src/index.tsx
+++ b/packages/responsive-image/src/index.tsx
@@ -113,7 +113,8 @@ const ResponsiveImage = (props: ResponsiveImageProps) => {
   React.useEffect(
     () => {
       if ('queryCache' in Image && width && !checkedCache) {
-        const cache = Image.queryCache && Image.queryCache([onlineUrl]);
+        const cache =
+          Image.queryCache && Image.queryCache([onlineUrl, offlineUrl]);
         setCheckedCache(true);
         if (!cache) {
           return;
@@ -124,6 +125,10 @@ const ResponsiveImage = (props: ResponsiveImageProps) => {
             setShowOffline(false);
             setShowPlaceholder(false);
             return;
+          }
+          if (offlineUrl in results) {
+            setShowOffline(true);
+            setShowPlaceholder(false);
           }
         });
       }


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Attempt to get offline image as well as online from the react cache before trying the normal placeholder->tarball->online sequence.