### PR TITLE
fix: issue with topics

### DIFF
--- a/packages/ssr/src/client/article.js
+++ b/packages/ssr/src/client/article.js
@@ -51,10 +51,7 @@ if (window.nuk && window.nuk.ssr && window.nuk.article) {
 
   const clientOptions = {
     rootTag,
-    useGET: false,
-    headers: {
-      "x-new-topic-data-source": true
-    }
+    useGET: false
   };
 
   runClient(article, clientOptions, data);

--- a/packages/ssr/src/client/topic.js
+++ b/packages/ssr/src/client/topic.js
@@ -8,7 +8,13 @@ if (window.nuk && window.nuk.ssr && window.nuk.topicPage) {
     makeTopicUrl,
     mapTopicToAdConfig
   } = window.nuk.ssr;
-  const { debounceTimeMs, page, pageSize, topicSlug } = window.nuk.topicPage;
+  const {
+    debounceTimeMs,
+    page,
+    pageSize,
+    topicSlug,
+    useNewTopicDataSource
+  } = window.nuk.topicPage;
 
   const data = {
     debounceTimeMs,
@@ -24,9 +30,11 @@ if (window.nuk && window.nuk.ssr && window.nuk.topicPage) {
     rootTag,
     useGET: true,
     skipAuthorization: true,
-    headers: {
-      "x-new-topic-data-source": true
-    }
+    headers: useNewTopicDataSource
+      ? {
+          "x-new-topic-data-source": true
+        }
+      : {}
   };
 
   runClient(topic, clientOptions, data);

--- a/packages/ssr/src/server/topic.js
+++ b/packages/ssr/src/server/topic.js
@@ -4,7 +4,7 @@ const defaultAdConfig = require("../lib/ads/make-topic-ad-config")
   .defaultServer;
 
 module.exports = (
-  { currentPage, topicSlug },
+  { currentPage, topicSlug, useNewTopicDataSource = false },
   { graphqlApiUrl, logger, makeArticleUrl, makeTopicUrl }
 ) => {
   if (typeof topicSlug !== "string") {
@@ -36,9 +36,11 @@ module.exports = (
     client: {
       logger,
       uri: graphqlApiUrl,
-      headers: {
-        "x-new-topic-data-source": true
-      }
+      headers: useNewTopicDataSource
+        ? {
+            "x-new-topic-data-source": true
+          }
+        : {}
     },
     data: {
       debounceTimeMs: 0,
@@ -47,7 +49,8 @@ module.exports = (
       mapTopicToAdConfig: defaultAdConfig,
       page: currentPage,
       pageSize: 20,
-      topicSlug
+      topicSlug,
+      useNewTopicDataSource
     },
     name: "topicPage"
   };


### PR DESCRIPTION
Topics had prematurely been updated to use v2. This was causing mismatches between the article and the topics pages. This PR reverts everything back to topics v1
