### PR TITLE
feat(TNLT-5506): Change confirmation copy in newsletter puff

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/inline-newsletter-puff.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/inline-newsletter-puff.test.js.snap
@@ -10,25 +10,25 @@ exports[`Inline Newsletter Puff renders 'saving' when the button is clicked 1`] 
     Image rendered with imageUri=https://nuk-tnl-deck-prod-static.s3-eu-west-1.amazonaws.com/uploads/2aa9050e6c3d4de682f11a4802ebba96.jpg
   </View>
   <View
-    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-5 fhcdpp"
+    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-4 kPWsJB"
   >
     <Text
-      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-6 bMAtxh"
+      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-5 hYAenB"
     >
       STRAIGHT IN YOUR INBOX
     </Text>
     <Text
-      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-7 hYPuGW"
+      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-6 dblhCJ"
     >
       Politics. Explained.
     </Text>
     <Text
-      className="inline-newsletter-puff__InpCopy-sc-13hmjc-8 jDEpQZ"
+      className="inline-newsletter-puff__InpCopy-sc-13hmjc-7 jiVhJw"
     >
       Sign up to receive our brilliant Red Box newsletter, Matt Chorley\`s poke at politics delivered every weekday morning at 8am.
     </Text>
     <View
-      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO"
+      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-8 ekxAnz"
     >
       <View
         accessibilityLabel="Saving…"
@@ -124,25 +124,25 @@ exports[`Inline Newsletter Puff renders signup state 1`] = `
     Image rendered with imageUri=https://nuk-tnl-deck-prod-static.s3-eu-west-1.amazonaws.com/uploads/2aa9050e6c3d4de682f11a4802ebba96.jpg
   </View>
   <View
-    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-5 fhcdpp"
+    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-4 kPWsJB"
   >
     <Text
-      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-6 bMAtxh"
+      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-5 hYAenB"
     >
       STRAIGHT IN YOUR INBOX
     </Text>
     <Text
-      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-7 hYPuGW"
+      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-6 dblhCJ"
     >
       Politics. Explained.
     </Text>
     <Text
-      className="inline-newsletter-puff__InpCopy-sc-13hmjc-8 jDEpQZ"
+      className="inline-newsletter-puff__InpCopy-sc-13hmjc-7 jiVhJw"
     >
       Sign up to receive our brilliant Red Box newsletter, Matt Chorley\`s poke at politics delivered every weekday morning at 8am.
     </Text>
     <View
-      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO"
+      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-8 ekxAnz"
     >
       <View
         accessibilityLabel="Sign up now"
@@ -223,25 +223,25 @@ exports[`Inline Newsletter Puff renders signup view when not already subscribed 
     Image rendered with imageUri=https://nuk-tnl-deck-prod-static.s3-eu-west-1.amazonaws.com/uploads/2aa9050e6c3d4de682f11a4802ebba96.jpg
   </View>
   <View
-    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-5 fhcdpp"
+    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-4 kPWsJB"
   >
     <Text
-      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-6 bMAtxh"
+      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-5 hYAenB"
     >
       STRAIGHT IN YOUR INBOX
     </Text>
     <Text
-      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-7 hYPuGW"
+      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-6 dblhCJ"
     >
       Politics. Explained.
     </Text>
     <Text
-      className="inline-newsletter-puff__InpCopy-sc-13hmjc-8 jDEpQZ"
+      className="inline-newsletter-puff__InpCopy-sc-13hmjc-7 jiVhJw"
     >
       Sign up to receive our brilliant Red Box newsletter, Matt Chorley\`s poke at politics delivered every weekday morning at 8am.
     </Text>
     <View
-      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO"
+      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-8 ekxAnz"
     >
       <View
         accessibilityLabel="Sign up now"
@@ -327,15 +327,10 @@ exports[`Inline Newsletter Puff renders the success view after subscribing  1`] 
     <Text
       className="inline-newsletter-puff__InpSubscribedHeadline-sc-13hmjc-3 jmCvyH"
     >
-      You’ve successfully signed up
-    </Text>
-    <Text
-      className="inline-newsletter-puff__InpSubscribedCopy-sc-13hmjc-4 bAdDVG"
-    >
-      Congratulations you can now enjoy daily updates from Red Box.
+      You’ve successfully signed up to RED BOX
     </Text>
     <View
-      className="inline-newsletter-puff__InpPreferencesContainer-sc-13hmjc-10 jWzuZh"
+      className="inline-newsletter-puff__InpPreferencesContainer-sc-13hmjc-9 kfcFGB"
     >
       <View
         accessible={true}
@@ -357,15 +352,15 @@ exports[`Inline Newsletter Puff renders the success view after subscribing  1`] 
         style={Object {}}
       >
         <View
-          className="inline-newsletter-puff__InpPreferencesView-sc-13hmjc-13 iRumcp"
+          className="inline-newsletter-puff__InpPreferencesView-sc-13hmjc-12 eowBYw"
         >
           <Text
-            className="inline-newsletter-puff__InpPreferencesText-sc-13hmjc-11 bEnqSP"
+            className="inline-newsletter-puff__InpPreferencesText-sc-13hmjc-10 fjWboP"
           >
             Manage preferences here
           </Text>
           <View
-            className="inline-newsletter-puff__InpIconContainer-sc-13hmjc-12 fJlAxF"
+            className="inline-newsletter-puff__InpIconContainer-sc-13hmjc-11 fjCqVn"
           >
             <RNSVGSvgView
               align="xMidYMid"

--- a/packages/article-skeleton/__tests__/android/__snapshots__/newsletter-puff-link.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/newsletter-puff-link.test.js.snap
@@ -21,15 +21,15 @@ exports[`NewsletterPuffLink renders the link with the text \`Manage preferences 
   style={Object {}}
 >
   <View
-    className="inline-newsletter-puff__InpPreferencesView-sc-13hmjc-13 iRumcp"
+    className="inline-newsletter-puff__InpPreferencesView-sc-13hmjc-12 eowBYw"
   >
     <Text
-      className="inline-newsletter-puff__InpPreferencesText-sc-13hmjc-11 bEnqSP"
+      className="inline-newsletter-puff__InpPreferencesText-sc-13hmjc-10 fjWboP"
     >
       Manage preferences here
     </Text>
     <View
-      className="inline-newsletter-puff__InpIconContainer-sc-13hmjc-12 fJlAxF"
+      className="inline-newsletter-puff__InpIconContainer-sc-13hmjc-11 fjCqVn"
     >
       <RNSVGSvgView
         align="xMidYMid"

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/inline-newsletter-puff.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/inline-newsletter-puff.test.js.snap
@@ -10,25 +10,25 @@ exports[`Inline Newsletter Puff renders 'saving' when the button is clicked 1`] 
     Image rendered with imageUri=https://nuk-tnl-deck-prod-static.s3-eu-west-1.amazonaws.com/uploads/2aa9050e6c3d4de682f11a4802ebba96.jpg
   </View>
   <View
-    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-5 fhcdpp"
+    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-4 kPWsJB"
   >
     <Text
-      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-6 bMAtxh"
+      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-5 hYAenB"
     >
       STRAIGHT IN YOUR INBOX
     </Text>
     <Text
-      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-7 hYPuGW"
+      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-6 dblhCJ"
     >
       Politics. Explained.
     </Text>
     <Text
-      className="inline-newsletter-puff__InpCopy-sc-13hmjc-8 jDEpQZ"
+      className="inline-newsletter-puff__InpCopy-sc-13hmjc-7 jiVhJw"
     >
       Sign up to receive our brilliant Red Box newsletter, Matt Chorley\`s poke at politics delivered every weekday morning at 8am.
     </Text>
     <View
-      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO"
+      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-8 ekxAnz"
     >
       <View
         accessibilityLabel="Saving…"
@@ -123,25 +123,25 @@ exports[`Inline Newsletter Puff renders signup state 1`] = `
     Image rendered with imageUri=https://nuk-tnl-deck-prod-static.s3-eu-west-1.amazonaws.com/uploads/2aa9050e6c3d4de682f11a4802ebba96.jpg
   </View>
   <View
-    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-5 fhcdpp"
+    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-4 kPWsJB"
   >
     <Text
-      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-6 bMAtxh"
+      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-5 hYAenB"
     >
       STRAIGHT IN YOUR INBOX
     </Text>
     <Text
-      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-7 hYPuGW"
+      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-6 dblhCJ"
     >
       Politics. Explained.
     </Text>
     <Text
-      className="inline-newsletter-puff__InpCopy-sc-13hmjc-8 jDEpQZ"
+      className="inline-newsletter-puff__InpCopy-sc-13hmjc-7 jiVhJw"
     >
       Sign up to receive our brilliant Red Box newsletter, Matt Chorley\`s poke at politics delivered every weekday morning at 8am.
     </Text>
     <View
-      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO"
+      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-8 ekxAnz"
     >
       <View
         accessibilityLabel="Sign up now"
@@ -221,25 +221,25 @@ exports[`Inline Newsletter Puff renders signup view when not already subscribed 
     Image rendered with imageUri=https://nuk-tnl-deck-prod-static.s3-eu-west-1.amazonaws.com/uploads/2aa9050e6c3d4de682f11a4802ebba96.jpg
   </View>
   <View
-    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-5 fhcdpp"
+    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-4 kPWsJB"
   >
     <Text
-      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-6 bMAtxh"
+      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-5 hYAenB"
     >
       STRAIGHT IN YOUR INBOX
     </Text>
     <Text
-      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-7 hYPuGW"
+      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-6 dblhCJ"
     >
       Politics. Explained.
     </Text>
     <Text
-      className="inline-newsletter-puff__InpCopy-sc-13hmjc-8 jDEpQZ"
+      className="inline-newsletter-puff__InpCopy-sc-13hmjc-7 jiVhJw"
     >
       Sign up to receive our brilliant Red Box newsletter, Matt Chorley\`s poke at politics delivered every weekday morning at 8am.
     </Text>
     <View
-      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO"
+      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-8 ekxAnz"
     >
       <View
         accessibilityLabel="Sign up now"
@@ -324,15 +324,10 @@ exports[`Inline Newsletter Puff renders the success view after subscribing  1`] 
     <Text
       className="inline-newsletter-puff__InpSubscribedHeadline-sc-13hmjc-3 jmCvyH"
     >
-      You’ve successfully signed up
-    </Text>
-    <Text
-      className="inline-newsletter-puff__InpSubscribedCopy-sc-13hmjc-4 bAdDVG"
-    >
-      Congratulations you can now enjoy daily updates from Red Box.
+      You’ve successfully signed up to RED BOX
     </Text>
     <View
-      className="inline-newsletter-puff__InpPreferencesContainer-sc-13hmjc-10 jWzuZh"
+      className="inline-newsletter-puff__InpPreferencesContainer-sc-13hmjc-9 kfcFGB"
     >
       <View
         accessible={true}
@@ -352,15 +347,15 @@ exports[`Inline Newsletter Puff renders the success view after subscribing  1`] 
         }
       >
         <View
-          className="inline-newsletter-puff__InpPreferencesView-sc-13hmjc-13 iRumcp"
+          className="inline-newsletter-puff__InpPreferencesView-sc-13hmjc-12 eowBYw"
         >
           <Text
-            className="inline-newsletter-puff__InpPreferencesText-sc-13hmjc-11 bEnqSP"
+            className="inline-newsletter-puff__InpPreferencesText-sc-13hmjc-10 fjWboP"
           >
             Manage preferences here
           </Text>
           <View
-            className="inline-newsletter-puff__InpIconContainer-sc-13hmjc-12 fJlAxF"
+            className="inline-newsletter-puff__InpIconContainer-sc-13hmjc-11 fjCqVn"
           >
             <ARTSurfaceView
               style={

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/newsletter-puff-link.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/newsletter-puff-link.test.js.snap
@@ -19,15 +19,15 @@ exports[`NewsletterPuffLink renders the link with the text \`Manage preferences 
   }
 >
   <View
-    className="inline-newsletter-puff__InpPreferencesView-sc-13hmjc-13 iRumcp"
+    className="inline-newsletter-puff__InpPreferencesView-sc-13hmjc-12 eowBYw"
   >
     <Text
-      className="inline-newsletter-puff__InpPreferencesText-sc-13hmjc-11 bEnqSP"
+      className="inline-newsletter-puff__InpPreferencesText-sc-13hmjc-10 fjWboP"
     >
       Manage preferences here
     </Text>
     <View
-      className="inline-newsletter-puff__InpIconContainer-sc-13hmjc-12 fJlAxF"
+      className="inline-newsletter-puff__InpIconContainer-sc-13hmjc-11 fjCqVn"
     >
       <ARTSurfaceView
         style={

--- a/packages/article-skeleton/__tests__/web/__snapshots__/inline-newsletter-puff.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/inline-newsletter-puff.test.js.snap
@@ -10,28 +10,28 @@ exports[`Inline Newsletter Puff renders 'saving' when the button is clicked 1`] 
     Image rendered with imageUri=https://nuk-tnl-deck-prod-static.s3-eu-west-1.amazonaws.com/uploads/2aa9050e6c3d4de682f11a4802ebba96.jpg
   </div>
   <div
-    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-5 fgHAmw inline-newsletter-puff__InpSignupContainer-sc-13hmjc-5 fgHAmw css-view-1dbjc4n"
+    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-4 dfzxZt inline-newsletter-puff__InpSignupContainer-sc-13hmjc-4 dfzxZt css-view-1dbjc4n"
   >
     <div
-      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-6 fGDuEb inline-newsletter-puff__InpSignupLabel-sc-13hmjc-6 fGDuEb css-text-901oao"
+      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-5 cvZns inline-newsletter-puff__InpSignupLabel-sc-13hmjc-5 cvZns css-text-901oao"
       dir="auto"
     >
       STRAIGHT IN YOUR INBOX
     </div>
     <div
-      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-7 kSVfs inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-7 kSVfs css-text-901oao"
+      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-6 iKicZl inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-6 iKicZl css-text-901oao"
       dir="auto"
     >
       Politics. Explained.
     </div>
     <div
-      className="inline-newsletter-puff__InpCopy-sc-13hmjc-8 hLhbxF inline-newsletter-puff__InpCopy-sc-13hmjc-8 hLhbxF css-text-901oao"
+      className="inline-newsletter-puff__InpCopy-sc-13hmjc-7 bNTRNy inline-newsletter-puff__InpCopy-sc-13hmjc-7 bNTRNy css-text-901oao"
       dir="auto"
     >
       Sign up to receive our brilliant Red Box newsletter, Matt Chorley\`s poke at politics delivered every weekday morning at 8am.
     </div>
     <div
-      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO css-view-1dbjc4n"
+      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-8 ekxAnz inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-8 ekxAnz css-view-1dbjc4n"
     >
       <button
         onClick={[Function]}
@@ -91,28 +91,28 @@ exports[`Inline Newsletter Puff renders signup state 1`] = `
     Image rendered with imageUri=https://nuk-tnl-deck-prod-static.s3-eu-west-1.amazonaws.com/uploads/2aa9050e6c3d4de682f11a4802ebba96.jpg
   </div>
   <div
-    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-5 fgHAmw inline-newsletter-puff__InpSignupContainer-sc-13hmjc-5 fgHAmw css-view-1dbjc4n"
+    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-4 dfzxZt inline-newsletter-puff__InpSignupContainer-sc-13hmjc-4 dfzxZt css-view-1dbjc4n"
   >
     <div
-      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-6 fGDuEb inline-newsletter-puff__InpSignupLabel-sc-13hmjc-6 fGDuEb css-text-901oao"
+      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-5 cvZns inline-newsletter-puff__InpSignupLabel-sc-13hmjc-5 cvZns css-text-901oao"
       dir="auto"
     >
       STRAIGHT IN YOUR INBOX
     </div>
     <div
-      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-7 kSVfs inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-7 kSVfs css-text-901oao"
+      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-6 iKicZl inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-6 iKicZl css-text-901oao"
       dir="auto"
     >
       Politics. Explained.
     </div>
     <div
-      className="inline-newsletter-puff__InpCopy-sc-13hmjc-8 hLhbxF inline-newsletter-puff__InpCopy-sc-13hmjc-8 hLhbxF css-text-901oao"
+      className="inline-newsletter-puff__InpCopy-sc-13hmjc-7 bNTRNy inline-newsletter-puff__InpCopy-sc-13hmjc-7 bNTRNy css-text-901oao"
       dir="auto"
     >
       Sign up to receive our brilliant Red Box newsletter, Matt Chorley\`s poke at politics delivered every weekday morning at 8am.
     </div>
     <div
-      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO css-view-1dbjc4n"
+      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-8 ekxAnz inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-8 ekxAnz css-view-1dbjc4n"
     >
       <button
         onClick={[Function]}
@@ -157,28 +157,28 @@ exports[`Inline Newsletter Puff renders signup view when not already subscribed 
     Image rendered with imageUri=https://nuk-tnl-deck-prod-static.s3-eu-west-1.amazonaws.com/uploads/2aa9050e6c3d4de682f11a4802ebba96.jpg
   </div>
   <div
-    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-5 fgHAmw inline-newsletter-puff__InpSignupContainer-sc-13hmjc-5 fgHAmw css-view-1dbjc4n"
+    className="inline-newsletter-puff__InpSignupContainer-sc-13hmjc-4 dfzxZt inline-newsletter-puff__InpSignupContainer-sc-13hmjc-4 dfzxZt css-view-1dbjc4n"
   >
     <div
-      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-6 fGDuEb inline-newsletter-puff__InpSignupLabel-sc-13hmjc-6 fGDuEb css-text-901oao"
+      className="inline-newsletter-puff__InpSignupLabel-sc-13hmjc-5 cvZns inline-newsletter-puff__InpSignupLabel-sc-13hmjc-5 cvZns css-text-901oao"
       dir="auto"
     >
       STRAIGHT IN YOUR INBOX
     </div>
     <div
-      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-7 kSVfs inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-7 kSVfs css-text-901oao"
+      className="inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-6 iKicZl inline-newsletter-puff__InpSignupHeadline-sc-13hmjc-6 iKicZl css-text-901oao"
       dir="auto"
     >
       Politics. Explained.
     </div>
     <div
-      className="inline-newsletter-puff__InpCopy-sc-13hmjc-8 hLhbxF inline-newsletter-puff__InpCopy-sc-13hmjc-8 hLhbxF css-text-901oao"
+      className="inline-newsletter-puff__InpCopy-sc-13hmjc-7 bNTRNy inline-newsletter-puff__InpCopy-sc-13hmjc-7 bNTRNy css-text-901oao"
       dir="auto"
     >
       Sign up to receive our brilliant Red Box newsletter, Matt Chorley\`s poke at politics delivered every weekday morning at 8am.
     </div>
     <div
-      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-9 hrIwVO css-view-1dbjc4n"
+      className="inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-8 ekxAnz inline-newsletter-puff__InpSignupCTAContainer-sc-13hmjc-8 ekxAnz css-view-1dbjc4n"
     >
       <button
         onClick={[Function]}
@@ -229,16 +229,10 @@ exports[`Inline Newsletter Puff renders the success view after subscribing  1`] 
       className="inline-newsletter-puff__InpSubscribedHeadline-sc-13hmjc-3 gFPzTp inline-newsletter-puff__InpSubscribedHeadline-sc-13hmjc-3 gFPzTp css-text-901oao"
       dir="auto"
     >
-      You’ve successfully signed up
+      You’ve successfully signed up to RED BOX
     </div>
     <div
-      className="inline-newsletter-puff__InpSubscribedCopy-sc-13hmjc-4 fopmPr inline-newsletter-puff__InpSubscribedCopy-sc-13hmjc-4 fopmPr css-text-901oao"
-      dir="auto"
-    >
-      Congratulations you can now enjoy daily updates from Red Box.
-    </div>
-    <div
-      className="inline-newsletter-puff__InpPreferencesContainer-sc-13hmjc-10 jWzuZh inline-newsletter-puff__InpPreferencesContainer-sc-13hmjc-10 jWzuZh css-view-1dbjc4n"
+      className="inline-newsletter-puff__InpPreferencesContainer-sc-13hmjc-9 kfcFGB inline-newsletter-puff__InpPreferencesContainer-sc-13hmjc-9 kfcFGB css-view-1dbjc4n"
     >
       <a
         className="linkweb__RespLink-yfb9n-0 cCCShB"
@@ -247,16 +241,16 @@ exports[`Inline Newsletter Puff renders the success view after subscribing  1`] 
         target={null}
       >
         <div
-          className="inline-newsletter-puff__InpPreferencesView-sc-13hmjc-13 iRumcp inline-newsletter-puff__InpPreferencesView-sc-13hmjc-13 iRumcp css-view-1dbjc4n"
+          className="inline-newsletter-puff__InpPreferencesView-sc-13hmjc-12 eowBYw inline-newsletter-puff__InpPreferencesView-sc-13hmjc-12 eowBYw css-view-1dbjc4n"
         >
           <div
-            className="inline-newsletter-puff__InpPreferencesText-sc-13hmjc-11 bEnqSP inline-newsletter-puff__InpPreferencesText-sc-13hmjc-11 bEnqSP css-text-901oao"
+            className="inline-newsletter-puff__InpPreferencesText-sc-13hmjc-10 fjWboP inline-newsletter-puff__InpPreferencesText-sc-13hmjc-10 fjWboP css-text-901oao"
             dir="auto"
           >
             Manage preferences here
           </div>
           <div
-            className="inline-newsletter-puff__InpIconContainer-sc-13hmjc-12 fJlAxF inline-newsletter-puff__InpIconContainer-sc-13hmjc-12 fJlAxF css-view-1dbjc4n"
+            className="inline-newsletter-puff__InpIconContainer-sc-13hmjc-11 fjCqVn inline-newsletter-puff__InpIconContainer-sc-13hmjc-11 fjCqVn css-view-1dbjc4n"
           >
             <svg
               aria-label="icon-forward-arrow"

--- a/packages/article-skeleton/__tests__/web/__snapshots__/newsletter-puff-link.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/newsletter-puff-link.test.js.snap
@@ -8,16 +8,16 @@ exports[`NewsletterPuffLink renders the link with the text \`Manage preferences 
   target={null}
 >
   <div
-    className="inline-newsletter-puff__InpPreferencesView-sc-13hmjc-13 iRumcp inline-newsletter-puff__InpPreferencesView-sc-13hmjc-13 iRumcp css-view-1dbjc4n"
+    className="inline-newsletter-puff__InpPreferencesView-sc-13hmjc-12 eowBYw inline-newsletter-puff__InpPreferencesView-sc-13hmjc-12 eowBYw css-view-1dbjc4n"
   >
     <div
-      className="inline-newsletter-puff__InpPreferencesText-sc-13hmjc-11 bEnqSP inline-newsletter-puff__InpPreferencesText-sc-13hmjc-11 bEnqSP css-text-901oao"
+      className="inline-newsletter-puff__InpPreferencesText-sc-13hmjc-10 fjWboP inline-newsletter-puff__InpPreferencesText-sc-13hmjc-10 fjWboP css-text-901oao"
       dir="auto"
     >
       Manage preferences here
     </div>
     <div
-      className="inline-newsletter-puff__InpIconContainer-sc-13hmjc-12 fJlAxF inline-newsletter-puff__InpIconContainer-sc-13hmjc-12 fJlAxF css-view-1dbjc4n"
+      className="inline-newsletter-puff__InpIconContainer-sc-13hmjc-11 fjCqVn inline-newsletter-puff__InpIconContainer-sc-13hmjc-11 fjCqVn css-view-1dbjc4n"
     >
       <svg
         aria-label="icon-forward-arrow"

--- a/packages/article-skeleton/src/article-body/inline-newsletter-puff.js
+++ b/packages/article-skeleton/src/article-body/inline-newsletter-puff.js
@@ -17,7 +17,6 @@ import {
   InpSignupHeadline,
   InpSignupLabel,
   InpSubscribedContainer,
-  InpSubscribedCopy,
   InpSubscribedHeadline
 } from "../styles/inline-newsletter-puff";
 import NewsletterPuffButton from "./newsletter-puff-button";
@@ -81,12 +80,8 @@ const InlineNewsletterPuff = ({
                 {justSubscribed ? (
                   <InpSubscribedContainer>
                     <InpSubscribedHeadline>
-                      You’ve successfully signed up
+                      You’ve successfully signed up to {newsletter.title}
                     </InpSubscribedHeadline>
-                    <InpSubscribedCopy>
-                      Congratulations you can now enjoy daily updates from Red
-                      Box.
-                    </InpSubscribedCopy>
                     <InpPreferencesContainer>
                       <NewsletterPuffLink
                         newsletterPuffName={newsletter.title}

--- a/packages/article-skeleton/src/article-body/inline-newsletter-puff.js
+++ b/packages/article-skeleton/src/article-body/inline-newsletter-puff.js
@@ -80,7 +80,7 @@ const InlineNewsletterPuff = ({
                 {justSubscribed ? (
                   <InpSubscribedContainer>
                     <InpSubscribedHeadline>
-                      You’ve successfully signed up to {newsletter.title}
+                      {`You’ve successfully signed up to ${newsletter.title}`}
                     </InpSubscribedHeadline>
                     <InpPreferencesContainer>
                       <NewsletterPuffLink

--- a/packages/article-skeleton/src/styles/inline-newsletter-puff.js
+++ b/packages/article-skeleton/src/styles/inline-newsletter-puff.js
@@ -50,21 +50,6 @@ export const InpSubscribedHeadline = styled(Text)`
   margin-bottom: ${spacing(2)};
 `;
 
-export const InpSubscribedCopy = styled(Text)`
-  font-family: ${fonts.body};
-  font-size: ${fontSizes.newsletterPuffCopy}px;
-  text-align: center;
-  color: ${colours.functional.primary};
-  margin-bottom: ${spacing(2)};
-  @media (min-width: ${breakpoints.small}px) {
-    padding: ${spacing(0)} ${spacing(1)};
-    margin-bottom: ${spacing(1)};
-  }
-  @media (min-width: ${breakpoints.medium}px) {
-    padding: ${spacing(0)} ${spacing(4)};
-  }
-`;
-
 export const InpSignupContainer = styled(View)`
   justify-content: center;
   padding: ${spacing(4)}px;


### PR DESCRIPTION
### Description

In this PR we change the copy that is displayed when a user sign up successfully to a newsletter

[TNLT-5506](https://nidigitalsolutions.jira.com/browse/TNLT-5506)

### Checklist

- [x] Does it have automated tests?
- [x] Is there another PR linked to this issue (if so please list)?
PR [#179](https://github.com/newsuk/times-components-native/pull/179) in `times-components-native`

