### PR TITLE
fix: TNLT-1210 heading colour updated for native

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -878,6 +878,7 @@ exports[`6. an article with heading tags 1`] = `
               <Text
                 style={
                   Object {
+                    "color": "#000000",
                     "fontFamily": "TimesModern-Bold",
                     "fontSize": 25,
                     "lineHeight": 26,
@@ -915,6 +916,7 @@ exports[`6. an article with heading tags 1`] = `
               <Text
                 style={
                   Object {
+                    "color": "#000000",
                     "fontFamily": "TimesModern-Bold",
                     "fontSize": 22,
                     "lineHeight": 26,

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -1333,6 +1333,7 @@ exports[`6. an article with heading tags 1`] = `
                 selectable={true}
                 style={
                   Object {
+                    "color": "#000000",
                     "fontFamily": "TimesModern-Bold",
                     "fontSize": 25,
                     "lineHeight": 26,
@@ -1385,6 +1386,7 @@ exports[`6. an article with heading tags 1`] = `
                 selectable={true}
                 style={
                   Object {
+                    "color": "#000000",
                     "fontFamily": "TimesModern-Bold",
                     "fontSize": 22,
                     "lineHeight": 26,

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -878,6 +878,7 @@ exports[`6. an article with heading tags 1`] = `
               <Text
                 style={
                   Object {
+                    "color": "#000000",
                     "fontFamily": "TimesModern-Bold",
                     "fontSize": 25,
                     "lineHeight": 26,
@@ -915,6 +916,7 @@ exports[`6. an article with heading tags 1`] = `
               <Text
                 style={
                   Object {
+                    "color": "#000000",
                     "fontFamily": "TimesModern-Bold",
                     "fontSize": 22,
                     "lineHeight": 26,

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -1333,6 +1333,7 @@ exports[`6. an article with heading tags 1`] = `
                 selectable={true}
                 style={
                   Object {
+                    "color": "#000000",
                     "fontFamily": "TimesModern-Bold",
                     "fontSize": 25,
                     "lineHeight": 26,
@@ -1385,6 +1386,7 @@ exports[`6. an article with heading tags 1`] = `
                 selectable={true}
                 style={
                   Object {
+                    "color": "#000000",
                     "fontFamily": "TimesModern-Bold",
                     "fontSize": 22,
                     "lineHeight": 26,

--- a/packages/article-skeleton/src/styles/article-body/shared.js
+++ b/packages/article-skeleton/src/styles/article-body/shared.js
@@ -68,35 +68,40 @@ const sharedStyles = scale => {
         font: "headline",
         fontSize: "heading2Mobile"
       }),
-      marginBottom: spacing(2)
+      marginBottom: spacing(2),
+      color: colours.functional.black
     },
     heading3: {
       ...fontFactory({
         font: "headline",
         fontSize: "heading3Mobile"
       }),
-      marginBottom: spacing(2)
+      marginBottom: spacing(2),
+      color: colours.functional.black
     },
     heading4: {
       ...fontFactory({
         font: "headline",
         fontSize: "heading4Mobile"
       }),
-      marginBottom: spacing(2)
+      marginBottom: spacing(2),
+      color: colours.functional.black
     },
     heading5: {
       ...fontFactory({
         font: "headline",
         fontSize: "heading5Mobile"
       }),
-      marginBottom: spacing(2)
+      marginBottom: spacing(2),
+      color: colours.functional.black
     },
     heading6: {
       ...fontFactory({
         font: "headline",
         fontSize: "heading5Mobile"
       }),
-      marginBottom: spacing(2)
+      marginBottom: spacing(2),
+      color: colours.functional.black
     }
   };
 };


### PR DESCRIPTION
[TNLT-1212](https://nidigitalsolutions.jira.com/browse/TNLT-1210)

Fix colour of the sub heading tags for android.

Before:
<img width="378" alt="android-heading-color-before" src="https://user-images.githubusercontent.com/8720661/83236128-b06a9800-a19b-11ea-8701-6539c19beeb2.png">


After:
<img width="390" alt="android-heading-color-after" src="https://user-images.githubusercontent.com/8720661/83236133-b3658880-a19b-11ea-80a6-6e5757b89530.png">
