### PR TITLE
feat(TNLT-4872): Update newsletter puff tracking

### DIFF
--- a/packages/article-skeleton/src/article-body/inline-newsletter-puff.js
+++ b/packages/article-skeleton/src/article-body/inline-newsletter-puff.js
@@ -84,6 +84,7 @@ const InlineNewsletterPuff = ({
                     </InpSubscribedHeadline>
                     <InpPreferencesContainer>
                       <NewsletterPuffLink
+                        enforceTracking
                         newsletterPuffName={newsletter.title}
                         analyticsStream={analyticsStream}
                         onPress={() => onManagePreferencesPress()}
@@ -97,6 +98,7 @@ const InlineNewsletterPuff = ({
                     <InpCopy>{copy}</InpCopy>
                     <InpSignupCTAContainer>
                       <NewsletterPuffButton
+                        enforceTracking
                         newsletterPuffName={newsletter.title}
                         analyticsStream={analyticsStream}
                         updatingSubscription={updatingSubscription}

--- a/packages/article-skeleton/src/article-body/newsletter-puff-button.js
+++ b/packages/article-skeleton/src/article-body/newsletter-puff-button.js
@@ -1,11 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import Button from "@times-components/button";
+import Button from "@times-components-native/button";
 import {
   withTrackingContext,
   withTrackEvents
-} from "@times-components/tracking";
+} from "@times-components-native/tracking";
 import { buttonStyles, textStyle } from "../styles/inline-newsletter-puff";
 
 const NewsletterPuffButton = ({ updatingSubscription, onPress }) => (
@@ -29,6 +29,7 @@ export default withTrackingContext(
       {
         actionName: "onPress",
         eventName: "onPress",
+        trackingName: "NewsletterPuffButton",
         getAttrs: ({ newsletterPuffName }) => ({
           article_parent_name: `${newsletterPuffName}`,
           event_navigation_name: "widget : puff : sign up now",
@@ -44,6 +45,7 @@ export default withTrackingContext(
       article_parent_name: `${newsletterPuffName}`,
       event_navigation_browsing_method: "automated"
     }),
+    trackingName: "NewsletterPuffButton",
     trackingObjectName: "NewsletterPuffButton"
   }
 );

--- a/packages/article-skeleton/src/article-body/newsletter-puff-button.js
+++ b/packages/article-skeleton/src/article-body/newsletter-puff-button.js
@@ -1,11 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import Button from "@times-components-native/button";
+import Button from "@times-components/button";
 import {
   withTrackingContext,
   withTrackEvents
-} from "@times-components-native/tracking";
+} from "@times-components/tracking";
 import { buttonStyles, textStyle } from "../styles/inline-newsletter-puff";
 
 const NewsletterPuffButton = ({ updatingSubscription, onPress }) => (

--- a/packages/article-skeleton/src/article-body/newsletter-puff-link.js
+++ b/packages/article-skeleton/src/article-body/newsletter-puff-link.js
@@ -1,34 +1,29 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import Link from "@times-components-native/link";
-import { IconForwardArrow } from "@times-components-native/icons";
+import Link from "@times-components/link";
+import { IconForwardArrow } from "@times-components/icons";
 import {
   withTrackingContext,
   withTrackEvents
-} from "@times-components-native/tracking";
-import { colours } from "@times-components-native/styleguide";
-import { styleFactory } from "../styles/inline-newsletter-puff";
-import { useResponsiveContext } from "@times-components-native/responsive";
-import { Text, View } from "react-native";
+} from "@times-components/tracking";
+import { colours } from "@times-components/styleguide";
+import {
+  InpPreferencesView,
+  InpPreferencesText,
+  InpIconContainer
+} from "../styles/inline-newsletter-puff";
 
-const NewsletterPuffLink = ({ onPress }) => {
-  const { editionBreakpoint: breakpoint } = useResponsiveContext();
-  const styles = styleFactory(breakpoint);
-  return (
-    <Link url="https://home.thetimes.co.uk/myNews" onPress={onPress}>
-      <View style={styles.preferencesView}>
-        <Text style={styles.preferencesText}>Manage preferences here</Text>
-        <View style={styles.iconContainer}>
-          <IconForwardArrow
-            fillColour={colours.functional.action}
-            height={12}
-          />
-        </View>
-      </View>
-    </Link>
-  );
-};
+const NewsletterPuffLink = ({ onPress }) => (
+  <Link url="https://home.thetimes.co.uk/myNews" onPress={onPress}>
+    <InpPreferencesView>
+      <InpPreferencesText>Manage preferences here</InpPreferencesText>
+      <InpIconContainer>
+        <IconForwardArrow fillColour={colours.functional.action} />
+      </InpIconContainer>
+    </InpPreferencesView>
+  </Link>
+);
 
 NewsletterPuffLink.propTypes = {
   onPress: PropTypes.func.isRequired

--- a/packages/article-skeleton/src/article-body/newsletter-puff-link.js
+++ b/packages/article-skeleton/src/article-body/newsletter-puff-link.js
@@ -1,29 +1,34 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import Link from "@times-components/link";
-import { IconForwardArrow } from "@times-components/icons";
+import Link from "@times-components-native/link";
+import { IconForwardArrow } from "@times-components-native/icons";
 import {
   withTrackingContext,
   withTrackEvents
-} from "@times-components/tracking";
-import { colours } from "@times-components/styleguide";
-import {
-  InpPreferencesView,
-  InpPreferencesText,
-  InpIconContainer
-} from "../styles/inline-newsletter-puff";
+} from "@times-components-native/tracking";
+import { colours } from "@times-components-native/styleguide";
+import { styleFactory } from "../styles/inline-newsletter-puff";
+import { useResponsiveContext } from "@times-components-native/responsive";
+import { Text, View } from "react-native";
 
-const NewsletterPuffLink = ({ onPress }) => (
-  <Link url="https://home.thetimes.co.uk/myNews" onPress={onPress}>
-    <InpPreferencesView>
-      <InpPreferencesText>Manage preferences here</InpPreferencesText>
-      <InpIconContainer>
-        <IconForwardArrow fillColour={colours.functional.action} />
-      </InpIconContainer>
-    </InpPreferencesView>
-  </Link>
-);
+const NewsletterPuffLink = ({ onPress }) => {
+  const { editionBreakpoint: breakpoint } = useResponsiveContext();
+  const styles = styleFactory(breakpoint);
+  return (
+    <Link url="https://home.thetimes.co.uk/myNews" onPress={onPress}>
+      <View style={styles.preferencesView}>
+        <Text style={styles.preferencesText}>Manage preferences here</Text>
+        <View style={styles.iconContainer}>
+          <IconForwardArrow
+            fillColour={colours.functional.action}
+            height={12}
+          />
+        </View>
+      </View>
+    </Link>
+  );
+};
 
 NewsletterPuffLink.propTypes = {
   onPress: PropTypes.func.isRequired
@@ -35,6 +40,7 @@ export default withTrackingContext(
       {
         actionName: "onPress",
         eventName: "onPress",
+        trackingName: "NewsletterPuffLink",
         getAttrs: ({ newsletterPuffName }) => ({
           article_parent_name: `${newsletterPuffName}`,
           event_navigation_name: "widget : puff : manage preferences here",
@@ -51,6 +57,7 @@ export default withTrackingContext(
       article_parent_name: `${newsletterPuffName}`,
       event_navigation_browsing_method: "automated"
     }),
+    trackingName: "NewsletterPuffLink",
     trackingObjectName: "NewsletterPuffLink"
   }
 );

--- a/packages/tracking/src/tracking-context.js
+++ b/packages/tracking/src/tracking-context.js
@@ -82,7 +82,7 @@ const withTrackingContext = (
     attemptTrackPageEvent(props) {
       if (
         isDataReady(props) &&
-        this.isRootTrackingContext() &&
+        (this.isRootTrackingContext() || props.newsletterPuffName) &&
         this.pageEventTriggered === false
       ) {
         this.pageEventTriggered = true;

--- a/packages/tracking/src/tracking-context.js
+++ b/packages/tracking/src/tracking-context.js
@@ -82,7 +82,7 @@ const withTrackingContext = (
     attemptTrackPageEvent(props) {
       if (
         isDataReady(props) &&
-        (this.isRootTrackingContext() || props.newsletterPuffName) &&
+        (this.isRootTrackingContext() || props.enforceTracking) &&
         this.pageEventTriggered === false
       ) {
         this.pageEventTriggered = true;


### PR DESCRIPTION
### Description 
In this PR we fix the `onPress` and `oneView` tracking by adding the `trackingName` to the NewsletterPuff components.


### Jira Ticket
[TNLT-4872](https://nidigitalsolutions.jira.com/browse/TNLT-4872)


### Checklist

- [x] Does it have automated tests?
- [x] Is there another PR linked to this issue (if so please list)?
 PR [#244](https://github.com/newsuk/times-components-native/pull/244) in `times-components-native`