### PR TITLE
feat(TD-49): added meta description to author and topic pages

### DIFF
--- a/packages/author-profile/src/author-profile-head-prop-types.base.js
+++ b/packages/author-profile/src/author-profile-head-prop-types.base.js
@@ -7,7 +7,8 @@ export const propTypes = {
   jobTitle: PropTypes.string,
   name: PropTypes.string,
   twitter: PropTypes.string,
-  uri: PropTypes.string
+  uri: PropTypes.string,
+  metaDescription: PropTypes.string
 };
 
 export const defaultProps = {
@@ -16,5 +17,6 @@ export const defaultProps = {
   jobTitle: "",
   name: "",
   twitter: "",
-  uri: ""
+  uri: "",
+  metaDescription: ""
 };

--- a/packages/author-profile/src/author-profile-prop-types.base.js
+++ b/packages/author-profile/src/author-profile-prop-types.base.js
@@ -7,7 +7,8 @@ export const propTypes = {
     image: authorProfileHeadPropTypes.uri,
     jobTitle: authorProfileHeadPropTypes.jobTitle,
     name: authorProfileHeadPropTypes.name,
-    twitter: authorProfileHeadPropTypes.twitter
+    twitter: authorProfileHeadPropTypes.twitter,
+    metaDescription: PropTypes.string
   }),
   error: PropTypes.object,
   isLoading: authorProfileHeadPropTypes.isLoading,

--- a/packages/author-profile/src/author-profile.web.js
+++ b/packages/author-profile/src/author-profile.web.js
@@ -26,7 +26,8 @@ const AuthorProfile = ({
   page,
   pageSize: initPageSize,
   refetch,
-  slug
+  slug,
+  metaDescription
 }) => {
   const emptyStateMessage =
     "Unfortunately, there are no articles relating to this author";
@@ -110,7 +111,7 @@ const AuthorProfile = ({
 
         return (
           <Responsive>
-            <Head description={biography} name={name} />
+            <Head description={metaDescription || biography} name={name} />
             <ArticleList
               articleListHeader={articleListHeader}
               articles={get(data, "articles.list", [])}

--- a/packages/author-profile/src/author-profile.web.js
+++ b/packages/author-profile/src/author-profile.web.js
@@ -111,7 +111,7 @@ const AuthorProfile = ({
 
         return (
           <Responsive>
-            <Head description={metaDescription || biography} name={name} />
+            <Head metaDescription={metaDescription} description={biography} name={name} />
             <ArticleList
               articleListHeader={articleListHeader}
               articles={get(data, "articles.list", [])}

--- a/packages/author-profile/src/head.web.js
+++ b/packages/author-profile/src/head.web.js
@@ -6,10 +6,14 @@ import { renderTreeArrayAsText } from "@times-components/markup-forest";
 import { propTypes as authorProfileHeadPropTypes } from "./author-profile-head-prop-types";
 
 function Head({ description, name }) {
-  const content =
-    description && description.length
-      ? renderTreeArrayAsText(description).substring(0, 200)
-      : `Get up to date information and read all the latest articles from ${name}.`;
+  let content = `Get up to date information and read all the latest articles from ${name}.`;
+
+  if (description && typeof description === "object") {
+    content = renderTreeArrayAsText(description).substring(0, 200);
+  } else if (description && typeof description === "string"){
+    content = description;
+  }
+
   return (
     <Helmet>
       <title>{name} | The Times &amp; The Sunday Times</title>

--- a/packages/author-profile/src/head.web.js
+++ b/packages/author-profile/src/head.web.js
@@ -5,13 +5,13 @@ import { renderTreeArrayAsText } from "@times-components/markup-forest";
 
 import { propTypes as authorProfileHeadPropTypes } from "./author-profile-head-prop-types";
 
-function Head({ description, name }) {
+function Head({ metaDescription, description, name }) {
   let content = `Get up to date information and read all the latest articles from ${name}.`;
 
-  if (description && typeof description === "object") {
+  if (metaDescription){
+    content = metaDescription;
+  }else if (description && typeof description === "object") {
     content = renderTreeArrayAsText(description).substring(0, 200);
-  } else if (description && typeof description === "string"){
-    content = description;
   }
 
   return (
@@ -23,6 +23,7 @@ function Head({ description, name }) {
 }
 
 Head.propTypes = {
+  metaDescription: PropTypes.string,
   description: authorProfileHeadPropTypes.biography.isRequired,
   name: PropTypes.string.isRequired
 };

--- a/packages/provider-queries/src/author.graphql
+++ b/packages/provider-queries/src/author.graphql
@@ -9,5 +9,6 @@ query AuthorQuery($slug: Slug!) {
     jobTitle
     name
     twitter
+    metaDescription
   }
 }

--- a/packages/provider-queries/src/topic.graphql
+++ b/packages/provider-queries/src/topic.graphql
@@ -2,5 +2,6 @@ query TopicQuery($slug: Slug!) {
   topic(slug: $slug) {
     name
     description
+    metaDescription
   }
 }

--- a/packages/topic/src/head.web.js
+++ b/packages/topic/src/head.web.js
@@ -7,10 +7,14 @@ import { renderTreeArrayAsText } from "@times-components/markup-forest";
 import { propTypes as topicHeadPropTypes } from "./topic-head-prop-types";
 
 function Head({ description, name, slug }) {
-  const content =
-    description && description.length
-      ? renderTreeArrayAsText(description).substring(0, 200)
-      : `Discover expert ${name} articles from The Times and The Sunday Times.`;
+
+  let content = `Discover expert ${name} articles from The Times and The Sunday Times.`;
+
+  if (description && typeof description === "object") {
+    content = renderTreeArrayAsText(description).substring(0, 200);
+  } else if (description && typeof description === "string"){
+    content = description;
+  }
 
   return (
     <Context.Consumer>

--- a/packages/topic/src/head.web.js
+++ b/packages/topic/src/head.web.js
@@ -6,14 +6,14 @@ import { renderTreeArrayAsText } from "@times-components/markup-forest";
 
 import { propTypes as topicHeadPropTypes } from "./topic-head-prop-types";
 
-function Head({ description, name, slug }) {
+function Head({ metaDescription, description, name, slug }) {
 
   let content = `Discover expert ${name} articles from The Times and The Sunday Times.`;
 
-  if (description && typeof description === "object") {
+  if (metaDescription) {
+    content = metaDescription;
+  } else if (description && typeof description === "object") {
     content = renderTreeArrayAsText(description).substring(0, 200);
-  } else if (description && typeof description === "string"){
-    content = description;
   }
 
   return (
@@ -30,6 +30,7 @@ function Head({ description, name, slug }) {
 }
 
 Head.propTypes = {
+  metaDescription: PropTypes.string,
   description: topicHeadPropTypes.description.isRequired,
   name: PropTypes.string.isRequired,
   slug: PropTypes.string.isRequired

--- a/packages/topic/src/topic-head-prop-types.js
+++ b/packages/topic/src/topic-head-prop-types.js
@@ -2,12 +2,14 @@ import PropTypes from "prop-types";
 import { propTypes as treePropType } from "@times-components/markup-forest";
 
 export const propTypes = {
+  metaDescription: PropTypes.string,
   description: PropTypes.arrayOf(treePropType),
   isLoading: PropTypes.bool,
   name: PropTypes.string
 };
 
 export const defaultProps = {
+  metaDescription: "",
   description: [],
   isLoading: true,
   name: ""

--- a/packages/topic/src/topic-prop-types.base.js
+++ b/packages/topic/src/topic-prop-types.base.js
@@ -9,6 +9,7 @@ export const propTypes = {
   refetch: PropTypes.func.isRequired,
   slug: PropTypes.string.isRequired,
   topic: PropTypes.shape({
+    metaDescription: PropTypes.string,
     description: topicHeadPropTypes.description,
     name: topicHeadPropTypes.name
   })

--- a/packages/topic/src/topic.web.js
+++ b/packages/topic/src/topic.web.js
@@ -22,7 +22,8 @@ const Topic = ({
   onPrev,
   refetch,
   slug,
-  topic
+  topic,
+  metaDescription
 }) => {
   const emptyStateMessage =
     "Unfortunately, there are no articles relating to this topic";
@@ -87,7 +88,7 @@ const Topic = ({
 
         return (
           <Responsive>
-            <Head {...{ description, name, slug }} />
+            <Head {...{ description: metaDescription || description, name, slug }} />
             <ArticleList
               articleListHeader={articleListHeader}
               articles={get(data, "articles.list", [])}

--- a/packages/topic/src/topic.web.js
+++ b/packages/topic/src/topic.web.js
@@ -88,7 +88,7 @@ const Topic = ({
 
         return (
           <Responsive>
-            <Head {...{ description: metaDescription || description, name, slug }} />
+            <Head {...{ metaDescription, description, name, slug }} />
             <ArticleList
               articleListHeader={articleListHeader}
               articles={get(data, "articles.list", [])}


### PR DESCRIPTION
**Background**

Currently on topic and author page types the meta description is populated using either the page introduction (topic) or the bio (author)

Those are also shown to readers which means they cannot be optimised for SEO.

Topic Donald Trump | The Times & The Sunday Times 

Profile/author page Mike Atherton | The Times & The Sunday Times 

**Work done**

[Topic & author pages] Updated metadescription to source data from new a new metadescription field in TPA