### PR TITLE
feat: TNLT-2611 add testID to byline links

### DIFF
--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links-style.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links-style.android.test.js.snap
@@ -13,6 +13,7 @@ exports[`1. with a single author 1`] = `
         "textDecorationLine": "none",
       }
     }
+    testID="author-profile-link"
   >
     Alexandra Frean
   </Text>
@@ -32,6 +33,7 @@ exports[`2. with a very long byline 1`] = `
         "textDecorationLine": "none",
       }
     }
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>
@@ -59,6 +61,7 @@ exports[`2. with a very long byline 1`] = `
         "textDecorationLine": "none",
       }
     }
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>
@@ -86,6 +89,7 @@ exports[`2. with a very long byline 1`] = `
         "textDecorationLine": "none",
       }
     }
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>

--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links.android.test.js.snap
@@ -12,6 +12,7 @@ exports[`2. with the author in the begining 1`] = `
 <View>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>
@@ -28,6 +29,7 @@ exports[`3. with the author at the end 1`] = `
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Mike Atherton
   </Text>
@@ -38,6 +40,7 @@ exports[`4. with multiple authors separated by a pipe 1`] = `
 <View>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>
@@ -46,6 +49,7 @@ exports[`4. with multiple authors separated by a pipe 1`] = `
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Mike Atherton
   </Text>
@@ -54,6 +58,7 @@ exports[`4. with multiple authors separated by a pipe 1`] = `
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Alexandra Frean
   </Text>
@@ -64,6 +69,7 @@ exports[`5. with multiple authors separated by text with commas 1`] = `
 <View>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>
@@ -72,6 +78,7 @@ exports[`5. with multiple authors separated by text with commas 1`] = `
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Mike Atherton
   </Text>
@@ -80,6 +87,7 @@ exports[`5. with multiple authors separated by text with commas 1`] = `
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Alexandra Frean
   </Text>
@@ -90,6 +98,7 @@ exports[`6. with multiple authors separated by spaces 1`] = `
 <View>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>
@@ -98,11 +107,13 @@ exports[`6. with multiple authors separated by spaces 1`] = `
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Mike Atherton
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Alexandra Frean
   </Text>

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links-style.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links-style.ios.test.js.snap
@@ -13,6 +13,7 @@ exports[`1. with a single author 1`] = `
         "textDecorationLine": "none",
       }
     }
+    testID="author-profile-link"
   >
     Alexandra Frean
   </Text>
@@ -32,6 +33,7 @@ exports[`2. with a very long byline 1`] = `
         "textDecorationLine": "none",
       }
     }
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>
@@ -59,6 +61,7 @@ exports[`2. with a very long byline 1`] = `
         "textDecorationLine": "none",
       }
     }
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>
@@ -86,6 +89,7 @@ exports[`2. with a very long byline 1`] = `
         "textDecorationLine": "none",
       }
     }
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links.ios.test.js.snap
@@ -12,6 +12,7 @@ exports[`2. with the author in the begining 1`] = `
 <View>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>
@@ -28,6 +29,7 @@ exports[`3. with the author at the end 1`] = `
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Mike Atherton
   </Text>
@@ -38,6 +40,7 @@ exports[`4. with multiple authors separated by a pipe 1`] = `
 <View>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>
@@ -46,6 +49,7 @@ exports[`4. with multiple authors separated by a pipe 1`] = `
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Mike Atherton
   </Text>
@@ -54,6 +58,7 @@ exports[`4. with multiple authors separated by a pipe 1`] = `
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Alexandra Frean
   </Text>
@@ -64,6 +69,7 @@ exports[`5. with multiple authors separated by text with commas 1`] = `
 <View>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>
@@ -72,6 +78,7 @@ exports[`5. with multiple authors separated by text with commas 1`] = `
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Mike Atherton
   </Text>
@@ -80,6 +87,7 @@ exports[`5. with multiple authors separated by text with commas 1`] = `
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Alexandra Frean
   </Text>
@@ -90,6 +98,7 @@ exports[`6. with multiple authors separated by spaces 1`] = `
 <View>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Camilla Long
   </Text>
@@ -98,11 +107,13 @@ exports[`6. with multiple authors separated by spaces 1`] = `
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Mike Atherton
   </Text>
   <Text
     accessibilityRole="link"
+    testID="author-profile-link"
   >
     Alexandra Frean
   </Text>

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links-style.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links-style.web.test.js.snap
@@ -15,6 +15,7 @@ exports[`1. with a single author 1`] = `
 >
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu S1"
+    data-testid="author-profile-link"
     href="/profile/alexandra-frean"
     role="link"
   >
@@ -50,6 +51,7 @@ exports[`2. with a very long byline 1`] = `
 >
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu S1"
+    data-testid="author-profile-link"
     href="/profile/camilla-long"
     role="link"
   >
@@ -62,6 +64,7 @@ exports[`2. with a very long byline 1`] = `
   </div>
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu S1"
+    data-testid="author-profile-link"
     href="/profile/camilla-long"
     role="link"
   >
@@ -74,6 +77,7 @@ exports[`2. with a very long byline 1`] = `
   </div>
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu S1"
+    data-testid="author-profile-link"
     href="/profile/camilla-long"
     role="link"
   >

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links.web.test.js.snap
@@ -18,6 +18,7 @@ exports[`2. with the author in the begining 1`] = `
 >
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    data-testid="author-profile-link"
     href="/profile/camilla-long"
     role="link"
   >
@@ -42,6 +43,7 @@ exports[`3. with the author at the end 1`] = `
   </div>
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    data-testid="author-profile-link"
     href="/profile/mike-atherton"
     role="link"
   >
@@ -56,6 +58,7 @@ exports[`4. with multiple authors separated by a pipe 1`] = `
 >
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    data-testid="author-profile-link"
     href="/profile/camilla-long"
     role="link"
   >
@@ -68,6 +71,7 @@ exports[`4. with multiple authors separated by a pipe 1`] = `
   </div>
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    data-testid="author-profile-link"
     href="/profile/mike-atherton"
     role="link"
   >
@@ -80,6 +84,7 @@ exports[`4. with multiple authors separated by a pipe 1`] = `
   </div>
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    data-testid="author-profile-link"
     href="/profile/alexandra-frean"
     role="link"
   >
@@ -94,6 +99,7 @@ exports[`5. with multiple authors separated by text with commas 1`] = `
 >
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    data-testid="author-profile-link"
     href="/profile/camilla-long"
     role="link"
   >
@@ -106,6 +112,7 @@ exports[`5. with multiple authors separated by text with commas 1`] = `
   </div>
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    data-testid="author-profile-link"
     href="/profile/mike-atherton"
     role="link"
   >
@@ -118,6 +125,7 @@ exports[`5. with multiple authors separated by text with commas 1`] = `
   </div>
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    data-testid="author-profile-link"
     href="/profile/alexandra-frean"
     role="link"
   >
@@ -132,6 +140,7 @@ exports[`6. with multiple authors separated by spaces 1`] = `
 >
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    data-testid="author-profile-link"
     href="/profile/camilla-long"
     role="link"
   >
@@ -144,6 +153,7 @@ exports[`6. with multiple authors separated by spaces 1`] = `
   </div>
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    data-testid="author-profile-link"
     href="/profile/mike-atherton"
     role="link"
   >
@@ -151,6 +161,7 @@ exports[`6. with multiple authors separated by spaces 1`] = `
   </a>
   <a
     className="css-reset-4rbku5 css-cursor-18t94o4 css-text-901oao r-color-j7kcqb r-cursor-1loqt21 r-fontFamily-j2s0nr r-fontSize-n6v787 r-lineHeight-fxxt2n r-textDecorationLine-13wfysu"
+    data-testid="author-profile-link"
     href="/profile/alexandra-frean"
     role="link"
   >

--- a/packages/article-byline/src/article-byline-with-links.js
+++ b/packages/article-byline/src/article-byline-with-links.js
@@ -19,6 +19,7 @@ const AuthorComponent = ({ slug, className, onAuthorPress, children }) => {
       }}
       style={styles.link}
       url={url}
+      testID="author-profile-link"
     >
       {children}
     </TextLink>


### PR DESCRIPTION
[TNLT-2611](https://nidigitalsolutions.jira.com/browse/TNLT-2611)

Add testID to author name in the article screen so Appium can select and tap it on iOS devices.
testID value:  `author-profile-link`

![image](https://user-images.githubusercontent.com/8720661/84627428-98ab4780-aeef-11ea-8c91-0f8db49ed376.png)

In the screenshot you can see that the author link is still not accessible.

The react native component structure is:

```
<View>
  <Text>
    <Text
      accessibilityRole="link"
      testID="author-profile-link"
    >
      Chris Smyth
    </Text>
    <Text>
      , Whitehall Editor
    </Text>
  </Text>
</View>
```

![image](https://user-images.githubusercontent.com/8720661/84627729-12dbcc00-aef0-11ea-9496-1d35e13880cf.png)
