### PR TITLE
fix: manual version increment of ios app

### DIFF
--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@times-components/ios-app",
-  "version": "0.17.110",
+  "version": "0.17.111",
   "license": "BSD-3-Clause",
   "scripts": {
     "build": "cat package.json | grep version | head -1 | sed 's/[\",\t ]//g' | awk -F: '{ print \"Bundle Version: \" $2 }' > ios-assets/js/version.meta",


### PR DESCRIPTION
Manual bump of ios app, because of failing publish.

![image](https://user-images.githubusercontent.com/8720661/82910080-d2350680-9f72-11ea-99a2-be71d221ab95.png)
![image](https://user-images.githubusercontent.com/8720661/82910108-de20c880-9f72-11ea-95ac-e396db2d6028.png)
