### PR TITLE
fix(TNLT-1331): add subsection to targeting attribute path

### DIFF
--- a/packages/ad/src/ad.js
+++ b/packages/ad/src/ad.js
@@ -76,13 +76,7 @@ class Ad extends Component {
   };
 
   renderAd(adConfig) {
-    const {
-      baseUrl,
-      contextUrl,
-      isLoading,
-      slotName,
-      style
-    } = this.props;
+    const { baseUrl, contextUrl, isLoading, slotName, style } = this.props;
     const { config, hasError, isAdReady, offline } = this.state;
 
     if (hasError || offline) return null;

--- a/packages/ad/src/ad.js
+++ b/packages/ad/src/ad.js
@@ -80,7 +80,6 @@ class Ad extends Component {
       baseUrl,
       contextUrl,
       isLoading,
-      section,
       slotName,
       style
     } = this.props;
@@ -91,7 +90,7 @@ class Ad extends Component {
     this.slots = adConfig.bidderSlots.map(slot =>
       getPrebidSlotConfig(
         slot,
-        section,
+        adConfig.slotTargeting.section,
         config.maxSizes.width,
         adConfig.biddersConfig.bidders
       )
@@ -118,7 +117,7 @@ class Ad extends Component {
         minPrice: adConfig.biddersConfig.minPrice,
         timeout: adConfig.biddersConfig.timeout
       }),
-      section,
+      section: adConfig.slotTargeting.section,
       sizingMap: config.mappings,
       slotName,
       slots: this.slots,


### PR DESCRIPTION
[TNLT-2614](https://nidigitalsolutions.jira.com/browse/TNLT-2614)

Fix for Ad Section based targeting.
The variable `section` in Ad props was undefined.
Updated to use section name from ad config slot targeting.

![ad-section-fix](https://user-images.githubusercontent.com/8720661/86262651-d636f280-bbc8-11ea-86cf-f9c4d50105ad.png)
![ad-section-timeline](https://user-images.githubusercontent.com/8720661/86262669-da631000-bbc8-11ea-81fa-9564d35e61b8.png)
