### PR TITLE
fix: resolve default Webcomponent polyfill response

### DIFF
--- a/packages/interactive-wrapper/__tests__/web/interactive-wrapper.test.js
+++ b/packages/interactive-wrapper/__tests__/web/interactive-wrapper.test.js
@@ -69,7 +69,7 @@ describe("interactive-wrapper", () => {
 
       it("does nothing if both html imports and custom elements are supported", () => {
         const { innerHTML } = document.body;
-        
+
         expect(document.body.innerHTML).toEqual(innerHTML);
         return expect(polyfillWCIfNecessary()).resolves.toBe(undefined);
       });

--- a/packages/interactive-wrapper/__tests__/web/interactive-wrapper.test.js
+++ b/packages/interactive-wrapper/__tests__/web/interactive-wrapper.test.js
@@ -69,8 +69,9 @@ describe("interactive-wrapper", () => {
 
       it("does nothing if both html imports and custom elements are supported", () => {
         const { innerHTML } = document.body;
-        expect(polyfillWCIfNecessary()).toEqual(null);
+        
         expect(document.body.innerHTML).toEqual(innerHTML);
+        return expect(polyfillWCIfNecessary()).resolves.toBe(undefined);
       });
 
       it("polyfills if html imports are not supported", () => {

--- a/packages/interactive-wrapper/src/interactive-wrapper.web.js
+++ b/packages/interactive-wrapper/src/interactive-wrapper.web.js
@@ -54,7 +54,7 @@ export function polyfillWCIfNecessary() {
     ]);
   }
 
-  return null;
+  return Promise.resolve();
 }
 
 export default class InteractiveWrapper extends Component {


### PR DESCRIPTION
This returns a valid Promise from the default `fetchPolyfill` function