### PR TITLE
fix: update v8 for linking issues

### DIFF
--- a/android-app/package.json
+++ b/android-app/package.json
@@ -21,7 +21,7 @@
     "react-native-v8": "0.61.1-patch.3",
     "react-native-webview": "7.0.5",
     "url-polyfill": "1.1.0",
-    "v8-android": "7.5.1"
+    "v8-android": "7.8.2"
   },
   "devDependencies": {
     "@bam.tech/react-native-graphql-transformer": "0.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21712,10 +21712,10 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
-v8-android@7.5.1:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/v8-android/-/v8-android-7.5.1.tgz#490288785381826d6c96323cecfb3fdbf2200424"
-  integrity sha512-FFte/j4T8UtrEd6IB8hGFZS40+kTvgoSa/+krCTBbRPij18mez2CPGyfOa+sJdCSxuXGEj7g7pzOBdtqgzdqow==
+v8-android@7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/v8-android/-/v8-android-7.8.2.tgz#cab9196d2afad6b931630dcfa8ab3609ca18864e"
+  integrity sha512-LZLtehBxj4rLgf3+gWs3ITTmnVvlD3KQubLzFmtdI+l3G9tbi8ckWm6tJv7KQXZu3L/ok5M2bZz1AGnofPiMfQ==
 
 "v8-android@7.8.x >= 7.8.1":
   version "7.8.1"


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
The maintainer of react-native-v8 has published new versions that require a renamed lib for linking, he did not republish the v8 version so we need to roll forward or risk crashes on new builds.