### PR TITLE
chore(TNLT-1941): prevent crash of puff slice

### DIFF
--- a/android-app/package.json
+++ b/android-app/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@react-native-community/netinfo": "5.3.3",
-    "@times-components/pages": "2.1.96",
+    "@times-components/pages": "2.1.98",
     "@times-components/typeset": "0.1.2",
     "prop-types": "15.7.2",
     "react": "16.9.0",

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@times-components/ios-app",
-  "version": "0.17.100",
+  "version": "0.17.102",
   "license": "BSD-3-Clause",
   "scripts": {
     "build": "cat package.json | grep version | head -1 | sed 's/[\",\t ]//g' | awk -F: '{ print \"Bundle Version: \" $2 }' > ios-assets/js/version.meta",
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@react-native-community/netinfo": "5.3.3",
-    "@times-components/pages": "2.1.96",
+    "@times-components/pages": "2.1.98",
     "@times-components/typeset": "0.1.2",
     "prop-types": "15.7.2",
     "react": "16.9.0",

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@times-components/pages",
-  "version": "2.1.96",
+  "version": "2.1.98",
   "main": "dist/pages",
   "dev": "src/pages",
   "scripts": {
@@ -58,7 +58,7 @@
     "@times-components/context": "1.2.14",
     "@times-components/provider": "1.22.11",
     "@times-components/schema": "0.6.23",
-    "@times-components/section": "1.6.56",
+    "@times-components/section": "1.6.59",
     "@times-components/styleguide": "3.38.7",
     "@times-components/topic": "5.3.1",
     "apollo-cache-inmemory": "1.5.1",

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@times-components/section",
-  "version": "1.6.56",
+  "version": "1.6.59",
   "description": "Section Page",
   "main": "dist/section",
   "dev": "src/section",

--- a/packages/section/src/section-tracking-context.js
+++ b/packages/section/src/section-tracking-context.js
@@ -8,7 +8,7 @@ export default Component =>
       const { slices } = section;
       const firstSlice = slices[0];
       const nonName = Object.keys(firstSlice).filter(n => n !== "name")[0];
-      const { article: data } = firstSlice[nonName];
+      const { article: data } = firstSlice[nonName] || {};
       const published = DateTime.fromJSDate(
         new Date(get(data, "publishedTime", ""))
       );


### PR DESCRIPTION
This is preventing the apps from crashing when there is puff slice in the edition. It also includes version bumps for ios, pages and section packages. 

Linked with: https://github.com/newsuk/times-components/pull/2593