### PR TITLE
fix: register fonts for storybook native

### DIFF
--- a/storybook-native/index.js
+++ b/storybook-native/index.js
@@ -1,6 +1,15 @@
 import "core-js";
 import "regenerator-runtime/runtime";
 import { AppRegistry } from "react-native";
+import { FontStorage } from "@times-components/typeset";
 import StorybookUIRoot from "./storybook";
+import ttf from "../fonts";
+
+Object.keys(ttf).forEach(fontName => {
+  FontStorage.registerFont(fontName, ttf[fontName]);
+});
+
+// Suppress all warnings (WIP solution until issues are correctly addressed)
+// YellowBox.ignoreWarnings([""]);
 
 AppRegistry.registerComponent("storybooknative", () => StorybookUIRoot);

--- a/storybook-native/package.json
+++ b/storybook-native/package.json
@@ -29,6 +29,7 @@
     "@storybook/react": "5.3.18",
     "@storybook/react-native": "5.3.18",
     "@times-components/storybook": "4.1.54",
+    "@times-components/typeset": "0.1.3",
     "core-js": "^2.6.5",
     "prop-types": "15.7.2",
     "react": "16.9.0",


### PR DESCRIPTION
Some of the article rendering logic on native requires fonts to be registered with `FontStorage`.