### PR TITLE
feat: allow native to override breakpoints

### DIFF
--- a/packages/edition-slices/src/edition-slices.js
+++ b/packages/edition-slices/src/edition-slices.js
@@ -1,5 +1,6 @@
 import { getDimensions } from "@times-components/utils";
 import { tabletWidth } from "@times-components/styleguide";
+import { NativeModules } from "react-native";
 import {
   CommentLeadAndCartoonSlice,
   DailyRegisterLeadFourSlice,
@@ -19,8 +20,11 @@ import {
   PuzzleSlice
 } from "./slices";
 
+const config = (NativeModules || {}).ReactConfig;
+
 const { width } = getDimensions();
-const isTablet = width > tabletWidth;
+const isTablet =
+  (config && config.breakpoint !== "small") || width > tabletWidth;
 const SecondaryTwoAndTwoMapper = isTablet
   ? SecondaryTwoNoPicAndTwoSlice
   : SecondaryTwoAndTwoSlice;

--- a/packages/responsive/src/responsive.js
+++ b/packages/responsive/src/responsive.js
@@ -9,12 +9,15 @@ import {
   addDimensionsListener,
   removeDimensionsListener
 } from "@times-components/utils";
+import { NativeModules } from "react-native";
 import ResponsiveContext from "./context";
+
+const config = (NativeModules || {}).ReactConfig;
 
 const calculateState = (width, fontScale) => ({
   editionBreakpoint: getEditionBreakpoint(width),
   fontScale,
-  isTablet: width > tabletWidth,
+  isTablet: (config && config.breakpoint !== "small") || width > tabletWidth,
   screenWidth: width
 });
 

--- a/packages/styleguide/src/breakpoints/index.shared.js
+++ b/packages/styleguide/src/breakpoints/index.shared.js
@@ -1,0 +1,29 @@
+const editionBreakpoints = {
+  huge: "huge",
+  medium: "medium",
+  small: "small",
+  wide: "wide"
+};
+
+const editionBreakpointWidths = {
+  huge: 1366,
+  medium: 768,
+  wide: 1024
+};
+const editionMaxWidth = editionBreakpointWidths.huge;
+const sliceContentMaxWidth = 1180;
+
+export default {
+  huge: 1320,
+  medium: 768,
+  nativeTablet: 660,
+  nativeTabletWide: 1194,
+  small: 520,
+  wide: 1024
+};
+export {
+  editionBreakpoints,
+  editionMaxWidth,
+  editionBreakpointWidths,
+  sliceContentMaxWidth
+};

--- a/packages/styleguide/src/breakpoints/index.web.js
+++ b/packages/styleguide/src/breakpoints/index.web.js
@@ -1,4 +1,3 @@
-import { NativeModules } from "react-native";
 import widths, {
   editionBreakpoints,
   editionMaxWidth,
@@ -6,12 +5,7 @@ import widths, {
   sliceContentMaxWidth
 } from "./index.shared";
 
-const config = (NativeModules || {}).ReactConfig;
-
 const getEditionBreakpoint = width => {
-  if (config && config.breakpoint) {
-    return config.breakpoint;
-  }
   if (width < editionBreakpointWidths.medium) {
     return editionBreakpoints.small;
   }


### PR DESCRIPTION
This is so that the native side on android can set all parts of the app into tablet mode when unfolding a folding phone, which is not quite big enough to trigger the tablet breakpoints but is too large for mobile layouts to look reasonable.

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
