### PR TITLE
feat(TE-43): InArticlePuff - cleaner section colour implementation

### DIFF
--- a/packages/ts-components/src/components/in-article-puff/InArticlePuff.tsx
+++ b/packages/ts-components/src/components/in-article-puff/InArticlePuff.tsx
@@ -48,10 +48,7 @@ export const InArticlePuff: React.FC<{
   const hasImage = Boolean(image);
 
   return (
-    <Container
-      style={{ borderTop: `2px ${sectionColour} solid` }}
-      data-testid="InArticlePuff - Container"
-    >
+    <Container sectionColour={sectionColour}>
       {image ? (
         <ImageContainer>
           <a href={link}>
@@ -62,7 +59,7 @@ export const InArticlePuff: React.FC<{
 
       <ContentContainer hasImage={hasImage}>
         <div>
-          <Label hasImage={hasImage} style={{ color: sectionColour }}>
+          <Label hasImage={hasImage} sectionColour={sectionColour}>
             {label}
           </Label>
           <a href={link}>

--- a/packages/ts-components/src/components/in-article-puff/__tests__/InArticlePuff.test.tsx
+++ b/packages/ts-components/src/components/in-article-puff/__tests__/InArticlePuff.test.tsx
@@ -92,24 +92,6 @@ describe('InArticlePuff', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should render section colour correctly', () => {
-    (useFetch as jest.Mock).mockReturnValue(
-      deckApiPayloadWrapper(requiredFields)
-    );
-
-    const { getByText, getByTestId } = render(
-      <InArticlePuff {...requiredProps} />
-    );
-
-    expect(getByTestId('InArticlePuff - Container')).toHaveStyle(
-      `border-top: 2px ${requiredProps.sectionColour} solid`
-    );
-
-    expect(getByText(requiredFields.label)).toHaveStyle(
-      `color: ${requiredProps.sectionColour}`
-    );
-  });
-
   it('should render the error state correctly', () => {
     (useFetch as jest.Mock).mockReturnValue({ error: 'Some error occurred' });
 

--- a/packages/ts-components/src/components/in-article-puff/__tests__/__snapshots__/InArticlePuff.test.tsx.snap
+++ b/packages/ts-components/src/components/in-article-puff/__tests__/__snapshots__/InArticlePuff.test.tsx.snap
@@ -3,9 +3,7 @@
 exports[`InArticlePuff should render optional fields correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bwzfXH fJttQd"
-    data-testid="InArticlePuff - Container"
-    style="border-top: 2px solid #13354E;"
+    class="sc-bwzfXH fZayOF"
   >
     <div
       class="sc-htpNat jUgmOU"
@@ -23,8 +21,7 @@ exports[`InArticlePuff should render optional fields correctly 1`] = `
     >
       <div>
         <div
-          class="sc-ifAKCX fewBDO"
-          style="color: rgb(19, 53, 78);"
+          class="sc-ifAKCX cukKbE"
         >
           interactive
         </div>
@@ -64,17 +61,14 @@ exports[`InArticlePuff should render optional fields correctly 1`] = `
 exports[`InArticlePuff should render required fields correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bwzfXH fJttQd"
-    data-testid="InArticlePuff - Container"
-    style="border-top: 2px solid #13354E;"
+    class="sc-bwzfXH fZayOF"
   >
     <div
       class="sc-bxivhb cfsDhB"
     >
       <div>
         <div
-          class="sc-ifAKCX cWvuvC"
-          style="color: rgb(19, 53, 78);"
+          class="sc-ifAKCX cFeZSy"
         >
           interactive
         </div>

--- a/packages/ts-components/src/components/in-article-puff/styles.ts
+++ b/packages/ts-components/src/components/in-article-puff/styles.ts
@@ -15,12 +15,13 @@ export const PlaceholderContainer = styled.div`
   }
 `;
 
-export const Container = styled.div`
+export const Container = styled.div<{ sectionColour: string }>`
   display: flex;
   flex-direction: column;
   margin: 0 auto 20px auto;
   padding: 20px;
   background-color: #f9f9f9;
+  border-top: ${({ sectionColour }) => `2px solid ${sectionColour}`};
 
   a {
     text-decoration: none;
@@ -61,8 +62,9 @@ export const ContentContainer = styled.div<{ hasImage?: boolean }>`
   }
 `;
 
-export const Label = styled.div<{ hasImage?: boolean }>`
+export const Label = styled.div<{ hasImage?: boolean; sectionColour: string }>`
   padding-bottom: ${({ hasImage }) => (hasImage ? '8px' : '12px')};
+  color: ${({ sectionColour }) => sectionColour};
   font-family: ${fonts.supporting};
   font-size: 12px;
   text-transform: uppercase;


### PR DESCRIPTION
This PR updates how the `InArticlePuff` uses `sectionColour`

* Remove inline styles
* Pass `sectionColour` to component styles

This approach does mean we are unable to unit test the `sectionColour` is rendering correctly? Is this a problem?
