### PR TITLE
fix(FNLT-1964): update web font for ST magazine articles

### DIFF
--- a/packages/article-paragraph/article-paragraph.showcase.web.js
+++ b/packages/article-paragraph/article-paragraph.showcase.web.js
@@ -16,9 +16,9 @@ const dropCapTypes = { dropCap: dropCapData, dropCapAsLink, dropCapAsQuote };
 
 const renderParagraph = ({ select, boolean }, ast) => {
   const sections = Object.keys(colours.section).sort();
-  const sectionIdx = select("Section", sections, 0);
+  const sectionIdx = sections.indexOf(select("Section", sections, sections[0]));
   const enableDropcap = boolean && boolean("Enable DropCap", true);
-  const section = sections[sectionIdx];
+  const section = sections[sectionIdx] || sections[0];
   const theme = themeFactory(section, "magazinecomment");
   const colour = theme.sectionColour;
   const font = theme.dropCapFont;

--- a/packages/styleguide/__tests__/shared.js
+++ b/packages/styleguide/__tests__/shared.js
@@ -110,6 +110,9 @@ const tests = [
         "dropCap"
       );
       expect(themeFactory().dropCapFont).toEqual("dropCap");
+      expect(
+        themeFactory("the sunday times magazine", "indepth").dropCapFont
+      ).toEqual("stMagazine");
     }
   },
   {
@@ -136,6 +139,9 @@ const tests = [
       expect(themeFactory("thesundaytimesmagazine", null).headlineFont).toEqual(
         "headline"
       );
+      expect(
+        themeFactory("the sunday times magazine", "indepth").headlineFont
+      ).toEqual("stMagazine");
     }
   },
   {
@@ -162,6 +168,9 @@ const tests = [
       expect(
         themeFactory("thesundaytimesmagazine", null).pullQuoteFont
       ).toEqual("headlineRegular");
+      expect(
+        themeFactory("the sunday times magazine", "indepth").pullQuoteFont
+      ).toEqual("stMagazine");
     }
   },
   {

--- a/packages/styleguide/src/theme/theme-factory.js
+++ b/packages/styleguide/src/theme/theme-factory.js
@@ -30,7 +30,8 @@ const magazineFontPicker = (defaultFont, section, template) => {
     style: "styleMagazine",
     Style: "styleMagazine",
     "The Sunday Times Magazine": "stMagazine",
-    thesundaytimesmagazine: "stMagazine"
+    thesundaytimesmagazine: "stMagazine",
+    "the sunday times magazine": "stMagazine"
   };
 
   const config = {


### PR DESCRIPTION
Sync fonts between mobile and web for dropcap and headline in the following case:

- When the article template is `indepth`, `magazinestandard` or `magazinestandard` in `The Sunday Times Magazine` section.
Font used: `Tiempos-Headline-Bold`

- Minor storybook knobs fixes


[TNLT-1964](https://nidigitalsolutions.jira.com/browse/TNLT-1964)

Before:
![ST-Magazine-font-before](https://user-images.githubusercontent.com/8720661/81827746-bfb5d880-9541-11ea-8235-c596dff95216.png)


After:
![ST-Magazine-font-after](https://user-images.githubusercontent.com/8720661/81827756-c17f9c00-9541-11ea-8ab3-bc2f0a093232.png)
