### PR TITLE
chore: Update README

### DIFF
--- a/doc/running-ios-dev.md
+++ b/doc/running-ios-dev.md
@@ -2,14 +2,14 @@
 
 ## Prequisites
 * clone https://github.com/newsuk/times-components
-* clone https://github.com/newsuk/nu-digital-projectd-times-smartphone-ios/
+* clone https://github.com/newsuk/nuk-tnl-app-ios-universal/
 * brew install cocoapods (https://brew.sh)
 
 The directory structure should look like:
 ```
 root
   | -> times-components
-  | -> nu-digital-projectd-times-smartphone-ios
+  | -> nuk-tnl-app-ios-universal
 ```
 
 ## Set up Times-Components
@@ -20,7 +20,7 @@ GRAPHQL_ENDPOINT="https://api.thetimes.co.uk/graphql" yarn
 
 ## Set up the IOS App
 ```
-cd nu-digital-projectd-times-smartphone-ios
+cd nuk-tnl-app-ios-universal
 pod update
 ```
 

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -21,13 +21,13 @@ on-the-fly bundles for the react development.
 
 ### Prerequisites
 
-- Get the latest code on `develop` for [nu-digital-projectd-times-smartphone-ios](https://github.com/newsuk/nu-digital-projectd-times-smartphone-ios)
+- Get the latest code on `develop` for [nuk-tnl-app-ios-universal](https://github.com/newsuk/nuk-tnl-app-ios-universal)
 - Get the latest Xcode [here](https://developer.apple.com/xcode/)
 
 ### Step-by-step Guide
 
 - Run `yarn ios:app` in `times-components` to bundles the latest code on-the-fly once the emulator request a bundle.
-- Open `TheTimesProjectD.xcworkspace` from [nu-digital-projectd-times-smartphone-ios](https://github.com/newsuk/nu-digital-projectd-times-smartphone-ios) in Xcode.
+- Open `TheTimesProjectD.xcworkspace` from [nuk-tnl-app-ios-universal](https://github.com/newsuk/nuk-tnl-app-ios-universal) in Xcode.
 - In Xcode, click `TheTimes` next to the play/stop icons.
 - Edit Scheme... -> Run -> Arguments -> Tick the `REACT_DEV_DEBUG_MODE` checkbox.
 - Run the application with Xcode.
@@ -36,4 +36,4 @@ on-the-fly bundles for the react development.
 
 ### Upgrade Times Component in the iOS app
 
-see [Readme](https://github.com/newsuk/nu-digital-projectd-times-smartphone-ios/blob/develop/README.md)
+see [Readme](https://github.com/newsuk/nuk-tnl-app-ios-universal/blob/develop/README.md)

--- a/lib/publish.sh
+++ b/lib/publish.sh
@@ -29,6 +29,6 @@ npx lerna publish --conventional-commits --yes --concurrency=1 --exact -m "$MESS
 
 # push above changes to git
 echo "Pushing to master"
-git config user.name "Publish Bot"
-git config user.email "publish@ghbot.com"
+git config user.name "times-tools"
+git config user.email "tools@news.co.uk"
 git push origin master --tags --quiet > /dev/null 2>&1


### PR DESCRIPTION
Just updating the repository URL for the universal app as we had to rename it in order to match the new standard `newsuk` naming convention. I've also updated the git username/email for the publish step to use our service account.