### PR TITLE
fix: REPLAT-12259 Show lead asset captions for mobile native apps 

### DIFF
--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -12,6 +12,15 @@ exports[`full article with style on mobile 1`] = `
         }
       >
         <ModalImage />
+        <Caption
+          style={
+            Object {
+              "container": Object {
+                "paddingHorizontal": 10,
+              },
+            }
+          }
+        />
       </View>
     </View>
     <View
@@ -144,6 +153,15 @@ exports[`full article with style on tablet 1`] = `
         }
       >
         <ModalImage />
+        <Caption
+          style={
+            Object {
+              "container": Object {
+                "paddingHorizontal": 10,
+              },
+            }
+          }
+        />
       </View>
     </View>
     <View

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -18,6 +18,10 @@ exports[`1. an article 1`] = `
           onImagePress={null}
           uri="https://crop169.io"
         />
+        <Caption
+          credits="Some Credits"
+          text="Some Caption"
+        />
       </View>
     </View>
     <View>
@@ -171,6 +175,10 @@ exports[`6. an article with no byline 1`] = `
           onImagePress={null}
           uri="https://crop169.io"
         />
+        <Caption
+          credits="Some Credits"
+          text="Some Caption"
+        />
       </View>
     </View>
     <View>
@@ -237,6 +245,10 @@ exports[`7. an article with no label 1`] = `
           index={0}
           onImagePress={null}
           uri="https://crop169.io"
+        />
+        <Caption
+          credits="Some Credits"
+          text="Some Caption"
         />
       </View>
     </View>

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -12,6 +12,15 @@ exports[`full article with style on mobile 1`] = `
         }
       >
         <ModalImage />
+        <Caption
+          style={
+            Object {
+              "container": Object {
+                "paddingHorizontal": 10,
+              },
+            }
+          }
+        />
       </View>
     </View>
     <View
@@ -144,6 +153,15 @@ exports[`full article with style on tablet 1`] = `
         }
       >
         <ModalImage />
+        <Caption
+          style={
+            Object {
+              "container": Object {
+                "paddingHorizontal": 10,
+              },
+            }
+          }
+        />
       </View>
     </View>
     <View

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -18,6 +18,10 @@ exports[`1. an article 1`] = `
           onImagePress={null}
           uri="https://crop169.io"
         />
+        <Caption
+          credits="Some Credits"
+          text="Some Caption"
+        />
       </View>
     </View>
     <View>
@@ -171,6 +175,10 @@ exports[`6. an article with no byline 1`] = `
           onImagePress={null}
           uri="https://crop169.io"
         />
+        <Caption
+          credits="Some Credits"
+          text="Some Caption"
+        />
       </View>
     </View>
     <View>
@@ -237,6 +245,10 @@ exports[`7. an article with no label 1`] = `
           index={0}
           onImagePress={null}
           uri="https://crop169.io"
+        />
+        <Caption
+          credits="Some Credits"
+          text="Some Caption"
         />
       </View>
     </View>

--- a/packages/article-main-standard/src/article-main-standard.js
+++ b/packages/article-main-standard/src/article-main-standard.js
@@ -53,9 +53,12 @@ class ArticlePage extends Component {
                 getImageCrop={getStandardTemplateCrop}
                 onImagePress={onImagePress}
                 onVideoPress={onVideoPress}
-                renderCaption={({ caption }) =>
-                  isTablet && <Caption {...caption} />
-                }
+                renderCaption={({ caption }) => (
+                  <Caption
+                    {...caption}
+                    style={!isTablet && { container: styles.captionContainer }}
+                  />
+                )}
                 style={[styles.leadAsset, isTablet && styles.leadAssetTablet]}
                 width={Math.min(parentProps.width, tabletWidth)}
               />

--- a/packages/article-main-standard/src/styles/article-body/shared.js
+++ b/packages/article-main-standard/src/styles/article-body/shared.js
@@ -49,6 +49,9 @@ const sharedStyles = scale => {
       flexDirection: "column",
       paddingBottom: spacing(5),
       width: "100%"
+    },
+    captionContainer: {
+      paddingHorizontal: spacing(2)
     }
   };
 };


### PR DESCRIPTION
[REPLAT-12259](https://nidigitalsolutions.jira.com/browse/REPLAT-12259)

Before:
![mobile-caption-before](https://user-images.githubusercontent.com/8720661/74153817-109ff300-4c1a-11ea-8928-cf2f6bd40b6a.png)


After:
![mobile-caption-after](https://user-images.githubusercontent.com/8720661/74153826-139ae380-4c1a-11ea-8395-77e8dec1f162.png)