### PR TITLE
feat(TE-35): add auto newsletter puff - refactored to use display:non…

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Tests are currently using [jest](https://jestjs.io/) to run so if you want to de
 3. (START TESTS IN DEBUG MODE) We need to start the same command but through node while in debug mode like so:
    `node --inspect-brk ./node_modules/.bin/jest --config="./packages/provider/__tests__/jest.config.js" --runInBand`
 
-> NOTE: `--runInBand` is a `jest` flag that runs all tests serially in the current process. If we don't add this flag, only the node process that started `jest` will be debuggable.
+> NOTE: `--runInBand` is a `jest` flag that runs all tests serially in the current process. If we don't add this flag, only the node process that started `jest` will be debuggable .
 
 4. (ADD DEBUG STATEMENTS) Normaly we would add breakpoints, but when remote debugging that's not always possible, because the files we need to put the breakpoints on aren't loaded yet by `jest`. So in order to make the debugger stop where we want it to, we need to add [`debugger;`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger) statements instead of breakpoints in the code and re-transpile if necessary.
 

--- a/packages/article-skeleton/__tests__/web/__snapshots__/auto-place-newsletter-puff.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/auto-place-newsletter-puff.web.test.js.snap
@@ -168,6 +168,7 @@ exports[`Article with automatically placed NewsletterPuff should render a Newsle
         <p>
           Some paragraph 3
         </p>
+        <div />
         <div>
           <NewsletterPuff
             code="TNL-101"

--- a/packages/article-skeleton/__tests__/web/__snapshots__/view-count-wrapper.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/view-count-wrapper.test.js.snap
@@ -1,13 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ViewCountWrapper> display function always renders 1`] = `
-<div>
-  <span>
-    Hello
-  </span>
-</div>
+Array [
+  <div
+    className="view-count-observer"
+  />,
+  <div
+    className="view-count"
+    style={
+      Object {
+        "display": "block",
+      }
+    }
+  >
+    <span>
+      Hello
+    </span>
+  </div>,
+]
 `;
 
-exports[`<ViewCountWrapper> display function doesnt render without consent 1`] = `<div />`;
+exports[`<ViewCountWrapper> display function doesnt render without consent 1`] = `
+Array [
+  <div
+    className="view-count-observer"
+  />,
+  <div
+    className="view-count"
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+  >
+    <span>
+      Hello
+    </span>
+  </div>,
+]
+`;
 
-exports[`<ViewCountWrapper> display function never renders 1`] = `<div />`;
+exports[`<ViewCountWrapper> display function never renders 1`] = `
+Array [
+  <div
+    className="view-count-observer"
+  />,
+  <div
+    className="view-count"
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+  >
+    <span>
+      Hello
+    </span>
+  </div>,
+]
+`;

--- a/packages/article-skeleton/__tests__/web/auto-place-newsletter-puff.web.test.js
+++ b/packages/article-skeleton/__tests__/web/auto-place-newsletter-puff.web.test.js
@@ -125,8 +125,9 @@ describe("Article with automatically placed NewsletterPuff", () => {
     article.section = "News";
     article.content[3] = paywallContent;
     const output = TestRenderer.create(renderArticle(article));
-    const isNewsletterPuffs = output.root.findAllByType("NewsletterPuff");
-    expect(isNewsletterPuffs.length).toBe(0);
+    expect(
+      output.root.findByProps({ className: "view-count" }).props.style.display
+    ).toEqual("none");
   });
 
   it("should render a NewsletterPuff correctly", async () => {

--- a/packages/article-skeleton/__tests__/web/view-count-wrapper.test.js
+++ b/packages/article-skeleton/__tests__/web/view-count-wrapper.test.js
@@ -21,7 +21,10 @@ describe("<ViewCountWrapper>", () => {
           <span>Hello</span>
         </ViewCountWrapper>
       );
-      expect(component.root.findAllByType("span").length).toEqual(1);
+      expect(
+        component.root.findByProps({ className: "view-count" }).props.style
+          .display
+      ).toEqual("block");
       expect(component).toMatchSnapshot();
     });
 
@@ -33,7 +36,10 @@ describe("<ViewCountWrapper>", () => {
           <span>Hello</span>
         </ViewCountWrapper>
       );
-      expect(component.root.findAllByType("span").length).toEqual(0);
+      expect(
+        component.root.findByProps({ className: "view-count" }).props.style
+          .display
+      ).toEqual("none");
       expect(component).toMatchSnapshot();
     });
     it("never renders", () => {
@@ -42,7 +48,10 @@ describe("<ViewCountWrapper>", () => {
           <span>Hello</span>
         </ViewCountWrapper>
       );
-      expect(component.root.findAllByType("span").length).toEqual(0);
+      expect(
+        component.root.findByProps({ className: "view-count" }).props.style
+          .display
+      ).toEqual("none");
       expect(component).toMatchSnapshot();
     });
   });
@@ -98,8 +107,8 @@ describe("<ViewCountWrapper>", () => {
       ).toHaveBeenCalledWith();
     });
   });
-  describe("using a display function [1,3,5]", () => {
-    it("only on first", async () => {
+  describe("using a display function", () => {
+    it("[1,3]", async () => {
       const trackingName = "hello1";
       const setCount = count =>
         window.sessionStorage.setItem(
@@ -119,27 +128,42 @@ describe("<ViewCountWrapper>", () => {
       setCount(1);
       let component = render();
       await delay(0);
-      expect(component.root.findAllByType("span").length).toEqual(1);
+      expect(
+        component.root.findByProps({ className: "view-count" }).props.style
+          .display
+      ).toEqual("block");
 
       setCount(2);
       component = render();
       await delay(0);
-      expect(component.root.findAllByType("span").length).toEqual(0);
+      expect(
+        component.root.findByProps({ className: "view-count" }).props.style
+          .display
+      ).toEqual("none");
 
       setCount(3);
       component = render();
       await delay(0);
-      expect(component.root.findAllByType("span").length).toEqual(1);
+      expect(
+        component.root.findByProps({ className: "view-count" }).props.style
+          .display
+      ).toEqual("block");
 
       setCount(4);
       component = render();
       await delay(0);
-      expect(component.root.findAllByType("span").length).toEqual(0);
+      expect(
+        component.root.findByProps({ className: "view-count" }).props.style
+          .display
+      ).toEqual("none");
 
       setCount(5);
       component = render();
       await delay(0);
-      expect(component.root.findAllByType("span").length).toEqual(0);
+      expect(
+        component.root.findByProps({ className: "view-count" }).props.style
+          .display
+      ).toEqual("none");
     });
   });
 });


### PR DESCRIPTION
Using display:none instead of rendering null when set to not view.
because of this, added an empty <div/> for the intersectionobserver as display:none wont trigger an intersection event.