### PR TITLE
fix(TNLT-1826): support bold/italic links for native

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -954,7 +954,667 @@ exports[`6. an article with heading tags 1`] = `
 </View>
 `;
 
-exports[`7. an article skeleton with responsive items 1`] = `
+exports[`7. an article with link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView>
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        />
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+              }
+            }
+          >
+            <View>
+              <Text
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                      "marginBottom": 25,
+                      "marginTop": 0,
+                      "textDecorationLine": "underline",
+                    }
+                  }
+                >
+                  Jack Dorsey
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                   said today that while the company was unlikely to open its offices before September, almost all staff could now work permanently from wherever they want.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "width": undefined,
+              }
+            }
+          >
+            <ArticleExtras />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <ActivityIndicator />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`8. an article with italic link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView>
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        />
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+              }
+            }
+          >
+            <View>
+              <Text
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  In his 2015 book on the tournaments, 
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "italic",
+                      "lineHeight": 52,
+                      "marginBottom": 25,
+                      "marginTop": 0,
+                      "textDecorationLine": "underline",
+                    }
+                  }
+                >
+                  Superforecasting
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  , Professor Tetlock said the most accurate predictors all used very similar methods. They used a historical “base rate” for predicting how likely an event was, adjusting constantly in the light of new information.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "width": undefined,
+              }
+            }
+          >
+            <ArticleExtras />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <ActivityIndicator />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`9. an article with bold text followed by bold link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView>
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        />
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+              }
+            }
+          >
+            <View>
+              <Text
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  2 
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                      "marginBottom": 25,
+                      "marginTop": 0,
+                      "textDecorationLine": "underline",
+                    }
+                  }
+                >
+                  Becoming by Michelle Obama
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "width": undefined,
+              }
+            }
+          >
+            <ArticleExtras />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <ActivityIndicator />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`10. an article with italic and normal text link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView>
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        />
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+              }
+            }
+          >
+            <View>
+              <Text
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  Family Action is one of two charities being supported by 
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "italic",
+                      "lineHeight": 52,
+                      "marginBottom": 25,
+                      "marginTop": 0,
+                      "textDecorationLine": "underline",
+                    }
+                  }
+                >
+                  The Times
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                      "marginBottom": 25,
+                      "marginTop": 0,
+                      "textDecorationLine": "underline",
+                    }
+                  }
+                >
+                   Coronavirus Charity Appeal
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                   to support people in greatest hardship under the restrictions. The second charity is The Big Issue Foundation.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "width": undefined,
+              }
+            }
+          >
+            <ArticleExtras />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <ActivityIndicator />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`11. an article with bold and italic text at the same time 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView>
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        />
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+              }
+            }
+          >
+            <View>
+              <Text
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "italic",
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  Conversations with Friends
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "width": undefined,
+              }
+            }
+          >
+            <ArticleExtras />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <ActivityIndicator />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`12. an article skeleton with responsive items 1`] = `
 <View
   style={
     Object {

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -1433,7 +1433,1019 @@ exports[`6. an article with heading tags 1`] = `
 </View>
 `;
 
-exports[`8. an inline link reports analytics event on press 1`] = `
+exports[`7. an article with link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView
+    ListHeaderComponent={
+      <Gutter
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      >
+        <Header
+          width={750}
+        />
+      </Gutter>
+    }
+    extraData={true}
+    initialNumToRender={2}
+    maxToRenderPerBatch={10}
+    nestedScrollEnabled={true}
+    numColumns={1}
+    onEndReachedThreshold={2}
+    removeClippedSubviews={true}
+    scrollEventThrottle={50}
+    showsVerticalScrollIndicator={false}
+    updateCellsBatchingPeriod={50}
+    windowSize={3}
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+                Object {},
+              ]
+            }
+          >
+            <View>
+              <Text
+                selectable={true}
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="link"
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 36,
+                        "lineHeight": 52,
+                        "marginBottom": 25,
+                        "marginTop": 0,
+                      },
+                    ]
+                  }
+                >
+                  Jack Dorsey
+                </Text>
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                   said today that while the company was unlikely to open its offices before September, almost all staff could now work permanently from wherever they want.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "maxWidth": "100%",
+                  "width": undefined,
+                },
+              ]
+            }
+          >
+            <ArticleExtras
+              articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+              articleUrl="https://url.io"
+            />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <ActivityIndicator
+            animating={true}
+            color={null}
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`8. an article with italic link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView
+    ListHeaderComponent={
+      <Gutter
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      >
+        <Header
+          width={750}
+        />
+      </Gutter>
+    }
+    extraData={true}
+    initialNumToRender={2}
+    maxToRenderPerBatch={10}
+    nestedScrollEnabled={true}
+    numColumns={1}
+    onEndReachedThreshold={2}
+    removeClippedSubviews={true}
+    scrollEventThrottle={50}
+    showsVerticalScrollIndicator={false}
+    updateCellsBatchingPeriod={50}
+    windowSize={3}
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+                Object {},
+              ]
+            }
+          >
+            <View>
+              <Text
+                selectable={true}
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  In his 2015 book on the tournaments, 
+                </Text>
+                <Text
+                  accessibilityRole="link"
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 36,
+                        "fontStyle": "italic",
+                        "lineHeight": 52,
+                        "marginBottom": 25,
+                        "marginTop": 0,
+                      },
+                    ]
+                  }
+                >
+                  Superforecasting
+                </Text>
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  , Professor Tetlock said the most accurate predictors all used very similar methods. They used a historical “base rate” for predicting how likely an event was, adjusting constantly in the light of new information.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "maxWidth": "100%",
+                  "width": undefined,
+                },
+              ]
+            }
+          >
+            <ArticleExtras
+              articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+              articleUrl="https://url.io"
+            />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <ActivityIndicator
+            animating={true}
+            color={null}
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`9. an article with bold text followed by bold link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView
+    ListHeaderComponent={
+      <Gutter
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      >
+        <Header
+          width={750}
+        />
+      </Gutter>
+    }
+    extraData={true}
+    initialNumToRender={2}
+    maxToRenderPerBatch={10}
+    nestedScrollEnabled={true}
+    numColumns={1}
+    onEndReachedThreshold={2}
+    removeClippedSubviews={true}
+    scrollEventThrottle={50}
+    showsVerticalScrollIndicator={false}
+    updateCellsBatchingPeriod={50}
+    windowSize={3}
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+                Object {},
+              ]
+            }
+          >
+            <View>
+              <Text
+                selectable={true}
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  2 
+                </Text>
+                <Text
+                  accessibilityRole="link"
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 36,
+                        "fontWeight": "bold",
+                        "lineHeight": 52,
+                        "marginBottom": 25,
+                        "marginTop": 0,
+                      },
+                    ]
+                  }
+                >
+                  Becoming by Michelle Obama
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "maxWidth": "100%",
+                  "width": undefined,
+                },
+              ]
+            }
+          >
+            <ArticleExtras
+              articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+              articleUrl="https://url.io"
+            />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <ActivityIndicator
+            animating={true}
+            color={null}
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`10. an article with italic and normal text link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView
+    ListHeaderComponent={
+      <Gutter
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      >
+        <Header
+          width={750}
+        />
+      </Gutter>
+    }
+    extraData={true}
+    initialNumToRender={2}
+    maxToRenderPerBatch={10}
+    nestedScrollEnabled={true}
+    numColumns={1}
+    onEndReachedThreshold={2}
+    removeClippedSubviews={true}
+    scrollEventThrottle={50}
+    showsVerticalScrollIndicator={false}
+    updateCellsBatchingPeriod={50}
+    windowSize={3}
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+                Object {},
+              ]
+            }
+          >
+            <View>
+              <Text
+                selectable={true}
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  Family Action is one of two charities being supported by 
+                </Text>
+                <Text
+                  accessibilityRole="link"
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 36,
+                        "fontStyle": "italic",
+                        "lineHeight": 52,
+                        "marginBottom": 25,
+                        "marginTop": 0,
+                      },
+                    ]
+                  }
+                >
+                  The Times
+                </Text>
+                <Text
+                  accessibilityRole="link"
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 36,
+                        "lineHeight": 52,
+                        "marginBottom": 25,
+                        "marginTop": 0,
+                      },
+                    ]
+                  }
+                >
+                   Coronavirus Charity Appeal
+                </Text>
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                   to support people in greatest hardship under the restrictions. The second charity is The Big Issue Foundation.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "maxWidth": "100%",
+                  "width": undefined,
+                },
+              ]
+            }
+          >
+            <ArticleExtras
+              articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+              articleUrl="https://url.io"
+            />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <ActivityIndicator
+            animating={true}
+            color={null}
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`11. an article with bold and italic text at the same time 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView
+    ListHeaderComponent={
+      <Gutter
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      >
+        <Header
+          width={750}
+        />
+      </Gutter>
+    }
+    extraData={true}
+    initialNumToRender={2}
+    maxToRenderPerBatch={10}
+    nestedScrollEnabled={true}
+    numColumns={1}
+    onEndReachedThreshold={2}
+    removeClippedSubviews={true}
+    scrollEventThrottle={50}
+    showsVerticalScrollIndicator={false}
+    updateCellsBatchingPeriod={50}
+    windowSize={3}
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+                Object {},
+              ]
+            }
+          >
+            <View>
+              <Text
+                selectable={true}
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "italic",
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  Conversations with Friends
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "maxWidth": "100%",
+                  "width": undefined,
+                },
+              ]
+            }
+          >
+            <ArticleExtras
+              articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+              articleUrl="https://url.io"
+            />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <ActivityIndicator
+            animating={true}
+            color={null}
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`13. an inline link reports analytics event on press 1`] = `
 Object {
   "action": "Pressed",
   "attrs": Object {
@@ -1466,7 +2478,7 @@ Object {
 }
 `;
 
-exports[`9. renders content 1`] = `
+exports[`14. renders content 1`] = `
 <View
   style={
     Object {
@@ -1712,7 +2724,7 @@ exports[`9. renders content 1`] = `
 </View>
 `;
 
-exports[`10. an article with inline paragraph 1`] = `
+exports[`15. an article with inline paragraph 1`] = `
 <View
   style={
     Object {

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -954,7 +954,667 @@ exports[`6. an article with heading tags 1`] = `
 </View>
 `;
 
-exports[`7. an article skeleton with responsive items 1`] = `
+exports[`7. an article with link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView>
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        />
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+              }
+            }
+          >
+            <View>
+              <Text
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                      "marginBottom": 25,
+                      "marginTop": 0,
+                      "textDecorationLine": "underline",
+                    }
+                  }
+                >
+                  Jack Dorsey
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                   said today that while the company was unlikely to open its offices before September, almost all staff could now work permanently from wherever they want.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "width": undefined,
+              }
+            }
+          >
+            <ArticleExtras />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <ActivityIndicator />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`8. an article with italic link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView>
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        />
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+              }
+            }
+          >
+            <View>
+              <Text
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  In his 2015 book on the tournaments, 
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "italic",
+                      "lineHeight": 52,
+                      "marginBottom": 25,
+                      "marginTop": 0,
+                      "textDecorationLine": "underline",
+                    }
+                  }
+                >
+                  Superforecasting
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  , Professor Tetlock said the most accurate predictors all used very similar methods. They used a historical “base rate” for predicting how likely an event was, adjusting constantly in the light of new information.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "width": undefined,
+              }
+            }
+          >
+            <ArticleExtras />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <ActivityIndicator />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`9. an article with bold text followed by bold link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView>
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        />
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+              }
+            }
+          >
+            <View>
+              <Text
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  2 
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                      "marginBottom": 25,
+                      "marginTop": 0,
+                      "textDecorationLine": "underline",
+                    }
+                  }
+                >
+                  Becoming by Michelle Obama
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "width": undefined,
+              }
+            }
+          >
+            <ArticleExtras />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <ActivityIndicator />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`10. an article with italic and normal text link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView>
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        />
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+              }
+            }
+          >
+            <View>
+              <Text
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  Family Action is one of two charities being supported by 
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "italic",
+                      "lineHeight": 52,
+                      "marginBottom": 25,
+                      "marginTop": 0,
+                      "textDecorationLine": "underline",
+                    }
+                  }
+                >
+                  The Times
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                      "marginBottom": 25,
+                      "marginTop": 0,
+                      "textDecorationLine": "underline",
+                    }
+                  }
+                >
+                   Coronavirus Charity Appeal
+                </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                   to support people in greatest hardship under the restrictions. The second charity is The Big Issue Foundation.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "width": undefined,
+              }
+            }
+          >
+            <ArticleExtras />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <ActivityIndicator />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`11. an article with bold and italic text at the same time 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView>
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        />
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+              }
+            }
+          >
+            <View>
+              <Text
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "italic",
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  Conversations with Friends
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "overflow": "hidden",
+                "width": undefined,
+              }
+            }
+          >
+            <ArticleExtras />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "maxWidth": "100%",
+              "overflow": "hidden",
+              "width": undefined,
+            }
+          }
+        >
+          <ActivityIndicator />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`12. an article skeleton with responsive items 1`] = `
 <View
   style={
     Object {

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -1433,7 +1433,1019 @@ exports[`6. an article with heading tags 1`] = `
 </View>
 `;
 
-exports[`8. an inline link reports analytics event on press 1`] = `
+exports[`7. an article with link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView
+    ListHeaderComponent={
+      <Gutter
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      >
+        <Header
+          width={750}
+        />
+      </Gutter>
+    }
+    extraData={true}
+    initialNumToRender={2}
+    maxToRenderPerBatch={10}
+    nestedScrollEnabled={true}
+    numColumns={1}
+    onEndReachedThreshold={2}
+    removeClippedSubviews={true}
+    scrollEventThrottle={50}
+    showsVerticalScrollIndicator={false}
+    updateCellsBatchingPeriod={50}
+    windowSize={3}
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+                Object {},
+              ]
+            }
+          >
+            <View>
+              <Text
+                selectable={true}
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="link"
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 36,
+                        "lineHeight": 52,
+                        "marginBottom": 25,
+                        "marginTop": 0,
+                      },
+                    ]
+                  }
+                >
+                  Jack Dorsey
+                </Text>
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                   said today that while the company was unlikely to open its offices before September, almost all staff could now work permanently from wherever they want.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "maxWidth": "100%",
+                  "width": undefined,
+                },
+              ]
+            }
+          >
+            <ArticleExtras
+              articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+              articleUrl="https://url.io"
+            />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <ActivityIndicator
+            animating={true}
+            color="#999999"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`8. an article with italic link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView
+    ListHeaderComponent={
+      <Gutter
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      >
+        <Header
+          width={750}
+        />
+      </Gutter>
+    }
+    extraData={true}
+    initialNumToRender={2}
+    maxToRenderPerBatch={10}
+    nestedScrollEnabled={true}
+    numColumns={1}
+    onEndReachedThreshold={2}
+    removeClippedSubviews={true}
+    scrollEventThrottle={50}
+    showsVerticalScrollIndicator={false}
+    updateCellsBatchingPeriod={50}
+    windowSize={3}
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+                Object {},
+              ]
+            }
+          >
+            <View>
+              <Text
+                selectable={true}
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  In his 2015 book on the tournaments, 
+                </Text>
+                <Text
+                  accessibilityRole="link"
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 36,
+                        "fontStyle": "italic",
+                        "lineHeight": 52,
+                        "marginBottom": 25,
+                        "marginTop": 0,
+                      },
+                    ]
+                  }
+                >
+                  Superforecasting
+                </Text>
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  , Professor Tetlock said the most accurate predictors all used very similar methods. They used a historical “base rate” for predicting how likely an event was, adjusting constantly in the light of new information.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "maxWidth": "100%",
+                  "width": undefined,
+                },
+              ]
+            }
+          >
+            <ArticleExtras
+              articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+              articleUrl="https://url.io"
+            />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <ActivityIndicator
+            animating={true}
+            color="#999999"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`9. an article with bold text followed by bold link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView
+    ListHeaderComponent={
+      <Gutter
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      >
+        <Header
+          width={750}
+        />
+      </Gutter>
+    }
+    extraData={true}
+    initialNumToRender={2}
+    maxToRenderPerBatch={10}
+    nestedScrollEnabled={true}
+    numColumns={1}
+    onEndReachedThreshold={2}
+    removeClippedSubviews={true}
+    scrollEventThrottle={50}
+    showsVerticalScrollIndicator={false}
+    updateCellsBatchingPeriod={50}
+    windowSize={3}
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+                Object {},
+              ]
+            }
+          >
+            <View>
+              <Text
+                selectable={true}
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  2 
+                </Text>
+                <Text
+                  accessibilityRole="link"
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 36,
+                        "fontWeight": "bold",
+                        "lineHeight": 52,
+                        "marginBottom": 25,
+                        "marginTop": 0,
+                      },
+                    ]
+                  }
+                >
+                  Becoming by Michelle Obama
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "maxWidth": "100%",
+                  "width": undefined,
+                },
+              ]
+            }
+          >
+            <ArticleExtras
+              articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+              articleUrl="https://url.io"
+            />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <ActivityIndicator
+            animating={true}
+            color="#999999"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`10. an article with italic and normal text link 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView
+    ListHeaderComponent={
+      <Gutter
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      >
+        <Header
+          width={750}
+        />
+      </Gutter>
+    }
+    extraData={true}
+    initialNumToRender={2}
+    maxToRenderPerBatch={10}
+    nestedScrollEnabled={true}
+    numColumns={1}
+    onEndReachedThreshold={2}
+    removeClippedSubviews={true}
+    scrollEventThrottle={50}
+    showsVerticalScrollIndicator={false}
+    updateCellsBatchingPeriod={50}
+    windowSize={3}
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+                Object {},
+              ]
+            }
+          >
+            <View>
+              <Text
+                selectable={true}
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  Family Action is one of two charities being supported by 
+                </Text>
+                <Text
+                  accessibilityRole="link"
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 36,
+                        "fontStyle": "italic",
+                        "lineHeight": 52,
+                        "marginBottom": 25,
+                        "marginTop": 0,
+                      },
+                    ]
+                  }
+                >
+                  The Times
+                </Text>
+                <Text
+                  accessibilityRole="link"
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 36,
+                        "lineHeight": 52,
+                        "marginBottom": 25,
+                        "marginTop": 0,
+                      },
+                    ]
+                  }
+                >
+                   Coronavirus Charity Appeal
+                </Text>
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                   to support people in greatest hardship under the restrictions. The second charity is The Big Issue Foundation.
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "maxWidth": "100%",
+                  "width": undefined,
+                },
+              ]
+            }
+          >
+            <ArticleExtras
+              articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+              articleUrl="https://url.io"
+            />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <ActivityIndicator
+            animating={true}
+            color="#999999"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`11. an article with bold and italic text at the same time 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#f0f0f0",
+    }
+  }
+>
+  <RCTScrollView
+    ListHeaderComponent={
+      <Gutter
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      >
+        <Header
+          width={750}
+        />
+      </Gutter>
+    }
+    extraData={true}
+    initialNumToRender={2}
+    maxToRenderPerBatch={10}
+    nestedScrollEnabled={true}
+    numColumns={1}
+    onEndReachedThreshold={2}
+    removeClippedSubviews={true}
+    scrollEventThrottle={50}
+    showsVerticalScrollIndicator={false}
+    updateCellsBatchingPeriod={50}
+    windowSize={3}
+  >
+    <View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        />
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                },
+                Object {
+                  "marginBottom": 20,
+                },
+                false,
+                Object {},
+              ]
+            }
+          >
+            <View>
+              <Text
+                selectable={true}
+                style={
+                  Object {
+                    "lineHeight": 52,
+                  }
+                }
+              >
+                <Text
+                  selectable={true}
+                  style={
+                    Object {
+                      "color": "#000000",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 36,
+                      "fontStyle": "italic",
+                      "fontWeight": "bold",
+                      "lineHeight": 52,
+                    }
+                  }
+                >
+                  Conversations with Friends
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "maxWidth": "100%",
+                  "width": undefined,
+                },
+              ]
+            }
+          >
+            <ArticleExtras
+              articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+              articleUrl="https://url.io"
+            />
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              Object {
+                "backgroundColor": "#ffffff",
+                "maxWidth": "100%",
+                "width": undefined,
+              },
+            ]
+          }
+        >
+          <ActivityIndicator
+            animating={true}
+            color="#999999"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`13. an inline link reports analytics event on press 1`] = `
 Object {
   "action": "Pressed",
   "attrs": Object {
@@ -1466,7 +2478,7 @@ Object {
 }
 `;
 
-exports[`9. renders content 1`] = `
+exports[`14. renders content 1`] = `
 <View
   style={
     Object {
@@ -1712,7 +2724,7 @@ exports[`9. renders content 1`] = `
 </View>
 `;
 
-exports[`10. an article with inline paragraph 1`] = `
+exports[`15. an article with inline paragraph 1`] = `
 <View
   style={
     Object {

--- a/packages/article-skeleton/__tests__/shared.base.js
+++ b/packages/article-skeleton/__tests__/shared.base.js
@@ -8,6 +8,11 @@ import contentWithNestedFirstParagraph from "../fixtures/bold-article-content";
 import contentWithHeadingTags from "../fixtures/headings-article-content";
 import articleFixture, { testFixture } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";
+import articleContentWithLink from "../fixtures/link-text-article-content";
+import articleContentWithItalicLink from "../fixtures/italic-link-article-content";
+import articleContentWithTextAndBoldLink from "../fixtures/text-bold-link-article-content";
+import articleContentWithMixedLink from "../fixtures/mixed-link-article-content";
+import articleContentWithBoldItalicText from "../fixtures/boldItalic-text-article-content";
 
 jest.mock("@times-components/save-and-share-bar", () => "SaveAndShareBar");
 
@@ -440,6 +445,66 @@ export const snapshotTests = renderComponent => [
       const article = articleFixture({
         ...fixtureArgs,
         content: contentWithHeadingTags
+      });
+      const output = renderComponent(renderArticle(article));
+
+      expect(output).toMatchSnapshot();
+    }
+  },
+  {
+    name: "an article with link",
+    test() {
+      const article = articleFixture({
+        ...fixtureArgs,
+        content: articleContentWithLink
+      });
+      const output = renderComponent(renderArticle(article));
+
+      expect(output).toMatchSnapshot();
+    }
+  },
+  {
+    name: "an article with italic link",
+    test() {
+      const article = articleFixture({
+        ...fixtureArgs,
+        content: articleContentWithItalicLink
+      });
+      const output = renderComponent(renderArticle(article));
+
+      expect(output).toMatchSnapshot();
+    }
+  },
+  {
+    name: "an article with bold text followed by bold link",
+    test() {
+      const article = articleFixture({
+        ...fixtureArgs,
+        content: articleContentWithTextAndBoldLink
+      });
+      const output = renderComponent(renderArticle(article));
+
+      expect(output).toMatchSnapshot();
+    }
+  },
+  {
+    name: "an article with italic and normal text link",
+    test() {
+      const article = articleFixture({
+        ...fixtureArgs,
+        content: articleContentWithMixedLink
+      });
+      const output = renderComponent(renderArticle(article));
+
+      expect(output).toMatchSnapshot();
+    }
+  },
+  {
+    name: "an article with bold and italic text at the same time",
+    test() {
+      const article = articleFixture({
+        ...fixtureArgs,
+        content: articleContentWithBoldItalicText
       });
       const output = renderComponent(renderArticle(article));
 

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -1017,3 +1017,685 @@ exports[`6. an article with heading tags 1`] = `
   </article>
 </div>
 `;
+
+exports[`7. an article with link 1`] = `
+<div>
+  <div
+    id="article-marketing-header"
+  />
+  <article
+    data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+    data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
+    id="article-main"
+  >
+    <Head />
+    <div>
+      <AdContainer
+        slotName="header"
+      />
+    </div>
+    <main
+      role="main"
+    >
+      <div>
+        <div>
+          <div
+            data-tc-sticky-placeholder={true}
+          />
+          <div
+            data-tc-sticky-container={true}
+          >
+            <div>
+              <div
+                data-tc-sticky-sizer={true}
+              >
+                <SaveAndShareBar
+                  articleHeadline="Some Headline"
+                  articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+                  articleUrl="https://url.io"
+                  savingEnabled={true}
+                  sharingEnabled={true}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <article
+        role="article"
+      >
+        <p>
+          <Link
+            underlined={true}
+            url="https://www.thetimes.co.uk/article/i-like-it-boiling-hot-says-twitter-boss-jack-dorsey-cjclqjpb2"
+          >
+            Jack Dorsey
+          </Link>
+           said today that while the company was unlikely to open its offices before September, almost all staff could now work permanently from wherever they want.
+        </p>
+        <div
+          id="paywall-portal-article-footer"
+        />
+        <ArticleExtras
+          articleHeadline="Some Headline"
+          articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+          articleUrl="https://url.io"
+          commentsEnabled={true}
+          relatedArticleSlice={
+            Object {
+              "items": Array [
+                Object {
+                  "article": Object {
+                    "__typename": "Article",
+                    "bylines": Array [],
+                    "hasVideo": false,
+                    "headline": "RA Headline",
+                    "id": "ra-1",
+                    "label": "RA Label",
+                    "leadAsset": Object {
+                      "__typename": "Image",
+                      "crop169": Object {
+                        "__typename": "Crop",
+                        "url": "https://racrop169.io",
+                      },
+                      "crop32": Object {
+                        "__typename": "Crop",
+                        "url": "https://racrop32.io",
+                      },
+                      "title": "RA Title",
+                    },
+                    "publicationName": "TIMES",
+                    "publishedTime": "2015-03-23T19:39:39.000Z",
+                    "savingEnabled": true,
+                    "sharingEnabled": true,
+                    "shortHeadline": "Headline",
+                    "shortIdentifier": "2k629tpvh",
+                    "slug": "this-is-slug",
+                    "summary105": Array [],
+                    "summary125": Array [],
+                    "summary145": Array [],
+                    "summary160": Array [],
+                    "summary175": Array [],
+                    "summary225": Array [],
+                    "url": "https://ra.io",
+                  },
+                },
+              ],
+              "sliceName": "StandardSlice",
+            }
+          }
+          relatedArticlesVisible={false}
+          savingEnabled={true}
+          sharingEnabled={true}
+          spotAccountId=""
+          topics={
+            Array [
+              Object {
+                "name": "Topic",
+                "slug": "topic",
+              },
+            ]
+          }
+        />
+      </article>
+    </main>
+    <AdContainer
+      slotName="pixel"
+    />
+    <AdContainer
+      slotName="pixelteads"
+    />
+    <AdContainer
+      slotName="pixelskin"
+    />
+  </article>
+</div>
+`;
+
+exports[`8. an article with italic link 1`] = `
+<div>
+  <div
+    id="article-marketing-header"
+  />
+  <article
+    data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+    data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
+    id="article-main"
+  >
+    <Head />
+    <div>
+      <AdContainer
+        slotName="header"
+      />
+    </div>
+    <main
+      role="main"
+    >
+      <div>
+        <div>
+          <div
+            data-tc-sticky-placeholder={true}
+          />
+          <div
+            data-tc-sticky-container={true}
+          >
+            <div>
+              <div
+                data-tc-sticky-sizer={true}
+              >
+                <SaveAndShareBar
+                  articleHeadline="Some Headline"
+                  articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+                  articleUrl="https://url.io"
+                  savingEnabled={true}
+                  sharingEnabled={true}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <article
+        role="article"
+      >
+        <p>
+          In his 2015 book on the tournaments, 
+          <Link
+            underlined={true}
+            url="https://www.thetimes.co.uk/article/superforecasting-by-philip-tetlock-and-dan-gardner-gkwwpbf3gsb"
+          >
+            <i>
+              Superforecasting
+            </i>
+          </Link>
+          , Professor Tetlock said the most accurate predictors all used very similar methods. They used a historical “base rate” for predicting how likely an event was, adjusting constantly in the light of new information.
+        </p>
+        <div
+          id="paywall-portal-article-footer"
+        />
+        <ArticleExtras
+          articleHeadline="Some Headline"
+          articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+          articleUrl="https://url.io"
+          commentsEnabled={true}
+          relatedArticleSlice={
+            Object {
+              "items": Array [
+                Object {
+                  "article": Object {
+                    "__typename": "Article",
+                    "bylines": Array [],
+                    "hasVideo": false,
+                    "headline": "RA Headline",
+                    "id": "ra-1",
+                    "label": "RA Label",
+                    "leadAsset": Object {
+                      "__typename": "Image",
+                      "crop169": Object {
+                        "__typename": "Crop",
+                        "url": "https://racrop169.io",
+                      },
+                      "crop32": Object {
+                        "__typename": "Crop",
+                        "url": "https://racrop32.io",
+                      },
+                      "title": "RA Title",
+                    },
+                    "publicationName": "TIMES",
+                    "publishedTime": "2015-03-23T19:39:39.000Z",
+                    "savingEnabled": true,
+                    "sharingEnabled": true,
+                    "shortHeadline": "Headline",
+                    "shortIdentifier": "2k629tpvh",
+                    "slug": "this-is-slug",
+                    "summary105": Array [],
+                    "summary125": Array [],
+                    "summary145": Array [],
+                    "summary160": Array [],
+                    "summary175": Array [],
+                    "summary225": Array [],
+                    "url": "https://ra.io",
+                  },
+                },
+              ],
+              "sliceName": "StandardSlice",
+            }
+          }
+          relatedArticlesVisible={false}
+          savingEnabled={true}
+          sharingEnabled={true}
+          spotAccountId=""
+          topics={
+            Array [
+              Object {
+                "name": "Topic",
+                "slug": "topic",
+              },
+            ]
+          }
+        />
+      </article>
+    </main>
+    <AdContainer
+      slotName="pixel"
+    />
+    <AdContainer
+      slotName="pixelteads"
+    />
+    <AdContainer
+      slotName="pixelskin"
+    />
+  </article>
+</div>
+`;
+
+exports[`9. an article with bold text followed by bold link 1`] = `
+<div>
+  <div
+    id="article-marketing-header"
+  />
+  <article
+    data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+    data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
+    id="article-main"
+  >
+    <Head />
+    <div>
+      <AdContainer
+        slotName="header"
+      />
+    </div>
+    <main
+      role="main"
+    >
+      <div>
+        <div>
+          <div
+            data-tc-sticky-placeholder={true}
+          />
+          <div
+            data-tc-sticky-container={true}
+          >
+            <div>
+              <div
+                data-tc-sticky-sizer={true}
+              >
+                <SaveAndShareBar
+                  articleHeadline="Some Headline"
+                  articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+                  articleUrl="https://url.io"
+                  savingEnabled={true}
+                  sharingEnabled={true}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <article
+        role="article"
+      >
+        <p>
+          <b>
+            2 
+            <Link
+              underlined={true}
+              url="https://www.thetimes.co.uk/article/review-becoming-by-michelle-obama-the-astonishing-pressures-of-being-first-lady-zb6jkpffd"
+            >
+              Becoming by Michelle Obama
+            </Link>
+          </b>
+        </p>
+        <div
+          id="paywall-portal-article-footer"
+        />
+        <ArticleExtras
+          articleHeadline="Some Headline"
+          articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+          articleUrl="https://url.io"
+          commentsEnabled={true}
+          relatedArticleSlice={
+            Object {
+              "items": Array [
+                Object {
+                  "article": Object {
+                    "__typename": "Article",
+                    "bylines": Array [],
+                    "hasVideo": false,
+                    "headline": "RA Headline",
+                    "id": "ra-1",
+                    "label": "RA Label",
+                    "leadAsset": Object {
+                      "__typename": "Image",
+                      "crop169": Object {
+                        "__typename": "Crop",
+                        "url": "https://racrop169.io",
+                      },
+                      "crop32": Object {
+                        "__typename": "Crop",
+                        "url": "https://racrop32.io",
+                      },
+                      "title": "RA Title",
+                    },
+                    "publicationName": "TIMES",
+                    "publishedTime": "2015-03-23T19:39:39.000Z",
+                    "savingEnabled": true,
+                    "sharingEnabled": true,
+                    "shortHeadline": "Headline",
+                    "shortIdentifier": "2k629tpvh",
+                    "slug": "this-is-slug",
+                    "summary105": Array [],
+                    "summary125": Array [],
+                    "summary145": Array [],
+                    "summary160": Array [],
+                    "summary175": Array [],
+                    "summary225": Array [],
+                    "url": "https://ra.io",
+                  },
+                },
+              ],
+              "sliceName": "StandardSlice",
+            }
+          }
+          relatedArticlesVisible={false}
+          savingEnabled={true}
+          sharingEnabled={true}
+          spotAccountId=""
+          topics={
+            Array [
+              Object {
+                "name": "Topic",
+                "slug": "topic",
+              },
+            ]
+          }
+        />
+      </article>
+    </main>
+    <AdContainer
+      slotName="pixel"
+    />
+    <AdContainer
+      slotName="pixelteads"
+    />
+    <AdContainer
+      slotName="pixelskin"
+    />
+  </article>
+</div>
+`;
+
+exports[`10. an article with italic and normal text link 1`] = `
+<div>
+  <div
+    id="article-marketing-header"
+  />
+  <article
+    data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+    data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
+    id="article-main"
+  >
+    <Head />
+    <div>
+      <AdContainer
+        slotName="header"
+      />
+    </div>
+    <main
+      role="main"
+    >
+      <div>
+        <div>
+          <div
+            data-tc-sticky-placeholder={true}
+          />
+          <div
+            data-tc-sticky-container={true}
+          >
+            <div>
+              <div
+                data-tc-sticky-sizer={true}
+              >
+                <SaveAndShareBar
+                  articleHeadline="Some Headline"
+                  articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+                  articleUrl="https://url.io"
+                  savingEnabled={true}
+                  sharingEnabled={true}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <article
+        role="article"
+      >
+        <p>
+          Family Action is one of two charities being supported by 
+          <Link
+            underlined={true}
+            url="https://www.thetimes.co.uk/article/the-times-coronavirus-charity-appeal-2020-help-those-in-hardship-lp6f2jdsb"
+          >
+            <i>
+              The Times
+            </i>
+             Coronavirus Charity Appeal
+          </Link>
+           to support people in greatest hardship under the restrictions. The second charity is The Big Issue Foundation.
+        </p>
+        <div
+          id="paywall-portal-article-footer"
+        />
+        <ArticleExtras
+          articleHeadline="Some Headline"
+          articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+          articleUrl="https://url.io"
+          commentsEnabled={true}
+          relatedArticleSlice={
+            Object {
+              "items": Array [
+                Object {
+                  "article": Object {
+                    "__typename": "Article",
+                    "bylines": Array [],
+                    "hasVideo": false,
+                    "headline": "RA Headline",
+                    "id": "ra-1",
+                    "label": "RA Label",
+                    "leadAsset": Object {
+                      "__typename": "Image",
+                      "crop169": Object {
+                        "__typename": "Crop",
+                        "url": "https://racrop169.io",
+                      },
+                      "crop32": Object {
+                        "__typename": "Crop",
+                        "url": "https://racrop32.io",
+                      },
+                      "title": "RA Title",
+                    },
+                    "publicationName": "TIMES",
+                    "publishedTime": "2015-03-23T19:39:39.000Z",
+                    "savingEnabled": true,
+                    "sharingEnabled": true,
+                    "shortHeadline": "Headline",
+                    "shortIdentifier": "2k629tpvh",
+                    "slug": "this-is-slug",
+                    "summary105": Array [],
+                    "summary125": Array [],
+                    "summary145": Array [],
+                    "summary160": Array [],
+                    "summary175": Array [],
+                    "summary225": Array [],
+                    "url": "https://ra.io",
+                  },
+                },
+              ],
+              "sliceName": "StandardSlice",
+            }
+          }
+          relatedArticlesVisible={false}
+          savingEnabled={true}
+          sharingEnabled={true}
+          spotAccountId=""
+          topics={
+            Array [
+              Object {
+                "name": "Topic",
+                "slug": "topic",
+              },
+            ]
+          }
+        />
+      </article>
+    </main>
+    <AdContainer
+      slotName="pixel"
+    />
+    <AdContainer
+      slotName="pixelteads"
+    />
+    <AdContainer
+      slotName="pixelskin"
+    />
+  </article>
+</div>
+`;
+
+exports[`11. an article with bold and italic text at the same time 1`] = `
+<div>
+  <div
+    id="article-marketing-header"
+  />
+  <article
+    data-article-identifier="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+    data-article-sectionname="Some Section"
+    data-article-template="mainstandard"
+    id="article-main"
+  >
+    <Head />
+    <div>
+      <AdContainer
+        slotName="header"
+      />
+    </div>
+    <main
+      role="main"
+    >
+      <div>
+        <div>
+          <div
+            data-tc-sticky-placeholder={true}
+          />
+          <div
+            data-tc-sticky-container={true}
+          >
+            <div>
+              <div
+                data-tc-sticky-sizer={true}
+              >
+                <SaveAndShareBar
+                  articleHeadline="Some Headline"
+                  articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+                  articleUrl="https://url.io"
+                  savingEnabled={true}
+                  sharingEnabled={true}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <article
+        role="article"
+      >
+        <p>
+          <b>
+            <i>
+              Conversations with Friends
+            </i>
+          </b>
+        </p>
+        <div
+          id="paywall-portal-article-footer"
+        />
+        <ArticleExtras
+          articleHeadline="Some Headline"
+          articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+          articleUrl="https://url.io"
+          commentsEnabled={true}
+          relatedArticleSlice={
+            Object {
+              "items": Array [
+                Object {
+                  "article": Object {
+                    "__typename": "Article",
+                    "bylines": Array [],
+                    "hasVideo": false,
+                    "headline": "RA Headline",
+                    "id": "ra-1",
+                    "label": "RA Label",
+                    "leadAsset": Object {
+                      "__typename": "Image",
+                      "crop169": Object {
+                        "__typename": "Crop",
+                        "url": "https://racrop169.io",
+                      },
+                      "crop32": Object {
+                        "__typename": "Crop",
+                        "url": "https://racrop32.io",
+                      },
+                      "title": "RA Title",
+                    },
+                    "publicationName": "TIMES",
+                    "publishedTime": "2015-03-23T19:39:39.000Z",
+                    "savingEnabled": true,
+                    "sharingEnabled": true,
+                    "shortHeadline": "Headline",
+                    "shortIdentifier": "2k629tpvh",
+                    "slug": "this-is-slug",
+                    "summary105": Array [],
+                    "summary125": Array [],
+                    "summary145": Array [],
+                    "summary160": Array [],
+                    "summary175": Array [],
+                    "summary225": Array [],
+                    "url": "https://ra.io",
+                  },
+                },
+              ],
+              "sliceName": "StandardSlice",
+            }
+          }
+          relatedArticlesVisible={false}
+          savingEnabled={true}
+          sharingEnabled={true}
+          spotAccountId=""
+          topics={
+            Array [
+              Object {
+                "name": "Topic",
+                "slug": "topic",
+              },
+            ]
+          }
+        />
+      </article>
+    </main>
+    <AdContainer
+      slotName="pixel"
+    />
+    <AdContainer
+      slotName="pixelteads"
+    />
+    <AdContainer
+      slotName="pixelskin"
+    />
+  </article>
+</div>
+`;

--- a/packages/article-skeleton/fixtures/boldItalic-text-article-content.js
+++ b/packages/article-skeleton/fixtures/boldItalic-text-article-content.js
@@ -1,0 +1,24 @@
+export default [
+  {
+    name: "paragraph",
+    children: [
+      {
+        name: "bold",
+        children: [
+          {
+            name: "italic",
+            children: [
+              {
+                name: "text",
+                children: [],
+                attributes: {
+                  value: "Conversations with Friends"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+];

--- a/packages/article-skeleton/fixtures/italic-link-article-content.js
+++ b/packages/article-skeleton/fixtures/italic-link-article-content.js
@@ -1,0 +1,46 @@
+export default [
+  {
+    name: "paragraph",
+    children: [
+      {
+        name: "text",
+        children: [],
+        attributes: {
+          value: "In his 2015 book on the tournaments, "
+        }
+      },
+      {
+        name: "link",
+        children: [
+          {
+            name: "italic",
+            children: [
+              {
+                name: "text",
+                children: [],
+                attributes: {
+                  value: "Superforecasting"
+                }
+              }
+            ]
+          }
+        ],
+        attributes: {
+          href:
+            "https://www.thetimes.co.uk/article/superforecasting-by-philip-tetlock-and-dan-gardner-gkwwpbf3gsb",
+          type: "article",
+          canonicalId:
+            "superforecasting-by-philip-tetlock-and-dan-gardner-gkwwpbf3gsb"
+        }
+      },
+      {
+        name: "text",
+        children: [],
+        attributes: {
+          value:
+            ", Professor Tetlock said the most accurate predictors all used very similar methods. They used a historical “base rate” for predicting how likely an event was, adjusting constantly in the light of new information."
+        }
+      }
+    ]
+  }
+];

--- a/packages/article-skeleton/fixtures/link-text-article-content.js
+++ b/packages/article-skeleton/fixtures/link-text-article-content.js
@@ -1,0 +1,34 @@
+export default [
+  {
+    name: "paragraph",
+    children: [
+      {
+        name: "link",
+        attributes: {
+          href:
+            "https://www.thetimes.co.uk/article/i-like-it-boiling-hot-says-twitter-boss-jack-dorsey-cjclqjpb2",
+          type: "article",
+          canonicalId:
+            "i-like-it-boiling-hot-says-twitter-boss-jack-dorsey-cjclqjpb2"
+        },
+        children: [
+          {
+            name: "text",
+            attributes: {
+              value: "Jack Dorsey"
+            },
+            children: []
+          }
+        ]
+      },
+      {
+        name: "text",
+        attributes: {
+          value:
+            " said today that while the company was unlikely to open its offices before September, almost all staff could now work permanently from wherever they want."
+        },
+        children: []
+      }
+    ]
+  }
+];

--- a/packages/article-skeleton/fixtures/mixed-link-article-content.js
+++ b/packages/article-skeleton/fixtures/mixed-link-article-content.js
@@ -1,0 +1,53 @@
+export default [
+  {
+    name: "paragraph",
+    children: [
+      {
+        name: "text",
+        children: [],
+        attributes: {
+          value: "Family Action is one of two charities being supported by "
+        }
+      },
+      {
+        name: "link",
+        children: [
+          {
+            name: "italic",
+            children: [
+              {
+                name: "text",
+                children: [],
+                attributes: {
+                  value: "The Times"
+                }
+              }
+            ]
+          },
+          {
+            name: "text",
+            children: [],
+            attributes: {
+              value: " Coronavirus Charity Appeal"
+            }
+          }
+        ],
+        attributes: {
+          href:
+            "https://www.thetimes.co.uk/article/the-times-coronavirus-charity-appeal-2020-help-those-in-hardship-lp6f2jdsb",
+          type: "article",
+          canonicalId:
+            "the-times-coronavirus-charity-appeal-2020-help-those-in-hardship-lp6f2jdsb"
+        }
+      },
+      {
+        name: "text",
+        children: [],
+        attributes: {
+          value:
+            " to support people in greatest hardship under the restrictions. The second charity is The Big Issue Foundation."
+        }
+      }
+    ]
+  }
+];

--- a/packages/article-skeleton/fixtures/text-bold-link-article-content.js
+++ b/packages/article-skeleton/fixtures/text-bold-link-article-content.js
@@ -1,0 +1,38 @@
+export default [
+  {
+    name: "paragraph",
+    children: [
+      {
+        name: "bold",
+        children: [
+          {
+            name: "text",
+            attributes: {
+              value: "2 "
+            },
+            children: []
+          },
+          {
+            name: "link",
+            attributes: {
+              href:
+                "https://www.thetimes.co.uk/article/review-becoming-by-michelle-obama-the-astonishing-pressures-of-being-first-lady-zb6jkpffd",
+              type: "article",
+              canonicalId:
+                "review-becoming-by-michelle-obama-the-astonishing-pressures-of-being-first-lady-zb6jkpffd"
+            },
+            children: [
+              {
+                name: "text",
+                attributes: {
+                  value: "Becoming by Michelle Obama"
+                },
+                children: []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+];

--- a/packages/article-skeleton/src/article-body/simple-paragraph.js
+++ b/packages/article-skeleton/src/article-body/simple-paragraph.js
@@ -21,31 +21,33 @@ const SimpleParagraph = ({
   return (
     <ArticleParagraphWrapper ast={tree} key={key} uid={key}>
       <Text allowFontScaling={false} selectable style={{ lineHeight }}>
-        {children.map(child => {
-          const [attribute, href] = child.collapsedAttributes(0);
-          const style = attribute ? attribute.settings : defaultFont;
-          const type = href ? href.type : null;
-          const canonicalId = href ? href.canonicalId : null;
-          if (href) {
-            const { color, ...linkStyle } = style;
+        {children.map(child =>
+          child.splitByDifferenceInAttributes().map(nestedChild => {
+            const [attribute, href] = nestedChild.collapsedAttributes(0);
+            const style = attribute ? attribute.settings : defaultFont;
+            const type = href ? href.type : null;
+            const canonicalId = href ? href.canonicalId : null;
+            if (href) {
+              const { color, ...linkStyle } = style;
+              return (
+                <LinkComponent
+                  url={href}
+                  style={linkStyle}
+                  onPress={e =>
+                    onLinkPress(e, { canonicalId, type, url: href.href })
+                  }
+                >
+                  {nestedChild.string}
+                </LinkComponent>
+              );
+            }
             return (
-              <LinkComponent
-                url={href}
-                style={linkStyle}
-                onPress={e =>
-                  onLinkPress(e, { canonicalId, type, url: href.href })
-                }
-              >
-                {child.string}
-              </LinkComponent>
+              <Text selectable allowFontScaling={false} style={style}>
+                {nestedChild.string}
+              </Text>
             );
-          }
-          return (
-            <Text selectable allowFontScaling={false} style={style}>
-              {child.string}
-            </Text>
-          );
-        })}
+          })
+        )}
       </Text>
     </ArticleParagraphWrapper>
   );

--- a/packages/typeset/__tests__/AttributedString.test.ts
+++ b/packages/typeset/__tests__/AttributedString.test.ts
@@ -229,3 +229,249 @@ test('AttributedString.split()', () => {
     ]
   `);
 });
+
+test('AttributedString.splitByDifferenceInAttributes() should return flat attributed string when attributes length is the same', () => {
+  const attrs: AttributeTag[][] = [];
+  makeAttribute(attrs, 0, 7);
+  const newString = new AttributedString('foo bar', attrs);
+  const split = newString.splitByDifferenceInAttributes();
+
+  expect(split.length).toEqual(1);
+  expect(split).toMatchInlineSnapshot(`
+    Array [
+      AttributedString {
+        "attributes": Array [
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+        ],
+        "length": 7,
+        "split": [Function],
+        "string": "foo bar",
+      },
+    ]
+  `);
+});
+
+test('AttributedString.splitByDifferenceInAttributes() should return attributed string with more than one element when string has nested attributes styling', () => {
+  const attrs: AttributeTag[][] = [];
+  makeAttribute(attrs, 0, 7);
+  makeAttribute(attrs, 4, 7);
+  const newString = new AttributedString('foo bar', attrs);
+  const split = newString.splitByDifferenceInAttributes();
+
+  expect(split.length).toEqual(2);
+  expect(split).toMatchInlineSnapshot(`
+    Array [
+      AttributedString {
+        "attributes": Array [
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+        ],
+        "length": 4,
+        "split": [Function],
+        "string": "foo ",
+      },
+      AttributedString {
+        "attributes": Array [
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+          Array [
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+            Object {
+              "settings": Object {
+                "fontFamily": "TimesDigitalW04",
+                "fontSize": 18,
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+                "lineHeight": 30,
+              },
+              "tag": "FONT",
+            },
+          ],
+        ],
+        "length": 3,
+        "split": [Function],
+        "string": "bar",
+      },
+    ]
+  `);
+});

--- a/packages/typeset/src/AttributedString.ts
+++ b/packages/typeset/src/AttributedString.ts
@@ -69,6 +69,23 @@ export default class AttributedString {
     }
   }
 
+  public splitByDifferenceInAttributes() {
+    const attrs = this.attributes;
+    const chunks: AttributedString[] = [];
+    let start = 0;
+
+    for (let i = 0; i < attrs.length; i++) {
+      if (attrs.length === i + 1) {
+        chunks.push(this.slice(start, i + 1));
+      } else if (attrs[i].length !== attrs[i + 1].length) {
+        chunks.push(this.slice(start, i + 1));
+        start = i + 1;
+      }
+    }
+
+    return chunks;
+  };
+
   public split = (chars: string[] = [' ', '\n']) => {
     const attrs = this.attributes;
     let start = 0;


### PR DESCRIPTION
[TNLT-1826](https://nidigitalsolutions.jira.com/browse/TNLT-1826)

Handling flat article content structure like: 
`<p><b>For full TV listings for the week, see <a>thetimes.co.uk/tvplanner</a></b></p>`

In order to style hyperlinks as expected on native devices

Before:
![image](https://user-images.githubusercontent.com/8720661/82666579-e1e4e000-9c3e-11ea-8902-ea0096b83a81.png)


Result:
![text-bold-links-after](https://user-images.githubusercontent.com/8720661/82666492-b661f580-9c3e-11ea-8322-a4194141df3b.png)
![text-italic-text-after](https://user-images.githubusercontent.com/8720661/82666497-b82bb900-9c3e-11ea-9c44-9acfbffb1793.png)
![text-bold-link-after](https://user-images.githubusercontent.com/8720661/82666501-b95ce600-9c3e-11ea-87ca-296c740d2e51.png)
![text-italic-link-after](https://user-images.githubusercontent.com/8720661/82666506-ba8e1300-9c3e-11ea-885a-6f202d117bbb.png)
