### PR TITLE
Encode image urls again so they render correctly in the component

### DIFF
--- a/packages/article-skeleton/__tests__/web/__snapshots__/auto-place-newsletter-puff.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/auto-place-newsletter-puff.web.test.js.snap
@@ -172,7 +172,7 @@ exports[`Article with automatically placed NewsletterPuff should render a Newsle
           code="TNL-101"
           copy="We’ll send you our top stories, across all sections, straight to your inbox. Simple as that."
           headline="Best of Times"
-          imageUri="https://www.thetimes.co.uk/imageserver/image/methode/times/prod/web/bin/728c3e68-5311-4533-809a-b313a6503789.jpg?resize=800"
+          imageUri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F728c3e68-5311-4533-809a-b313a6503789.jpg?resize=800"
           label="In your inbox"
         />
         <span>

--- a/packages/article-skeleton/src/newsletter-puff.web.js
+++ b/packages/article-skeleton/src/newsletter-puff.web.js
@@ -21,7 +21,7 @@ const newslettersBySection = [
       copy:
         "We’ll send you our top stories, across all sections, straight to your inbox. Simple as that.",
       imageUri:
-        "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F728c3e68-5311-4533-809a-b313a6503789.jpg?resize=800"
+        "https%3A%2F%2Fwww.thetimes.co.uk%2Fimageserver%2Fimage%2Fmethode%252Ftimes%252Fprod%252Fweb%252Fbin%252F728c3e68-5311-4533-809a-b313a6503789.jpg%3Fresize%3D800"
     })
   },
   {
@@ -32,7 +32,7 @@ const newslettersBySection = [
       copy:
         "Wit and wisdom from our award-winning stable of columnists and guest writers, including Caitlin Moran, Matthew Parris, Rod Liddle and Dominic Lawson.",
       imageUri:
-        "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb49851bd-b182-43fc-bd5d-1816bcda19fe.jpg?resize=800"
+        "https%3A%2F%2Fwww.thetimes.co.uk%2Fimageserver%2Fimage%2Fmethode%252Ftimes%252Fprod%252Fweb%252Fbin%252Fb49851bd-b182-43fc-bd5d-1816bcda19fe.jpg%3Fresize%3D800"
     })
   },
   {
@@ -43,7 +43,7 @@ const newslettersBySection = [
       copy:
         "In-depth analysis and comment on the latest financial and economic news from our award-winning Business teams.",
       imageUri:
-        "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F306637af-2b6f-48fc-b264-d661b2067818.jpg?resize=800"
+        "https%3A%2F%2Fwww.thetimes.co.uk%2Fimageserver%2Fimage%2Fmethode%252Ftimes%252Fprod%252Fweb%252Fbin%252F306637af-2b6f-48fc-b264-d661b2067818.jpg%3Fresize%3D800"
     })
   },
   {
@@ -54,7 +54,7 @@ const newslettersBySection = [
       copy:
         "Every Friday morning, Elgan Alderman takes you through the best of sport from the past week and looks ahead to the weekend, featuring exclusive interviews, agenda-setting comment and razor-sharp analysis.",
       imageUri:
-        "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8920eef8-e084-47db-a1bf-00be3d72080e.jpg?resize=800"
+        "https%3A%2F%2Fwww.thetimes.co.uk%2Fimageserver%2Fimage%2Fmethode%252Ftimes%252Fprod%252Fweb%252Fbin%252F8920eef8-e084-47db-a1bf-00be3d72080e.jpg%3Fresize%3D800"
     })
   },
   {
@@ -65,7 +65,7 @@ const newslettersBySection = [
       copy:
         "The biggest stories of the week from The Times and The Sunday Times Scotland, delivered directly to you every Saturday morning.",
       imageUri:
-        "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5777acf9-363f-4aa3-8176-1ea09cdae7d6.jpg?resize=800"
+        "https%3A%2F%2Fwww.thetimes.co.uk%2Fimageserver%2Fimage%2Fmethode%252Ftimes%252Fprod%252Fweb%252Fbin%252F5777acf9-363f-4aa3-8176-1ea09cdae7d6.jpg%3Fresize%3D800"
     })
   }
 ];


### PR DESCRIPTION
### Descripton 

The Images in the automated Newsletter Puff were not rendering. [TE-34](https://nidigitalsolutions.jira.com/jira/software/c/projects/TE/issues/TE-34)


- The component expects to receive an encoded string and then decodes it, however the encoded url works and the decoded url doesn't. To fix the issue I encoded the string the url receives twice.

- Encoded: https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F728c3e68-5311-4533-809a-b313a6503789.jpg?resize=800
- Decoded: https://www.thetimes.co.uk/imageserver/image/methode/times/prod/web/bin/728c3e68-5311-4533-809a-b313a6503789.jpg?resize=800
