### PR TITLE
fix: REPLAT-11059 adding article-marketing-header in article skeleton web

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -545,6 +545,7 @@ exports[`full article with style 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>
@@ -1306,6 +1307,7 @@ exports[`full article with style in the culture magazine 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>
@@ -2068,6 +2070,7 @@ exports[`full article with style in the style magazine 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>
@@ -2829,6 +2832,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>

--- a/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -6,6 +6,9 @@ exports[`2. loading 1`] = `null`;
 
 exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -264,6 +267,9 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 
 exports[`4. an article with ads 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -517,6 +517,7 @@ exports[`full article with style 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>
@@ -1259,6 +1260,7 @@ exports[`full article with style in the culture magazine 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>
@@ -2002,6 +2004,7 @@ exports[`full article with style in the style magazine 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>
@@ -2744,6 +2747,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -6,6 +6,9 @@ exports[`2. loading 1`] = `null`;
 
 exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -258,6 +261,9 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 
 exports[`4. an article with ads 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -510,6 +516,9 @@ exports[`4. an article with ads 1`] = `
 
 exports[`7. an article with no author 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -484,6 +484,7 @@ exports[`full article with style 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>
@@ -1171,6 +1172,7 @@ exports[`full article with style in the culture magazine 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>
@@ -1859,6 +1861,7 @@ exports[`full article with style in the style magazine 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>
@@ -2546,6 +2549,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -6,6 +6,9 @@ exports[`2. loading 1`] = `null`;
 
 exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -252,6 +255,9 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 
 exports[`4. an article with ads 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -478,6 +478,7 @@ exports[`full article with style 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Helmet>
       <title>

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -6,6 +6,9 @@ exports[`2. loading 1`] = `null`;
 
 exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -244,6 +247,9 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
 
 exports[`4. an article with ads 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -523,6 +523,7 @@ exports[`full article with style 1`] = `
   className="c0 responsiveweb__ArticleMainStandardContainer-sc-1gngn7q-4 c0 css-view-1dbjc4n"
 >
   <div>
+    <div />
     <article>
       <Helmet>
         <title>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -3,6 +3,9 @@
 exports[`1. an article 1`] = `
 <div>
   <div>
+    <div
+      id="article-marketing-header"
+    />
     <article
       data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
       data-article-sectionname="Some Section"
@@ -310,6 +313,9 @@ exports[`3. an error 1`] = `null`;
 exports[`4. an article with no headline falls back to use shortheadline 1`] = `
 <div>
   <div>
+    <div
+      id="article-marketing-header"
+    />
     <article
       data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
       data-article-sectionname="Some Section"
@@ -459,6 +465,9 @@ exports[`4. an article with no headline falls back to use shortheadline 1`] = `
 exports[`5. an article with ads 1`] = `
 <div>
   <div>
+    <div
+      id="article-marketing-header"
+    />
     <article
       data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
       data-article-sectionname="Some Section"
@@ -608,6 +617,9 @@ exports[`5. an article with ads 1`] = `
 exports[`6. should show topics when logged in or shared 1`] = `
 <div>
   <div>
+    <div
+      id="article-marketing-header"
+    />
     <article
       data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
       data-article-sectionname="Some Section"
@@ -945,6 +957,9 @@ exports[`6. should show topics when logged in or shared 1`] = `
 exports[`7. an article with no byline 1`] = `
 <div>
   <div>
+    <div
+      id="article-marketing-header"
+    />
     <article
       data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
       data-article-sectionname="Some Section"
@@ -1200,6 +1215,9 @@ exports[`7. an article with no byline 1`] = `
 exports[`8. an article with no label 1`] = `
 <div>
   <div>
+    <div
+      id="article-marketing-header"
+    />
     <article
       data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
       data-article-sectionname="Some Section"

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
@@ -132,6 +132,7 @@ exports[`1. a primary image 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Head />
     <div
@@ -299,6 +300,7 @@ exports[`2. a fullwidth image 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Head />
     <div
@@ -490,6 +492,7 @@ exports[`3. a secondary image 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Head />
     <div
@@ -682,6 +685,7 @@ exports[`4. an inline image 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Head />
     <div

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
@@ -2,6 +2,9 @@
 
 exports[`1. a primary image 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -93,6 +96,9 @@ exports[`1. a primary image 1`] = `
 
 exports[`2. a fullwidth image 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -184,6 +190,9 @@ exports[`2. a fullwidth image 1`] = `
 
 exports[`3. a secondary image 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -275,6 +284,9 @@ exports[`3. a secondary image 1`] = `
 
 exports[`4. an inline image 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -340,6 +340,7 @@ exports[`full article with style 1`] = `
 </style>
 
 <div>
+  <div />
   <article>
     <Head />
     <div

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-user-state.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-user-state.web.test.js.snap
@@ -2,6 +2,9 @@
 
 exports[`Article with user state Render full article when user has access to full article 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -347,6 +350,9 @@ exports[`Article with user state Render full article when user has access to ful
 
 exports[`Article with user state Render teaser article when user does not have access to full article 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -2,6 +2,9 @@
 
 exports[`1. a full article with all content items with dropcap template 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -373,6 +376,9 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
 
 exports[`2. an article with interactives 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -514,6 +520,9 @@ exports[`2. an article with interactives 1`] = `
 
 exports[`3. an article with no content 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -633,6 +642,9 @@ exports[`3. an article with no content 1`] = `
 
 exports[`4. an article with no content if content is set as null 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
@@ -752,6 +764,9 @@ exports[`4. an article with no content if content is set as null 1`] = `
 
 exports[`5. an article with a nested markup in first paragraph displays a drop cap 1`] = `
 <div>
+  <div
+    id="article-marketing-header"
+  />
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -85,6 +85,7 @@ class ArticleSkeleton extends Component {
 
     return (
       <StickyProvider>
+        <div id="article-marketing-header" />
         <article
           id="article-main"
           data-article-identifier={article.id}


### PR DESCRIPTION
[Jira.](https://nidigitalsolutions.jira.com/browse/REPLAT-11059)
The sticky bar position wasn't calculated right when the article is shared.
The reason is that the marketing header above the article is outside the react context. 
Please check the screenshots to understand the issue.

After the PR is merged. [We should delete the container in render repo.](https://github.com/newsuk/cps-content-render/pull/3214)

**Before:**

![image](https://user-images.githubusercontent.com/8720661/72332416-ac454e80-36c2-11ea-83b9-e1120d13354c.png)

![image](https://user-images.githubusercontent.com/8720661/72332316-7d2edd00-36c2-11ea-8d4e-d992700375be.png)

![image](https://user-images.githubusercontent.com/8720661/72332362-96d02480-36c2-11ea-84b3-c9644692d676.png)


**After:**

![image](https://user-images.githubusercontent.com/8720661/72332335-8cae2600-36c2-11ea-8a6c-522f50c7fe61.png)



**This screenshot is a verification that the layout is unchanged:**
![marketing-header-unchanged](https://user-images.githubusercontent.com/8720661/72332130-25907180-36c2-11ea-8cc8-cc5240f8f727.png)
