### PR TITLE
feat: handle crash takeoverpage ios

### DIFF
--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -70,7 +70,8 @@
     "@times-components/message-bar": "0.3.51",
     "@times-components/provider": "1.22.14",
     "@times-components/responsive": "0.6.14",
-    "@times-components/styleguide": "3.38.9"
+    "@times-components/styleguide": "3.38.9",
+    "react-native-webview": "7.0.5"
   },
   "resolutions": {
     "react": "16.9.0",

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Platform } from "react-native";
 import ArticleMagazineComment from "@times-components/article-magazine-comment";
 import ArticleInDepth from "@times-components/article-in-depth";
 import ArticleMagazineStandard from "@times-components/article-magazine-standard";
@@ -8,6 +9,7 @@ import Responsive from "@times-components/responsive";
 import { scales } from "@times-components/styleguide";
 import { MessageManager } from "@times-components/message-bar";
 import { getMediaList, addIndexesToInlineImages } from "./utils";
+import handleTakeoverpageUrl from "./utils/handle-takeoverpage-url";
 
 export const templates = {
   indepth: ArticleInDepth,
@@ -28,15 +30,22 @@ const Article = props => {
   const { article, onImagePress } = props;
   const { leadAsset, template } = article || {};
   let { content } = article || {};
+
   if (template === "takeoverpage") {
+    if (Platform.OS === "ios") {
+      return handleTakeoverpageUrl(article.url);
+    }
     throw new TakeoverBailout("Aborted react render: Takeover page");
   }
+
   let onImagePressArticle = null;
+
   if (onImagePress) {
     content = addIndexesToInlineImages(content, leadAsset);
     const mediaList = getMediaList(content, leadAsset);
     onImagePressArticle = index => onImagePress(index, mediaList);
   }
+
   const Component = templates[template] || ArticleMainStandard;
   const newProps = {
     ...props,

--- a/packages/article/src/utils/handle-takeoverpage-url.js
+++ b/packages/article/src/utils/handle-takeoverpage-url.js
@@ -1,0 +1,13 @@
+import React, { useState } from "react";
+import { WebView } from "react-native-webview";
+import { ActivityIndicator } from "react-native";
+
+export default url => {
+  const [isSpinnerShown, hideSpinner] = useState(true);
+  return (
+    <>
+      <WebView source={{ uri: url }} onLoad={() => hideSpinner(false)} />
+      {isSpinnerShown && <ActivityIndicator size="large" />}
+    </>
+  );
+};


### PR DESCRIPTION
Handle app crash on opening the app with a takeover page link from an external app. 

The problem is coming from a deep link setup from the native ios app. Every link that starting with https://thetimes.co.uk will be fist open inside the app and when this happens with takeover page, which is not supported by the app, it will crash. 

There is no way to redirect this link from the react native side, because it will initiate the deep link "loop" again and the will end up crashing.

My fix is currently using a webview to open the article inside the app, which may lead to confusion for some users, but at least we will show the clicked article to the user. (Again, this will happen only on IOS platform with a takeoverpage link opened from an external app, which is really rare case...)

Other way of handling this, will be to show some king of pop up alert, that this article is not supported by the app, and when the user clicks okay, it will redirect to the main edition screen.

![takeoverpage](https://user-images.githubusercontent.com/7889661/82068120-469db900-96da-11ea-8eaa-b55314d70a7d.gif)

