### PR TITLE
fix: prevent default for copy and email buttons

### DIFF
--- a/packages/save-and-share-bar/__tests__/shared-tracking.js
+++ b/packages/save-and-share-bar/__tests__/shared-tracking.js
@@ -6,6 +6,10 @@ import "./mocks";
 import BarItem from "../src/bar-item";
 import SaveAndShareBar from "../src/save-and-share-bar";
 
+const mockEvent = {
+  preventDefault: () => {}
+};
+
 class WithTrackingContext extends Component {
   getChildContext() {
     const { analyticsStream } = this.props;
@@ -106,7 +110,7 @@ export default () => {
       const copyToClipboardBarItem = testInstance.root.findAllByType(
         BarItem
       )[3];
-      copyToClipboardBarItem.props.onPress();
+      copyToClipboardBarItem.props.onPress(mockEvent);
 
       const call = stream.mock.calls[0][0];
 
@@ -118,7 +122,7 @@ export default () => {
       const shareArticleUrlByEmailBarItem = testInstance.root.findAllByType(
         BarItem
       )[0];
-      await shareArticleUrlByEmailBarItem.props.onPress();
+      await shareArticleUrlByEmailBarItem.props.onPress(mockEvent);
 
       const call = stream.mock.calls[0][0];
 

--- a/packages/save-and-share-bar/__tests__/shared.base.js
+++ b/packages/save-and-share-bar/__tests__/shared.base.js
@@ -8,6 +8,10 @@ import BarItem from "../src/bar-item";
 import SaveAndShareBar from "../src/save-and-share-bar";
 import EmailShare from "../src/email-share";
 
+const mockEvent = {
+  preventDefault: () => {}
+};
+
 export default () => {
   describe("save and share bar component", () => {
     const onCopyLink = jest.fn();
@@ -56,7 +60,7 @@ export default () => {
 
     it("onPress events triggers correctly", () => {
       const testInstance = TestRenderer.create(<SaveAndShareBar {...props} />);
-      testInstance.root.findAllByType(BarItem)[3].props.onPress();
+      testInstance.root.findAllByType(BarItem)[3].props.onPress(mockEvent);
       expect(Clipboard.setString).toHaveBeenCalledWith(articleUrl);
       expect(onCopyLink).toHaveBeenCalled();
     });
@@ -91,7 +95,7 @@ export default () => {
           publicationName="TIMES"
         />
       );
-      await testInstance.root.findByType(BarItem).props.onPress();
+      await testInstance.root.findByType(BarItem).props.onPress(mockEvent);
 
       expect(testInstance).toMatchSnapshot();
     });
@@ -106,7 +110,9 @@ export default () => {
 
       const mailtoUrl = `mailto:?subject=${articleHeadline} from The Times&body=I thought you would be interested in this story from The Times%0A%0A${articleHeadline}%0A%0A${url}`;
 
-      await testInstance.root.findAllByType(BarItem)[0].props.onPress();
+      await testInstance.root
+        .findAllByType(BarItem)[0]
+        .props.onPress(mockEvent);
       expect(window.location.assign).toBeCalledWith(mailtoUrl);
     });
 
@@ -124,7 +130,9 @@ export default () => {
 
       const mailtoUrl = `mailto:?subject=${articleHeadline} from The Sunday Times&body=I thought you would be interested in this story from The Sunday Times%0A%0A${articleHeadline}%0A%0A${url}`;
 
-      await testInstance.root.findAllByType(BarItem)[0].props.onPress();
+      await testInstance.root
+        .findAllByType(BarItem)[0]
+        .props.onPress(mockEvent);
       expect(window.location.assign).toBeCalledWith(mailtoUrl);
     });
 
@@ -137,7 +145,9 @@ export default () => {
       const url = `${articleUrl}?shareToken=foo`;
       const mailtoUrl = `mailto:?subject=${articleHeadline} from The Times&body=I thought you would be interested in this story from The Times%0A%0A${articleHeadline}%0A%0A${url}`;
 
-      await testInstance.root.findAllByType(BarItem)[0].props.onPress();
+      await testInstance.root
+        .findAllByType(BarItem)[0]
+        .props.onPress(mockEvent);
       expect(window.location.assign).toBeCalledWith(mailtoUrl);
     });
 
@@ -148,7 +158,9 @@ export default () => {
 
       const mailtoUrl = `mailto:?subject=${articleHeadline} from The Times&body=I thought you would be interested in this story from The Times%0A%0A${articleHeadline}%0A%0A${articleUrl}`;
 
-      await testInstance.root.findAllByType(BarItem)[0].props.onPress();
+      await testInstance.root
+        .findAllByType(BarItem)[0]
+        .props.onPress(mockEvent);
       expect(window.location.assign).toBeCalledWith(mailtoUrl);
     });
   });

--- a/packages/save-and-share-bar/src/email-share.js
+++ b/packages/save-and-share-bar/src/email-share.js
@@ -13,7 +13,7 @@ class EmailShare extends Component {
     this.onShare = this.onShare.bind(this);
   }
 
-  onShare() {
+  onShare(e) {
     const {
       articleId,
       getTokenisedShareUrl,
@@ -22,6 +22,8 @@ class EmailShare extends Component {
       onShareEmail,
       articleHeadline
     } = this.props;
+
+    e.preventDefault();
 
     onShareEmail({ articleId, articleUrl, articleHeadline });
 

--- a/packages/save-and-share-bar/src/save-and-share-bar.js
+++ b/packages/save-and-share-bar/src/save-and-share-bar.js
@@ -24,8 +24,10 @@ class SaveAndShareBar extends Component {
     this.copyToClipboard = this.copyToClipboard.bind(this);
   }
 
-  copyToClipboard() {
+  copyToClipboard(e) {
     const { onCopyLink, articleUrl } = this.props;
+    e.preventDefault();
+
     Clipboard.setString(articleUrl);
     onCopyLink();
   }


### PR DESCRIPTION
Add prevent default to copy and email buttons in save and share bar

TODO: I will create a PR in render with e2e tests for these scenarios 