### PR TITLE
fix: REPLAT-11812 caption appearing over images

### DIFF
--- a/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
@@ -14,14 +14,6 @@ exports[`1. landscape default modal 1`] = `
         }
       }
     >
-      <SafeAreaView
-        style={
-          Object {
-            "backgroundColor": "#000000",
-            "flex": 0,
-          }
-        }
-      />
       <View
         style={
           Object {
@@ -54,22 +46,52 @@ exports[`1. landscape default modal 1`] = `
           />
         </View>
       </View>
-      <SafeAreaView
+      <ImageZoomView />
+      <View
         style={
           Object {
+            "backgroundColor": "#000000B3",
             "bottom": 0,
-            "height": "100%",
-            "left": 0,
+            "flex": 0,
+            "marginTop": "auto",
             "position": "absolute",
-            "right": 0,
-            "top": 0,
             "width": "100%",
-            "zIndex": 1,
+            "zIndex": 2,
           }
         }
       >
-        <ImageZoomView />
-      </SafeAreaView>
+        <View
+          style={
+            Object {
+              "margin": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 15,
+                "lineHeight": 15,
+              }
+            }
+          >
+            Caption
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 10,
+                "lineHeight": 10,
+                "marginTop": 5,
+              }
+            }
+          >
+            Credits
+          </Text>
+        </View>
+      </View>
     </View>
   </Modal>
   <View>
@@ -118,14 +140,6 @@ exports[`2. portrait default modal 1`] = `
         }
       }
     >
-      <SafeAreaView
-        style={
-          Object {
-            "backgroundColor": "#000000",
-            "flex": 0,
-          }
-        }
-      />
       <View
         style={
           Object {
@@ -158,22 +172,52 @@ exports[`2. portrait default modal 1`] = `
           />
         </View>
       </View>
-      <SafeAreaView
+      <ImageZoomView />
+      <View
         style={
           Object {
+            "backgroundColor": "#000000B3",
             "bottom": 0,
-            "height": "100%",
-            "left": 0,
+            "flex": 0,
+            "marginTop": "auto",
             "position": "absolute",
-            "right": 0,
-            "top": 0,
             "width": "100%",
-            "zIndex": 1,
+            "zIndex": 2,
           }
         }
       >
-        <ImageZoomView />
-      </SafeAreaView>
+        <View
+          style={
+            Object {
+              "margin": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 15,
+                "lineHeight": 15,
+              }
+            }
+          >
+            Caption
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 10,
+                "lineHeight": 10,
+                "marginTop": 5,
+              }
+            }
+          >
+            Credits
+          </Text>
+        </View>
+      </View>
     </View>
   </Modal>
   <View>
@@ -222,14 +266,6 @@ exports[`3. tablet landscape default modal 1`] = `
         }
       }
     >
-      <SafeAreaView
-        style={
-          Object {
-            "backgroundColor": "#000000",
-            "flex": 0,
-          }
-        }
-      />
       <View
         style={
           Object {
@@ -262,22 +298,52 @@ exports[`3. tablet landscape default modal 1`] = `
           />
         </View>
       </View>
-      <SafeAreaView
+      <ImageZoomView />
+      <View
         style={
           Object {
+            "backgroundColor": "#000000B3",
             "bottom": 0,
-            "height": "100%",
-            "left": 0,
+            "flex": 0,
+            "marginTop": "auto",
             "position": "absolute",
-            "right": 0,
-            "top": 0,
             "width": "100%",
-            "zIndex": 1,
+            "zIndex": 2,
           }
         }
       >
-        <ImageZoomView />
-      </SafeAreaView>
+        <View
+          style={
+            Object {
+              "margin": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 15,
+                "lineHeight": 15,
+              }
+            }
+          >
+            Caption
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 10,
+                "lineHeight": 10,
+                "marginTop": 5,
+              }
+            }
+          >
+            Credits
+          </Text>
+        </View>
+      </View>
     </View>
   </Modal>
   <View>
@@ -326,14 +392,6 @@ exports[`4. tablet portrait default modal 1`] = `
         }
       }
     >
-      <SafeAreaView
-        style={
-          Object {
-            "backgroundColor": "#000000",
-            "flex": 0,
-          }
-        }
-      />
       <View
         style={
           Object {
@@ -366,22 +424,52 @@ exports[`4. tablet portrait default modal 1`] = `
           />
         </View>
       </View>
-      <SafeAreaView
+      <ImageZoomView />
+      <View
         style={
           Object {
+            "backgroundColor": "#000000B3",
             "bottom": 0,
-            "height": "100%",
-            "left": 0,
+            "flex": 0,
+            "marginTop": "auto",
             "position": "absolute",
-            "right": 0,
-            "top": 0,
             "width": "100%",
-            "zIndex": 1,
+            "zIndex": 2,
           }
         }
       >
-        <ImageZoomView />
-      </SafeAreaView>
+        <View
+          style={
+            Object {
+              "margin": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 15,
+                "lineHeight": 15,
+              }
+            }
+          >
+            Caption
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 10,
+                "lineHeight": 10,
+                "marginTop": 5,
+              }
+            }
+          >
+            Credits
+          </Text>
+        </View>
+      </View>
     </View>
   </Modal>
   <View>

--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -15,9 +15,6 @@ exports[`1. modal image 1`] = `
     visible={false}
   >
     <View>
-      <View
-        pointerEvents="box-none"
-      />
       <View>
         <View
           focusable={true}
@@ -32,18 +29,26 @@ exports[`1. modal image 1`] = `
           />
         </View>
       </View>
+      <ImageZoomView
+        captureEvent={true}
+        enablePreload={true}
+        enableSwipeDown={true}
+        imageUrls={
+          Array [
+            Object {
+              "url": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0",
+            },
+          ]
+        }
+      />
       <View
-        pointerEvents="box-none"
+        pointerEvents="none"
       >
-        <ImageZoomView
-          imageUrls={
-            Array [
-              Object {
-                "url": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0",
-              },
-            ]
-          }
-        />
+        <View>
+          <Text>
+            Caption
+          </Text>
+        </View>
       </View>
     </View>
   </Modal>
@@ -80,9 +85,6 @@ exports[`2. modal image with no caption 1`] = `
     visible={false}
   >
     <View>
-      <View
-        pointerEvents="box-none"
-      />
       <View>
         <View
           focusable={true}
@@ -97,19 +99,21 @@ exports[`2. modal image with no caption 1`] = `
           />
         </View>
       </View>
+      <ImageZoomView
+        captureEvent={true}
+        enablePreload={true}
+        enableSwipeDown={true}
+        imageUrls={
+          Array [
+            Object {
+              "url": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0",
+            },
+          ]
+        }
+      />
       <View
-        pointerEvents="box-none"
-      >
-        <ImageZoomView
-          imageUrls={
-            Array [
-              Object {
-                "url": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0",
-              },
-            ]
-          }
-        />
-      </View>
+        pointerEvents="none"
+      />
     </View>
   </Modal>
   <View
@@ -146,9 +150,6 @@ exports[`3. modal image with custom highressize 1`] = `
     visible={false}
   >
     <View>
-      <View
-        pointerEvents="box-none"
-      />
       <View>
         <View
           focusable={true}
@@ -163,18 +164,26 @@ exports[`3. modal image with custom highressize 1`] = `
           />
         </View>
       </View>
+      <ImageZoomView
+        captureEvent={true}
+        enablePreload={true}
+        enableSwipeDown={true}
+        imageUrls={
+          Array [
+            Object {
+              "url": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0",
+            },
+          ]
+        }
+      />
       <View
-        pointerEvents="box-none"
+        pointerEvents="none"
       >
-        <ImageZoomView
-          imageUrls={
-            Array [
-              Object {
-                "url": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0",
-              },
-            ]
-          }
-        />
+        <View>
+          <Text>
+            Caption
+          </Text>
+        </View>
       </View>
     </View>
   </Modal>

--- a/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
@@ -14,14 +14,6 @@ exports[`1. landscape default modal 1`] = `
         }
       }
     >
-      <SafeAreaView
-        style={
-          Object {
-            "backgroundColor": "#000000",
-            "flex": 0,
-          }
-        }
-      />
       <View
         style={
           Object {
@@ -55,22 +47,55 @@ exports[`1. landscape default modal 1`] = `
           />
         </View>
       </View>
-      <SafeAreaView
+      <ImageZoomView />
+      <OverlayGradient
         style={
           Object {
             "bottom": 0,
-            "height": "100%",
-            "left": 0,
+            "flex": 0,
+            "height": 140,
+            "justifyContent": "flex-end",
+            "marginTop": "auto",
             "position": "absolute",
-            "right": 0,
-            "top": 0,
             "width": "100%",
-            "zIndex": 1,
+            "zIndex": 2,
           }
         }
       >
-        <ImageZoomView />
-      </SafeAreaView>
+        <SafeAreaView>
+          <View
+            style={
+              Object {
+                "margin": 20,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 15,
+                  "lineHeight": 15,
+                }
+              }
+            >
+              Caption
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 10,
+                  "lineHeight": 10,
+                  "marginTop": 5,
+                }
+              }
+            >
+              Credits
+            </Text>
+          </View>
+        </SafeAreaView>
+      </OverlayGradient>
     </View>
   </Modal>
   <View
@@ -125,14 +150,6 @@ exports[`2. portrait default modal 1`] = `
         }
       }
     >
-      <SafeAreaView
-        style={
-          Object {
-            "backgroundColor": "#000000",
-            "flex": 0,
-          }
-        }
-      />
       <View
         style={
           Object {
@@ -166,22 +183,55 @@ exports[`2. portrait default modal 1`] = `
           />
         </View>
       </View>
-      <SafeAreaView
+      <ImageZoomView />
+      <OverlayGradient
         style={
           Object {
             "bottom": 0,
-            "height": "100%",
-            "left": 0,
+            "flex": 0,
+            "height": 140,
+            "justifyContent": "flex-end",
+            "marginTop": "auto",
             "position": "absolute",
-            "right": 0,
-            "top": 0,
             "width": "100%",
-            "zIndex": 1,
+            "zIndex": 2,
           }
         }
       >
-        <ImageZoomView />
-      </SafeAreaView>
+        <SafeAreaView>
+          <View
+            style={
+              Object {
+                "margin": 20,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 15,
+                  "lineHeight": 15,
+                }
+              }
+            >
+              Caption
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 10,
+                  "lineHeight": 10,
+                  "marginTop": 5,
+                }
+              }
+            >
+              Credits
+            </Text>
+          </View>
+        </SafeAreaView>
+      </OverlayGradient>
     </View>
   </Modal>
   <View
@@ -236,14 +286,6 @@ exports[`3. tablet landscape default modal 1`] = `
         }
       }
     >
-      <SafeAreaView
-        style={
-          Object {
-            "backgroundColor": "#000000",
-            "flex": 0,
-          }
-        }
-      />
       <View
         style={
           Object {
@@ -277,22 +319,55 @@ exports[`3. tablet landscape default modal 1`] = `
           />
         </View>
       </View>
-      <SafeAreaView
+      <ImageZoomView />
+      <OverlayGradient
         style={
           Object {
             "bottom": 0,
-            "height": "100%",
-            "left": 0,
+            "flex": 0,
+            "height": 140,
+            "justifyContent": "flex-end",
+            "marginTop": "auto",
             "position": "absolute",
-            "right": 0,
-            "top": 0,
             "width": "100%",
-            "zIndex": 1,
+            "zIndex": 2,
           }
         }
       >
-        <ImageZoomView />
-      </SafeAreaView>
+        <SafeAreaView>
+          <View
+            style={
+              Object {
+                "margin": 20,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 15,
+                  "lineHeight": 15,
+                }
+              }
+            >
+              Caption
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 10,
+                  "lineHeight": 10,
+                  "marginTop": 5,
+                }
+              }
+            >
+              Credits
+            </Text>
+          </View>
+        </SafeAreaView>
+      </OverlayGradient>
     </View>
   </Modal>
   <View
@@ -347,14 +422,6 @@ exports[`4. tablet portrait default modal 1`] = `
         }
       }
     >
-      <SafeAreaView
-        style={
-          Object {
-            "backgroundColor": "#000000",
-            "flex": 0,
-          }
-        }
-      />
       <View
         style={
           Object {
@@ -388,22 +455,55 @@ exports[`4. tablet portrait default modal 1`] = `
           />
         </View>
       </View>
-      <SafeAreaView
+      <ImageZoomView />
+      <OverlayGradient
         style={
           Object {
             "bottom": 0,
-            "height": "100%",
-            "left": 0,
+            "flex": 0,
+            "height": 140,
+            "justifyContent": "flex-end",
+            "marginTop": "auto",
             "position": "absolute",
-            "right": 0,
-            "top": 0,
             "width": "100%",
-            "zIndex": 1,
+            "zIndex": 2,
           }
         }
       >
-        <ImageZoomView />
-      </SafeAreaView>
+        <SafeAreaView>
+          <View
+            style={
+              Object {
+                "margin": 20,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 15,
+                  "lineHeight": 15,
+                }
+              }
+            >
+              Caption
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 10,
+                  "lineHeight": 10,
+                  "marginTop": 5,
+                }
+              }
+            >
+              Credits
+            </Text>
+          </View>
+        </SafeAreaView>
+      </OverlayGradient>
     </View>
   </Modal>
   <View

--- a/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
@@ -15,9 +15,6 @@ exports[`1. modal image 1`] = `
     visible={false}
   >
     <View>
-      <View
-        pointerEvents="box-none"
-      />
       <View>
         <View
           focusable={true}
@@ -32,18 +29,83 @@ exports[`1. modal image 1`] = `
           />
         </View>
       </View>
-      <View
-        pointerEvents="box-none"
-      >
-        <ImageZoomView
-          imageUrls={
-            Array [
-              Object {
-                "url": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0",
-              },
-            ]
-          }
-        />
+      <ImageZoomView
+        captureEvent={true}
+        enablePreload={true}
+        enableSwipeDown={true}
+        imageUrls={
+          Array [
+            Object {
+              "url": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0",
+            },
+          ]
+        }
+      />
+      <View>
+        <ARTSurfaceView>
+          <ARTShape
+            d={
+              Array [
+                2,
+                750,
+                0,
+                2,
+                750,
+                140,
+                2,
+                0,
+                140,
+                2,
+                0,
+                0,
+              ]
+            }
+            fill={
+              Array [
+                1,
+                750,
+                140,
+                749.9999999999999,
+                -3.108624468950438e-14,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0.9019607843137255,
+                1,
+                0.35714285714285715,
+              ]
+            }
+            opacity={1}
+            stroke={null}
+            strokeCap={1}
+            strokeDash={null}
+            strokeJoin={1}
+            strokeWidth={1}
+            transform={
+              Array [
+                1,
+                0,
+                0,
+                1,
+                0,
+                0,
+              ]
+            }
+          />
+        </ARTSurfaceView>
+        <View
+          pointerEvents="box-none"
+        >
+          <View>
+            <Text>
+              Caption
+            </Text>
+          </View>
+        </View>
       </View>
     </View>
   </Modal>
@@ -80,9 +142,6 @@ exports[`2. modal image with no caption 1`] = `
     visible={false}
   >
     <View>
-      <View
-        pointerEvents="box-none"
-      />
       <View>
         <View
           focusable={true}
@@ -97,17 +156,76 @@ exports[`2. modal image with no caption 1`] = `
           />
         </View>
       </View>
-      <View
-        pointerEvents="box-none"
-      >
-        <ImageZoomView
-          imageUrls={
-            Array [
-              Object {
-                "url": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0",
-              },
-            ]
-          }
+      <ImageZoomView
+        captureEvent={true}
+        enablePreload={true}
+        enableSwipeDown={true}
+        imageUrls={
+          Array [
+            Object {
+              "url": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0",
+            },
+          ]
+        }
+      />
+      <View>
+        <ARTSurfaceView>
+          <ARTShape
+            d={
+              Array [
+                2,
+                750,
+                0,
+                2,
+                750,
+                140,
+                2,
+                0,
+                140,
+                2,
+                0,
+                0,
+              ]
+            }
+            fill={
+              Array [
+                1,
+                750,
+                140,
+                749.9999999999999,
+                -3.108624468950438e-14,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0.9019607843137255,
+                1,
+                0.35714285714285715,
+              ]
+            }
+            opacity={1}
+            stroke={null}
+            strokeCap={1}
+            strokeDash={null}
+            strokeJoin={1}
+            strokeWidth={1}
+            transform={
+              Array [
+                1,
+                0,
+                0,
+                1,
+                0,
+                0,
+              ]
+            }
+          />
+        </ARTSurfaceView>
+        <View
+          pointerEvents="box-none"
         />
       </View>
     </View>
@@ -146,9 +264,6 @@ exports[`3. modal image with custom highressize 1`] = `
     visible={false}
   >
     <View>
-      <View
-        pointerEvents="box-none"
-      />
       <View>
         <View
           focusable={true}
@@ -163,18 +278,83 @@ exports[`3. modal image with custom highressize 1`] = `
           />
         </View>
       </View>
-      <View
-        pointerEvents="box-none"
-      >
-        <ImageZoomView
-          imageUrls={
-            Array [
-              Object {
-                "url": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0",
-              },
-            ]
-          }
-        />
+      <ImageZoomView
+        captureEvent={true}
+        enablePreload={true}
+        enableSwipeDown={true}
+        imageUrls={
+          Array [
+            Object {
+              "url": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0",
+            },
+          ]
+        }
+      />
+      <View>
+        <ARTSurfaceView>
+          <ARTShape
+            d={
+              Array [
+                2,
+                750,
+                0,
+                2,
+                750,
+                140,
+                2,
+                0,
+                140,
+                2,
+                0,
+                0,
+              ]
+            }
+            fill={
+              Array [
+                1,
+                750,
+                140,
+                749.9999999999999,
+                -3.108624468950438e-14,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0.9019607843137255,
+                1,
+                0.35714285714285715,
+              ]
+            }
+            opacity={1}
+            stroke={null}
+            strokeCap={1}
+            strokeDash={null}
+            strokeJoin={1}
+            strokeWidth={1}
+            transform={
+              Array [
+                1,
+                0,
+                0,
+                1,
+                0,
+                0,
+              ]
+            }
+          />
+        </ARTSurfaceView>
+        <View
+          pointerEvents="box-none"
+        >
+          <View>
+            <Text>
+              Caption
+            </Text>
+          </View>
+        </View>
       </View>
     </View>
   </Modal>

--- a/packages/image/__tests__/modal-shared.native.js
+++ b/packages/image/__tests__/modal-shared.native.js
@@ -33,7 +33,10 @@ export default () => {
       minimaliseTransform(
         (value, key) => key === "style" || key === "nativeBackgroundAndroid"
       ),
-      replacePropTransform((value, key) => (key === "d" ? hash(value) : value))
+      replacePropTransform(
+        (value, key) =>
+          key === "d" && typeof d === "string" ? hash(value) : value
+      )
     )
   );
 

--- a/packages/image/src/modal-image/modal-image.js
+++ b/packages/image/src/modal-image/modal-image.js
@@ -5,7 +5,6 @@ import Button from "@times-components/link";
 import ImageViewer from "react-native-image-zoom-viewer";
 import CloseButton from "../close-button";
 import ModalCaptionContainer from "../modal-caption-container";
-import SafeAreaView from "../safeAreaView";
 import Image from "../image";
 import { modalPropTypes, modalDefaultProps } from "./modal-image-prop-types";
 import styles, { captionStyles, tabletCaptionStyles } from "../styles";
@@ -85,14 +84,6 @@ class ModalImage extends Component {
             <ResponsiveContext.Consumer>
               {({ isTablet, screenWidth }) => (
                 <Fragment>
-                  <SafeAreaView
-                    forceInset={{
-                      bottom: "never",
-                      horizontal: "always",
-                      top: "always"
-                    }}
-                    style={styles.topSafeView}
-                  />
                   <View
                     style={[
                       styles.buttonContainer,
@@ -106,32 +97,32 @@ class ModalImage extends Component {
                       />
                     ) : null}
                   </View>
-                  <SafeAreaView
-                    forceInset={{ horizontal: "always", vertical: "always" }}
-                    style={styles.middleSafeView}
-                  >
-                    <ImageViewer
-                      imageUrls={urls}
-                      renderImage={({ source }) => [
-                        <Image
-                          {...this.props}
-                          uri={source.uri}
-                          highResSize={screenWidth}
-                          lowResSize={lowResSize}
-                          resizeMode="contain"
-                          style={styles.modalImageContainer}
-                        />,
-                        elementsVisible ? (
-                          <ModalCaptionContainer
-                            pointerEvents="none"
-                            style={styles.bottomSafeView}
-                          >
-                            {this.renderCaption({ isTablet })}
-                          </ModalCaptionContainer>
-                        ) : null
-                      ]}
-                    />
-                  </SafeAreaView>
+                  <ImageViewer
+                    imageUrls={urls}
+                    renderIndicator={() => null}
+                    enableSwipeDown
+                    captureEvent
+                    onSwipeDown={this.hideModal}
+                    enablePreload
+                    renderImage={({ source }) => [
+                      <Image
+                        {...this.props}
+                        uri={source.uri}
+                        highResSize={screenWidth}
+                        lowResSize={lowResSize}
+                        resizeMode="contain"
+                        style={styles.modalImageContainer}
+                      />
+                    ]}
+                  />
+                  {elementsVisible ? (
+                    <ModalCaptionContainer
+                      pointerEvents="none"
+                      style={styles.bottomSafeView}
+                    >
+                      {this.renderCaption({ isTablet })}
+                    </ModalCaptionContainer>
+                  ) : null}
                 </Fragment>
               )}
             </ResponsiveContext.Consumer>

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -7,8 +7,9 @@ const styles = {
   bottomSafeView: {
     flex: 0,
     marginTop: "auto",
-    position: "relative",
+    position: "absolute",
     width: "100%",
+    bottom: 0,
     zIndex: 2
   },
   buttonContainer: {


### PR DESCRIPTION
Before, captions were over the top of the image, this moves them to the bottom of the modal as per the designs and turns on preloading as people complained about load time in image modals. It also enabled the swipe down to close gesture so that it works the same on iOS and Android.

https://nidigitalsolutions.jira.com/browse/REPLAT-11812
![Screenshot_1579280060](https://user-images.githubusercontent.com/615608/72630851-22f47d00-394b-11ea-9b2a-757d54525848.png)
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
