### PR TITLE
fix: (REPLAT-11799) add a lower bound for images on web

### DIFF
--- a/packages/utils/src/screen.base.js
+++ b/packages/utils/src/screen.base.js
@@ -2,6 +2,7 @@ import { Dimensions } from "react-native";
 import { tabletWidth } from "@times-components/styleguide";
 
 export const acceptedWidths = [
+  160,
   320,
   440,
   660,


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
On mobile we want to display smaller images, the lower bound of 320 means that on a retina display the lower bound is actually 640 which hurts our mobile score.