### PR TITLE
feat(TNLT-000): add long read support to web articles

### DIFF
--- a/packages/article-in-depth/src/article-header/article-header.web.js
+++ b/packages/article-in-depth/src/article-header/article-header.web.js
@@ -52,7 +52,11 @@ const ArticleHeader = ({
               {headline}
             </HeadlineContainer>
             <FlagsContainer>
-              <ArticleFlags color={textColour} flags={flags} longRead={longRead} />
+              <ArticleFlags
+                color={textColour}
+                flags={flags}
+                longRead={longRead}
+              />
             </FlagsContainer>
             <Standfirst color={textColour} standfirst={standfirst} />
           </HeaderContainer>

--- a/packages/article-in-depth/src/article-header/article-header.web.js
+++ b/packages/article-in-depth/src/article-header/article-header.web.js
@@ -25,6 +25,7 @@ const ArticleHeader = ({
   hasVideo,
   headline,
   label,
+  longRead,
   standfirst,
   textColour: rgbTextColour
 }) => {
@@ -51,7 +52,7 @@ const ArticleHeader = ({
               {headline}
             </HeadlineContainer>
             <FlagsContainer>
-              <ArticleFlags color={textColour} flags={flags} />
+              <ArticleFlags color={textColour} flags={flags} longRead={longRead} />
             </FlagsContainer>
             <Standfirst color={textColour} standfirst={standfirst} />
           </HeaderContainer>

--- a/packages/article-in-depth/src/article-in-depth.web.js
+++ b/packages/article-in-depth/src/article-in-depth.web.js
@@ -28,6 +28,7 @@ class ArticlePage extends Component {
       hasVideo,
       headline,
       label,
+      longRead,
       publicationName,
       publishedTime,
       shortHeadline,
@@ -43,6 +44,7 @@ class ArticlePage extends Component {
           hasVideo={hasVideo}
           headline={getHeadline(headline, shortHeadline)}
           label={label}
+          longRead={longRead}
           standfirst={standfirst}
           textColour={textColour}
         />

--- a/packages/article-magazine-comment/src/article-header/article-header.web.js
+++ b/packages/article-magazine-comment/src/article-header/article-header.web.js
@@ -27,6 +27,7 @@ const ArticleHeader = ({
   hasVideo,
   headline,
   label,
+  longRead,
   publicationName,
   publishedTime,
   standfirst
@@ -54,7 +55,7 @@ const ArticleHeader = ({
           {headline}
         </HeadlineContainer>
         <FlagsContainer>
-          <ArticleFlags flags={flags} />
+          <ArticleFlags flags={flags} longRead={longRead} />
         </FlagsContainer>
         <Standfirst standfirst={standfirst} />
         <Meta

--- a/packages/article-magazine-comment/src/article-magazine-comment.web.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.web.js
@@ -28,6 +28,7 @@ class ArticlePage extends Component {
       hasVideo,
       headline,
       label,
+      longRead,
       publicationName,
       publishedTime,
       shortHeadline,
@@ -52,6 +53,7 @@ class ArticlePage extends Component {
           hasVideo={hasVideo}
           headline={getHeadline(headline, shortHeadline)}
           label={label}
+          longRead={longRead}
           publicationName={publicationName}
           publishedTime={publishedTime}
           standfirst={standfirst}

--- a/packages/article-magazine-standard/src/article-header/article-header.web.js
+++ b/packages/article-magazine-standard/src/article-header/article-header.web.js
@@ -43,7 +43,7 @@ const ArticleHeader = ({
           ]}
         >
           {headline}
-          </HeadlineContainer>
+        </HeadlineContainer>
         <FlagsContainer>
           <ArticleFlags flags={flags} longRead={longRead} />
         </FlagsContainer>

--- a/packages/article-magazine-standard/src/article-header/article-header.web.js
+++ b/packages/article-magazine-standard/src/article-header/article-header.web.js
@@ -24,6 +24,7 @@ const ArticleHeader = ({
   hasVideo,
   headline,
   label,
+  longRead,
   publicationName,
   publishedTime,
   standfirst
@@ -42,9 +43,9 @@ const ArticleHeader = ({
           ]}
         >
           {headline}
-        </HeadlineContainer>
+          </HeadlineContainer>
         <FlagsContainer>
-          <ArticleFlags flags={flags} />
+          <ArticleFlags flags={flags} longRead={longRead} />
         </FlagsContainer>
         <Standfirst standfirst={standfirst} />
         <Meta

--- a/packages/article-magazine-standard/src/article-magazine-standard.web.js
+++ b/packages/article-magazine-standard/src/article-magazine-standard.web.js
@@ -28,6 +28,7 @@ class ArticlePage extends Component {
       hasVideo,
       headline,
       label,
+      longRead,
       publicationName,
       publishedTime,
       shortHeadline,
@@ -42,6 +43,7 @@ class ArticlePage extends Component {
           hasVideo={hasVideo}
           headline={getHeadline(headline, shortHeadline)}
           label={label}
+          longRead={longRead}
           publicationName={publicationName}
           publishedTime={publishedTime}
           standfirst={standfirst}

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -97,7 +97,9 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
             Some Short Headline
           </h1>
           <div>
-            <ArticleFlags />
+            <ArticleFlags
+              longRead={false}
+            />
           </div>
           <div>
             <div>
@@ -343,7 +345,9 @@ exports[`4. an article with ads 1`] = `
             Some Headline
           </h1>
           <div>
-            <ArticleFlags />
+            <ArticleFlags
+              longRead={false}
+            />
           </div>
           <div>
             <div>

--- a/packages/article-main-comment/src/article-header/article-header.web.js
+++ b/packages/article-main-comment/src/article-header/article-header.web.js
@@ -25,6 +25,7 @@ const ArticleHeader = ({
   hasVideo,
   headline,
   label,
+  longRead,
   publicationName,
   publishedTime,
   standfirst
@@ -46,7 +47,7 @@ const ArticleHeader = ({
       {headline}
     </HeadlineContainer>
     <FlagsContainer>
-      <ArticleFlags flags={flags} />
+      <ArticleFlags flags={flags} longRead={longRead} />
     </FlagsContainer>
     <Standfirst standfirst={standfirst} />
     <Meta

--- a/packages/article-main-comment/src/article-main-comment.web.js
+++ b/packages/article-main-comment/src/article-main-comment.web.js
@@ -21,6 +21,7 @@ class ArticlePage extends Component {
       hasVideo,
       headline,
       label,
+      longRead,
       publicationName,
       publishedTime,
       shortHeadline,
@@ -44,6 +45,7 @@ class ArticlePage extends Component {
         hasVideo={hasVideo}
         headline={getHeadline(headline, shortHeadline)}
         label={label}
+        longRead={longRead}
         publicationName={publicationName}
         publishedTime={publishedTime}
         standfirst={standfirst}

--- a/packages/article-main-standard/src/article-header/article-header.web.js
+++ b/packages/article-main-standard/src/article-header/article-header.web.js
@@ -16,6 +16,7 @@ const ArticleHeader = ({
   hasVideo,
   headline,
   label,
+  longRead,
   standfirst,
   style
 }) => (
@@ -30,7 +31,7 @@ const ArticleHeader = ({
     </HeadlineContainer>
     <HeaderStandfirst standfirst={standfirst} />
     <View style={styles.flags}>
-      <ArticleFlags flags={flags} />
+      <ArticleFlags flags={flags} longRead={longRead} />
     </View>
   </View>
 );
@@ -45,6 +46,7 @@ ArticleHeader.propTypes = {
   hasVideo: PropTypes.bool,
   headline: PropTypes.string.isRequired,
   label: PropTypes.string,
+  longRead: PropTypes.bool,
   standfirst: PropTypes.string,
   style: ViewStylePropTypes
 };
@@ -53,6 +55,7 @@ ArticleHeader.defaultProps = {
   flags: [],
   hasVideo: false,
   label: null,
+  longRead: false,
   standfirst: null,
   style: {}
 };

--- a/packages/article-main-standard/src/article-main-standard.web.js
+++ b/packages/article-main-standard/src/article-main-standard.web.js
@@ -39,6 +39,7 @@ class ArticlePage extends Component {
       headline,
       expirableFlags,
       label,
+      longRead,
       publicationName,
       publishedTime,
       shortHeadline,
@@ -57,6 +58,7 @@ class ArticlePage extends Component {
               hasVideo={hasVideo}
               headline={getHeadline(headline, shortHeadline)}
               label={label}
+              longRead={longRead}
               standfirst={standfirst}
             />
           </HeaderContainer>

--- a/packages/article/showcase-helper.js
+++ b/packages/article/showcase-helper.js
@@ -31,10 +31,11 @@ const KEY_FACTS = 4;
 const LABEL = 8;
 const LEAD_ASSET = 16;
 const LINKED_BYLINE = 32;
-const PULL_QUOTE = 64;
-const STANDFIRST = 128;
-const VIDEO = 256;
-const TEASED_CONTENT = 512;
+const LONG_READ = 64;
+const PULL_QUOTE = 128;
+const STANDFIRST = 256;
+const VIDEO = 512;
+const TEASED_CONTENT = 1024;
 
 export const makeArticleConfiguration = ({
   withFlags,
@@ -43,6 +44,7 @@ export const makeArticleConfiguration = ({
   withLabel,
   withLeadAsset,
   withLinkedByline,
+  withLongRead,
   withPullQuote,
   withStandfirst,
   withVideo,
@@ -72,6 +74,10 @@ export const makeArticleConfiguration = ({
 
   if (withLinkedByline) {
     mask = mask | LINKED_BYLINE;
+  }
+
+  if (withLongRead) {
+    mask = mask | LONG_READ;
   }
 
   if (withPullQuote) {
@@ -123,6 +129,10 @@ const makeArticle = configuration => article => {
 
   if (configuration & LINKED_BYLINE) {
     configuredArticle.bylines = fixtures.bylineWithLink;
+  }
+
+  if (configuration & LONG_READ) {
+    configuredArticle.longRead = true;
   }
 
   if (configuration & PULL_QUOTE) {
@@ -197,7 +207,7 @@ class ArticleConfigurator extends Component {
     if (!mocks.length || reRendering) {
       return null;
     }
-
+    
     return <MockedProvider mocks={mocks}>{children}</MockedProvider>;
   }
 }
@@ -303,6 +313,7 @@ const renderArticleConfig = ({
   const withLabel = boolean("Label", true);
   const withLeadAsset = boolean("Lead Asset", true);
   const withLinkedByline = boolean("Linked Byline", true);
+  const withLongRead = boolean("Long Read", false);
   const withPullQuote = boolean("Pull Quote", false);
   const withStandfirst = boolean("Standfirst", true);
   const withVideo = boolean("Video", true);
@@ -335,6 +346,7 @@ const renderArticleConfig = ({
             withLabel,
             withLeadAsset,
             withLinkedByline,
+            withLongRead,
             withPullQuote,
             withStandfirst,
             withVideo,

--- a/packages/article/showcase-helper.js
+++ b/packages/article/showcase-helper.js
@@ -207,7 +207,7 @@ class ArticleConfigurator extends Component {
     if (!mocks.length || reRendering) {
       return null;
     }
-    
+
     return <MockedProvider mocks={mocks}>{children}</MockedProvider>;
   }
 }

--- a/packages/provider-queries/src/article_web.graphql
+++ b/packages/provider-queries/src/article_web.graphql
@@ -123,6 +123,7 @@ fragment articleProps on Article {
   headline
   id
   label
+  longRead
   publicationName
   publishedTime
   updatedTime

--- a/packages/provider-test-tools/src/article.js
+++ b/packages/provider-test-tools/src/article.js
@@ -46,6 +46,7 @@ export default ({
               });
             }
 
+
             return makeRelatedArticle(parent);
           },
           ArticleSlice: () => ({

--- a/packages/provider-test-tools/src/article.js
+++ b/packages/provider-test-tools/src/article.js
@@ -46,7 +46,6 @@ export default ({
               });
             }
 
-
             return makeRelatedArticle(parent);
           },
           ArticleSlice: () => ({


### PR DESCRIPTION
Now TPA exposes the `longRead` boolean flag on articles, this PR adds support to web articles to render the flag.

Currently as a draft, while I get design feedback.