### PR TITLE
feat(TNLT-2993): Add ssr prop in QueryProvider

### DIFF
--- a/packages/provider/src/connect.js
+++ b/packages/provider/src/connect.js
@@ -20,6 +20,7 @@ export const QueryProvider = ({
   query,
   propsToVariables,
   debounceTimeMs,
+  ssr,
   ...props
 }) => (
   <Debounce
@@ -31,7 +32,7 @@ export const QueryProvider = ({
       );
 
       return (
-        <Query query={query} variables={variables}>
+        <Query query={query} ssr={ssr} variables={variables}>
           {({ loading, data, refetch, fetchMore, error }) =>
             children({
               error,
@@ -68,11 +69,13 @@ QueryProvider.propTypes = {
         )
       })
     ).isRequired
-  }).isRequired
+  }).isRequired,
+  ssr: PropTypes.bool
 };
 
 QueryProvider.defaultProps = {
-  propsToVariables: i => i
+  propsToVariables: i => i,
+  ssr: true
 };
 
 const connectGraphql = (query, propsToVariables) => props => (

--- a/packages/provider/src/connect.js
+++ b/packages/provider/src/connect.js
@@ -75,7 +75,7 @@ QueryProvider.propTypes = {
 
 QueryProvider.defaultProps = {
   propsToVariables: i => i,
-  ssr: true
+  ssr: undefined
 };
 
 const connectGraphql = (query, propsToVariables) => props => (


### PR DESCRIPTION
This PR:

* Add `ssr` prop in QueryProvider so we can use the `false` value when we don't want to call the GraphQL query from the server and call it only form the client. We set this prop as optional with the default value equal to `undefined` as the `Query` only checks if the value is false (See screenshot). From the documentation of the `Query` component

```
ssr: boolean
Pass in false to skip your query during server-side rendering.
```

We need it for the `GetNewsletter` query but it will be useful if we need it in another query in the future.

[TNLT-2993](https://nidigitalsolutions.jira.com/browse/TNLT-2993)

<img width="1440" alt="Screenshot 2020-06-25 at 18 53 44" src="https://user-images.githubusercontent.com/46359871/85773303-9a59e400-b715-11ea-980b-0ea939e1a726.png">
