### PR TITLE
TNLT-474: copy all contents from `assets/js` directory

### DIFF
--- a/TimesComponents.podspec
+++ b/TimesComponents.podspec
@@ -3,41 +3,41 @@ require 'json'
 
 # Please read very carefully or you will be in world of massive massive pain.
 # You been warned!!!
-# 
+#
 # Versions:
 #   - React Native: 0.55.4
 #   - cocoapods : 1.5.3
 #   - yarn: 1.12.3
 #   - node: v8.15.1
 #   - npm: 6.4.1
-# 
+#
 # Source Specs:
 #   - https://github.com/newsuk/times-pod-specs.git
 #   - https://github.com/CocoaPods/Specs
-# 
+#
 # Salient Information:
 #   - The current supported version of `ReactNative` is 0.55.4. It is picked from NewsUK specs.
-#   - The current supported version of `cocoapods` is 1.5.3. It is not important for generating this podspec but it generates 
+#   - The current supported version of `cocoapods` is 1.5.3. It is not important for generating this podspec but it generates
 #     incorrect .xcconfig file for the native app while trying to use this Podspec.
-#   - React Native code does not compile on its own without the changes made by plugin cocoapods-fix-react-native. The fixes 
+#   - React Native code does not compile on its own without the changes made by plugin cocoapods-fix-react-native. The fixes
 #     are applied as part of the native app Podfile when trying to use this podspec. But fixes cant be made while linting this
-#     podspec. 
-#   - Linting is disabled while pushing the podspec to specs repo due to above mention issue. This is done by disabling the 
-#     validation step in local code for cocoapods gem (Comment out the method call to validate_podspec_files). 
+#     podspec.
+#   - Linting is disabled while pushing the podspec to specs repo due to above mention issue. This is done by disabling the
+#     validation step in local code for cocoapods gem (Comment out the method call to validate_podspec_files).
 #     A sample path for file to be changed:
 #     /usr/local/lib/ruby/gems/2.6.0/gems/cocoapods-1.5.3/lib/cocoapods/command/repo/push.rb
 #   - Publish json podspec. Do not publish ruby podspec as it has run time code and it wont work while being used in Podfile.
-# 
+#
 # Issues:
 #   - `pod lib lint` and `pod spec lint` commands fail because React fails to compile without `cocoapods-fix-react-native` patch.
 #   - Native app works with cocoapods 1.5.3. Generated Pods fails to compile with cocoapods 1.6.1 (failure in React).
 #   - Issues with blue folder vs yellow folder for assets for generated TimesComponents spec. Need to investigate cocoapods why it is doing that.
-# 
+#
 # Update Podspec Steps (with broken React Native):
 #   - Make change in cocoapods:push.rb to disable podspec validation step.
 #   - $ pod repo push newsuk TimesComponents.podspec  --verbose --allow-warnings --use-json
 #   - Unroll changes in push.rb
-# 
+#
 # Update Podspec Steps (in future):
 #   - These are not complete steps for publishing podspec. Please refer cocoapods documentation for details.
 #   - $ pod lib lint TimesComponents.podspec --sources='https://github.com/newsuk/times-pod-specs,https://github.com/CocoaPods/Specs'
@@ -61,7 +61,7 @@ Pod::Spec.new do |s|
   s.swift_version    = '4.2'
   s.source           = { :git => 'https://github.com/newsuk/times-components-ios-artifacts', :tag => "#{s.version}"}
   s.resource_bundles = {
-    'TimesComponents' => ['assets/js/index.ios.bundle', 'assets/res/*']
+    'TimesComponents' => ['assets/js/*', 'assets/res/*']
   }
-  
+
 end


### PR DESCRIPTION
In order to add the current TimesComponents version to the iOS app settings screen, we need to add the `version.meta` file from the js directory to the podspec's `resource_bundles` container
