### PR TITLE
fix: manual ios bump

### DIFF
--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@times-components/ios-app",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "license": "BSD-3-Clause",
   "scripts": {
     "build": "cat package.json | grep version | head -1 | sed 's/[\",\t ]//g' | awk -F: '{ print \"Bundle Version: \" $2 }' > ios-assets/js/version.meta",


### PR DESCRIPTION
Trying manually to sync ios-app version.
Because publish ios is failing.