### PR TITLE
fix(TE-115):  Add aspect ratio to in article puff image

### DIFF
--- a/packages/ts-components/src/components/in-article-puff/__tests__/__snapshots__/InArticlePuff.test.tsx.snap
+++ b/packages/ts-components/src/components/in-article-puff/__tests__/__snapshots__/InArticlePuff.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`InArticlePuff should render optional fields correctly 1`] = `
     class="sc-bwzfXH fZayOF"
   >
     <div
-      class="sc-htpNat jUgmOU"
+      class="sc-htpNat fBzokr"
     >
       <a
         href="https://www.thetimes.co.uk"

--- a/packages/ts-components/src/components/in-article-puff/styles.ts
+++ b/packages/ts-components/src/components/in-article-puff/styles.ts
@@ -43,6 +43,8 @@ export const ImageContainer = styled.div`
   img {
     display: block;
     width: 100%;
+    aspect-ratio: 3/2;
+    object-fit: cover;
   }
 
   @media (min-width: ${breakpoints.medium}px) {


### PR DESCRIPTION
### Description ###

This PR forces an aspect ratio of 3/2 on the images in the InArticlePuff. If the image provided does not have that aspect ratio it will crop the image from the centre to fit. 
Ticket: https://nidigitalsolutions.jira.com/browse/TE-115

Mobile before: 
<img width="324" alt="Screenshot 2021-05-26 at 14 56 14" src="https://user-images.githubusercontent.com/44647540/119673257-20edd880-be33-11eb-9747-649c7aa90b69.png">

Mobile after: 
<img width="324" alt="Screenshot 2021-05-26 at 14 49 32" src="https://user-images.githubusercontent.com/44647540/119673361-34993f00-be33-11eb-9724-19c91e355d2f.png">

Tablet before: 
<img width="623" alt="Screenshot 2021-05-26 at 14 56 44" src="https://user-images.githubusercontent.com/44647540/119673276-2519f600-be33-11eb-85df-cd3f452daa4b.png">

Tablet after:
<img width="622" alt="Screenshot 2021-05-26 at 14 49 06" src="https://user-images.githubusercontent.com/44647540/119673387-38c55c80-be33-11eb-976b-b1f42ba18bf0.png">

Desktop before: 
<img width="436" alt="Screenshot 2021-05-26 at 14 57 03" src="https://user-images.githubusercontent.com/44647540/119673296-2814e680-be33-11eb-90d1-74dd8b956f66.png">

Desktop after: 

<img width="438" alt="Screenshot 2021-05-26 at 14 48 55" src="https://user-images.githubusercontent.com/44647540/119673407-3cf17a00-be33-11eb-9662-eebc2e3176f6.png">


