### PR TITLE
fix: close icon on modal images

### DIFF
--- a/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
@@ -19,6 +19,7 @@ exports[`1. landscape default modal 1`] = `
           Object {
             "padding": 20,
             "position": "absolute",
+            "right": 5,
             "top": 0,
             "zIndex": 2,
           }
@@ -145,6 +146,7 @@ exports[`2. portrait default modal 1`] = `
           Object {
             "padding": 20,
             "position": "absolute",
+            "right": 5,
             "top": 0,
             "zIndex": 2,
           }
@@ -271,6 +273,7 @@ exports[`3. tablet landscape default modal 1`] = `
           Object {
             "padding": 20,
             "position": "absolute",
+            "right": 5,
             "top": 0,
             "zIndex": 2,
           }
@@ -397,6 +400,7 @@ exports[`4. tablet portrait default modal 1`] = `
           Object {
             "padding": 20,
             "position": "absolute",
+            "right": 5,
             "top": 0,
             "zIndex": 2,
           }

--- a/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
@@ -20,6 +20,7 @@ exports[`1. landscape default modal 1`] = `
             "marginLeft": 10,
             "padding": 20,
             "position": "absolute",
+            "right": 5,
             "top": 0,
             "zIndex": 2,
           }
@@ -157,6 +158,7 @@ exports[`2. portrait default modal 1`] = `
             "marginLeft": 10,
             "padding": 20,
             "position": "absolute",
+            "right": 5,
             "top": 0,
             "zIndex": 2,
           }
@@ -294,6 +296,7 @@ exports[`3. tablet landscape default modal 1`] = `
             "marginLeft": 10,
             "padding": 20,
             "position": "absolute",
+            "right": 5,
             "top": 0,
             "zIndex": 2,
           }
@@ -431,6 +434,7 @@ exports[`4. tablet portrait default modal 1`] = `
             "marginLeft": 10,
             "padding": 20,
             "position": "absolute",
+            "right": 5,
             "top": 0,
             "zIndex": 2,
           }

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -16,6 +16,7 @@ const styles = {
     padding: spacing(3),
     position: "absolute",
     top: 0,
+    right: 5,
     zIndex: 2
   },
   buttonContainerTablet: {


### PR DESCRIPTION
[Jira](https://nidigitalsolutions.jira.com/browse/TNLT-652)

Before:
<img width="389" alt="beforeX" src="https://user-images.githubusercontent.com/7889661/76434848-e8ddaf80-63be-11ea-8342-d0d1cfd25ea8.png">

After:

<img width="379" alt="afterX" src="https://user-images.githubusercontent.com/7889661/76434856-ed09cd00-63be-11ea-9763-aa58f8cae47c.png">

