### PR TITLE
fix: REPLAT-12031 'and' keyword bylines handling

### DIFF
--- a/packages/article-byline/__tests__/shared.base.web.js
+++ b/packages/article-byline/__tests__/shared.base.web.js
@@ -154,6 +154,46 @@ export default Component => {
 
         expect(testInstance).toMatchSnapshot();
       }
+    },
+    {
+      name: "main standard template - with multiple authors separated by and",
+      test: () => {
+        const testInstance = renderArticleBylineMainStandard({
+          ast: authorsFixture.multipleAuthorsAndSeparated
+        });
+
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "main standard template - inline text with 'and' and author",
+      test: () => {
+        const testInstance = renderArticleBylineMainStandard({
+          ast: authorsFixture.authorAndText
+        });
+
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "with multiple authors separated by and",
+      test: () => {
+        const testInstance = renderArticleByline({
+          ast: authorsFixture.multipleAuthorsAndSeparated
+        });
+
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "maiinline text with 'and' and author",
+      test: () => {
+        const testInstance = renderArticleByline({
+          ast: authorsFixture.authorAndText
+        });
+
+        expect(testInstance).toMatchSnapshot();
+      }
     }
   ];
 

--- a/packages/article-byline/__tests__/unit/utils.test.js
+++ b/packages/article-byline/__tests__/unit/utils.test.js
@@ -20,4 +20,40 @@ describe("trimCommasAndDashes", () => {
       "John Simpson, Crime Correspondent"
     );
   });
+  it("should remove spaces and 'and' keyword", () => {
+    expect(trimCommasAndDashes(" and ")).toBe("");
+  });
+  it("should remove 'and' + space", () => {
+    expect(trimCommasAndDashes("and ")).toBe("");
+  });
+  it("should remove space + 'and'", () => {
+    expect(trimCommasAndDashes(" and")).toBe("");
+  });
+  it("should remove 'and'", () => {
+    expect(trimCommasAndDashes("and")).toBe("");
+  });
+  it("shouldn't modify if the name, title or location ends with 'and' and space", () => {
+    expect(trimCommasAndDashes(" Georgi Mayand ")).toBe("Georgi Mayand");
+  });
+  it("shouldn't modify if the name, title or location ends with 'and'", () => {
+    expect(trimCommasAndDashes("Georgi Mayand")).toBe("Georgi Mayand");
+  });
+  it("shouldn't modify if the name, title or location starts with 'and'", () => {
+    expect(trimCommasAndDashes("andGeorgi")).toBe("andGeorgi");
+  });
+  it("should remove leading 'and' keyword", () => {
+    expect(trimCommasAndDashes("   and Ben Chambers")).toBe("Ben Chambers");
+  });
+  it("should remove leading 'and' keyword and space", () => {
+    expect(trimCommasAndDashes("and Ben Chambers")).toBe("Ben Chambers");
+  });
+  it("should remove trailing 'and' keyword and spaces", () => {
+    expect(trimCommasAndDashes("Ben Chambers and     ")).toBe("Ben Chambers");
+  });
+  it("should remove trailing 'and' keyword", () => {
+    expect(trimCommasAndDashes("Ben Chambers and")).toBe("Ben Chambers");
+  });
+  it("shouldn't modify 'and' in the middle", () => {
+    expect(trimCommasAndDashes("Ben and Jerry")).toBe("Ben and Jerry");
+  });
 });

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-opinion.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-opinion.web.test.js.snap
@@ -350,3 +350,104 @@ exports[`13. main standard template - with multiple authors separated by spaces 
   </span>
 </div>
 `;
+
+exports[`14. main standard template - with multiple authors separated by and 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <span
+    className="responsiveweb-e5ajv9-0 gOHwqY"
+  >
+    <div
+      className="css-text-901oao r-color-1dunems r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw"
+    >
+      Tim Shipman
+    </div>
+    <div
+      className="css-text-901oao"
+    >
+      , 
+    </div>
+  </span>
+  <span
+    className="responsiveweb-e5ajv9-0 gOHwqY"
+  >
+    <div
+      className="css-text-901oao r-color-1dunems r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw"
+    >
+      Sam Chambers
+    </div>
+    
+  </span>
+</div>
+`;
+
+exports[`15. main standard template - inline text with 'and' and author 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <span
+    className="responsiveweb-e5ajv9-0 gOHwqY"
+  >
+    <div
+      className="css-text-901oao r-color-1dunems r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw"
+    >
+      Tim Hook
+      <span
+        className="css-text-901oao css-textHasAncestor-16my406"
+      >
+        , 
+      </span>
+    </div>
+  </span>
+  <span
+    className="responsiveweb-e5ajv9-0 gOHwqY"
+  >
+    <div
+      className="css-text-901oao r-color-1dunems r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw"
+    >
+      Sabah Meddings
+    </div>
+    
+  </span>
+</div>
+`;
+
+exports[`16. with multiple authors separated by and 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <div
+    className="css-text-901oao r-color-1dunems r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw"
+  >
+    Tim Shipman
+  </div>
+  <div
+    className="css-text-901oao r-color-1dunems r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw"
+  >
+     and 
+  </div>
+  <div
+    className="css-text-901oao r-color-1dunems r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw"
+  >
+    Sam Chambers
+  </div>
+</div>
+`;
+
+exports[`17. maiinline text with 'and' and author 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <div
+    className="css-text-901oao r-color-1dunems r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw"
+  >
+    Tim Hook and 
+  </div>
+  <div
+    className="css-text-901oao r-color-1dunems r-fontFamily-iirzy8 r-fontSize-evnaw r-fontWeight-16dba41 r-lineHeight-1kt6imw"
+  >
+    Sabah Meddings
+  </div>
+</div>
+`;

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links.web.test.js.snap
@@ -394,3 +394,116 @@ exports[`13. main standard template - with multiple authors separated by spaces 
   </span>
 </div>
 `;
+
+exports[`14. main standard template - with multiple authors separated by and 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <span
+    className="responsiveweb-e5ajv9-0 gOHwqY"
+  >
+    <a
+      className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+      href="/profile/tim-shipman"
+      role="link"
+    >
+      Tim Shipman
+    </a>
+    <div
+      className="css-text-901oao"
+    >
+      , 
+    </div>
+  </span>
+  <span
+    className="responsiveweb-e5ajv9-0 gOHwqY"
+  >
+    <a
+      className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+      href="/profile/sam-chambers"
+      role="link"
+    >
+      Sam Chambers
+    </a>
+    
+  </span>
+</div>
+`;
+
+exports[`15. main standard template - inline text with 'and' and author 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <span
+    className="responsiveweb-e5ajv9-0 gOHwqY"
+  >
+    <div
+      className="css-text-901oao r-color-1khp51w r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n"
+    >
+      Tim Hook
+      <span
+        className="css-text-901oao css-textHasAncestor-16my406"
+      >
+        , 
+      </span>
+    </div>
+  </span>
+  <span
+    className="responsiveweb-e5ajv9-0 gOHwqY"
+  >
+    <a
+      className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+      href="/profile/sabah-meddings"
+      role="link"
+    >
+      Sabah Meddings
+    </a>
+    
+  </span>
+</div>
+`;
+
+exports[`16. with multiple authors separated by and 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <a
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    href="/profile/tim-shipman"
+    role="link"
+  >
+    Tim Shipman
+  </a>
+  <div
+    className="css-text-901oao r-color-1khp51w r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n"
+  >
+     and 
+  </div>
+  <a
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    href="/profile/sam-chambers"
+    role="link"
+  >
+    Sam Chambers
+  </a>
+</div>
+`;
+
+exports[`17. maiinline text with 'and' and author 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <div
+    className="css-text-901oao r-color-1khp51w r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n"
+  >
+    Tim Hook and 
+  </div>
+  <a
+    className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    href="/profile/sabah-meddings"
+    role="link"
+  >
+    Sabah Meddings
+  </a>
+</div>
+`;

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
@@ -350,3 +350,104 @@ exports[`13. main standard template - with multiple authors separated by spaces 
   </span>
 </div>
 `;
+
+exports[`14. main standard template - with multiple authors separated by and 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <span
+    className="responsiveweb-e5ajv9-0 gOHwqY"
+  >
+    <div
+      className="css-text-901oao r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n"
+    >
+      Tim Shipman
+    </div>
+    <div
+      className="css-text-901oao"
+    >
+      , 
+    </div>
+  </span>
+  <span
+    className="responsiveweb-e5ajv9-0 gOHwqY"
+  >
+    <div
+      className="css-text-901oao r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n"
+    >
+      Sam Chambers
+    </div>
+    
+  </span>
+</div>
+`;
+
+exports[`15. main standard template - inline text with 'and' and author 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <span
+    className="responsiveweb-e5ajv9-0 gOHwqY"
+  >
+    <div
+      className="css-text-901oao r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n"
+    >
+      Tim Hook
+      <span
+        className="css-text-901oao css-textHasAncestor-16my406"
+      >
+        , 
+      </span>
+    </div>
+  </span>
+  <span
+    className="responsiveweb-e5ajv9-0 gOHwqY"
+  >
+    <div
+      className="css-text-901oao r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n"
+    >
+      Sabah Meddings
+    </div>
+    
+  </span>
+</div>
+`;
+
+exports[`16. with multiple authors separated by and 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <div
+    className="css-text-901oao r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n"
+  >
+    Tim Shipman
+  </div>
+  <div
+    className="css-text-901oao r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n"
+  >
+     and 
+  </div>
+  <div
+    className="css-text-901oao r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n"
+  >
+    Sam Chambers
+  </div>
+</div>
+`;
+
+exports[`17. maiinline text with 'and' and author 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <div
+    className="css-text-901oao r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n"
+  >
+    Tim Hook and 
+  </div>
+  <div
+    className="css-text-901oao r-color-1khnkhu r-flexDirection-18u37iz r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n"
+  >
+    Sabah Meddings
+  </div>
+</div>
+`;

--- a/packages/article-byline/fixtures/authors.json
+++ b/packages/article-byline/fixtures/authors.json
@@ -499,5 +499,108 @@
         }
       ]
     }
+  ],
+  "multipleAuthorsAndSeparated": [
+    {
+      "__typename": "AuthorByline",
+      "byline": [
+        {
+          "name": "author",
+          "children": [
+            {
+              "name": "text",
+              "children": [],
+              "attributes": {
+                "value": "Tim Shipman"
+              }
+            }
+          ],
+          "attributes": {
+            "slug": "tim-shipman"
+          }
+        }
+      ],
+      "image": null
+    },
+    {
+      "__typename": "TextByline",
+      "byline": [
+        {
+          "name": "inline",
+          "children": [
+            {
+              "name": "text",
+              "children": [],
+              "attributes": {
+                "value": " and "
+              }
+            }
+          ]
+        }
+      ],
+      "image": null
+    },
+    {
+      "__typename": "AuthorByline",
+      "byline": [
+        {
+          "name": "author",
+          "children": [
+            {
+              "name": "text",
+              "children": [],
+              "attributes": {
+                "value": "Sam Chambers"
+              }
+            }
+          ],
+          "attributes": {
+            "slug": "sam-chambers"
+          }
+        }
+      ],
+      "image": null
+    }
+  ],
+  "authorAndText": [
+    {
+      "__typename": "TextByline",
+      "byline": [
+        {
+          "name": "inline",
+          "children": [
+            {
+              "name": "text",
+              "children": [],
+              "attributes": {
+                "value": "Tim Hook and "
+              }
+            }
+          ]
+        }
+      ],
+      "image": null
+    },
+    {
+      "__typename": "AuthorByline",
+      "byline": [
+        {
+          "name": "author",
+          "children": [
+            {
+              "name": "text",
+              "children": [],
+              "attributes": {
+                "value": "Sabah Meddings"
+              }
+            }
+          ],
+          "attributes": {
+            "slug": "sabah-meddings"
+          }
+        }
+      ],
+      "image": null
+    }
   ]
 }

--- a/packages/article-byline/src/utils.js
+++ b/packages/article-byline/src/utils.js
@@ -1,6 +1,7 @@
 export default str =>
   str
     .trim()
-    .replace(/^(\||,)/, "")
-    .replace(/(\||,)$/, "")
+    .replace(/^(and)$/, "")
+    .replace(/^(\||,|and )/, "")
+    .replace(/(\||,| and)$/, "")
     .trim();


### PR DESCRIPTION
'and' word handling for main standard template on huge and wide breakpoints.

Before:
![image](https://user-images.githubusercontent.com/8720661/74418706-76c28b00-4e51-11ea-9627-dce119d6e31b.png)


After:
![and-bylines-after](https://user-images.githubusercontent.com/8720661/74418717-7d510280-4e51-11ea-98c1-956d237e0068.png)
