### PR TITLE
feat(TE-90): add section colour to label and byline in article puff

### DIFF
--- a/packages/article-skeleton/src/article-body/article-body.web.js
+++ b/packages/article-skeleton/src/article-body/article-body.web.js
@@ -162,14 +162,19 @@ const renderers = ({
         );
       case "in-article-puff":
         return inArticlePuffFlag ? (
-          <InArticlePuff
-            label={label}
-            imageUri={imageUri}
-            headline={headline}
-            copy={copy}
-            link={link}
-            linkText={linkText}
-          />
+          <Context.Consumer key={key}>
+            {({ theme: { sectionColour } }) => (
+              <InArticlePuff
+                label={label}
+                imageUri={imageUri}
+                headline={headline}
+                copy={copy}
+                link={link}
+                linkText={linkText}
+                sectionColour={sectionColour || colours.section.default}
+              />
+            )}
+          </Context.Consumer>
         ) : null;
       default:
         return (

--- a/packages/ts-components/src/__tests__/InArticlePuff.test.tsx
+++ b/packages/ts-components/src/__tests__/InArticlePuff.test.tsx
@@ -11,7 +11,8 @@ const baseProps = {
   copy:
     'Enter your postcode in our tool to find your nearest vacination centre',
   link: 'https://www.thetimes.co.uk/',
-  linkText: 'Read more'
+  linkText: 'Read more',
+  sectionColour: "#13354E"
 };
 
 describe('InArticlePuff', () => {
@@ -28,10 +29,12 @@ describe('InArticlePuff', () => {
       expect(asFragment()).toMatchSnapshot();
     });
     it('renders the props correctly', () => {
-      const { getByText, getAllByRole, queryByRole } = render(
+      const { getByText, getAllByRole, queryByRole, getByTestId } = render(
         <InArticlePuff {...{ ...baseProps }} />
       );
+      expect(getByTestId('InArticlePuff - Container')).toHaveStyle(`border-top: 2px ${baseProps.sectionColour} solid`)
       expect(getByText('INTERACTIVE')).toBeVisible();
+      expect(getByText('INTERACTIVE')).toHaveStyle(`color: ${baseProps.sectionColour}`)
       expect(
         getByText('Where can I get a Covid vaccine in England?')
       ).toBeVisible();
@@ -75,7 +78,7 @@ describe('InArticlePuff', () => {
       expect(asFragment()).toMatchSnapshot();
     });
     it('renders the props correctly', () => {
-      const { getByText, getAllByRole, getByRole } = render(
+      const { getByText, getAllByRole, getByRole, getByTestId } = render(
         <InArticlePuff
           {...{
             ...baseProps,
@@ -84,7 +87,9 @@ describe('InArticlePuff', () => {
           }}
         />
       );
+      expect(getByTestId('InArticlePuff - Container')).toHaveStyle(`border-top: 2px ${baseProps.sectionColour} solid`)
       expect(getByText('INTERACTIVE')).toBeVisible();
+      expect(getByText('INTERACTIVE')).toHaveStyle(`color: ${baseProps.sectionColour}`)
       expect(
         getByText('Where can I get a Covid vaccine in England?')
       ).toBeVisible();

--- a/packages/ts-components/src/__tests__/InArticlePuff.test.tsx
+++ b/packages/ts-components/src/__tests__/InArticlePuff.test.tsx
@@ -12,7 +12,7 @@ const baseProps = {
     'Enter your postcode in our tool to find your nearest vacination centre',
   link: 'https://www.thetimes.co.uk/',
   linkText: 'Read more',
-  sectionColour: "#13354E"
+  sectionColour: '#13354E'
 };
 
 describe('InArticlePuff', () => {
@@ -32,9 +32,13 @@ describe('InArticlePuff', () => {
       const { getByText, getAllByRole, queryByRole, getByTestId } = render(
         <InArticlePuff {...{ ...baseProps }} />
       );
-      expect(getByTestId('InArticlePuff - Container')).toHaveStyle(`border-top: 2px ${baseProps.sectionColour} solid`)
+      expect(getByTestId('InArticlePuff - Container')).toHaveStyle(
+        `border-top: 2px ${baseProps.sectionColour} solid`
+      );
       expect(getByText('INTERACTIVE')).toBeVisible();
-      expect(getByText('INTERACTIVE')).toHaveStyle(`color: ${baseProps.sectionColour}`)
+      expect(getByText('INTERACTIVE')).toHaveStyle(
+        `color: ${baseProps.sectionColour}`
+      );
       expect(
         getByText('Where can I get a Covid vaccine in England?')
       ).toBeVisible();
@@ -87,9 +91,13 @@ describe('InArticlePuff', () => {
           }}
         />
       );
-      expect(getByTestId('InArticlePuff - Container')).toHaveStyle(`border-top: 2px ${baseProps.sectionColour} solid`)
+      expect(getByTestId('InArticlePuff - Container')).toHaveStyle(
+        `border-top: 2px ${baseProps.sectionColour} solid`
+      );
       expect(getByText('INTERACTIVE')).toBeVisible();
-      expect(getByText('INTERACTIVE')).toHaveStyle(`color: ${baseProps.sectionColour}`)
+      expect(getByText('INTERACTIVE')).toHaveStyle(
+        `color: ${baseProps.sectionColour}`
+      );
       expect(
         getByText('Where can I get a Covid vaccine in England?')
       ).toBeVisible();

--- a/packages/ts-components/src/__tests__/__snapshots__/InArticlePuff.test.tsx.snap
+++ b/packages/ts-components/src/__tests__/__snapshots__/InArticlePuff.test.tsx.snap
@@ -42,7 +42,6 @@ exports[`InArticlePuff With an Image matches the snapshot 1`] = `
       </div>
       <a
         class="sc-htoDjs djguHq"
-        data-testid="InArticlePuff - LinkWrapper"
         href="https://www.thetimes.co.uk/"
       >
         <span
@@ -103,7 +102,6 @@ exports[`InArticlePuff Without an image matches the snapshot 1`] = `
       </div>
       <a
         class="sc-htoDjs bFrbzf"
-        data-testid="InArticlePuff - LinkWrapper"
         href="https://www.thetimes.co.uk/"
       >
         <span

--- a/packages/ts-components/src/__tests__/__snapshots__/InArticlePuff.test.tsx.snap
+++ b/packages/ts-components/src/__tests__/__snapshots__/InArticlePuff.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`InArticlePuff With an Image matches the snapshot 1`] = `
       href="https://www.thetimes.co.uk/"
     >
       <img
-        class="sc-dnqmqq dIDdMH"
+        class="sc-dnqmqq emoKWP"
         src="https://nuk-tnl-deck-prod-static.s3-eu-west-1.amazonaws.com/uploads/b309b4cc1fe7a2d9a940f93e29701615.jpg"
       />
     </a>

--- a/packages/ts-components/src/__tests__/__snapshots__/InArticlePuff.test.tsx.snap
+++ b/packages/ts-components/src/__tests__/__snapshots__/InArticlePuff.test.tsx.snap
@@ -3,7 +3,9 @@
 exports[`InArticlePuff With an Image matches the snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa kKnmIb"
+    class="sc-bdVaJa gMPYKf"
+    data-testid="InArticlePuff - Container"
+    style="border-top: 2px solid #13354E;"
   >
     <a
       class="sc-bwzfXH hJnROK"
@@ -22,6 +24,7 @@ exports[`InArticlePuff With an Image matches the snapshot 1`] = `
       >
         <span
           class="sc-htpNat iMpDKo"
+          style="color: rgb(19, 53, 78);"
         >
           INTERACTIVE
         </span>
@@ -39,6 +42,7 @@ exports[`InArticlePuff With an Image matches the snapshot 1`] = `
       </div>
       <a
         class="sc-htoDjs djguHq"
+        data-testid="InArticlePuff - LinkWrapper"
         href="https://www.thetimes.co.uk/"
       >
         <span
@@ -69,7 +73,9 @@ exports[`InArticlePuff With an Image matches the snapshot 1`] = `
 exports[`InArticlePuff Without an image matches the snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa kKnmIb"
+    class="sc-bdVaJa gMPYKf"
+    data-testid="InArticlePuff - Container"
+    style="border-top: 2px solid #13354E;"
   >
     <div
       class="sc-bZQynM jVKIde"
@@ -79,6 +85,7 @@ exports[`InArticlePuff Without an image matches the snapshot 1`] = `
       >
         <span
           class="sc-htpNat fhZNeJ"
+          style="color: rgb(19, 53, 78);"
         >
           INTERACTIVE
         </span>
@@ -96,6 +103,7 @@ exports[`InArticlePuff Without an image matches the snapshot 1`] = `
       </div>
       <a
         class="sc-htoDjs bFrbzf"
+        data-testid="InArticlePuff - LinkWrapper"
         href="https://www.thetimes.co.uk/"
       >
         <span

--- a/packages/ts-components/src/in-article-puff/index.stories.tsx
+++ b/packages/ts-components/src/in-article-puff/index.stories.tsx
@@ -14,6 +14,7 @@ const showcase = {
           copy="Enter your postcode in our tool to find your nearest vacination centre"
           link="https://www.thetimes.co.uk/"
           linkText="Read more"
+          sectionColour="#13354E"
         />
       ),
       name: 'In Article Puff',
@@ -27,6 +28,7 @@ const showcase = {
           copy="See how the virus has escalated in areas scross the country as the number of identified cases in Britain continues to grow"
           link="https://www.thetimes.co.uk/"
           linkText="Read more"
+          sectionColour="#184e13"
         />
       ),
       name: 'In Article Puff - No Image',

--- a/packages/ts-components/src/in-article-puff/index.tsx
+++ b/packages/ts-components/src/in-article-puff/index.tsx
@@ -18,11 +18,11 @@ import {
 type InArticlePuffProps = {
   label: string;
   imageUri?: string;
-
   headline: string;
   copy: string;
   link: string;
   linkText: string;
+  sectionColour: string;
 };
 
 const InArticlePuff: React.FC<InArticlePuffProps> = ({
@@ -31,12 +31,13 @@ const InArticlePuff: React.FC<InArticlePuffProps> = ({
   headline,
   copy,
   link,
-  linkText
+  linkText,
+  sectionColour
 }) => {
   const [colour, setColour] = useState('#BF0000');
 
   return (
-    <Container>
+    <Container style={{ borderTop: `2px ${sectionColour} solid`}} data-testid="InArticlePuff - Container">
       {imageUri ? (
         <ImageContainer href={link}>
           <Image src={imageUri} />
@@ -44,7 +45,7 @@ const InArticlePuff: React.FC<InArticlePuffProps> = ({
       ) : null}
       <ContentContainer imageUri={imageUri}>
         <MainContentContainer>
-          <Label imageUri={imageUri}>{label}</Label>
+          <Label imageUri={imageUri} style={{ color: sectionColour }}>{label}</Label>
           <Headline href={link}>{headline}</Headline>
           <Copy>{copy}</Copy>
         </MainContentContainer>

--- a/packages/ts-components/src/in-article-puff/index.tsx
+++ b/packages/ts-components/src/in-article-puff/index.tsx
@@ -37,7 +37,10 @@ const InArticlePuff: React.FC<InArticlePuffProps> = ({
   const [colour, setColour] = useState('#BF0000');
 
   return (
-    <Container style={{ borderTop: `2px ${sectionColour} solid`}} data-testid="InArticlePuff - Container">
+    <Container
+      style={{ borderTop: `2px ${sectionColour} solid` }}
+      data-testid="InArticlePuff - Container"
+    >
       {imageUri ? (
         <ImageContainer href={link}>
           <Image src={imageUri} />
@@ -45,7 +48,9 @@ const InArticlePuff: React.FC<InArticlePuffProps> = ({
       ) : null}
       <ContentContainer imageUri={imageUri}>
         <MainContentContainer>
-          <Label imageUri={imageUri} style={{ color: sectionColour }}>{label}</Label>
+          <Label imageUri={imageUri} style={{ color: sectionColour }}>
+            {label}
+          </Label>
           <Headline href={link}>{headline}</Headline>
           <Copy>{copy}</Copy>
         </MainContentContainer>

--- a/packages/ts-components/src/in-article-puff/styles.ts
+++ b/packages/ts-components/src/in-article-puff/styles.ts
@@ -108,5 +108,6 @@ export const LinkWrapper = styled.a<ContainerType>`
 
 export const Image = styled.img`
   width: 100%;
-  object-fit: contain;
+  height: 100%;
+  object-fit: cover;
 `;

--- a/packages/ts-components/src/in-article-puff/styles.ts
+++ b/packages/ts-components/src/in-article-puff/styles.ts
@@ -15,7 +15,6 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   background-color: #f9f9f9;
-  border-top: 2px #13354e solid;
   padding: 20px;
   margin-right: ${spacing(2)};
   margin-bottom: ${spacing(4)};


### PR DESCRIPTION
## Description

- Added section colour to the style of label and byline of InArticlePuff component. This logic is already used in other components in the repo so have followed the application in those examples.

![Screenshot 2021-05-06 at 16 23 25](https://user-images.githubusercontent.com/44647540/117333306-b5969380-ae90-11eb-9cd3-bb7e52ca46e3.png)
![Screenshot 2021-05-06 at 16 23 12](https://user-images.githubusercontent.com/44647540/117333321-b7f8ed80-ae90-11eb-8b08-31fa4d01ddc3.png)

