### PR TITLE
feat(TNLT-3719): add once to spot IM comment call

### DIFF
--- a/packages/article-comments/src/comments.web.js
+++ b/packages/article-comments/src/comments.web.js
@@ -59,7 +59,10 @@ class Comments extends Component {
 
     document.addEventListener(
       "spot-im-current-user-typing-start",
-      onCommentStart
+      onCommentStart,
+      {
+        once: true
+      }
     );
     document.addEventListener(
       "spot-im-current-user-sent-message",


### PR DESCRIPTION
This PR adds the once option to the comments event listener as it was firing multiple times.
After investigating, the event listener was only registered once, so multiple firing must be to do with slightly dodgy event listener firing. Once option should limit the event listener to firing just once

https://nidigitalsolutions.jira.com/browse/TNLT-3719