### PR TITLE
feat: add template name as data attr for debugging

### DIFF
--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
@@ -8,6 +8,7 @@ exports[`1. a primary image 1`] = `
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
     id="article-main"
   >
     <Head />
@@ -102,6 +103,7 @@ exports[`2. a fullwidth image 1`] = `
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
     id="article-main"
   >
     <Head />
@@ -196,6 +198,7 @@ exports[`3. a secondary image 1`] = `
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
     id="article-main"
   >
     <Head />
@@ -290,6 +293,7 @@ exports[`4. an inline image 1`] = `
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
     id="article-main"
   >
     <Head />

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-isPreview.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-isPreview.web.test.js.snap
@@ -33,6 +33,7 @@ exports[`Article with isPreview Render article with ArticleMetaBanner when isPre
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
     id="article-main"
   >
     <Head />
@@ -381,6 +382,7 @@ exports[`Article with isPreview Render article without ArticleMetaBanner when is
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
     id="article-main"
   >
     <Head />

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-user-state.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-user-state.web.test.js.snap
@@ -8,6 +8,7 @@ exports[`Article with user state Render full article when user has access to ful
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
     id="article-main"
   >
     <Head />
@@ -356,6 +357,7 @@ exports[`Article with user state Render teaser article when user does not have a
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
     id="article-main"
   >
     <Head />

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -8,6 +8,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="maincomment"
     id="article-main"
   >
     <Head />
@@ -397,6 +398,7 @@ exports[`2. an article with interactives 1`] = `
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
     id="article-main"
   >
     <Head />
@@ -541,6 +543,7 @@ exports[`3. an article with no content 1`] = `
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
     id="article-main"
   >
     <Head />
@@ -663,6 +666,7 @@ exports[`4. an article with no content if content is set as null 1`] = `
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
     id="article-main"
   >
     <Head />
@@ -785,6 +789,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
   <article
     data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
     data-article-sectionname="Some Section"
+    data-article-template="maincomment"
     id="article-main"
   >
     <Head />

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -119,6 +119,7 @@ class ArticleSkeleton extends Component {
           id="article-main"
           data-article-identifier={article.id}
           data-article-sectionname={section}
+          data-article-template={template}
           ref={node => {
             this.node = node;
           }}


### PR DESCRIPTION
- on legacy article pages it was easy to id the article template by viewing source.  This adds the template name to the article element as a data attribute.