### PR TITLE
feat(TNLT-2519): Decode imageUri and change NewsletterPuffButton copy

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/inline-newsletter-puff.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/inline-newsletter-puff.test.js.snap
@@ -145,7 +145,7 @@ exports[`Inline Newsletter Puff renders signup state 1`] = `
       className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO"
     >
       <View
-        accessibilityLabel="Sign up to newsletter"
+        accessibilityLabel="Sign up now"
         accessibilityRole="button"
         accessible={true}
         focusable={true}
@@ -203,9 +203,9 @@ exports[`Inline Newsletter Puff renders signup state 1`] = `
               },
             ]
           }
-          title="Sign up to newsletter"
+          title="Sign up now"
         >
-          Sign up to newsletter
+          Sign up now
         </Text>
       </View>
     </View>
@@ -244,7 +244,7 @@ exports[`Inline Newsletter Puff renders signup view when not already subscribed 
       className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO"
     >
       <View
-        accessibilityLabel="Sign up to newsletter"
+        accessibilityLabel="Sign up now"
         accessibilityRole="button"
         accessible={true}
         focusable={true}
@@ -302,9 +302,9 @@ exports[`Inline Newsletter Puff renders signup view when not already subscribed 
               },
             ]
           }
-          title="Sign up to newsletter"
+          title="Sign up now"
         >
-          Sign up to newsletter
+          Sign up now
         </Text>
       </View>
     </View>

--- a/packages/article-skeleton/__tests__/android/__snapshots__/newsletter-puff-button.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/newsletter-puff-button.test.js.snap
@@ -69,7 +69,7 @@ exports[`NewsletterPuffButton renders the button with the text \`Saving...\` 1`]
 
 exports[`NewsletterPuffButton renders the button with the text \`Sign up to newsletter\` 1`] = `
 <View
-  accessibilityLabel="Sign up to newsletter"
+  accessibilityLabel="Sign up now"
   accessibilityRole="button"
   accessible={true}
   focusable={true}
@@ -127,9 +127,9 @@ exports[`NewsletterPuffButton renders the button with the text \`Sign up to news
         },
       ]
     }
-    title="Sign up to newsletter"
+    title="Sign up now"
   >
-    Sign up to newsletter
+    Sign up now
   </Text>
 </View>
 `;

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/inline-newsletter-puff.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/inline-newsletter-puff.test.js.snap
@@ -144,7 +144,7 @@ exports[`Inline Newsletter Puff renders signup state 1`] = `
       className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO"
     >
       <View
-        accessibilityLabel="Sign up to newsletter"
+        accessibilityLabel="Sign up now"
         accessibilityRole="button"
         accessible={true}
         focusable={true}
@@ -201,9 +201,9 @@ exports[`Inline Newsletter Puff renders signup state 1`] = `
               },
             ]
           }
-          title="Sign up to newsletter"
+          title="Sign up now"
         >
-          Sign up to newsletter
+          Sign up now
         </Text>
       </View>
     </View>
@@ -242,7 +242,7 @@ exports[`Inline Newsletter Puff renders signup view when not already subscribed 
       className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO"
     >
       <View
-        accessibilityLabel="Sign up to newsletter"
+        accessibilityLabel="Sign up now"
         accessibilityRole="button"
         accessible={true}
         focusable={true}
@@ -299,9 +299,9 @@ exports[`Inline Newsletter Puff renders signup view when not already subscribed 
               },
             ]
           }
-          title="Sign up to newsletter"
+          title="Sign up now"
         >
-          Sign up to newsletter
+          Sign up now
         </Text>
       </View>
     </View>

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/newsletter-puff-button.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/newsletter-puff-button.test.js.snap
@@ -68,7 +68,7 @@ exports[`NewsletterPuffButton renders the button with the text \`Saving...\` 1`]
 
 exports[`NewsletterPuffButton renders the button with the text \`Sign up to newsletter\` 1`] = `
 <View
-  accessibilityLabel="Sign up to newsletter"
+  accessibilityLabel="Sign up now"
   accessibilityRole="button"
   accessible={true}
   focusable={true}
@@ -125,9 +125,9 @@ exports[`NewsletterPuffButton renders the button with the text \`Sign up to news
         },
       ]
     }
-    title="Sign up to newsletter"
+    title="Sign up now"
   >
-    Sign up to newsletter
+    Sign up now
   </Text>
 </View>
 `;

--- a/packages/article-skeleton/__tests__/web/__snapshots__/inline-newsletter-puff.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/inline-newsletter-puff.test.js.snap
@@ -140,7 +140,7 @@ exports[`Inline Newsletter Puff renders signup state 1`] = `
         }
         type="button"
       >
-        Sign up to newsletter
+        Sign up now
       </button>
     </div>
   </div>
@@ -206,7 +206,7 @@ exports[`Inline Newsletter Puff renders signup view when not already subscribed 
         }
         type="button"
       >
-        Sign up to newsletter
+        Sign up now
       </button>
     </div>
   </div>

--- a/packages/article-skeleton/__tests__/web/__snapshots__/newsletter-puff-button.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/newsletter-puff-button.test.js.snap
@@ -58,7 +58,7 @@ exports[`NewsletterPuffButton renders the button with the text \`Sign up to news
   }
   type="button"
 >
-  Sign up to newsletter
+  Sign up now
 </button>
 `;
 

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -252,7 +252,7 @@ export default ({
             code={code}
             copy={decodeURIComponent(copy)}
             headline={decodeURIComponent(headline)}
-            imageUri={imageUri}
+            imageUri={decodeURIComponent(imageUri)}
             label={decodeURIComponent(label)}
           />
         );

--- a/packages/article-skeleton/src/article-body/article-body.web.js
+++ b/packages/article-skeleton/src/article-body/article-body.web.js
@@ -123,7 +123,7 @@ const renderers = ({ paidContentClassName, template, analyticsStream }) => ({
             code={code}
             copy={decodeURIComponent(copy)}
             headline={decodeURIComponent(headline)}
-            imageUri={imageUri}
+            imageUri={decodeURIComponent(imageUri)}
             label={decodeURIComponent(label)}
           />
         );

--- a/packages/article-skeleton/src/article-body/newsletter-puff-button.js
+++ b/packages/article-skeleton/src/article-body/newsletter-puff-button.js
@@ -10,7 +10,7 @@ import { buttonStyles, textStyle } from "../styles/inline-newsletter-puff";
 
 const NewsletterPuffButton = ({ updatingSubscription, onPress }) => (
   <Button
-    title={updatingSubscription ? "Saving…" : "Sign up to newsletter"}
+    title={updatingSubscription ? "Saving…" : "Sign up now"}
     onPress={onPress}
     style={buttonStyles}
     underlayColor="transparent"


### PR DESCRIPTION
This PR:

* Decode the imageUri that comes encoded from the component builder before we pass it as a prop to `inline-newsletter-puff`
* Change the copy of NewsletterPuffButton from `Sign up to newsletter` to `Sign up now` 


[TNLT-2519](https://nidigitalsolutions.jira.com/browse/TNLT-2519)