### PR TITLE
fix(TNLT-2359): add new user state check for comments readOnly state

### DIFF
--- a/packages/article-extras/__tests__/shared.web.js
+++ b/packages/article-extras/__tests__/shared.web.js
@@ -33,7 +33,10 @@ export default () => {
     {
       name: "renders correctly",
       test: () => {
-        UserState.mockStates = [UserState.fullArticle, UserState.loggedInOrLoggedInAndNotShared];
+        UserState.mockStates = [
+          UserState.fullArticle,
+          UserState.loggedInOrLoggedInAndNotShared
+        ];
         const testInstance = TestRenderer.create(
           <ArticleExtras
             analyticsStream={() => {}}

--- a/packages/article-extras/__tests__/shared.web.js
+++ b/packages/article-extras/__tests__/shared.web.js
@@ -33,7 +33,7 @@ export default () => {
     {
       name: "renders correctly",
       test: () => {
-        UserState.mockStates = [UserState.fullArticle, UserState.loggedIn];
+        UserState.mockStates = [UserState.fullArticle, UserState.loggedInOrLoggedInAndNotShared];
         const testInstance = TestRenderer.create(
           <ArticleExtras
             analyticsStream={() => {}}

--- a/packages/article-extras/src/article-extras.web.js
+++ b/packages/article-extras/src/article-extras.web.js
@@ -67,7 +67,7 @@ const ArticleExtras = ({
       {sponsoredArticles}
 
       <UserState
-        state={UserState.loggedIn}
+        state={UserState.loggedInOrLoggedInAndNotShared}
         fallback={
           <ArticleComments
             articleId={articleId}

--- a/packages/user-state/src/matchers.js
+++ b/packages/user-state/src/matchers.js
@@ -18,3 +18,6 @@ export const shouldShowFullArticle = user =>
   isShared(user) || isNonMeteredExpiredUser(user);
 
 export const isLoggedInOrShared = user => isShared(user) || isLoggedIn(user);
+
+export const isLoggedInOrLoggedInAndNotShared = user =>
+  isLoggedIn(user) || (!isShared(user) && isLoggedIn(user));

--- a/packages/user-state/src/user-state.js
+++ b/packages/user-state/src/user-state.js
@@ -20,7 +20,8 @@ import {
   isShared,
   shouldShowFullArticle,
   isSubscriber,
-  isLoggedInOrShared
+  isLoggedInOrShared,
+  isLoggedInOrLoggedInAndNotShared
 } from "./matchers";
 
 function UserState({
@@ -46,6 +47,7 @@ UserState.nonMeteredExpiredUser = isNonMeteredExpiredUser;
 UserState.fullArticle = shouldShowFullArticle;
 UserState.subscriber = isSubscriber;
 UserState.loggedInOrShared = isLoggedInOrShared;
+UserState.loggedInOrLoggedInAndNotShared = isLoggedInOrLoggedInAndNotShared;
 
 UserState.propTypes = {
   state: PropTypes.func.isRequired,


### PR DESCRIPTION
When we render comments as read only, or read/write, we used to check the `UserState.loggedIn` state. This check effectively looks at whether the request came in through a non-`_tp_` or non-`_fp_/open_anonymous` route  in Render.

The downside to thios approach, is that for readers that come as logged out with a `?shareToken=` param,  they also get routed through the full article path in Render. This ultimately means that despite being logged out, they are actually treated as 'logged in'.

This means the check we make on comments isn't valid, as it's trying to make them writable for readers that should only get read-only access.

Instead, I have introduced a new state checker, with the catchy name: `isLoggedInOrLoggedInAndNotShared`. This effectively does the following:
* If the reader is logged in, return `true`
* If the reader is logged in, and has a share token, return `true`
* If the reader is logged out, return `false`
* If the reader is logged out, and has a share token, return `false`

This is different from the previous behaviour, where now an additional explicit check is made to the customer's share token status, in addition to the route them came through on Render. The presence of a share token is checked client-side by inspecting the page URL, which cannot be done server side as Render does not get given the information to determine if the request was a share token request.