### PR TITLE
fix: revert ios interactive wrapper

### DIFF
--- a/packages/interactive-wrapper/src/interactive-wrapper.android.js
+++ b/packages/interactive-wrapper/src/interactive-wrapper.android.js
@@ -57,16 +57,17 @@ class InteractiveWrapper extends Component {
     }
   }
 
+  // eslint-disable-next-line class-methods-use-this
   handleNavigationStateChange(data) {
     if (
       !data.url.includes("data:text/html") &&
       data.url.includes("http") &&
       !data.url.includes(editorialLambdaOrigin)
     ) {
-      // Need to handle native routing when something is clicked.
       InteractiveWrapper.openURLInBrowser(data.url);
-      this.webview.reload();
+      return false;
     }
+    return true;
   }
 
   render() {
@@ -91,11 +92,11 @@ class InteractiveWrapper extends Component {
         injectedJavaScript={scriptToInject}
         onLoadEnd={this.onLoadEnd}
         onMessage={this.onMessage}
-        onNavigationStateChange={this.handleNavigationStateChange}
         ref={ref => {
           this.webview = ref;
         }}
         scrollEnabled={false}
+        onShouldStartLoadWithRequest={this.handleNavigationStateChange}
         source={{ uri }}
         style={{ height }}
       />


### PR DESCRIPTION
Split native interactive wrapper to ios and android
Revert [#2611](https://github.com/newsuk/times-components/pull/2611) changes for ios

![image](https://user-images.githubusercontent.com/8720661/85129851-835e5200-b23c-11ea-81d0-3792fce9eb8c.png)
