### PR TITLE
chore: name apollo clients

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "dependencies": {
-    "@times-components/styleguide": "3.38.13"
+    "@times-components/styleguide": "3.38.14"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "dependencies": {
-    "@times-components/styleguide": "3.38.13"
+    "@times-components/styleguide": "3.38.14"
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",

--- a/packages/pages/src/apollo-client.js
+++ b/packages/pages/src/apollo-client.js
@@ -8,7 +8,7 @@ import { fragmentMatcher } from "@times-components/schema";
 
 const {
   NativeFetch,
-  ReactConfig: { graphqlEndPoint, usePersistedQueries }
+  ReactConfig: { graphqlEndPoint, usePersistedQueries, clientName }
 } = NativeModules;
 
 const httpLink = NativeFetch
@@ -32,6 +32,7 @@ const link = ApolloLink.from(
 );
 
 export default new ApolloClient({
+  name: `@times-components/pages (${clientName || "unknown"})`,
   cache: new InMemoryCache({
     fragmentMatcher
   }),

--- a/packages/ssr/src/lib/run-client.js
+++ b/packages/ssr/src/lib/run-client.js
@@ -50,6 +50,7 @@ const makeClient = options => {
   );
 
   return new ApolloClient({
+    name: `@times-components/ssr/client (${options.clientName || "unknown"})`,
     cache: new InMemoryCache({ fragmentMatcher }).restore(
       options.initialState || {}
     ),
@@ -74,7 +75,8 @@ module.exports = (component, clientOptions, data) => {
     useGET: clientOptions.useGET,
     headers: clientOptions.headers,
     usePersistedQueries: window.nuk.graphqlapi.usePersistedQueries,
-    skipAuthorization: clientOptions.skipAuthorization
+    skipAuthorization: clientOptions.skipAuthorization,
+    clientName: window.nuk.graphqlapi.clientName
   });
 
   const reporterOptions = {

--- a/packages/ssr/src/lib/run-server.js
+++ b/packages/ssr/src/lib/run-server.js
@@ -43,6 +43,7 @@ const makeClient = options => {
   );
 
   return new ApolloClient({
+    name: `@times-components/ssr/client (${options.clientName || "unknown"})`,
     cache: new InMemoryCache({ addTypename: true, fragmentMatcher }),
     link,
     ssrMode: true

--- a/packages/ssr/src/server/article.js
+++ b/packages/ssr/src/server/article.js
@@ -11,6 +11,7 @@ module.exports = (
   {
     graphqlApiUrl,
     usePersistedQueries,
+    clientName,
     logger,
     logoUrl,
     makeArticleUrl,
@@ -53,7 +54,8 @@ module.exports = (
       headers,
       logger,
       uri: graphqlApiUrl,
-      usePersistedQueries
+      usePersistedQueries,
+      clientName
     },
     data: {
       articleId,

--- a/packages/ssr/src/server/author-profile.js
+++ b/packages/ssr/src/server/author-profile.js
@@ -3,7 +3,14 @@ const runServer = require("../lib/run-server");
 
 module.exports = (
   { authorSlug, currentPage },
-  { graphqlApiUrl, usePersistedQueries, logger, makeArticleUrl, makeTopicUrl }
+  {
+    graphqlApiUrl,
+    usePersistedQueries,
+    clientName,
+    logger,
+    makeArticleUrl,
+    makeTopicUrl
+  }
 ) => {
   if (typeof authorSlug !== "string") {
     throw new Error(`Author slug should be a string. Received ${authorSlug}`);
@@ -34,7 +41,8 @@ module.exports = (
     client: {
       logger,
       uri: graphqlApiUrl,
-      usePersistedQueries
+      usePersistedQueries,
+      clientName
     },
     data: {
       authorSlug,

--- a/packages/ssr/src/server/topic.js
+++ b/packages/ssr/src/server/topic.js
@@ -3,7 +3,14 @@ const runServer = require("../lib/run-server");
 
 module.exports = (
   { currentPage, topicSlug },
-  { graphqlApiUrl, usePersistedQueries, logger, makeArticleUrl, makeTopicUrl }
+  {
+    graphqlApiUrl,
+    usePersistedQueries,
+    clientName,
+    logger,
+    makeArticleUrl,
+    makeTopicUrl
+  }
 ) => {
   if (typeof topicSlug !== "string") {
     throw new Error(`Topic slug should be a string. Received ${topicSlug}`);
@@ -35,6 +42,7 @@ module.exports = (
       logger,
       uri: graphqlApiUrl,
       usePersistedQueries,
+      clientName,
       headers: {
         "x-new-topic-data-source": true
       }

--- a/packages/utils/src/make-client-util.js
+++ b/packages/utils/src/make-client-util.js
@@ -34,6 +34,8 @@ const makeClient = () => {
   );
 
   return new ApolloClient({
+    name: `@times-components/utils (${window.nuk.graphqlapi.clientName ||
+      "unknown"})`,
     cache: new InMemoryCache({ fragmentMatcher }),
     link
   });

--- a/packages/utils/src/make-client-util.js
+++ b/packages/utils/src/make-client-util.js
@@ -12,12 +12,14 @@ const makeClient = () => {
   let usePersistedQueries = null;
   let acsTnlCookie = null;
   let sacsTnlCookie = null;
+  let clientName = "unknown";
 
   if (typeof window !== "undefined" && window.nuk) {
     graphqlapi = window.nuk.graphqlapi.url;
     usePersistedQueries = !!window.nuk.graphqlapi.usePersistedQueries;
     acsTnlCookie = window.nuk.getCookieValue("acs_tnl");
     sacsTnlCookie = window.nuk.getCookieValue("sacs_tnl");
+    clientName = window.nuk.graphqlapi.clientName || clientName;
   }
   const networkInterfaceOptions = { fetch, headers: {}, uri: graphqlapi };
 
@@ -34,8 +36,7 @@ const makeClient = () => {
   );
 
   return new ApolloClient({
-    name: `@times-components/utils (${window.nuk.graphqlapi.clientName ||
-      "unknown"})`,
+    name: `@times-components/utils (${clientName})`,
     cache: new InMemoryCache({ fragmentMatcher }),
     link
   });


### PR DESCRIPTION
This PR adds the "name" config to all TPA Apollo clients - to improve request attribution in Apollo Studio.
