### PR TITLE
Fix(TNLT-6934): Made newsletter puff visible in preview

### DIFF
--- a/packages/article-skeleton/src/article-body/article-body.web.js
+++ b/packages/article-skeleton/src/article-body/article-body.web.js
@@ -134,15 +134,15 @@ const renderers = ({
     } = element;
 
     switch (value) {
-      case "newsletter-puff": 
-        isPreview ? (
-            <PreviewNewsletterPuff
-              copy={decodeURIComponent(copy)}
-              headline={decodeURIComponent(headline)}
-              imageUri={decodeURIComponent(imageUri)}
-              label={decodeURIComponent(label)}
-            />
-          ) : (
+      case "newsletter-puff":
+        return isPreview ? (
+          <PreviewNewsletterPuff
+            copy={decodeURIComponent(copy)}
+            headline={decodeURIComponent(headline)}
+            imageUri={decodeURIComponent(imageUri)}
+            label={decodeURIComponent(label)}
+          />
+        ) : (
           <InlineNewsletterPuff
             analyticsStream={analyticsStream}
             key={key}
@@ -153,7 +153,6 @@ const renderers = ({
             label={decodeURIComponent(label)}
           />
         );
-      break;
       default:
         return (
           <InteractiveContainer key={key} fullWidth={display === "fullwidth"}>

--- a/packages/article-skeleton/src/article-body/article-body.web.js
+++ b/packages/article-skeleton/src/article-body/article-body.web.js
@@ -134,7 +134,7 @@ const renderers = ({
     } = element;
 
     switch (value) {
-      case "newsletter-puff": {
+      case "newsletter-puff": 
         isPreview ? (
             <PreviewNewsletterPuff
               copy={decodeURIComponent(copy)}
@@ -153,7 +153,7 @@ const renderers = ({
             label={decodeURIComponent(label)}
           />
         );
-      }
+      break;
       default:
         return (
           <InteractiveContainer key={key} fullWidth={display === "fullwidth"}>

--- a/packages/article-skeleton/src/article-body/article-body.web.js
+++ b/packages/article-skeleton/src/article-body/article-body.web.js
@@ -135,18 +135,14 @@ const renderers = ({
 
     switch (value) {
       case "newsletter-puff": {
-        if (isPreview === true) {
-          return (
+        isPreview ? (
             <PreviewNewsletterPuff
               copy={decodeURIComponent(copy)}
               headline={decodeURIComponent(headline)}
               imageUri={decodeURIComponent(imageUri)}
               label={decodeURIComponent(label)}
             />
-          );
-        }
-
-        return (
+          ) : (
           <InlineNewsletterPuff
             analyticsStream={analyticsStream}
             key={key}

--- a/packages/article-skeleton/src/article-body/article-body.web.js
+++ b/packages/article-skeleton/src/article-body/article-body.web.js
@@ -17,7 +17,9 @@ import renderTrees from "@times-components/markup-forest";
 import { AspectRatioContainer } from "@times-components/utils";
 import ArticleLink from "./article-link";
 import InsetCaption from "./inset-caption";
-import InlineNewsletterPuff, {PreviewNewsletterPuff} from "./inline-newsletter-puff";
+import InlineNewsletterPuff, {
+  PreviewNewsletterPuff
+} from "./inline-newsletter-puff";
 import {
   PrimaryImg,
   SecondaryImg,
@@ -65,7 +67,12 @@ const highResSizeCalc = (observed, key, template) => {
   return indepthRetinaScreenWidth || screenWidth;
 };
 
-const renderers = ({ paidContentClassName, template, analyticsStream }) => ({
+const renderers = ({
+  paidContentClassName,
+  template,
+  analyticsStream,
+  isPreview
+}) => ({
   ...coreRenderers,
   ad(key) {
     return <AdContainer key={key} slotName="inline-ad" style={styles.ad} />;
@@ -126,22 +133,29 @@ const renderers = ({ paidContentClassName, template, analyticsStream }) => ({
       value
     } = element;
 
-    switch (value) { 
+    switch (value) {
       case "newsletter-puff": {
-        
+        if (isPreview === true) {
+          return (
+            <PreviewNewsletterPuff
+              copy={decodeURIComponent(copy)}
+              headline={decodeURIComponent(headline)}
+              imageUri={decodeURIComponent(imageUri)}
+              label={decodeURIComponent(label)}
+            />
+          );
+        }
+
         return (
-          // <div>'Hello'</div>
-          <PreviewNewsletterPuff copy={decodeURIComponent(copy)} headline={decodeURIComponent(headline)} imageUri={decodeURIComponent(imageUri)} label={decodeURIComponent(label)}
-        />
-          // <InlineNewsletterPuff
-          //   analyticsStream={analyticsStream}
-          //   key={key}
-          //   code={code}
-          //   copy={decodeURIComponent(copy)}
-          //   headline={decodeURIComponent(headline)}
-          //   imageUri={decodeURIComponent(imageUri)}
-          //   label={decodeURIComponent(label)}
-          // />
+          <InlineNewsletterPuff
+            analyticsStream={analyticsStream}
+            key={key}
+            code={code}
+            copy={decodeURIComponent(copy)}
+            headline={decodeURIComponent(headline)}
+            imageUri={decodeURIComponent(imageUri)}
+            label={decodeURIComponent(label)}
+          />
         );
       }
       default:
@@ -272,11 +286,12 @@ const ArticleBody = ({
   contextUrl,
   section,
   paidContentClassName,
-  template
+  template,
+  isPreview
 }) =>
   renderTrees(
     bodyContent.map(decorateAd({ contextUrl, section })),
-    renderers({ paidContentClassName, template })
+    renderers({ paidContentClassName, template, isPreview })
   );
 
 ArticleBody.propTypes = {

--- a/packages/article-skeleton/src/article-body/article-body.web.js
+++ b/packages/article-skeleton/src/article-body/article-body.web.js
@@ -17,7 +17,7 @@ import renderTrees from "@times-components/markup-forest";
 import { AspectRatioContainer } from "@times-components/utils";
 import ArticleLink from "./article-link";
 import InsetCaption from "./inset-caption";
-import InlineNewsletterPuff from "./inline-newsletter-puff";
+import InlineNewsletterPuff, {PreviewNewsletterPuff} from "./inline-newsletter-puff";
 import {
   PrimaryImg,
   SecondaryImg,
@@ -126,18 +126,22 @@ const renderers = ({ paidContentClassName, template, analyticsStream }) => ({
       value
     } = element;
 
-    switch (value) {
+    switch (value) { 
       case "newsletter-puff": {
+        
         return (
-          <InlineNewsletterPuff
-            analyticsStream={analyticsStream}
-            key={key}
-            code={code}
-            copy={decodeURIComponent(copy)}
-            headline={decodeURIComponent(headline)}
-            imageUri={decodeURIComponent(imageUri)}
-            label={decodeURIComponent(label)}
-          />
+          // <div>'Hello'</div>
+          <PreviewNewsletterPuff copy={decodeURIComponent(copy)} headline={decodeURIComponent(headline)} imageUri={decodeURIComponent(imageUri)} label={decodeURIComponent(label)}
+        />
+          // <InlineNewsletterPuff
+          //   analyticsStream={analyticsStream}
+          //   key={key}
+          //   code={code}
+          //   copy={decodeURIComponent(copy)}
+          //   headline={decodeURIComponent(headline)}
+          //   imageUri={decodeURIComponent(imageUri)}
+          //   label={decodeURIComponent(label)}
+          // />
         );
       }
       default:

--- a/packages/article-skeleton/src/article-body/inline-newsletter-puff.js
+++ b/packages/article-skeleton/src/article-body/inline-newsletter-puff.js
@@ -19,7 +19,9 @@ import {
   InpSubscribedContainer,
   InpSubscribedHeadline
 } from "../styles/inline-newsletter-puff";
-import {NewsletterPuffButton, PreviewNewsletterPuffButton} from "./newsletter-puff-button";
+import NewsletterPuffButton, {
+  PreviewNewsletterPuffButton
+} from "./newsletter-puff-button";
 import NewsletterPuffLink from "./newsletter-puff-link";
 
 function onManagePreferencesPress() {
@@ -35,23 +37,21 @@ function onManagePreferencesPress() {
       .catch(err => console.error("An error occurred", err)); // eslint-disable-line no-console
   }
 }
-export const PreviewNewsletterPuff = ({copy, headline, imageUri, label}) => {
-  return (
-    <InpContainer>
-      <InpImageContainer>
-        <Image aspectRatio={1.42} uri={imageUri} />
-      </InpImageContainer>
-      <InpSignupContainer>
-        <InpSignupLabel>{label}</InpSignupLabel>
-        <InpSignupHeadline>{headline}</InpSignupHeadline>
-        <InpCopy>{copy}</InpCopy>
+export const PreviewNewsletterPuff = ({ copy, headline, imageUri, label }) => (
+  <InpContainer>
+    <InpImageContainer>
+      <Image aspectRatio={1.42} uri={imageUri} />
+    </InpImageContainer>
+    <InpSignupContainer>
+      <InpSignupLabel>{label}</InpSignupLabel>
+      <InpSignupHeadline>{headline}</InpSignupHeadline>
+      <InpCopy>{copy}</InpCopy>
       <InpSignupCTAContainer>
         <PreviewNewsletterPuffButton />
       </InpSignupCTAContainer>
-      </InpSignupContainer>
-    </InpContainer>
-  )
-}
+    </InpSignupContainer>
+  </InpContainer>
+);
 
 const InlineNewsletterPuff = ({
   analyticsStream,
@@ -139,6 +139,12 @@ const InlineNewsletterPuff = ({
 
 export default InlineNewsletterPuff;
 
+PreviewNewsletterPuff.propTypes = {
+  copy: PropTypes.string.isRequired,
+  headline: PropTypes.string.isRequired,
+  imageUri: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired
+};
 
 InlineNewsletterPuff.propTypes = {
   analyticsStream: PropTypes.func.isRequired,

--- a/packages/article-skeleton/src/article-body/inline-newsletter-puff.js
+++ b/packages/article-skeleton/src/article-body/inline-newsletter-puff.js
@@ -19,7 +19,7 @@ import {
   InpSubscribedContainer,
   InpSubscribedHeadline
 } from "../styles/inline-newsletter-puff";
-import NewsletterPuffButton from "./newsletter-puff-button";
+import {NewsletterPuffButton, PreviewNewsletterPuffButton} from "./newsletter-puff-button";
 import NewsletterPuffLink from "./newsletter-puff-link";
 
 function onManagePreferencesPress() {
@@ -34,6 +34,23 @@ function onManagePreferencesPress() {
       })
       .catch(err => console.error("An error occurred", err)); // eslint-disable-line no-console
   }
+}
+export const PreviewNewsletterPuff = ({copy, headline, imageUri, label}) => {
+  return (
+    <InpContainer>
+      <InpImageContainer>
+        <Image aspectRatio={1.42} uri={imageUri} />
+      </InpImageContainer>
+      <InpSignupContainer>
+        <InpSignupLabel>{label}</InpSignupLabel>
+        <InpSignupHeadline>{headline}</InpSignupHeadline>
+        <InpCopy>{copy}</InpCopy>
+      <InpSignupCTAContainer>
+        <PreviewNewsletterPuffButton />
+      </InpSignupCTAContainer>
+      </InpSignupContainer>
+    </InpContainer>
+  )
 }
 
 const InlineNewsletterPuff = ({
@@ -121,6 +138,7 @@ const InlineNewsletterPuff = ({
 };
 
 export default InlineNewsletterPuff;
+
 
 InlineNewsletterPuff.propTypes = {
   analyticsStream: PropTypes.func.isRequired,

--- a/packages/article-skeleton/src/article-body/newsletter-puff-button.js
+++ b/packages/article-skeleton/src/article-body/newsletter-puff-button.js
@@ -8,6 +8,10 @@ import {
 } from "@times-components/tracking";
 import { buttonStyles, textStyle } from "../styles/inline-newsletter-puff";
 
+export const PreviewNewsletterPuffButton = () => (
+<Button title="Sign up now" style={buttonStyles} underlayColor="transparent" textStyle={textStyle}/>
+);
+
 const NewsletterPuffButton = ({ updatingSubscription, onPress }) => (
   <Button
     title={updatingSubscription ? "Saving…" : "Sign up now"}

--- a/packages/article-skeleton/src/article-body/newsletter-puff-button.js
+++ b/packages/article-skeleton/src/article-body/newsletter-puff-button.js
@@ -9,7 +9,12 @@ import {
 import { buttonStyles, textStyle } from "../styles/inline-newsletter-puff";
 
 export const PreviewNewsletterPuffButton = () => (
-<Button title="Sign up now" style={buttonStyles} underlayColor="transparent" textStyle={textStyle}/>
+  <Button
+    title="Sign up now"
+    style={buttonStyles}
+    underlayColor="transparent"
+    textStyle={textStyle}
+  />
 );
 
 const NewsletterPuffButton = ({ updatingSubscription, onPress }) => (

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -142,6 +142,7 @@ const ArticleSkeleton = ({
                     section={section}
                     paidContentClassName={paidContentClassName}
                     template={template}
+                    isPreview={isPreview}
                   />
                 )}
                 <PaywallPortal

--- a/packages/provider-test-tools/fixtures/article.json
+++ b/packages/provider-test-tools/fixtures/article.json
@@ -555,6 +555,25 @@
   ],
   "content": [
     {
+      "name": "interactive",
+      "attributes": {
+        "id": "e7c8c3ca-eaa7-433f-9668-417cb91a8a28",
+        "display": "primary",
+        "url": "https://components.timesdev.tools/lib2/newsletter-puff-1.0.0/newsletter-puff.html",
+        "element": {
+          "value": "newsletter-puff",
+          "attributes": {
+            "code": "TNL-103",
+            "copy": "In-depth%20analysis%20and%20comment%20on%20the%20latest%20financial%20and%20economic%20news.",
+            "label": "In%20your%20inbox",
+            "headline": "Business%20Briefing",
+            "imageUri": "https%3A%2F%2Fwww.thetimes.co.uk%2Fimageserver%2Fimage%2Fmethode%252Ftimes%252Fprod%252Fweb%252Fbin%252F306637af-2b6f-48fc-b264-d661b2067818.jpg%3Fresize%3D800"
+          }
+        }
+      },
+      "children": []
+    },
+    {
       "name": "heading2",
       "children": [
         {


### PR DESCRIPTION
This PR creates a dummy newsletter puff component and adds logic to the ArticleBody component to show the dummy puff when in Preview.

The dummy puff component in Storybook:
![image](https://user-images.githubusercontent.com/50234696/110631210-2de91d00-819e-11eb-950e-0276c907806d.png)

