### PR TITLE
feat: (REPLAT-12170) handle arbitrary newlines and nested styling

### DIFF
--- a/fonts.js
+++ b/fonts.js
@@ -15,7 +15,7 @@ const fonts = {
     require("./dist/public/fonts/TimesModern-Bold.js").default,
   "TimesDigitalW04-Regular": () =>
     require("./dist/public/fonts/TimesDigitalW04-Regular.js").default,
-  "TimesDigitalW04-Normal": () =>
+  TimesDigitalW04: () =>
     require("./dist/public/fonts/TimesDigitalW04.js").default,
   "TimesModern-Regular": () =>
     require("./dist/public/fonts/TimesModern-Regular.js").default

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -64,8 +64,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
                     "left": 146,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -73,7 +71,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                   }
                 }
               >
-                his
+                h
               </Text>
               <Text
                 style={
@@ -81,8 +79,21 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
+                    "left": 165.828125,
+                    "lineHeight": 52,
+                    "position": "absolute",
+                    "top": 0,
+                  }
+                }
+              >
+                is
+              </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#000000",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 36,
                     "left": 202.0390625,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -98,8 +109,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
                     "left": 299.017578125,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -115,8 +124,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
                     "left": 395.75,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -132,8 +139,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
                     "left": 519.095703125,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -149,8 +154,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
                     "left": 638.486328125,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -166,8 +169,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
                     "left": 146,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -457,7 +458,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 161,
                     "lineHeight": 52,
@@ -466,7 +466,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                   }
                 }
               >
-                Some
+                S
               </Text>
               <Text
                 style={
@@ -474,7 +474,22 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
+                    "fontWeight": "bold",
+                    "left": 182.357421875,
+                    "lineHeight": 52,
+                    "position": "absolute",
+                    "top": 0,
+                  }
+                }
+              >
+                ome
+              </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#000000",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 36,
                     "fontWeight": "bold",
                     "left": 262.42578125,
                     "lineHeight": 52,
@@ -491,7 +506,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 357.541015625,
                     "lineHeight": 52,
@@ -508,7 +522,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 426.763671875,
                     "lineHeight": 52,
@@ -525,7 +538,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 445.466796875,
                     "lineHeight": 52,
@@ -542,7 +554,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 544.888671875,
                     "lineHeight": 52,
@@ -559,7 +570,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 161,
                     "lineHeight": 52,
@@ -576,7 +586,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 304.560546875,
                     "lineHeight": 52,
@@ -593,7 +602,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 345.412109375,
                     "lineHeight": 52,
@@ -610,7 +618,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 422.6328125,
                     "lineHeight": 52,
@@ -627,7 +634,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 469.689453125,
                     "lineHeight": 52,
@@ -644,7 +650,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 498.18359375,
                     "lineHeight": 52,
@@ -661,7 +666,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 599.75,
                     "lineHeight": 52,
@@ -678,7 +682,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 161,
                     "lineHeight": 52,
@@ -695,7 +698,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 288.494140625,
                     "lineHeight": 52,
@@ -712,7 +714,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 364.818359375,
                     "lineHeight": 52,
@@ -729,7 +730,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 401.029296875,
                     "lineHeight": 52,
@@ -746,7 +746,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 475.75390625,
                     "lineHeight": 52,
@@ -795,7 +794,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     }
@@ -892,8 +890,6 @@ exports[`6. an article skeleton with responsive items 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     }
                   }

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -117,14 +117,33 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
                 }
               >
-                his
+                h
+              </Text>
+              <Text
+                numberOfLines={1}
+                selectable={true}
+                style={
+                  Array [
+                    Object {
+                      "left": 165.828125,
+                      "position": "absolute",
+                      "top": 0,
+                    },
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    },
+                  ]
+                }
+              >
+                is
               </Text>
               <Text
                 numberOfLines={1}
@@ -140,8 +159,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
@@ -163,8 +180,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
@@ -186,8 +201,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
@@ -209,8 +222,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
@@ -232,8 +243,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
@@ -255,8 +264,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
@@ -733,14 +740,35 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
                   ]
                 }
               >
-                Some
+                S
+              </Text>
+              <Text
+                numberOfLines={1}
+                selectable={true}
+                style={
+                  Array [
+                    Object {
+                      "left": 182.357421875,
+                      "position": "absolute",
+                      "top": 0,
+                    },
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    },
+                  ]
+                }
+              >
+                ome
               </Text>
               <Text
                 numberOfLines={1}
@@ -756,7 +784,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -779,7 +806,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -802,7 +828,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -825,7 +850,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -848,7 +872,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -871,7 +894,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -894,7 +916,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -917,7 +938,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -940,7 +960,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -963,7 +982,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -986,7 +1004,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1009,7 +1026,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1032,7 +1048,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1055,7 +1070,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1078,7 +1092,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1101,7 +1114,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1124,7 +1136,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1185,7 +1196,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     }
@@ -1247,7 +1257,12 @@ Object {
     "headline": "Some Headline",
     "label": "Some Label",
     "linkType": "",
-    "linkUrl": "https://link.io",
+    "linkUrl": Object {
+      "canonicalId": undefined,
+      "href": "https://link.io",
+      "tag": "LINK",
+      "type": undefined,
+    },
     "pageName": "this-is-slug-2k629tpvh",
     "parent_site": "TIMES",
     "past_edition_date": "2015-03-13T18:54:58.000Z",
@@ -1261,7 +1276,7 @@ Object {
 }
 `;
 
-exports[`8. breaks up malformed huge paragraphs 1`] = `
+exports[`8. renders content 1`] = `
 <View
   style={
     Object {
@@ -1360,8 +1375,6 @@ exports[`8. breaks up malformed huge paragraphs 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     }
                   }
@@ -1376,7 +1389,6 @@ exports[`8. breaks up malformed huge paragraphs 1`] = `
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
                       "fontStyle": "italic",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     }
                   }
@@ -1390,8 +1402,6 @@ exports[`8. breaks up malformed huge paragraphs 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     }
                   }
@@ -1405,7 +1415,6 @@ exports[`8. breaks up malformed huge paragraphs 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     }
@@ -1466,513 +1475,6 @@ exports[`8. breaks up malformed huge paragraphs 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "bold",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-                </Text>
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "height": 0,
-          }
-        }
-      />
-      <View>
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        >
-          <ActivityIndicator
-            animating={true}
-            color={null}
-            hidesWhenStopped={true}
-            size="large"
-          />
-        </View>
-      </View>
-    </View>
-  </RCTScrollView>
-</View>
-`;
-
-exports[`9. breaks up nested malformed markup 1`] = `
-<View
-  style={
-    Object {
-      "backgroundColor": "#f0f0f0",
-    }
-  }
->
-  <RCTScrollView
-    ListHeaderComponent={
-      <Gutter
-        style={
-          Object {
-            "overflow": "hidden",
-          }
-        }
-      >
-        <Header
-          width={750}
-        />
-      </Gutter>
-    }
-    extraData={true}
-    initialNumToRender={2}
-    maxToRenderPerBatch={10}
-    nestedScrollEnabled={true}
-    numColumns={1}
-    onEndReachedThreshold={2}
-    removeClippedSubviews={true}
-    scrollEventThrottle={50}
-    showsVerticalScrollIndicator={false}
-    updateCellsBatchingPeriod={50}
-    windowSize={3}
-  >
-    <View>
-      <View>
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        />
-      </View>
-      <View
-        style={null}
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                },
-                Object {
-                  "marginBottom": 20,
-                },
-                false,
-                Object {},
-              ]
-            }
-          >
-            <View>
-              <Text
-                selectable={true}
-                style={
-                  Object {
-                    "lineHeight": 52,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "italic",
-                      "fontWeight": "normal",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  Telegraph 
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "bold",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  When Thatcher joined the campaign trail for the 2001 general election...
-                </Text>
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
-        style={null}
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                },
-                Object {
-                  "marginBottom": 20,
-                },
-                false,
-                Object {},
-              ]
-            }
-          >
-            <View>
-              <Text
-                selectable={true}
-                style={
-                  Object {
-                    "lineHeight": 52,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "bold",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  test break bold
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "bold",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-                </Text>
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "height": 0,
-          }
-        }
-      />
-      <View>
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        >
-          <ActivityIndicator
-            animating={true}
-            color={null}
-            hidesWhenStopped={true}
-            size="large"
-          />
-        </View>
-      </View>
-    </View>
-  </RCTScrollView>
-</View>
-`;
-
-exports[`10. renders content 1`] = `
-<View
-  style={
-    Object {
-      "backgroundColor": "#f0f0f0",
-    }
-  }
->
-  <RCTScrollView
-    ListHeaderComponent={
-      <Gutter
-        style={
-          Object {
-            "overflow": "hidden",
-          }
-        }
-      >
-        <Header
-          width={750}
-        />
-      </Gutter>
-    }
-    extraData={true}
-    initialNumToRender={2}
-    maxToRenderPerBatch={10}
-    nestedScrollEnabled={true}
-    numColumns={1}
-    onEndReachedThreshold={2}
-    removeClippedSubviews={true}
-    scrollEventThrottle={50}
-    showsVerticalScrollIndicator={false}
-    updateCellsBatchingPeriod={50}
-    windowSize={3}
-  >
-    <View>
-      <View>
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        />
-      </View>
-      <View
-        style={null}
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                },
-                Object {
-                  "marginBottom": 20,
-                },
-                false,
-                Object {},
-              ]
-            }
-          >
-            <View>
-              <Text
-                selectable={true}
-                style={
-                  Object {
-                    "lineHeight": 52,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "italic",
-                      "fontWeight": "normal",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  Telegraph 
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "bold",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  When Thatcher joined the campaign trail for the 2001 general election...
-                </Text>
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
-        style={null}
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                },
-                Object {
-                  "marginBottom": 20,
-                },
-                false,
-                Object {},
-              ]
-            }
-          >
-            <View>
-              <Text
-                selectable={true}
-                style={
-                  Object {
-                    "lineHeight": 52,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     }

--- a/packages/article-skeleton/__tests__/header-with-style.native.js
+++ b/packages/article-skeleton/__tests__/header-with-style.native.js
@@ -12,7 +12,7 @@ import { FontStorage } from "@times-components/typeset";
 import shared from "./header-with-style.base";
 
 FontStorage.registerFont(
-  "TimesDigitalW04-Normal",
+  "TimesDigitalW04",
   () => require("@times-components/test-utils").TestFont
 );
 FontStorage.registerFont(

--- a/packages/article-skeleton/__tests__/images-with-style.native.js
+++ b/packages/article-skeleton/__tests__/images-with-style.native.js
@@ -11,7 +11,7 @@ import { FontStorage } from "@times-components/typeset";
 import shared from "./images.base";
 
 FontStorage.registerFont(
-  "TimesDigitalW04-Normal",
+  "TimesDigitalW04",
   () => require("@times-components/test-utils").TestFont
 );
 FontStorage.registerFont(

--- a/packages/article-skeleton/__tests__/images.native.js
+++ b/packages/article-skeleton/__tests__/images.native.js
@@ -11,7 +11,7 @@ import { FontStorage } from "@times-components/typeset";
 import shared from "./images.base";
 
 FontStorage.registerFont(
-  "TimesDigitalW04-Normal",
+  "TimesDigitalW04",
   () => require("@times-components/test-utils").TestFont
 );
 FontStorage.registerFont(

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-scaling.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-scaling.ios.test.js.snap
@@ -56,8 +56,6 @@ exports[`1. scaled medium full article 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     }
                   }
@@ -169,8 +167,6 @@ exports[`2. scaled large full article 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     }
                   }
@@ -282,8 +278,6 @@ exports[`3. scaled xlarge full article 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     }
                   }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -64,8 +64,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
                     "left": 146,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -73,7 +71,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                   }
                 }
               >
-                his
+                h
               </Text>
               <Text
                 style={
@@ -81,8 +79,21 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
+                    "left": 165.828125,
+                    "lineHeight": 52,
+                    "position": "absolute",
+                    "top": 0,
+                  }
+                }
+              >
+                is
+              </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#000000",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 36,
                     "left": 202.0390625,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -98,8 +109,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
                     "left": 299.017578125,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -115,8 +124,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
                     "left": 395.75,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -132,8 +139,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
                     "left": 519.095703125,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -149,8 +154,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
                     "left": 638.486328125,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -166,8 +169,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
                     "left": 146,
                     "lineHeight": 52,
                     "position": "absolute",
@@ -457,7 +458,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 161,
                     "lineHeight": 52,
@@ -466,7 +466,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                   }
                 }
               >
-                Some
+                S
               </Text>
               <Text
                 style={
@@ -474,7 +474,22 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
+                    "fontWeight": "bold",
+                    "left": 182.357421875,
+                    "lineHeight": 52,
+                    "position": "absolute",
+                    "top": 0,
+                  }
+                }
+              >
+                ome
+              </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#000000",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 36,
                     "fontWeight": "bold",
                     "left": 262.42578125,
                     "lineHeight": 52,
@@ -491,7 +506,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 357.541015625,
                     "lineHeight": 52,
@@ -508,7 +522,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 426.763671875,
                     "lineHeight": 52,
@@ -525,7 +538,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 445.466796875,
                     "lineHeight": 52,
@@ -542,7 +554,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 544.888671875,
                     "lineHeight": 52,
@@ -559,7 +570,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 161,
                     "lineHeight": 52,
@@ -576,7 +586,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 304.560546875,
                     "lineHeight": 52,
@@ -593,7 +602,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 345.412109375,
                     "lineHeight": 52,
@@ -610,7 +618,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 422.6328125,
                     "lineHeight": 52,
@@ -627,7 +634,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 469.689453125,
                     "lineHeight": 52,
@@ -644,7 +650,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 498.18359375,
                     "lineHeight": 52,
@@ -661,7 +666,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 599.75,
                     "lineHeight": 52,
@@ -678,7 +682,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 161,
                     "lineHeight": 52,
@@ -695,7 +698,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 288.494140625,
                     "lineHeight": 52,
@@ -712,7 +714,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 364.818359375,
                     "lineHeight": 52,
@@ -729,7 +730,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 401.029296875,
                     "lineHeight": 52,
@@ -746,7 +746,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                     "color": "#000000",
                     "fontFamily": "TimesDigitalW04",
                     "fontSize": 36,
-                    "fontStyle": "normal",
                     "fontWeight": "bold",
                     "left": 475.75390625,
                     "lineHeight": 52,
@@ -795,7 +794,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     }
@@ -892,8 +890,6 @@ exports[`6. an article skeleton with responsive items 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     }
                   }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -117,14 +117,33 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
                 }
               >
-                his
+                h
+              </Text>
+              <Text
+                numberOfLines={1}
+                selectable={true}
+                style={
+                  Array [
+                    Object {
+                      "left": 165.828125,
+                      "position": "absolute",
+                      "top": 0,
+                    },
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    },
+                  ]
+                }
+              >
+                is
               </Text>
               <Text
                 numberOfLines={1}
@@ -140,8 +159,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
@@ -163,8 +180,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
@@ -186,8 +201,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
@@ -209,8 +222,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
@@ -232,8 +243,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
@@ -255,8 +264,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     },
                   ]
@@ -733,14 +740,35 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
                   ]
                 }
               >
-                Some
+                S
+              </Text>
+              <Text
+                numberOfLines={1}
+                selectable={true}
+                style={
+                  Array [
+                    Object {
+                      "left": 182.357421875,
+                      "position": "absolute",
+                      "top": 0,
+                    },
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    },
+                  ]
+                }
+              >
+                ome
               </Text>
               <Text
                 numberOfLines={1}
@@ -756,7 +784,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -779,7 +806,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -802,7 +828,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -825,7 +850,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -848,7 +872,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -871,7 +894,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -894,7 +916,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -917,7 +938,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -940,7 +960,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -963,7 +982,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -986,7 +1004,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1009,7 +1026,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1032,7 +1048,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1055,7 +1070,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1078,7 +1092,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1101,7 +1114,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1124,7 +1136,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     },
@@ -1185,7 +1196,6 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     }
@@ -1247,7 +1257,12 @@ Object {
     "headline": "Some Headline",
     "label": "Some Label",
     "linkType": "",
-    "linkUrl": "https://link.io",
+    "linkUrl": Object {
+      "canonicalId": undefined,
+      "href": "https://link.io",
+      "tag": "LINK",
+      "type": undefined,
+    },
     "pageName": "this-is-slug-2k629tpvh",
     "parent_site": "TIMES",
     "past_edition_date": "2015-03-13T18:54:58.000Z",
@@ -1261,7 +1276,7 @@ Object {
 }
 `;
 
-exports[`8. breaks up malformed huge paragraphs 1`] = `
+exports[`8. renders content 1`] = `
 <View
   style={
     Object {
@@ -1360,8 +1375,6 @@ exports[`8. breaks up malformed huge paragraphs 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     }
                   }
@@ -1376,7 +1389,6 @@ exports[`8. breaks up malformed huge paragraphs 1`] = `
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
                       "fontStyle": "italic",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     }
                   }
@@ -1390,8 +1402,6 @@ exports[`8. breaks up malformed huge paragraphs 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
                       "lineHeight": 52,
                     }
                   }
@@ -1405,7 +1415,6 @@ exports[`8. breaks up malformed huge paragraphs 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     }
@@ -1466,513 +1475,6 @@ exports[`8. breaks up malformed huge paragraphs 1`] = `
                       "color": "#000000",
                       "fontFamily": "TimesDigitalW04",
                       "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "bold",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-                </Text>
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "height": 0,
-          }
-        }
-      />
-      <View>
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        >
-          <ActivityIndicator
-            animating={true}
-            color="#999999"
-            hidesWhenStopped={true}
-            size="large"
-          />
-        </View>
-      </View>
-    </View>
-  </RCTScrollView>
-</View>
-`;
-
-exports[`9. breaks up nested malformed markup 1`] = `
-<View
-  style={
-    Object {
-      "backgroundColor": "#f0f0f0",
-    }
-  }
->
-  <RCTScrollView
-    ListHeaderComponent={
-      <Gutter
-        style={
-          Object {
-            "overflow": "hidden",
-          }
-        }
-      >
-        <Header
-          width={750}
-        />
-      </Gutter>
-    }
-    extraData={true}
-    initialNumToRender={2}
-    maxToRenderPerBatch={10}
-    nestedScrollEnabled={true}
-    numColumns={1}
-    onEndReachedThreshold={2}
-    removeClippedSubviews={true}
-    scrollEventThrottle={50}
-    showsVerticalScrollIndicator={false}
-    updateCellsBatchingPeriod={50}
-    windowSize={3}
-  >
-    <View>
-      <View>
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        />
-      </View>
-      <View
-        style={null}
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                },
-                Object {
-                  "marginBottom": 20,
-                },
-                false,
-                Object {},
-              ]
-            }
-          >
-            <View>
-              <Text
-                selectable={true}
-                style={
-                  Object {
-                    "lineHeight": 52,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "italic",
-                      "fontWeight": "normal",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  Telegraph 
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "bold",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  When Thatcher joined the campaign trail for the 2001 general election...
-                </Text>
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
-        style={null}
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                },
-                Object {
-                  "marginBottom": 20,
-                },
-                false,
-                Object {},
-              ]
-            }
-          >
-            <View>
-              <Text
-                selectable={true}
-                style={
-                  Object {
-                    "lineHeight": 52,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "bold",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  test break bold
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "bold",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-                </Text>
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "height": 0,
-          }
-        }
-      />
-      <View>
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        >
-          <ActivityIndicator
-            animating={true}
-            color="#999999"
-            hidesWhenStopped={true}
-            size="large"
-          />
-        </View>
-      </View>
-    </View>
-  </RCTScrollView>
-</View>
-`;
-
-exports[`10. renders content 1`] = `
-<View
-  style={
-    Object {
-      "backgroundColor": "#f0f0f0",
-    }
-  }
->
-  <RCTScrollView
-    ListHeaderComponent={
-      <Gutter
-        style={
-          Object {
-            "overflow": "hidden",
-          }
-        }
-      >
-        <Header
-          width={750}
-        />
-      </Gutter>
-    }
-    extraData={true}
-    initialNumToRender={2}
-    maxToRenderPerBatch={10}
-    nestedScrollEnabled={true}
-    numColumns={1}
-    onEndReachedThreshold={2}
-    removeClippedSubviews={true}
-    scrollEventThrottle={50}
-    showsVerticalScrollIndicator={false}
-    updateCellsBatchingPeriod={50}
-    windowSize={3}
-  >
-    <View>
-      <View>
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        />
-      </View>
-      <View
-        style={null}
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                },
-                Object {
-                  "marginBottom": 20,
-                },
-                false,
-                Object {},
-              ]
-            }
-          >
-            <View>
-              <Text
-                selectable={true}
-                style={
-                  Object {
-                    "lineHeight": 52,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "italic",
-                      "fontWeight": "normal",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  Telegraph 
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
-                      "fontWeight": "bold",
-                      "lineHeight": 52,
-                    }
-                  }
-                >
-                  When Thatcher joined the campaign trail for the 2001 general election...
-                </Text>
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
-        style={null}
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "overflow": "hidden",
-              },
-              Object {
-                "backgroundColor": "#ffffff",
-                "maxWidth": "100%",
-                "width": undefined,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                },
-                Object {
-                  "marginBottom": 20,
-                },
-                false,
-                Object {},
-              ]
-            }
-          >
-            <View>
-              <Text
-                selectable={true}
-                style={
-                  Object {
-                    "lineHeight": 52,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={
-                    Object {
-                      "color": "#000000",
-                      "fontFamily": "TimesDigitalW04",
-                      "fontSize": 36,
-                      "fontStyle": "normal",
                       "fontWeight": "bold",
                       "lineHeight": 52,
                     }

--- a/packages/article-skeleton/__tests__/scaling.native.js
+++ b/packages/article-skeleton/__tests__/scaling.native.js
@@ -14,7 +14,7 @@ import { FontStorage } from "@times-components/typeset";
 import snapshotTests from "./scaling.base";
 
 FontStorage.registerFont(
-  "TimesDigitalW04-Normal",
+  "TimesDigitalW04",
   () => require("@times-components/test-utils").TestFont
 );
 FontStorage.registerFont(

--- a/packages/article-skeleton/__tests__/shared-tracking.js
+++ b/packages/article-skeleton/__tests__/shared-tracking.js
@@ -5,7 +5,7 @@ import { FontStorage } from "@times-components/typeset";
 import shared from "./shared-tracking.base";
 
 FontStorage.registerFont(
-  "TimesDigitalW04-Normal",
+  "TimesDigitalW04",
   () => require("@times-components/test-utils").TestFont
 );
 FontStorage.registerFont(

--- a/packages/article-skeleton/__tests__/shared-with-style.native.js
+++ b/packages/article-skeleton/__tests__/shared-with-style.native.js
@@ -17,7 +17,7 @@ import articleFixture from "../fixtures/full-article";
 import shared, { renderArticle, fixtureArgs } from "./shared.base";
 
 FontStorage.registerFont(
-  "TimesDigitalW04-Normal",
+  "TimesDigitalW04",
   () => require("@times-components/test-utils").TestFont
 );
 FontStorage.registerFont(

--- a/packages/article-skeleton/__tests__/shared.native.js
+++ b/packages/article-skeleton/__tests__/shared.native.js
@@ -16,15 +16,13 @@ import shared from "./shared.base";
 import ArticleSkeleton from "../src/article-skeleton";
 import articleFixture, {
   testFixture,
-  nestedContent,
-  styledNestedContent,
   longContent
 } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";
 import articleSkeletonProps from "./shared-article-skeleton-props";
 
 FontStorage.registerFont(
-  "TimesDigitalW04-Normal",
+  "TimesDigitalW04",
   () => require("@times-components/test-utils").TestFont
 );
 FontStorage.registerFont(
@@ -161,26 +159,6 @@ export default () => {
         const [, [call]] = stream.mock.calls;
 
         expect(call).toMatchSnapshot();
-      }
-    },
-    {
-      name: "breaks up malformed huge paragraphs",
-      test() {
-        const testInstance = TestRenderer.create(
-          renderArticleContent(nestedContent)
-        );
-
-        expect(testInstance.toJSON()).toMatchSnapshot();
-      }
-    },
-    {
-      name: "breaks up nested malformed markup",
-      test() {
-        const testInstance = TestRenderer.create(
-          renderArticleContent(styledNestedContent)
-        );
-
-        expect(testInstance.toJSON()).toMatchSnapshot();
       }
     },
     {

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -39,45 +39,41 @@ export default ({
       font: "body",
       fontSize: "bodyMobile"
     }),
-    fontStyle: "normal",
-    fontWeight: "normal",
     color: colours.functional.black
   };
 
   const { fontScale } = Dimensions.get("window");
   defaultFont.fontSize *= fontScale;
   defaultFont.lineHeight *= fontScale;
+  const headingSettings = fontFactory({
+    font: "headline",
+    fontSize: "smallHeadline"
+  });
 
   const fontConfig = {
     body: defaultFont,
     bold: {
-      ...defaultFont,
-      fontFamily: "TimesDigitalW04",
       fontWeight: "bold"
     },
     italic: {
-      ...defaultFont,
-      fontFamily: "TimesDigitalW04",
       fontStyle: "italic"
     },
-    link: defaultFont,
     subheading: {
-      ...defaultFont,
-      ...fontFactory({
-        font: "headline",
-        fontSize: "smallHeadline"
-      })
+      font: headingSettings.fontFamily,
+      fontSize: headingSettings.fontSize
     }
   };
 
   return {
     text(key, attributes) {
       const attr = {
-        length: attributes.value.length,
-        start: 0,
-        tag: { tag: "FONT", settings: fontConfig.body }
+        tag: "FONT",
+        settings: fontConfig.body
       };
-      return new AttributedString(attributes.value, [attr]);
+      return new AttributedString(
+        attributes.value,
+        attributes.value.split("").map(() => [attr])
+      );
     },
     heading2(key, attributes, children, index, tree) {
       const childStr = AttributedString.join(children);
@@ -112,11 +108,11 @@ export default ({
     bold(key, attributes, children) {
       const childStr = AttributedString.join(children);
       const attr = {
-        length: childStr.string.length,
-        start: 0,
-        tag: { tag: "FONT", settings: fontConfig.bold }
+        tag: "FONT",
+        settings: fontConfig.bold
       };
-      return new AttributedString(childStr.string, [attr]);
+      childStr.addAttribute(0, childStr.length, attr);
+      return childStr;
     },
     emphasis(key, attributes, children) {
       return this.bold(key, attributes, children);
@@ -127,38 +123,43 @@ export default ({
     italic(key, attributes, children) {
       const childStr = AttributedString.join(children);
       const attr = {
-        length: childStr.string.length,
-        start: 0,
-        tag: { tag: "FONT", settings: fontConfig.italic }
+        tag: "FONT",
+        settings: fontConfig.italic
       };
-      return new AttributedString(childStr.string, [attr]);
+      childStr.addAttribute(0, childStr.length, attr);
+      return childStr;
     },
     link(key, { href, canonicalId, type }, children) {
+      if (!children.length) {
+        return new AttributedString("", []);
+      }
       const childStr = AttributedString.join(children);
       const attr = {
-        length: childStr.string.length,
-        start: 0,
-        tag: { tag: "LINK", href, canonicalId, type, settings: fontConfig.body }
+        tag: "LINK",
+        href,
+        canonicalId,
+        type
       };
-      return new AttributedString(childStr.string, [attr]);
+      childStr.addAttribute(0, childStr.length, attr);
+      return childStr;
     },
     subscript(key, attributes, children) {
       const childStr = AttributedString.join(children);
       const attr = {
-        length: childStr.string.length,
-        start: 0,
-        tag: { tag: "FONT", settings: fontConfig.body }
+        tag: "FONT",
+        settings: fontConfig.body
       };
-      return new AttributedString(childStr.string, [attr]);
+      childStr.addAttribute(0, childStr.length, attr);
+      return childStr;
     },
     superscript(key, attributes, children) {
       const childStr = AttributedString.join(children);
       const attr = {
-        length: childStr.string.length,
-        start: 0,
-        tag: { tag: "FONT", settings: fontConfig.body }
+        tag: "FONT",
+        settings: fontConfig.body
       };
-      return new AttributedString(childStr.string, [attr]);
+      childStr.addAttribute(0, childStr.length, attr);
+      return childStr;
     },
     paragraph(key, attributes, children, index, tree) {
       return (
@@ -261,11 +262,10 @@ export default ({
     },
     break() {
       const attr = {
-        length: 1,
-        start: 0,
-        tag: { tag: "FONT", settings: fontConfig.body }
+        tag: "FONT",
+        settings: fontConfig.body
       };
-      return new AttributedString("\n", [attr]);
+      return new AttributedString("\n", [[attr]]);
     },
     keyFacts(key, attributes, children, index, tree) {
       return (

--- a/packages/article-skeleton/src/article-body/drop-cap.js
+++ b/packages/article-skeleton/src/article-body/drop-cap.js
@@ -12,7 +12,7 @@ export default (scale, color, dropCapFont, paragraph) => {
   if (!letter.attributes.length) {
     return false;
   }
-  const baseStyle = letter.attributes[0].tag.settings;
+  const baseStyle = letter.attributes[0][0].settings;
   const fontSize = baseStyle.fontSize * 6;
   const fontSettings = {
     fontFamily: fonts[dropCapFont],

--- a/packages/article-skeleton/src/article-body/inline-paragraph.js
+++ b/packages/article-skeleton/src/article-body/inline-paragraph.js
@@ -35,7 +35,7 @@ const InlineParagraph = ({
 
   const container = new TextContainer(
     isTablet ? contentWidth : screenWidth() - spacing(4),
-    10000,
+    Infinity,
     0,
     0,
     dropCap ? [dropCap.exclusion] : []
@@ -92,16 +92,17 @@ const InlineParagraph = ({
       )}
     >
       {positioned.map((p, i) => {
-        const attribute = p.text.attributes[0];
-        const style = attribute ? attribute.tag.settings : defaultFont;
-        const href = attribute ? attribute.tag.href : null;
-        const type = href ? attribute.tag.type : null;
-        const canonicalId = href ? attribute.tag.canonicalId : null;
+        const [attribute, href] = p.text.collapsedAttributes(0);
+        const style = attribute ? attribute.settings : defaultFont;
+        const type = href ? href.type : null;
+        const canonicalId = href ? href.canonicalId : null;
         if (href) {
           return (
             <LinkComponent
               url={href}
-              onPress={e => onLinkPress(e, { canonicalId, type, url: href })}
+              onPress={e =>
+                onLinkPress(e, { canonicalId, type, url: href.href })
+              }
               style={{
                 position: "absolute",
                 left: p.position.x,

--- a/packages/article-skeleton/src/article-body/simple-paragraph.js
+++ b/packages/article-skeleton/src/article-body/simple-paragraph.js
@@ -22,18 +22,19 @@ const SimpleParagraph = ({
     <ArticleParagraphWrapper ast={tree} key={key} uid={key}>
       <Text allowFontScaling={false} selectable style={{ lineHeight }}>
         {children.map(child => {
-          const attribute = child.attributes[0];
-          const style = attribute ? attribute.tag.settings : defaultFont;
-          const href = attribute ? attribute.tag.href : null;
-          const type = href ? attribute.tag.type : null;
-          const canonicalId = href ? attribute.tag.canonicalId : null;
+          const [attribute, href] = child.collapsedAttributes(0);
+          const style = attribute ? attribute.settings : defaultFont;
+          const type = href ? href.type : null;
+          const canonicalId = href ? href.canonicalId : null;
           if (href) {
             const { color, ...linkStyle } = style;
             return (
               <LinkComponent
                 url={href}
                 style={linkStyle}
-                onPress={e => onLinkPress(e, { canonicalId, type, url: href })}
+                onPress={e =>
+                  onLinkPress(e, { canonicalId, type, url: href.href })
+                }
               >
                 {child.string}
               </LinkComponent>

--- a/packages/article-skeleton/src/body-utils.js
+++ b/packages/article-skeleton/src/body-utils.js
@@ -2,71 +2,6 @@
 import memoize from "memoize-one";
 import { FontStorage } from "@times-components/typeset";
 
-// Handle the case where jounralist nest paragraph breaks inside styling markup
-const liftBreaks = paragraph => {
-  const children = paragraph.children.slice();
-  for (let i = 0; i < children.length; i++) {
-    const child = children[i];
-    const breaks = (child.children || []).filter(c => c.name === "break");
-    if (breaks.length > 1) {
-      children.splice(
-        i,
-        1,
-        ...breaks.concat({
-          ...child,
-          children: (child.children || []).filter(c => c.name !== "break")
-        })
-      );
-    }
-  }
-  return {
-    ...paragraph,
-    children
-  };
-};
-
-// Handle the case where journalists put everything in one paragraph
-const splitHuge = paragraph => {
-  const children = paragraph.children.reduceRight((acc, node) => {
-    const next = acc[0];
-    if (next && next.name === "break" && node.name === "break") {
-      const text = acc.slice(1).filter(n => n.name !== "paragraph");
-      return [
-        {
-          name: "paragraph",
-          attributes: {},
-          children: text
-        },
-        ...acc.slice(text.length + 1)
-      ];
-    }
-    return [node, ...acc];
-  }, []);
-  const wasSplit = children.filter(n => n.name === "paragraph").length > 0;
-  if (wasSplit) {
-    const text = children.filter(n => n.name !== "paragraph");
-    return [
-      {
-        name: "paragraph",
-        attributes: {},
-        children: text
-      },
-      ...children.slice(text.length)
-    ];
-  }
-  return [paragraph];
-};
-
-const split = content =>
-  [].concat(
-    ...content.map(node => {
-      if (node.name === "paragraph") {
-        return splitHuge(liftBreaks(node));
-      }
-      return [node];
-    })
-  );
-
 // Collapse inlines into the following paragraphs on tablet
 const collapsed = (isTablet, content) =>
   !isTablet
@@ -126,6 +61,4 @@ export const getStringBounds = (fontSettings, string) => {
   return { width, height };
 };
 
-export default memoize((isTablet, content) =>
-  collapsed(isTablet, split(content))
-);
+export default memoize((isTablet, content) => collapsed(isTablet, content));

--- a/packages/lazy-load/package.json
+++ b/packages/lazy-load/package.json
@@ -38,7 +38,7 @@
     "@times-components/eslint-config-thetimes": "0.8.16",
     "@times-components/jest-configurator": "2.6.11",
     "@times-components/jest-serializer": "3.2.23",
-    "@times-components/storybook": "4.1.39",
+    "@times-components/storybook": "4.1.40",
     "@times-components/test-utils": "2.3.8",
     "@times-components/webpack-configurator": "2.0.27",
     "babel-jest": "24.8.0",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -39,7 +39,7 @@
     "@times-components/jest-configurator": "2.6.11",
     "@times-components/jest-serializer": "3.2.23",
     "@times-components/provider-test-tools": "1.18.0",
-    "@times-components/storybook": "4.1.39",
+    "@times-components/storybook": "4.1.40",
     "@times-components/test-utils": "2.3.8",
     "@times-components/webpack-configurator": "2.0.27",
     "babel-jest": "24.8.0",

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -40,7 +40,7 @@
     "@times-components/eslint-config-thetimes": "0.8.16",
     "@times-components/jest-configurator": "2.6.11",
     "@times-components/jest-serializer": "3.2.23",
-    "@times-components/storybook": "4.1.39",
+    "@times-components/storybook": "4.1.40",
     "@times-components/tealium-utils": "0.7.67",
     "babel-jest": "24.8.0",
     "babel-loader": "8.0.5",

--- a/packages/typeset/__tests__/AttributedString.test.ts
+++ b/packages/typeset/__tests__/AttributedString.test.ts
@@ -1,19 +1,30 @@
-import { Attribute, AttributedString } from '../src';
+import { AttributedString, AttributeTag } from '../src';
 
-export const makeAttribute = (start: number, length: number): Attribute => ({
-  length,
-  start,
-  tag: {
-    settings: {
-      fontFamily: 'TimesDigitalW04',
-      fontSize: 18,
-      fontStyle: 'normal',
-      fontWeight: 'normal',
-      lineHeight: 30
-    },
-    tag: 'FONT'
+const tag: AttributeTag = {
+  settings: {
+    fontFamily: 'TimesDigitalW04',
+    fontSize: 18,
+    fontStyle: 'normal',
+    fontWeight: 'normal',
+    lineHeight: 30
+  },
+  tag: 'FONT'
+};
+
+export const makeAttribute = (
+  attrs: AttributeTag[][],
+  start: number,
+  length: number
+): AttributeTag[][] => {
+  for (let i = start; i < length; i++) {
+    if (attrs[i]) {
+      attrs[i].push(tag);
+    } else {
+      attrs[i] = [tag];
+    }
   }
-});
+  return attrs;
+};
 
 test('AttributedString#constructor(string, [])', () => {
   expect(() => {
@@ -30,42 +41,38 @@ test('AttributedString#charAt(number)', () => {
 
 test('AttributedString.join([Self, Self])', () => {
   const newString1 = new AttributedString('foo', []);
-  const newString2 = new AttributedString('bar', [makeAttribute(0, 3)]);
+  const newString2 = new AttributedString('bar', makeAttribute([], 0, 3));
   const joined = AttributedString.join([newString1, newString2]);
   expect(joined.string).toEqual('foobar');
 });
 
 test('AttributedString.slice(number)', () => {
-  const newString = new AttributedString('foobar', [
-    makeAttribute(0, 1),
-    makeAttribute(0, 3),
-    makeAttribute(0, 7),
-    makeAttribute(7, 3)
-  ]);
+  const attrs: AttributeTag[][] = [];
+  makeAttribute(attrs, 0, 1);
+  makeAttribute(attrs, 0, 3);
+  makeAttribute(attrs, 0, 7);
+  makeAttribute(attrs, 7, 3);
+  const newString = new AttributedString('foobar', attrs);
   const slice = newString.slice(2);
   expect(slice.string).toEqual('obar');
-  expect(slice.attributes.length).toEqual(2);
-  expect(slice.attributes[0].length).toEqual(1);
-  expect(slice.attributes[1].length).toEqual(4);
+  expect(slice.attributes.length).toEqual(4);
 });
 
 test('AttributedString.split()', () => {
-  const newString = new AttributedString('foo bar', [
-    makeAttribute(0, 1),
-    makeAttribute(0, 3),
-    makeAttribute(0, 8),
-    makeAttribute(7, 3)
-  ]);
+  const attrs: AttributeTag[][] = [];
+  makeAttribute(attrs, 0, 1);
+  makeAttribute(attrs, 0, 3);
+  makeAttribute(attrs, 0, 8);
+  makeAttribute(attrs, 7, 3);
+  const newString = new AttributedString('foo bar', attrs);
   const split = newString.split();
-  expect(split.length).toEqual(5);
+  expect(split.length).toEqual(4);
   expect(split).toMatchInlineSnapshot(`
     Array [
       AttributedString {
         "attributes": Array [
-          Object {
-            "length": 1,
-            "start": 0,
-            "tag": Object {
+          Array [
+            Object {
               "settings": Object {
                 "fontFamily": "TimesDigitalW04",
                 "fontSize": 18,
@@ -75,7 +82,27 @@ test('AttributedString.split()', () => {
               },
               "tag": "FONT",
             },
-          },
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
         ],
         "length": 1,
         "split": [Function],
@@ -83,10 +110,8 @@ test('AttributedString.split()', () => {
       },
       AttributedString {
         "attributes": Array [
-          Object {
-            "length": 1,
-            "start": 0,
-            "tag": Object {
+          Array [
+            Object {
               "settings": Object {
                 "fontFamily": "TimesDigitalW04",
                 "fontSize": 18,
@@ -96,18 +121,48 @@ test('AttributedString.split()', () => {
               },
               "tag": "FONT",
             },
-          },
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
         ],
-        "length": 3,
+        "length": 2,
         "split": [Function],
-        "string": "foo",
+        "string": "oo",
       },
       AttributedString {
         "attributes": Array [
-          Object {
-            "length": 1,
-            "start": 0,
-            "tag": Object {
+          Array [
+            Object {
               "settings": Object {
                 "fontFamily": "TimesDigitalW04",
                 "fontSize": 18,
@@ -117,20 +172,51 @@ test('AttributedString.split()', () => {
               },
               "tag": "FONT",
             },
-          },
+          ],
         ],
-        "length": 3,
-        "split": [Function],
-        "string": "foo",
-      },
-      AttributedString {
-        "attributes": Array [],
         "length": 1,
         "split": [Function],
         "string": " ",
       },
       AttributedString {
-        "attributes": Array [],
+        "attributes": Array [
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+        ],
         "length": 3,
         "split": [Function],
         "string": "bar",

--- a/packages/typeset/__tests__/LayoutManager.test.ts
+++ b/packages/typeset/__tests__/LayoutManager.test.ts
@@ -9,9 +9,10 @@ const testText = `Lorem Ipsum is simply dummy text of the \n printing and typese
 
 FontStorage.registerFont('TimesDigitalW04-Normal', () => TestFont);
 
-const testString = new AttributedString(testText, [
-  makeAttribute(0, testText.length)
-]);
+const testString = new AttributedString(
+  testText,
+  makeAttribute([], 0, testText.length)
+);
 const testContainer = new TextContainer(500, 500, 0, 0);
 
 test('LayoutManager#constructor()', () => {

--- a/packages/typeset/__tests__/__snapshots__/LayoutManager.test.ts.snap
+++ b/packages/typeset/__tests__/__snapshots__/LayoutManager.test.ts.snap
@@ -9,10 +9,8 @@ Array [
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -22,11 +20,72 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
       ],
-      "length": 5,
+      "length": 1,
       "split": [Function],
-      "string": "Lorem",
+      "string": "L",
+    },
+  },
+  Object {
+    "position": Point {
+      "x": 9.685546875,
+      "y": 0,
+    },
+    "text": AttributedString {
+      "attributes": Array [
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+      ],
+      "length": 4,
+      "split": [Function],
+      "string": "orem",
     },
   },
   Object {
@@ -36,10 +95,8 @@ Array [
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -49,7 +106,55 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 5,
       "split": [Function],
@@ -63,10 +168,8 @@ Array [
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 2,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -76,7 +179,19 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 2,
       "split": [Function],
@@ -90,10 +205,8 @@ Array [
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 6,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -103,7 +216,67 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 6,
       "split": [Function],
@@ -117,10 +290,8 @@ Array [
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -130,7 +301,55 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 5,
       "split": [Function],
@@ -144,10 +363,8 @@ Array [
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -157,7 +374,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -171,10 +424,8 @@ Array [
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 2,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -184,7 +435,19 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 2,
       "split": [Function],
@@ -198,10 +461,8 @@ Array [
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -211,7 +472,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -220,28 +505,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 335.07421875,
-      "y": 0,
-    },
-    "text": AttributedString {
-      "attributes": Array [],
-      "length": 1,
-      "split": [Function],
-      "string": "
-",
-    },
-  },
-  Object {
-    "position": Point {
-      "x": 339.5302734375,
-      "y": 0,
+      "x": 4.4560546875,
+      "y": 30,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 8,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -251,7 +521,91 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 8,
       "split": [Function],
@@ -260,15 +614,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 404.75390625,
-      "y": 0,
+      "x": 69.6796875,
+      "y": 30,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -278,7 +630,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -287,15 +663,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 0,
+      "x": 104.009765625,
       "y": 30,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 11,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -305,7 +679,127 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 11,
       "split": [Function],
@@ -314,15 +808,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 93.462890625,
+      "x": 197.47265625,
       "y": 30,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 9,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -332,7 +824,103 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 9,
       "split": [Function],
@@ -341,15 +929,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 166.0166015625,
+      "x": 270.0263671875,
       "y": 30,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -359,7 +945,55 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 5,
       "split": [Function],
@@ -368,15 +1002,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 221.66015625,
+      "x": 325.669921875,
       "y": 30,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -386,7 +1018,55 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 5,
       "split": [Function],
@@ -395,15 +1075,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 276.0908203125,
+      "x": 380.1005859375,
       "y": 30,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -413,7 +1091,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -422,15 +1124,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 309.533203125,
+      "x": 413.54296875,
       "y": 30,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -440,7 +1140,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -449,15 +1185,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 353.091796875,
+      "x": 457.1015625,
       "y": 30,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -467,7 +1201,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -476,15 +1234,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 382.8779296875,
-      "y": 30,
+      "x": 0,
+      "y": 60,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 10,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -494,7 +1250,115 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 10,
       "split": [Function],
@@ -503,15 +1367,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 0,
+      "x": 80.6044921875,
       "y": 60,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 8,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -521,7 +1383,91 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 8,
       "split": [Function],
@@ -530,15 +1476,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 75.357421875,
+      "x": 155.9619140625,
       "y": 60,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -548,7 +1492,55 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 5,
       "split": [Function],
@@ -557,15 +1549,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 139.95703125,
+      "x": 220.5615234375,
       "y": 60,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -575,7 +1565,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -584,15 +1610,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 174.6298828125,
+      "x": 255.234375,
       "y": 60,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -602,7 +1626,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -611,15 +1671,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 212.7392578125,
+      "x": 293.34375,
       "y": 60,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -629,7 +1687,55 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 5,
       "split": [Function],
@@ -638,15 +1744,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 259.734375,
+      "x": 340.3388671875,
       "y": 60,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -656,7 +1760,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -665,15 +1793,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 289.5205078125,
+      "x": 370.125,
       "y": 60,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 6,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -683,7 +1809,67 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 6,
       "split": [Function],
@@ -692,15 +1878,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 347.220703125,
+      "x": 427.8251953125,
       "y": 60,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -710,7 +1894,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -719,15 +1939,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 394.5849609375,
+      "x": 475.189453125,
       "y": 60,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 2,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -737,7 +1955,19 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 2,
       "split": [Function],
@@ -746,15 +1976,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 418.763671875,
-      "y": 60,
+      "x": 0,
+      "y": 90,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 7,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -764,7 +1992,79 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 7,
       "split": [Function],
@@ -773,15 +2073,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 0,
+      "x": 77.0888671875,
       "y": 90,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 7,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -791,7 +2089,79 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 7,
       "split": [Function],
@@ -800,15 +2170,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 56.4521484375,
+      "x": 133.541015625,
       "y": 90,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -818,7 +2186,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -827,15 +2231,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 96.2666015625,
+      "x": 173.35546875,
       "y": 90,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 1,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -845,7 +2247,7 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
       ],
       "length": 1,
       "split": [Function],
@@ -854,15 +2256,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 110.513671875,
+      "x": 187.6025390625,
       "y": 90,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 6,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -872,7 +2272,67 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 6,
       "split": [Function],
@@ -881,15 +2341,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 161.5341796875,
+      "x": 238.623046875,
       "y": 90,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 2,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -899,7 +2357,19 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 2,
       "split": [Function],
@@ -908,15 +2378,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 182.5048828125,
+      "x": 259.59375,
       "y": 90,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -926,7 +2394,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -935,15 +2439,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 220.9921875,
+      "x": 298.0810546875,
       "y": 90,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -953,7 +2455,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -962,15 +2488,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 255.322265625,
+      "x": 332.4111328125,
       "y": 90,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 9,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -980,7 +2504,103 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 9,
       "split": [Function],
@@ -989,15 +2609,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 343.9423828125,
+      "x": 421.03125,
       "y": 90,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 2,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1007,7 +2625,19 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 2,
       "split": [Function],
@@ -1016,15 +2646,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 358.646484375,
+      "x": 435.7353515625,
       "y": 90,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 2,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1034,7 +2662,19 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 2,
       "split": [Function],
@@ -1043,15 +2683,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 379.072265625,
-      "y": 90,
+      "x": 0,
+      "y": 120,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1061,7 +2699,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -1070,15 +2744,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 427.5791015625,
-      "y": 90,
+      "x": 48.5068359375,
+      "y": 120,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 1,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1088,7 +2760,7 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
       ],
       "length": 1,
       "split": [Function],
@@ -1097,15 +2769,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 441.826171875,
-      "y": 90,
+      "x": 62.75390625,
+      "y": 120,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1115,7 +2785,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -1124,15 +2830,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 0,
+      "x": 101.2412109375,
       "y": 120,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 8,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1142,7 +2846,91 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 8,
       "split": [Function],
@@ -1151,15 +2939,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 82.40625,
+      "x": 183.6474609375,
       "y": 120,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1169,7 +2955,55 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 5,
       "split": [Function],
@@ -1178,15 +3012,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 131.3525390625,
+      "x": 232.59375,
       "y": 120,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 2,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1196,7 +3028,19 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 2,
       "split": [Function],
@@ -1205,15 +3049,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 146.583984375,
+      "x": 247.8251953125,
       "y": 120,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1223,7 +3065,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -1232,15 +3098,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 180.0263671875,
+      "x": 281.267578125,
       "y": 120,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 8,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1250,7 +3114,91 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 8,
       "split": [Function],
@@ -1259,15 +3207,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 251.314453125,
+      "x": 352.5556640625,
       "y": 120,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1277,7 +3223,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -1286,15 +3256,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 281.84765625,
+      "x": 383.0888671875,
       "y": 120,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1304,7 +3272,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -1313,15 +3317,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 319.3857421875,
+      "x": 420.626953125,
       "y": 120,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1331,7 +3333,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -1340,15 +3378,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 352.599609375,
-      "y": 120,
+      "x": 0,
+      "y": 150,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 10,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1358,7 +3394,115 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 10,
       "split": [Function],
@@ -1367,15 +3511,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 434.5576171875,
-      "y": 120,
+      "x": 81.9580078125,
+      "y": 150,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1385,7 +3527,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -1394,15 +3560,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 464.9150390625,
-      "y": 120,
+      "x": 112.3154296875,
+      "y": 150,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1412,7 +3576,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -1421,15 +3621,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 0,
+      "x": 150.4775390625,
       "y": 150,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1439,7 +3637,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -1448,15 +3670,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 29.7861328125,
+      "x": 180.263671875,
       "y": 150,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1466,7 +3686,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -1475,15 +3731,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 68.0361328125,
+      "x": 218.513671875,
       "y": 150,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1493,7 +3747,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -1502,15 +3792,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 102.76171875,
+      "x": 253.2392578125,
       "y": 150,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 10,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1520,7 +3808,115 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 10,
       "split": [Function],
@@ -1529,15 +3925,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 185.8623046875,
+      "x": 336.33984375,
       "y": 150,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 12,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1547,7 +3941,139 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 12,
       "split": [Function],
@@ -1556,15 +4082,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 282.8583984375,
-      "y": 150,
+      "x": 0,
+      "y": 180,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 9,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1574,7 +4098,103 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 9,
       "split": [Function],
@@ -1583,15 +4203,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 367.0400390625,
-      "y": 150,
+      "x": 84.181640625,
+      "y": 180,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 11,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1601,7 +4219,127 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 11,
       "split": [Function],
@@ -1610,15 +4348,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 0,
+      "x": 173.49609375,
       "y": 180,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 10,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1628,7 +4364,115 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 10,
       "split": [Function],
@@ -1637,15 +4481,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 97.892578125,
+      "x": 271.388671875,
       "y": 180,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 2,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1655,7 +4497,19 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 2,
       "split": [Function],
@@ -1664,15 +4518,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 113.1240234375,
+      "x": 286.6201171875,
       "y": 180,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1682,7 +4534,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -1691,15 +4567,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 150.1787109375,
+      "x": 323.6748046875,
       "y": 180,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 11,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1709,7 +4583,127 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 11,
       "split": [Function],
@@ -1718,15 +4712,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 248.607421875,
+      "x": 422.103515625,
       "y": 180,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 2,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1736,7 +4728,19 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 2,
       "split": [Function],
@@ -1745,15 +4749,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 267.36328125,
+      "x": 440.859375,
       "y": 180,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1763,7 +4765,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -1772,15 +4798,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 297.1494140625,
-      "y": 180,
+      "x": 0,
+      "y": 210,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1790,7 +4814,55 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 5,
       "split": [Function],
@@ -1799,15 +4871,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 351.31640625,
-      "y": 180,
+      "x": 54.1669921875,
+      "y": 210,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1817,7 +4887,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -1826,15 +4932,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 389.4609375,
-      "y": 180,
+      "x": 92.3115234375,
+      "y": 210,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1844,7 +4948,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -1853,15 +4981,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 419.2470703125,
-      "y": 180,
+      "x": 122.09765625,
+      "y": 210,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 7,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1871,7 +4997,79 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 7,
       "split": [Function],
@@ -1880,15 +5078,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 481.67578125,
-      "y": 180,
+      "x": 184.5263671875,
+      "y": 210,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 2,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1898,7 +5094,19 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 2,
       "split": [Function],
@@ -1907,15 +5115,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 0,
+      "x": 205.4970703125,
       "y": 210,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 8,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1925,7 +5131,91 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 8,
       "split": [Function],
@@ -1934,15 +5224,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 69.78515625,
+      "x": 275.2822265625,
       "y": 210,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 6,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1952,7 +5240,67 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 6,
       "split": [Function],
@@ -1961,15 +5309,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 127.669921875,
+      "x": 333.1669921875,
       "y": 210,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 10,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -1979,7 +5325,115 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 10,
       "split": [Function],
@@ -1988,15 +5442,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 216.1142578125,
+      "x": 421.611328125,
       "y": 210,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2006,7 +5458,55 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 5,
       "split": [Function],
@@ -2015,15 +5515,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 271.7578125,
-      "y": 210,
+      "x": 0,
+      "y": 240,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2033,7 +5531,55 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 5,
       "split": [Function],
@@ -2042,15 +5588,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 326.1884765625,
-      "y": 210,
+      "x": 54.4306640625,
+      "y": 240,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 9,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2060,7 +5604,103 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 9,
       "split": [Function],
@@ -2069,15 +5709,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 411.3369140625,
-      "y": 210,
+      "x": 139.5791015625,
+      "y": 240,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 3,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2087,7 +5725,31 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 3,
       "split": [Function],
@@ -2096,15 +5758,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 445.6669921875,
-      "y": 210,
+      "x": 173.9091796875,
+      "y": 240,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2114,7 +5774,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -2123,15 +5819,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 0,
+      "x": 219.8671875,
       "y": 240,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 8,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2141,7 +5835,91 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 8,
       "split": [Function],
@@ -2150,15 +5928,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 67.5703125,
+      "x": 287.4375,
       "y": 240,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2168,7 +5944,43 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 4,
       "split": [Function],
@@ -2177,15 +5989,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 105.71484375,
+      "x": 325.58203125,
       "y": 240,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 7,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2195,7 +6005,79 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 7,
       "split": [Function],
@@ -2204,15 +6086,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 174.3310546875,
+      "x": 394.1982421875,
       "y": 240,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 10,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2222,92 +6102,119 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 10,
       "split": [Function],
       "string": "publishing",
-    },
-  },
-  Object {
-    "position": Point {
-      "x": 261.2373046875,
-      "y": 240,
-    },
-    "text": AttributedString {
-      "attributes": Array [
-        Object {
-          "length": 8,
-          "start": 0,
-          "tag": Object {
-            "settings": Object {
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 18,
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-              "lineHeight": 30,
-            },
-            "tag": "FONT",
-          },
-        },
-      ],
-      "length": 8,
-      "split": [Function],
-      "string": "software",
-    },
-  },
-  Object {
-    "position": Point {
-      "x": 336.146484375,
-      "y": 240,
-    },
-    "text": AttributedString {
-      "attributes": Array [
-        Object {
-          "length": 4,
-          "start": 0,
-          "tag": Object {
-            "settings": Object {
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 18,
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-              "lineHeight": 30,
-            },
-            "tag": "FONT",
-          },
-        },
-      ],
-      "length": 4,
-      "split": [Function],
-      "string": "like",
-    },
-  },
-  Object {
-    "position": Point {
-      "x": 367.822265625,
-      "y": 240,
-    },
-    "text": AttributedString {
-      "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
-            "settings": Object {
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 18,
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-              "lineHeight": 30,
-            },
-            "tag": "FONT",
-          },
-        },
-      ],
-      "length": 5,
-      "split": [Function],
-      "string": "Aldus",
     },
   },
   Object {
@@ -2317,10 +6224,8 @@ Array [
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 9,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2330,7 +6235,346 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+      ],
+      "length": 8,
+      "split": [Function],
+      "string": "software",
+    },
+  },
+  Object {
+    "position": Point {
+      "x": 74.9091796875,
+      "y": 270,
+    },
+    "text": AttributedString {
+      "attributes": Array [
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+      ],
+      "length": 4,
+      "split": [Function],
+      "string": "like",
+    },
+  },
+  Object {
+    "position": Point {
+      "x": 106.5849609375,
+      "y": 270,
+    },
+    "text": AttributedString {
+      "attributes": Array [
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+      ],
+      "length": 5,
+      "split": [Function],
+      "string": "Aldus",
+    },
+  },
+  Object {
+    "position": Point {
+      "x": 156.5068359375,
+      "y": 270,
+    },
+    "text": AttributedString {
+      "attributes": Array [
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 9,
       "split": [Function],
@@ -2339,15 +6583,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 95.220703125,
+      "x": 251.7275390625,
       "y": 270,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 9,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2357,7 +6599,103 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 9,
       "split": [Function],
@@ -2366,15 +6704,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 172.2392578125,
+      "x": 328.74609375,
       "y": 270,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 8,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2384,7 +6720,91 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 8,
       "split": [Function],
@@ -2393,15 +6813,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 244.0546875,
+      "x": 400.5615234375,
       "y": 270,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 2,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2411,7 +6829,19 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 2,
       "split": [Function],
@@ -2420,15 +6850,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 265.025390625,
+      "x": 421.5322265625,
       "y": 270,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 5,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2438,7 +6866,55 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 5,
       "split": [Function],
@@ -2447,15 +6923,13 @@ Array [
   },
   Object {
     "position": Point {
-      "x": 320.6689453125,
-      "y": 270,
+      "x": 0,
+      "y": 300,
     },
     "text": AttributedString {
       "attributes": Array [
-        Object {
-          "length": 6,
-          "start": 0,
-          "tag": Object {
+        Array [
+          Object {
             "settings": Object {
               "fontFamily": "TimesDigitalW04",
               "fontSize": 18,
@@ -2465,7 +6939,67 @@ Array [
             },
             "tag": "FONT",
           },
-        },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
+        Array [
+          Object {
+            "settings": Object {
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 18,
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+              "lineHeight": 30,
+            },
+            "tag": "FONT",
+          },
+        ],
       ],
       "length": 6,
       "split": [Function],

--- a/storybook-native/package.json
+++ b/storybook-native/package.json
@@ -27,7 +27,7 @@
     "@storybook/addons": "4.1.18",
     "@storybook/react": "4.1.18",
     "@storybook/react-native": "4.1.18",
-    "@times-components/storybook": "4.1.39",
+    "@times-components/storybook": "4.1.40",
     "core-js": "^2.6.5",
     "prop-types": "15.7.2",
     "react": "16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3403,6 +3403,68 @@
     fs-extra "6.0.0"
     glob "7.1.2"
 
+"@times-components/context@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@times-components/context/-/context-1.2.3.tgz#8d67fc3cd018db46b09f6d3f87db635829a5e8a9"
+  integrity sha512-pmK1KHYJRRHhao204oguZ2yWXDoU/b7QXcJERd4ne+RoLmkxMSaUbuVnNfEyJKRw/0PMhR9JXBacpg+mKO0Fzg==
+  dependencies:
+    "@times-components/styleguide" "3.36.5"
+
+"@times-components/storybook@4.1.39":
+  version "4.1.39"
+  resolved "https://registry.yarnpkg.com/@times-components/storybook/-/storybook-4.1.39.tgz#b28ed5a6e3236db515aa77120f8027a1485a00a1"
+  integrity sha512-D3Z6cITz4iEEnrEx+wnsDHpsAt8gt7kgOcTlJr+XblYVLVhm4JQw00Pa0RHDScgcjk+hi82jaw8kMUIG6arJ8A==
+  dependencies:
+    "@babel/core" "7.4.4"
+    "@storybook/addon-actions" "4.1.18"
+    "@storybook/addon-knobs" "4.1.18"
+    "@storybook/react-native" "4.1.18"
+    "@times-components/schema" "0.6.23"
+    "@times-components/user-state" "0.1.35"
+    apollo-cache-inmemory "1.5.1"
+    apollo-client "2.5.1"
+    apollo-link-http "1.5.14"
+    prop-types "15.7.2"
+    react "16.9.0"
+    react-apollo "2.5.5"
+    react-helmet-async "1.0.2"
+    react-test-renderer "16.9.0"
+    styled-components "4.3.2"
+
+"@times-components/styleguide@3.36.5":
+  version "3.36.5"
+  resolved "https://registry.yarnpkg.com/@times-components/styleguide/-/styleguide-3.36.5.tgz#c6089ec88bb2cddff399483f2cab7cb9d95dc494"
+  integrity sha512-rAAWDIiOe1h1iMb19vatCPwQLRyu5W5oevRp9gM/Et9oylhEgq3Pq2d8J3F+bvp1X6fXXUW4QuesminzCi7lrg==
+  dependencies:
+    prop-types "15.7.2"
+    styled-components "4.3.2"
+
+"@times-components/user-state@0.1.35":
+  version "0.1.35"
+  resolved "https://registry.yarnpkg.com/@times-components/user-state/-/user-state-0.1.35.tgz#ceec12733528e69012d5586e06e8c352df030cf1"
+  integrity sha512-mJPYNQI296cQ4JrZnJVuR7kv8z1Zy8Dn/ogMp/9WXZkHmJzsOT2F3tdjxaJ2Rq+2Ape6H55jlSsEQnNSP3fZKw==
+  dependencies:
+    "@storybook/addon-knobs" "4.1.18"
+    "@times-components/context" "1.2.3"
+    "@times-components/utils" "6.2.2"
+    prop-types "15.7.2"
+
+"@times-components/utils@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@times-components/utils/-/utils-6.2.2.tgz#5c1e2a84ea3a080e82216fcfa4e8780bd0161961"
+  integrity sha512-wItNvg5XUK7ENr6ulrH/Btzeav0+JFfJrEk7ZZweSA0rXCn5eR5aaBUwJyk13T2gQ5uglhddL3q1M+58Rc5o5g==
+  dependencies:
+    "@times-components/schema" "0.6.23"
+    "@times-components/styleguide" "3.36.5"
+    apollo-cache-inmemory "1.5.1"
+    apollo-client "2.5.1"
+    apollo-link-http "1.5.14"
+    lodash.omitby "4.6.0"
+    prop-types "15.7.2"
+    react-native "0.61.1"
+    styled-components "4.3.2"
+    unfetch "^3.0.0"
+
 "@types/accepts@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"


### PR DESCRIPTION
This PR removes any and all hacks around multiple newlines and nested styling markup and handles it properly. Newlines and nesting work as they would on web.

https://nidigitalsolutions.jira.com/browse/REPLAT-12170

![Screenshot_1582036769](https://user-images.githubusercontent.com/615608/74755182-aa931b80-526a-11ea-8991-7a5c7d8acb0e.png)


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
