### PR TITLE
chore: remove android and ios publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2.2
 
 executors:
     node:
@@ -89,30 +89,6 @@ jobs:
                       npx lerna run test --stream --since -- -- --ci --bail --coverage
                   working_directory: ~/project/
 
-    run_android_tests:
-        executor: node
-        steps:
-            - checkout
-            - attach_workspace:
-                  at: ./
-            - run:
-                  name: Run Android Tests
-                  command: |
-                      npx lerna run test:android --stream --since -- -- --ci --bail --coverage
-                  working_directory: ~/project/
-
-    run_ios_tests:
-        executor: node
-        steps:
-            - checkout
-            - attach_workspace:
-                  at: ./
-            - run:
-                  name: Run iOS Tests
-                  command: |
-                      npx lerna run test:ios --stream --since -- -- --ci --bail --coverage
-                  working_directory: ~/project/
-
     run_web_tests:
         executor: node
         steps:
@@ -169,45 +145,6 @@ jobs:
                       npx yarn@1.16.0 coverage:publish
                   working_directory: ~/project/
 
-    publish_android:
-        executor: node
-        steps:
-            - checkout
-            - attach_workspace:
-                  at: ./
-            - run:
-                  name: Build and publish android js bundles
-                  command: |
-                      # Install JDK and android SDK   
-                      sudo apt-get update
-                      sudo apt install default-jdk
-                      cd /home
-                      sudo wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
-                      sudo unzip sdk-tools-linux-4333796.zip
-                      sudo rm sdk-tools-linux-4333796.zip
-                      sudo mkdir /home/android-sdk
-                      sudo mv tools /home/android-sdk/tools
-                      export ANDROID_SDK_ROOT=/home/android-sdk
-                      echo $(yes | sudo $ANDROID_SDK_ROOT/tools/bin/sdkmanager --licenses)
-                      sudo chmod ugo+rwx "android-sdk"
-                      cd ~/project/
-                      # TODO: move above lines in a docker image
-                      npx yarn@1.16.0 android:build-lib
-                      npx yarn@1.16.0 android:publish-lib
-                  working_directory: ~/project/
-    publish_ios:
-        executor: node
-        steps:
-            - checkout
-            - attach_workspace:
-                  at: ./
-            - run:
-                  name: Build and publish iOS js bundles
-                  command: |
-                      npx yarn@1.16.0 ios:build-lib
-                      npx yarn@1.16.0 ios:publish-lib
-                  working_directory: ~/project/
-
     publish_npm:
         executor: node
         steps:
@@ -248,12 +185,6 @@ workflows:
             - run_noplatform_tests:
                   requires:
                       - setup
-            - run_android_tests:
-                  requires:
-                      - setup
-            - run_ios_tests:
-                  requires:
-                      - setup
             - run_web_tests:
                   requires:
                       - setup
@@ -268,8 +199,6 @@ workflows:
                       - build_storybook
                       - run_lint
                       - run_noplatform_tests
-                      - run_android_tests
-                      - run_ios_tests
                       - run_web_tests
                       - run_unit_tests
                       - run_cypress_tests
@@ -282,8 +211,6 @@ workflows:
                       - build_storybook
                       - run_lint
                       - run_noplatform_tests
-                      - run_android_tests
-                      - run_ios_tests
                       - run_web_tests
                       - run_unit_tests
                       - run_cypress_tests
@@ -296,22 +223,6 @@ workflows:
                       - build_storybook
                       - run_lint
                       - run_noplatform_tests
-                      - run_android_tests
-                      - run_ios_tests
                       - run_web_tests
                       - run_unit_tests
                       - run_cypress_tests
-            - publish_android:
-                  filters:
-                    branches:
-                        only: 
-                          - master
-                  requires:
-                      - publish_npm
-            - publish_ios:
-                  filters:
-                    branches:
-                        only: 
-                          - master
-                  requires:
-                      - publish_npm


### PR DESCRIPTION
- Now we have a separate repo for native times components we don't want both to publish native bundles.

- Further work will need to be done in future PRs: 

1. Remove native storybooks
2. Remove native tests
3. Remove native only code
