### PR TITLE
feat: add error boundaries to pages

### DIFF
--- a/packages/pages/src/pages.js
+++ b/packages/pages/src/pages.js
@@ -1,6 +1,6 @@
 import withErrorBoundaries from "./with-error-boundaries";
-
 /* eslint-disable global-require */
+
 const pageMapper = {
   Article: require("./article").default,
   AuthorProfile: require("./author-profile").default,
@@ -9,4 +9,4 @@ const pageMapper = {
 };
 
 export default page =>
-  withErrorBoundaries(pageMapper[page] || require("./article").default);
+  withErrorBoundaries(pageMapper[page] || pageMapper.Article);

--- a/packages/pages/src/pages.js
+++ b/packages/pages/src/pages.js
@@ -1,20 +1,12 @@
+import withErrorBoundaries from "./with-error-boundaries";
+
 /* eslint-disable global-require */
-export default page => {
-  switch (page) {
-    case "Article": {
-      return require("./article").default;
-    }
-    case "AuthorProfile": {
-      return require("./author-profile").default;
-    }
-    case "Section": {
-      return require("./section").default;
-    }
-    case "Topic": {
-      return require("./topic").default;
-    }
-    default: {
-      return require("./article").default;
-    }
-  }
+const pageMapper = {
+  Article: require("./article").default,
+  AuthorProfile: require("./author-profile").default,
+  Section: require("./section").default,
+  Topic: require("./topic").default
 };
+
+export default page =>
+  withErrorBoundaries(pageMapper[page] || require("./article").default);

--- a/packages/pages/src/pages.js
+++ b/packages/pages/src/pages.js
@@ -1,12 +1,22 @@
-import withErrorBoundaries from "./with-error-boundaries";
 /* eslint-disable global-require */
+import withErrorBoundaries from "./with-error-boundaries";
 
-const pageMapper = {
-  Article: require("./article").default,
-  AuthorProfile: require("./author-profile").default,
-  Section: require("./section").default,
-  Topic: require("./topic").default
+export default page => {
+  switch (page) {
+    case "Article": {
+      return withErrorBoundaries(require("./article").default);
+    }
+    case "AuthorProfile": {
+      return withErrorBoundaries(require("./author-profile").default);
+    }
+    case "Section": {
+      return withErrorBoundaries(require("./section").default);
+    }
+    case "Topic": {
+      return withErrorBoundaries(require("./topic").default);
+    }
+    default: {
+      return withErrorBoundaries(require("./article").default);
+    }
+  }
 };
-
-export default page =>
-  withErrorBoundaries(pageMapper[page] || pageMapper.Article);

--- a/packages/pages/src/with-error-boundaries.js
+++ b/packages/pages/src/with-error-boundaries.js
@@ -1,6 +1,8 @@
 import React, { Component } from "react";
-import { View, Text } from "react-native";
+import { View, Text, NativeModules, Platform } from "react-native";
 import { fonts, fontSizes } from "@times-components/styleguide";
+
+const { componentCaughtError } = NativeModules.ReactAnalytics;
 
 const styles = {
   container: {
@@ -30,6 +32,10 @@ const withErrorBoundaries = WrappedComponent =>
       return { hasError: true };
     }
 
+    componentDidCatch(error, errorInfo) {
+      componentCaughtError(error.message, errorInfo.componentStack);
+    }
+
     renderErrorMessage = () => (
       <View style={styles.container}>
         <Text style={styles.title}>Something went wrong</Text>
@@ -39,7 +45,9 @@ const withErrorBoundaries = WrappedComponent =>
 
     render() {
       const { hasError } = this.state;
-      return hasError ? (
+      const isNative = Platform.OS === "ios" || Platform.OS === "android";
+
+      return isNative && hasError ? (
         this.renderErrorMessage()
       ) : (
         <WrappedComponent {...this.props} />

--- a/packages/pages/src/with-error-boundaries.js
+++ b/packages/pages/src/with-error-boundaries.js
@@ -14,10 +14,6 @@ const styles = {
     fontFamily: fonts.headline,
     fontSize: fontSizes.heading2Mobile,
     marginBottom: 20
-  },
-  subTitle: {
-    fontFamily: fonts.body,
-    fontSize: fontSizes.heading4Mobile
   }
 };
 
@@ -39,7 +35,6 @@ const withErrorBoundaries = WrappedComponent =>
     renderErrorMessage = () => (
       <View style={styles.container}>
         <Text style={styles.title}>Something went wrong</Text>
-        <Text style={styles.subTitle}>Please try again</Text>
       </View>
     );
 

--- a/packages/pages/src/with-error-boundaries.js
+++ b/packages/pages/src/with-error-boundaries.js
@@ -1,0 +1,50 @@
+import React, { Component } from "react";
+import { View, Text } from "react-native";
+import { fonts, fontSizes } from "@times-components/styleguide";
+
+const styles = {
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center"
+  },
+  title: {
+    fontFamily: fonts.headline,
+    fontSize: fontSizes.heading2Mobile,
+    marginBottom: 20
+  },
+  subTitle: {
+    fontFamily: fonts.body,
+    fontSize: fontSizes.heading4Mobile
+  }
+};
+
+const withErrorBoundaries = WrappedComponent =>
+  class extends Component {
+    constructor(props) {
+      super(props);
+      this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError() {
+      return { hasError: true };
+    }
+
+    renderErrorMessage = () => (
+      <View style={styles.container}>
+        <Text style={styles.title}>Something went wrong</Text>
+        <Text style={styles.subTitle}>Please try again</Text>
+      </View>
+    );
+
+    render() {
+      const { hasError } = this.state;
+      return hasError ? (
+        this.renderErrorMessage()
+      ) : (
+        <WrappedComponent {...this.props} />
+      );
+    }
+  };
+
+export default withErrorBoundaries;


### PR DESCRIPTION
Adding error boundaries for all the pages. We do this to catch the errors caused by pages and their child components at the top level. Instead of a crash the user will see this screen:

![Image from iOS](https://user-images.githubusercontent.com/7889661/83062315-1e617300-a067-11ea-9011-e0784bb96ee9.png)

