### PR TITLE
fix (REPLAT-12165): key facts layout issue

### DIFF
--- a/packages/key-facts/__tests__/web/__snapshots__/key-facts-with-style.web.test.js.snap
+++ b/packages/key-facts/__tests__/web/__snapshots__/key-facts-with-style.web.test.js.snap
@@ -23,14 +23,14 @@ exports[`key facts with title 1`] = `
 
 @media (min-width:768px) {
   .c2 {
-    width: 80%;
+    width: 75%;
   }
 }
 
 @media (min-width:768px) {
   .c1 {
     padding-right: 20px;
-    width: 20%;
+    width: 25%;
   }
 }
 
@@ -99,14 +99,14 @@ exports[`key facts with title and context theme 1`] = `
 
 @media (min-width:768px) {
   .c2 {
-    width: 80%;
+    width: 75%;
   }
 }
 
 @media (min-width:768px) {
   .c1 {
     padding-right: 20px;
-    width: 20%;
+    width: 25%;
   }
 }
 

--- a/packages/key-facts/fixtures/key-facts-showcase.json
+++ b/packages/key-facts/fixtures/key-facts-showcase.json
@@ -1,7 +1,7 @@
 {
   "name": "keyFacts",
   "attributes": {
-    "title": "New Brexit referendum"
+    "title": "This week's programmes"
   },
   "children": [
     {

--- a/packages/key-facts/src/styles/responsive.web.js
+++ b/packages/key-facts/src/styles/responsive.web.js
@@ -18,13 +18,13 @@ export const KeyFactsResponsiveContainer = styled(View)`
 
 export const KeyFactsResponsiveWrapper = styled(View)`
   @media (min-width: ${breakpoints.medium}px) {
-    width: 80%;
+    width: 75%;
   }
 `;
 
 export const KeyFactsTitleResponsive = styled(Text)`
   @media (min-width: ${breakpoints.medium}px) {
     padding-right: ${spacing(4)};
-    width: 20%;
+    width: 25%;
   }
 `;


### PR DESCRIPTION
- https://nidigitalsolutions.jira.com/browse/REPLAT-12165
- Zeplin design had more horizontal space then the implementation so I updated `key-facts` component.

### Before
<img width="629" alt="Screenshot 2020-02-03 at 09 53 17" src="https://user-images.githubusercontent.com/1736782/73649467-c0ec8500-4677-11ea-90d1-f55bb31c1c59.png">

### After
<img width="601" alt="Screenshot 2020-02-03 at 09 53 32" src="https://user-images.githubusercontent.com/1736782/73649465-be8a2b00-4677-11ea-84bf-120de6ae9a4e.png">

