### PR TITLE
feat: get section name from tiles improvement

### DIFF
--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -4,6 +4,7 @@ const React = require("react");
 const { ApolloProvider } = require("react-apollo");
 const { HelmetProvider } = require("react-helmet-async");
 const { getSectionNameForAnalytics } = require("@times-components/utils/rnw");
+const { getSectionFromTiles } = require("@times-components/utils/rnw");
 const { ArticleProvider } = require("@times-components/provider/rnw");
 const { DraftArticleProvider } = require("@times-components/provider/rnw");
 const Article = require("@times-components/article/rnw").default;
@@ -12,7 +13,6 @@ const {
   defaults
 } = require("@times-components/context/rnw");
 const { scales, themeFactory } = require("@times-components/styleguide/rnw");
-const getSectionNameFromTiles = require("../lib/section-from-tiles");
 
 const scale = scales.large;
 
@@ -62,7 +62,7 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
                 newskit: enableNewskit,
                 theme: {
                   ...themeFactory(
-                    getSectionNameFromTiles(article),
+                    getSectionFromTiles(article),
                     article.template
                   ),
                   scale: scale || defaults.theme.scale

--- a/packages/ssr/src/lib/section-from-tiles.js
+++ b/packages/ssr/src/lib/section-from-tiles.js
@@ -1,11 +1,21 @@
+const hasTiles = t => t && t.tiles && t.tiles.length > 0;
+
+const hasSlices = s => s.slices && s.slices.length > 0;
+
+const hasSections = s =>
+  s.slices[0].sections && s.slices[0].sections.length > 0;
+
+const getSectionTitle = t =>
+  t.slices[0].sections[0].title
+    ? t.slices[0].sections[0].title.toLowerCase()
+    : "";
+
 module.exports = article =>
-  article &&
-  article.tiles &&
-  article.tiles.length > 0 &&
-  article.tiles[0].slices &&
-  article.tiles[0].slices.length > 0 &&
-  article.tiles[0].slices[0].sections &&
-  article.tiles[0].slices[0].sections.length > 0 &&
-  article.tiles[0].slices[0].sections[0].title
-    ? article.tiles[0].slices[0].sections[0].title.toLowerCase()
-    : "default";
+  hasTiles(article) &&
+  article.tiles.reduce(
+    (acc, curr) =>
+      hasSlices(curr) && hasSections(curr) && getSectionTitle(curr)
+        ? getSectionTitle(curr)
+        : acc,
+    "default"
+  );

--- a/packages/utils/__tests__/get-section-from-tiles.test.js
+++ b/packages/utils/__tests__/get-section-from-tiles.test.js
@@ -1,0 +1,84 @@
+import { getSectionFromTiles } from "../src";
+
+describe("getSectionFromTiles should", () => {
+  it("return the correct section name", () => {
+    const article = {
+      tiles: [
+        {
+          slices: [
+            {
+              sections: [
+                {
+                  title: "Culture"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          slices: [
+            {
+              sections: []
+            }
+          ]
+        }
+      ]
+    };
+    expect(getSectionFromTiles(article)).toEqual("culture");
+  });
+
+  it("return the correct section name no matter the slice index position", () => {
+    const article = {
+      tiles: [
+        {
+          slices: [
+            {
+              sections: []
+            }
+          ]
+        },
+        {
+          slices: [
+            {
+              sections: [
+                {
+                  title: "Culture"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+    expect(getSectionFromTiles(article)).toEqual("culture");
+  });
+
+  it("return the default section name when there is no data for the section", () => {
+    const article = {
+      tiles: [
+        {
+          slices: [
+            {
+              sections: []
+            }
+          ]
+        },
+        {
+          slices: [
+            {
+              sections: []
+            }
+          ]
+        }
+      ]
+    };
+    expect(getSectionFromTiles(article)).toEqual("default");
+  });
+
+  it("return the default section name when there is missing nested structure", () => {
+    const article = {
+      tiles: []
+    };
+    expect(getSectionFromTiles(article)).toEqual("default");
+  });
+});

--- a/packages/utils/src/get-section-from-tiles.js
+++ b/packages/utils/src/get-section-from-tiles.js
@@ -11,11 +11,12 @@ const getSectionTitle = t =>
     : "";
 
 module.exports = article =>
-  hasTiles(article) &&
-  article.tiles.reduce(
-    (acc, curr) =>
-      hasSlices(curr) && hasSections(curr) && getSectionTitle(curr)
-        ? getSectionTitle(curr)
-        : acc,
-    "default"
-  );
+  hasTiles(article)
+    ? article.tiles.reduce(
+        (acc, curr) =>
+          hasSlices(curr) && hasSections(curr) && getSectionTitle(curr)
+            ? getSectionTitle(curr)
+            : acc,
+        "default"
+      )
+    : "default";

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -12,3 +12,4 @@ export { default as getStandardTemplateCrop } from "./crop-config";
 export { default as getHeadline } from "./get-headline";
 export { default as gqlRgbaToHex } from "./gql-rgba-to-hex";
 export { default as gqlRgbaToStyle } from "./gql-rgba-to-style";
+export { default as getSectionFromTiles } from "./get-section-from-tiles";

--- a/packages/utils/src/index.web.js
+++ b/packages/utils/src/index.web.js
@@ -15,3 +15,4 @@ export { default as gqlRgbaToStyle } from "./gql-rgba-to-style";
 export { default as HoverIcon } from "./hover-icon";
 export { default as ServerClientRender } from "./server-client-render";
 export { default as appendToImageURL } from "./append-to-image-url";
+export { default as getSectionFromTiles } from "./get-section-from-tiles";


### PR DESCRIPTION
[Jira](https://nidigitalsolutions.jira.com/browse/REPLAT-12226)

Improvement on the get section name from tiles implementation. 
This is fixing the font issue on this article(https://www.thetimes.co.uk/article/johnny-flynn-interview-the-emma-star-on-playing-david-bowie-in-stardust-and-duncan-jones-reaction-to-the-biopic-mvt3x7x90) and probably a lot more fonts and theming related issues still currently uncaught.

Reason for the error: the current implementation is depending on the first tiles -> slices -> sections, which for this article is empty array.

![image](https://user-images.githubusercontent.com/7889661/73948265-69f9e080-4901-11ea-982d-4f0bd14d74b5.png)

