### PR TITLE
fix(TNLT-2359): make Spot read only for share token users

### DIFF
--- a/packages/article-extras/__tests__/shared.web.js
+++ b/packages/article-extras/__tests__/shared.web.js
@@ -33,7 +33,7 @@ export default () => {
     {
       name: "renders correctly",
       test: () => {
-        UserState.mockStates = [UserState.fullArticle];
+        UserState.mockStates = [UserState.fullArticle, UserState.loggedIn];
         const testInstance = TestRenderer.create(
           <ArticleExtras
             analyticsStream={() => {}}
@@ -55,6 +55,26 @@ export default () => {
         "no related articles, topics and comments when user not logged in, only sponsored div",
       test: () => {
         UserState.mockStates = [];
+        const testInstance = TestRenderer.create(
+          <ArticleExtras
+            analyticsStream={() => {}}
+            articleId="dummy-article-id"
+            commentsEnabled
+            registerNode={() => {}}
+            relatedArticleSlice={relatedArticleSlice}
+            relatedArticlesVisible
+            spotAccountId="dummy-spot-id"
+            topics={topics}
+          />
+        );
+
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "read only comments when the user is a share token reader",
+      test: () => {
+        UserState.mockStates = [UserState.fullArticle, UserState.shared];
         const testInstance = TestRenderer.create(
           <ArticleExtras
             analyticsStream={() => {}}

--- a/packages/article-extras/__tests__/web/__snapshots__/article-extras.web.test.js.snap
+++ b/packages/article-extras/__tests__/web/__snapshots__/article-extras.web.test.js.snap
@@ -41,3 +41,36 @@ exports[`2. no related articles, topics and comments when user not logged in, on
   />
 </div>
 `;
+
+exports[`3. read only comments when the user is a share token reader 1`] = `
+Array [
+  <div />,
+  <div>
+    <nav
+      data-cy="topic-tags"
+    >
+      <ArticleTopics />
+    </nav>
+  </div>,
+  <div
+    id="related-articles"
+  >
+    <RelatedArticles
+      isVisible={true}
+    />
+  </div>,
+  <div
+    id="sponsored-article-container"
+  >
+    <div
+      id="sponsored-article"
+    />
+  </div>,
+  <ArticleComments
+    articleId="dummy-article-id"
+    isEnabled={true}
+    isReadOnly={true}
+    spotAccountId="dummy-spot-id"
+  />,
+]
+`;

--- a/packages/article-extras/src/article-extras.web.js
+++ b/packages/article-extras/src/article-extras.web.js
@@ -73,7 +73,7 @@ const ArticleExtras = ({
             articleId={articleId}
             isEnabled={commentsEnabled}
             spotAccountId={spotAccountId}
-            isReadOnly={true}
+            isReadOnly
           />
         }
       >

--- a/packages/article-extras/src/article-extras.web.js
+++ b/packages/article-extras/src/article-extras.web.js
@@ -32,6 +32,7 @@ const ArticleExtras = ({
       <div id="sponsored-article" />
     </div>
   );
+
   return (
     <UserState state={UserState.fullArticle} fallback={sponsoredArticles}>
       <div style={clearingStyle} />
@@ -64,11 +65,24 @@ const ArticleExtras = ({
         />
       </div>
       {sponsoredArticles}
-      <ArticleComments
-        articleId={articleId}
-        isEnabled={commentsEnabled}
-        spotAccountId={spotAccountId}
-      />
+
+      <UserState
+        state={UserState.loggedIn}
+        fallback={
+          <ArticleComments
+            articleId={articleId}
+            isEnabled={commentsEnabled}
+            spotAccountId={spotAccountId}
+            isReadOnly={true}
+          />
+        }
+      >
+        <ArticleComments
+          articleId={articleId}
+          isEnabled={commentsEnabled}
+          spotAccountId={spotAccountId}
+        />
+      </UserState>
     </UserState>
   );
 };


### PR DESCRIPTION
At the moment we do not pass the `isReadOnly` flag into the `<ArticleComments />` component on web. This is fine for the most part, as the wrapping `<UserState>` component ensure it isn't visible to logged out readers. Unfortunately, there is an edge case where it _can_ be shown for readers who are logged out, but are using a share token (to see the full article). This wraps the comment component with an additional user state check, and falls back to pass in the `isReadOnly` flag.