### PR TITLE
fix:(TE-119) Strip HTML from copy in InArticlePuff

### DIFF
--- a/packages/article-skeleton/src/article-body/article-body.web.js
+++ b/packages/article-skeleton/src/article-body/article-body.web.js
@@ -174,6 +174,7 @@ const renderers = ({
                   <InArticlePuff
                     sectionColour={theme.sectionColour}
                     forceImageAspectRatio="3:2"
+                    sanitiseHtml={true}
                   />
                 </FetchProvider>
               )}

--- a/packages/ts-components/package.json
+++ b/packages/ts-components/package.json
@@ -56,6 +56,7 @@
     "@times-components/utils": "6.5.2",
     "isomorphic-unfetch": "3.1.0",
     "react": "16.9.0",
+    "sanitize-html": "^2.4.0",
     "styled-components": "4.3.2"
   },
   "devDependencies": {
@@ -69,6 +70,7 @@
     "@types/node-fetch": "2.5.10",
     "@types/react-dom": "17.0.3",
     "@types/react-test-renderer": "16.9.0",
+    "@types/sanitize-html": "^2.3.1",
     "@types/styled-components": "5.1.9",
     "jest": "24.8.0",
     "prettier": "1.14.3",

--- a/packages/ts-components/src/components/in-article-puff/InArticlePuff.stories.tsx
+++ b/packages/ts-components/src/components/in-article-puff/InArticlePuff.stories.tsx
@@ -20,8 +20,11 @@ const showcase = {
       decorator: (storyFn: () => React.ReactNode) => (
         <TrackingContextProvider
           context={{
-            articleHeadline: 'articleHeadline',
-            section: 'section'
+            component: 'ArticleSkeleton',
+            attrs: {
+              article_name: 'articleHeadline',
+              section_details: 'section'
+            }
           }}
           analyticsStream={analyticsStream}
         >
@@ -33,7 +36,7 @@ const showcase = {
     {
       component: () => (
         <FetchProvider url="https://gobble.timesdev.tools/deck/api/deck-post-action/41548">
-          <InArticlePuff sectionColour="#13354e" />
+          <InArticlePuff sectionColour="#13354e" sanitiseHtml={true} />
         </FetchProvider>
       ),
       name: 'In Article Puff - Image',
@@ -42,7 +45,7 @@ const showcase = {
     {
       component: () => (
         <FetchProvider url="https://gobble.timesdev.tools/deck/api/deck-post-action/41548">
-          <InArticlePuff sectionColour="#13354e" forceImageAspectRatio="3:2" />
+          <InArticlePuff sectionColour="#13354e" forceImageAspectRatio="3:2" sanitiseHtml={true} />
         </FetchProvider>
       ),
       name: 'In Article Puff - Image 3:2',
@@ -51,7 +54,7 @@ const showcase = {
     {
       component: () => (
         <FetchProvider url="https://gobble.timesdev.tools/deck/api/deck-post-action/41547">
-          <InArticlePuff sectionColour="#184e13" />
+          <InArticlePuff sectionColour="#184e13" sanitiseHtml={true} />
         </FetchProvider>
       ),
       name: 'In Article Puff - No Image',

--- a/packages/ts-components/src/components/in-article-puff/InArticlePuff.tsx
+++ b/packages/ts-components/src/components/in-article-puff/InArticlePuff.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import sanitizeHtml from 'sanitize-html';
 
 import { Placeholder } from '@times-components/image';
 import { IconForwardChevron } from '@times-components/icons';
@@ -6,7 +7,10 @@ import { IconForwardChevron } from '@times-components/icons';
 import { AspectRatios } from '../../types/aspectRatio';
 
 import { useFetch } from '../../helpers/fetch/FetchProvider';
-import { TrackingContextProvider } from '../../helpers/tracking/TrackingContextProvider';
+import {
+  TrackingContext,
+  TrackingContextProvider
+} from '../../helpers/tracking/TrackingContextProvider';
 
 import { AspectRatio } from '../aspect-ratio/AspectRatio';
 
@@ -23,23 +27,30 @@ import {
 } from './styles';
 
 const scrollEvent = {
-  event_navigation_name: 'in-article component displayed : puff',
-  event_navigation_browsing_method: 'scroll'
+  attrs: {
+    event_navigation_name: 'in-article component displayed : puff',
+    event_navigation_browsing_method: 'scroll'
+  }
 };
 
 const clickEvent = (buttonLabel: string) => ({
-  event_navigation_name: `button : ${buttonLabel}`,
-  event_navigation_browsing_method: 'click'
+  action: 'Clicked',
+  attrs: {
+    event_navigation_name: `button : ${buttonLabel}`,
+    event_navigation_browsing_method: 'click'
+  }
 });
 
 export const InArticlePuff: React.FC<{
   sectionColour: string;
   forceImageAspectRatio?: AspectRatios;
-}> = ({ sectionColour, forceImageAspectRatio }) => {
+  sanitiseHtml: boolean;
+}> = ({ sectionColour, forceImageAspectRatio, sanitiseHtml }) => {
+
   const [colour, setColour] = useState('#bf0000');
 
   const handleClick = (
-    fireAnalyticsEvent: (evt: any) => void,
+    fireAnalyticsEvent: (evt: TrackingContext) => void,
     buttonLabel: string
   ) => {
     fireAnalyticsEvent && fireAnalyticsEvent(clickEvent(buttonLabel));
@@ -68,14 +79,22 @@ export const InArticlePuff: React.FC<{
     linkText
   } = data.body.data[0].data;
 
+  const sanitisedCopy = sanitizeHtml(copy, {
+    allowedTags: [],
+    allowedAttributes: {},
+  });
+
   const hasImage = Boolean(image);
 
   return (
     <TrackingContextProvider
       context={{
-        component_type: 'in-article component : puff : interactive',
-        event_navigation_action: 'navigation',
-        component_name: `${headline}`
+        object: 'InArticlePuff',
+        attrs: {
+          component_type: 'in-article component : puff : interactive',
+          event_navigation_action: 'navigation',
+          component_name: `${headline}`
+        }
       }}
       scrolledEvent={scrollEvent}
     >
@@ -105,7 +124,7 @@ export const InArticlePuff: React.FC<{
               >
                 <Headline hasImage={hasImage}>{headline}</Headline>
               </a>
-              {copy && <Copy>{copy}</Copy>}
+              {copy && <Copy>{`${sanitiseHtml ? sanitisedCopy : copy}`}</Copy>}
             </div>
 
             <Link


### PR DESCRIPTION
### Description ###

Add property sanitiseHtml which will strip the HTML tags from the copy in the InArticlePuff component.
