### PR TITLE
fix: make sure we show the placeholder while image decode is running

### DIFF
--- a/packages/responsive-image/src/index.tsx
+++ b/packages/responsive-image/src/index.tsx
@@ -212,7 +212,7 @@ const ResponsiveImage = (props: ResponsiveImageProps) => {
       fadeDuration={0}
     />
   );
-  const placeholder = showPlaceholder && (
+  const placeholder = (
     <Image
       key="placeholder"
       source={logoPath}
@@ -229,9 +229,10 @@ const ResponsiveImage = (props: ResponsiveImageProps) => {
 
   return (
     <View style={{ ...styles.style, ...propStyle, aspectRatio, borderRadius }}>
-      {placeholder}
+      {showPlaceholder && placeholder}
       {lowRes}
       {highRes}
+      {!showPlaceholder && placeholder}
     </View>
   );
 };


### PR DESCRIPTION
Sometimes when we switch from the placeholder to the image the image decode takes a little while and you see just the background. This moves the placeholder over the image, it is removed anyway so will not cover it once its loaded.
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
