### PR TITLE
fix(te-000): update olympic schedule scroll

### DIFF
--- a/packages/ts-components/src/components/olympics/__tests__/OlympicsMedalTable.test.tsx
+++ b/packages/ts-components/src/components/olympics/__tests__/OlympicsMedalTable.test.tsx
@@ -24,9 +24,9 @@ describe('<OlympicsMedalTable>', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('renders with wrapHelmetProvider', () => {
+  it('renders outside of article', () => {
     const { asFragment } = render(
-      <OlympicsMedalTable keys={keys} wrapHelmetProvider />
+      <OlympicsMedalTable keys={keys} inArticle={false} />
     );
 
     expect(asFragment()).toMatchSnapshot();

--- a/packages/ts-components/src/components/olympics/__tests__/OlympicsSchedule.test.tsx
+++ b/packages/ts-components/src/components/olympics/__tests__/OlympicsSchedule.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import 'regenerator-runtime';
 import 'jest-styled-components';
@@ -27,15 +27,6 @@ describe('<OlympicsSchedule>', () => {
     const { asFragment } = render(
       <OlympicsSchedule keys={keys} wrapHelmetProvider />
     );
-    expect(asFragment()).toMatchSnapshot();
-  });
-  it('click show all', async () => {
-    const { asFragment, getByText, findByText } = render(
-      <OlympicsSchedule keys={keys} sectionColor="sectionColor" />
-    );
-    fireEvent.click(getByText('Show All'));
-    await findByText('Collapse');
-
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/packages/ts-components/src/components/olympics/__tests__/OlympicsSchedule.test.tsx
+++ b/packages/ts-components/src/components/olympics/__tests__/OlympicsSchedule.test.tsx
@@ -23,9 +23,9 @@ describe('<OlympicsSchedule>', () => {
     const { asFragment } = render(<OlympicsSchedule keys={keys} />);
     expect(asFragment()).toMatchSnapshot();
   });
-  it('renders with wrapHelmetProvider', () => {
+  it('renders outside of article', () => {
     const { asFragment } = render(
-      <OlympicsSchedule keys={keys} wrapHelmetProvider />
+      <OlympicsSchedule keys={keys} inArticle={false} />
     );
     expect(asFragment()).toMatchSnapshot();
   });

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsMedalTable.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsMedalTable.test.tsx.snap
@@ -91,6 +91,11 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
   border: 1px solid #DBDBDB;
   top: -80px;
   position: relative;
+  cursor: pointer;
+}
+
+.c1:hover {
+  background-color: #e4e4e4;
 }
 
 @media (min-width:768px) {
@@ -219,6 +224,11 @@ exports[`<OlympicsMedalTable> renders 1`] = `
   border: 1px solid #DBDBDB;
   top: -80px;
   position: relative;
+  cursor: pointer;
+}
+
+.c1:hover {
+  background-color: #e4e4e4;
 }
 
 @media (min-width:768px) {
@@ -256,7 +266,7 @@ exports[`<OlympicsMedalTable> renders 1`] = `
 </DocumentFragment>
 `;
 
-exports[`<OlympicsMedalTable> renders with wrapHelmetProvider 1`] = `
+exports[`<OlympicsMedalTable> renders outside of article 1`] = `
 <DocumentFragment>
   .c0 {
   position: relative;
@@ -347,18 +357,11 @@ exports[`<OlympicsMedalTable> renders with wrapHelmetProvider 1`] = `
   border: 1px solid #DBDBDB;
   top: -80px;
   position: relative;
+  cursor: pointer;
 }
 
-@media (min-width:768px) {
-  .c0 {
-    width: 80.8%;
-  }
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    width: 56.2%;
-  }
+.c1:hover {
+  background-color: #e4e4e4;
 }
 
 <div

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
 }
 
 .c0 .pa-schedule .pa_UnitListView_ctr {
-  max-height: 400px;
+  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
@@ -116,7 +116,7 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 }
 
 .c0 .pa-schedule .pa_UnitListView_ctr {
-  max-height: 400px;
+  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -146,19 +146,18 @@ exports[`<OlympicsSchedule> renders 1`] = `
   font-size: 16px;
 }
 
+.c0 .pa-schedule .pa_UnitListView_ctr {
+  height: 400px;
+}
+
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
-  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
   background-color: #F9F9F9;
   color: #1D1D1B;
-}
-
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li:nth-child(n + 8) {
-  display: none;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
@@ -179,8 +178,6 @@ exports[`<OlympicsSchedule> renders 1`] = `
 
 .c0 .pa-schedule .pa_OdfFooter_ctr {
   font-family: GillSansMTStd-Medium;
-  top: 60px;
-  position: relative;
   font-size: 12px;
 }
 
@@ -190,31 +187,11 @@ exports[`<OlympicsSchedule> renders 1`] = `
 }
 
 .c0 .pa-schedule .pa_Schedule_ctr {
-  padding-bottom: 60px;
   background: #EDEDED;
 }
 
 .c0 .pa-schedule .pa_ErrorMessage_ctr {
   background: #ededed;
-}
-
-.c0 .buttonContainer {
-  text-align: center;
-  height: 0;
-}
-
-.c0 .buttonContainer button {
-  background-color: #F9F9F9;
-}
-
-.c1 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
 }
 
 @media (min-width:768px) {
@@ -237,15 +214,6 @@ exports[`<OlympicsSchedule> renders 1`] = `
       data-auth-token="token"
       data-games-code="OG1896"
     />
-    <div
-      class="buttonContainer"
-    >
-      <button
-        class="c1"
-      >
-        Show All
-      </button>
-    </div>
   </div>
 </DocumentFragment>
 `;
@@ -271,19 +239,18 @@ exports[`<OlympicsSchedule> renders with wrapHelmetProvider 1`] = `
   font-size: 16px;
 }
 
+.c0 .pa-schedule .pa_UnitListView_ctr {
+  height: 400px;
+}
+
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
-  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
   background-color: #F9F9F9;
   color: #1D1D1B;
-}
-
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li:nth-child(n + 8) {
-  display: none;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
@@ -304,8 +271,6 @@ exports[`<OlympicsSchedule> renders with wrapHelmetProvider 1`] = `
 
 .c0 .pa-schedule .pa_OdfFooter_ctr {
   font-family: GillSansMTStd-Medium;
-  top: 60px;
-  position: relative;
   font-size: 12px;
 }
 
@@ -315,31 +280,11 @@ exports[`<OlympicsSchedule> renders with wrapHelmetProvider 1`] = `
 }
 
 .c0 .pa-schedule .pa_Schedule_ctr {
-  padding-bottom: 60px;
   background: #EDEDED;
 }
 
 .c0 .pa-schedule .pa_ErrorMessage_ctr {
   background: #ededed;
-}
-
-.c0 .buttonContainer {
-  text-align: center;
-  height: 0;
-}
-
-.c0 .buttonContainer button {
-  background-color: #F9F9F9;
-}
-
-.c1 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
 }
 
 @media (min-width:768px) {
@@ -362,15 +307,6 @@ exports[`<OlympicsSchedule> renders with wrapHelmetProvider 1`] = `
       data-auth-token="token"
       data-games-code="OG1896"
     />
-    <div
-      class="buttonContainer"
-    >
-      <button
-        class="c1"
-      >
-        Show All
-      </button>
-    </div>
   </div>
 </DocumentFragment>
 `;

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -1,130 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<OlympicsSchedule> click show all 1`] = `
-<DocumentFragment>
-  .c0 {
-  position: relative;
-  margin: 0 auto 20px auto;
-}
-
-.c0 .pa-schedule .pa_ScheduleHeader_header {
-  color: #1D1D1B;
-  font-family: GillSansMTStd-Medium;
-  font-size: 18px;
-  background: #EDEDED;
-}
-
-.c0 .pa-schedule .pa_ScheduleHeader_filterbar {
-  color: #1D1D1B;
-  font-family: GillSansMTStd-Medium;
-  background: #EDEDED;
-  font-size: 16px;
-}
-
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
-  font-family: GillSansMTStd-Medium;
-  font-size: 16px;
-  height: 400px;
-}
-
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
-  background-color: #F9F9F9;
-  color: #1D1D1B;
-}
-
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li:nth-child(n + 8) {
-  display: block;
-}
-
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
-  color: sectionColor;
-  line-height: 30px;
-}
-
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-text {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-}
-
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_discipline {
-  font-family: TimesModern-Bold;
-  text-transform: capitalize;
-  font-weight: 400;
-}
-
-.c0 .pa-schedule .pa_OdfFooter_ctr {
-  font-family: GillSansMTStd-Medium;
-  top: 60px;
-  position: relative;
-  font-size: 12px;
-}
-
-.c0 .pa-schedule .pa_UnitListView_message {
-  min-height: 70px;
-  background-color: #F9F9F9;
-}
-
-.c0 .pa-schedule .pa_Schedule_ctr {
-  padding-bottom: 60px;
-  background: #EDEDED;
-}
-
-.c0 .pa-schedule .pa_ErrorMessage_ctr {
-  background: #ededed;
-}
-
-.c0 .buttonContainer {
-  text-align: center;
-  height: 0;
-}
-
-.c0 .buttonContainer button {
-  background-color: #F9F9F9;
-}
-
-.c1 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    width: 80.8%;
-  }
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    width: 56.2%;
-  }
-}
-
-<div
-    class="c0"
-  >
-    <div
-      class="pa-schedule"
-      data-auth-token="token"
-      data-games-code="OG1896"
-    />
-    <div
-      class="buttonContainer"
-    >
-      <button
-        class="c1"
-      >
-        Collapse
-      </button>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`<OlympicsSchedule> renders 1`] = `
 <DocumentFragment>
   .c0 {
@@ -147,7 +22,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
 }
 
 .c0 .pa-schedule .pa_UnitListView_ctr {
-  height: 400px;
+  max-height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
@@ -240,7 +115,7 @@ exports[`<OlympicsSchedule> renders with wrapHelmetProvider 1`] = `
 }
 
 .c0 .pa-schedule .pa_UnitListView_ctr {
-  height: 400px;
+  max-height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`<OlympicsSchedule> click show all 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
+  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
@@ -148,6 +149,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
+  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
@@ -272,6 +274,7 @@ exports[`<OlympicsSchedule> renders with wrapHelmetProvider 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
+  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
   background-color: #F9F9F9;
   color: #1D1D1B;
+  border-bottom: 1px solid #DBDBDB;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
@@ -93,7 +94,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
 </DocumentFragment>
 `;
 
-exports[`<OlympicsSchedule> renders with wrapHelmetProvider 1`] = `
+exports[`<OlympicsSchedule> renders outside of article 1`] = `
 <DocumentFragment>
   .c0 {
   position: relative;
@@ -126,6 +127,7 @@ exports[`<OlympicsSchedule> renders with wrapHelmetProvider 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
   background-color: #F9F9F9;
   color: #1D1D1B;
+  border-bottom: 1px solid #DBDBDB;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
@@ -160,18 +162,6 @@ exports[`<OlympicsSchedule> renders with wrapHelmetProvider 1`] = `
 
 .c0 .pa-schedule .pa_ErrorMessage_ctr {
   background: #ededed;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    width: 80.8%;
-  }
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    width: 56.2%;
-  }
 }
 
 <div

--- a/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.stories.tsx
+++ b/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import { OlympicsMedalTable } from './OlympicsMedalTable';
 import { ArticleHarness } from '../../../fixtures/article-harness/ArticleHarness';
-import { text, select } from '@storybook/addon-knobs';
+import { text, select, boolean } from '@storybook/addon-knobs';
 
 storiesOf('Typescript Component/Olympics', module)
   .addDecorator((storyFn: () => React.ReactNode) => (
@@ -22,11 +22,13 @@ storiesOf('Typescript Component/Olympics', module)
     const authToken = text('Auth Token', '6i3DuEwbVhr2Fht6');
     const gamesCode = text('Games Code', 'OG2020-TR2');
     const highlighted = text('Highlighted Country', 'GBR');
+    const inArticle = boolean('Is In Article', true);
 
     return (
       <OlympicsMedalTable
         keys={{ endpoint, authToken, gamesCode }}
         highlighted={highlighted}
+        inArticle={inArticle}
       />
     );
   });

--- a/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.tsx
+++ b/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.tsx
@@ -8,11 +8,12 @@ export const OlympicsMedalTable: FC<{
   highlighted?: string;
   keys: OlympicsKeys;
   sectionColor?: string;
-  wrapHelmetProvider?: boolean;
+  inArticle?: boolean;
 }> = ({
   keys: { endpoint, authToken, gamesCode },
   highlighted = 'GBR',
-  sectionColor = colours.section.sport
+  sectionColor = colours.section.sport,
+  inArticle = true
 }) => {
   const [showAll, setShowAll] = useState(false);
   const handleShowAll = () => {
@@ -23,7 +24,11 @@ export const OlympicsMedalTable: FC<{
   }, []);
 
   return (
-    <Container sectionColour={sectionColor} showAll={showAll}>
+    <Container
+      sectionColour={sectionColor}
+      showAll={showAll}
+      inArticle={inArticle}
+    >
       <div
         className="pa-medaltable"
         data-auth-token={authToken}

--- a/packages/ts-components/src/components/olympics/medal-table/styles.ts
+++ b/packages/ts-components/src/components/olympics/medal-table/styles.ts
@@ -1,19 +1,21 @@
 import styled from 'styled-components';
 import { breakpoints, colours, fonts } from '@times-components/styleguide';
 
+const highlightColour = '#e4e4e4';
 export const Container = styled.div<{
   sectionColour: string;
   showAll: boolean;
+  inArticle: boolean;
 }>`
   position: relative;
   margin: 0 auto 20px auto;
 
   @media (min-width: ${breakpoints.medium}px) {
-    width: 80.8%;
+    width: ${({ inArticle }) => (inArticle ? `80.8%` : undefined)};
   }
 
   @media (min-width: ${breakpoints.wide}px) {
-    width: 56.2%;
+    width: ${({ inArticle }) => (inArticle ? `56.2%` : undefined)};
   }
 
   .pa-medaltable {
@@ -75,7 +77,7 @@ export const Container = styled.div<{
 
           &.pa_MedalTableView_highlight {
             display: table-row;
-            background-color: #e4e4e4;
+            background-color: ${highlightColour};
           }
         }
       }
@@ -102,4 +104,10 @@ export const Button = styled.button`
 
   top: -80px;
   position: relative;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${highlightColour};
+  }
 `;

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.stories.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.stories.tsx
@@ -17,7 +17,7 @@ storiesOf('Typescript Component/Olympics', module)
         staging: 'https://olympics-embed-staging.pamedia.io',
         prod: 'https://olympics-embed.pamedia.io'
       },
-      'https://olympics-embed-staging.pamedia.io'
+      'https://olympics-embed-staging.pamedia.io/'
     );
     const authToken = text('Auth Token', '6i3DuEwbVhr2Fht6');
     const gamesCode = text('Games Code', 'OG2020-TR2');

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.stories.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import { OlympicsSchedule } from './OlympicsSchedule';
 import { ArticleHarness } from '../../../fixtures/article-harness/ArticleHarness';
-import { text, select } from '@storybook/addon-knobs';
+import { text, select, boolean } from '@storybook/addon-knobs';
 
 storiesOf('Typescript Component/Olympics', module)
   .addDecorator((storyFn: () => React.ReactNode) => (
@@ -17,10 +17,16 @@ storiesOf('Typescript Component/Olympics', module)
         staging: 'https://olympics-embed-staging.pamedia.io',
         prod: 'https://olympics-embed.pamedia.io'
       },
-      'https://olympics-embed-staging.pamedia.io/'
+      'https://olympics-embed-staging.pamedia.io'
     );
     const authToken = text('Auth Token', '6i3DuEwbVhr2Fht6');
     const gamesCode = text('Games Code', 'OG2020-TR2');
+    const inArticle = boolean('Is In Article', true);
 
-    return <OlympicsSchedule keys={{ endpoint, authToken, gamesCode }} />;
+    return (
+      <OlympicsSchedule
+        keys={{ endpoint, authToken, gamesCode }}
+        inArticle={inArticle}
+      />
+    );
   });

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -16,6 +16,20 @@ export const OlympicsSchedule: FC<{
 }) => {
   useEffect(() => {
     injectScript(`${endpoint}/static/schedule.js`);
+    window.addEventListener(
+      'wheel',
+      event => {
+        if (
+          event
+            .composedPath()
+            // @ts-ignore
+            .includes(document.querySelector('.pa_UnitListView_ctr'))
+        ) {
+          event.stopImmediatePropagation();
+        }
+      },
+      true
+    )
   }, []);
 
   return (

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect } from 'react';
+
 import { Container } from './styles';
 import { colours } from '@times-components/styleguide';
 

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -9,10 +9,11 @@ import { injectScript } from '../../../helpers/widgets/inject-script';
 export const OlympicsSchedule: FC<{
   keys: OlympicsKeys;
   sectionColor?: string;
-  wrapHelmetProvider?: boolean;
+  inArticle?: boolean;
 }> = ({
   keys: { endpoint, authToken, gamesCode },
-  sectionColor = colours.section.sport
+  sectionColor = colours.section.sport,
+  inArticle = true
 }) => {
   useEffect(() => {
     injectScript(`${endpoint}/static/schedule.js`);
@@ -36,7 +37,7 @@ export const OlympicsSchedule: FC<{
   }, []);
 
   return (
-    <Container sectionColour={sectionColor}>
+    <Container sectionColour={sectionColor} inArticle={inArticle}>
       <div
         className="pa-schedule"
         data-auth-token={authToken}

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -1,9 +1,8 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect } from 'react';
 import { Container } from './styles';
 import { colours } from '@times-components/styleguide';
 
 import { OlympicsKeys } from '../types';
-import { Button } from '../medal-table/styles';
 import { injectScript } from '../../../helpers/widgets/inject-script';
 
 export const OlympicsSchedule: FC<{
@@ -14,27 +13,18 @@ export const OlympicsSchedule: FC<{
   keys: { endpoint, authToken, gamesCode },
   sectionColor = colours.section.sport
 }) => {
-  const [showAll, setShowAll] = useState(false);
-  const handleShowAll = () => {
-    setShowAll(!showAll);
-  };
 
   useEffect(() => {
     injectScript(`${endpoint}/static/schedule.js`);
   }, []);
 
   return (
-    <Container sectionColour={sectionColor} showAll={showAll}>
+    <Container sectionColour={sectionColor}>
       <div
         className="pa-schedule"
         data-auth-token={authToken}
         data-games-code={gamesCode}
       />
-      <div className="buttonContainer">
-        <Button onClick={handleShowAll}>
-          {showAll ? 'Collapse' : 'Show All'}
-        </Button>
-      </div>
     </Container>
   );
 };

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -14,7 +14,6 @@ export const OlympicsSchedule: FC<{
   keys: { endpoint, authToken, gamesCode },
   sectionColor = colours.section.sport
 }) => {
-
   useEffect(() => {
     injectScript(`${endpoint}/static/schedule.js`);
   }, []);

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -16,6 +16,9 @@ export const OlympicsSchedule: FC<{
 }) => {
   useEffect(() => {
     injectScript(`${endpoint}/static/schedule.js`);
+  }, []);
+
+  useEffect(() => {
     window.addEventListener(
       'wheel',
       event => {
@@ -29,7 +32,7 @@ export const OlympicsSchedule: FC<{
         }
       },
       true
-    )
+    );
   }, []);
 
   return (

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -3,16 +3,17 @@ import { breakpoints, colours, fonts } from '@times-components/styleguide';
 
 export const Container = styled.div<{
   sectionColour: string;
+  inArticle: boolean;
 }>`
   position: relative;
   margin: 0 auto 20px auto;
 
   @media (min-width: ${breakpoints.medium}px) {
-    width: 80.8%;
+    width: ${({ inArticle }) => (inArticle ? `80.8%` : undefined)};
   }
 
   @media (min-width: ${breakpoints.wide}px) {
-    width: 56.2%;
+    width: ${({ inArticle }) => (inArticle ? `56.2%` : undefined)};
   }
 
   .pa-schedule {
@@ -42,6 +43,7 @@ export const Container = styled.div<{
         ul.pa_UnitListView_list li {
           background-color: ${colours.functional.backgroundPrimary};
           color: ${colours.functional.brandColour};
+          border-bottom: 1px solid ${colours.functional.keyline};
         }
 
         .pa_UnitListView_unit-time {

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -31,7 +31,7 @@ export const Container = styled.div<{
     }
 
     .pa_UnitListView_ctr {
-      height: 400px;
+      max-height: 400px;
     }
 
     .pa_LoadingOverlayContainer_ctr {

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -3,7 +3,6 @@ import { breakpoints, colours, fonts } from '@times-components/styleguide';
 
 export const Container = styled.div<{
   sectionColour: string;
-  showAll: boolean;
 }>`
   position: relative;
   margin: 0 auto 20px auto;
@@ -30,20 +29,20 @@ export const Container = styled.div<{
       background: ${colours.functional.backgroundSecondary};
       font-size: 16px;
     }
+    
+    .pa_UnitListView_ctr {
+      height: 400px;
+    }
 
     .pa_LoadingOverlayContainer_ctr {
       .pa_UnitListView_ctr {
         font-family: ${fonts.supporting};
         font-size: 16px;
-        height: 400px;
 
         ul.pa_UnitListView_list li {
           background-color: ${colours.functional.backgroundPrimary};
           color: ${colours.functional.brandColour};
 
-          &:nth-child(n + 8) {
-            display: ${({ showAll }) => (showAll ? 'block' : 'none')};
-          }
         }
 
         .pa_UnitListView_unit-time {
@@ -83,14 +82,6 @@ export const Container = styled.div<{
 
     .pa_ErrorMessage_ctr {
       background: #ededed;
-    }
-  }
-  .buttonContainer {
-    text-align: center;
-    height: 0;
-
-    button {
-      background-color: ${colours.functional.backgroundPrimary};
     }
   }
 `;

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -35,6 +35,7 @@ export const Container = styled.div<{
       .pa_UnitListView_ctr {
         font-family: ${fonts.supporting};
         font-size: 16px;
+        height: 400px;
 
         ul.pa_UnitListView_list li {
           background-color: ${colours.functional.backgroundPrimary};

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -32,7 +32,7 @@ export const Container = styled.div<{
     }
 
     .pa_UnitListView_ctr {
-      max-height: 400px;
+      height: 400px;
     }
 
     .pa_LoadingOverlayContainer_ctr {

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -65,8 +65,6 @@ export const Container = styled.div<{
 
     .pa_OdfFooter_ctr {
       font-family: ${fonts.supporting};
-      top: 60px;
-      position: relative;
       font-size: 12px;
     }
 
@@ -76,7 +74,6 @@ export const Container = styled.div<{
     }
 
     .pa_Schedule_ctr {
-      padding-bottom: 60px;
       background: ${colours.functional.backgroundSecondary};
     }
 

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -29,7 +29,7 @@ export const Container = styled.div<{
       background: ${colours.functional.backgroundSecondary};
       font-size: 16px;
     }
-    
+
     .pa_UnitListView_ctr {
       height: 400px;
     }
@@ -42,7 +42,6 @@ export const Container = styled.div<{
         ul.pa_UnitListView_list li {
           background-color: ${colours.functional.backgroundPrimary};
           color: ${colours.functional.brandColour};
-
         }
 
         .pa_UnitListView_unit-time {


### PR DESCRIPTION
Enable scroll on the olympics schedule widget. -- Remove show all button as is no longer required, and adjust footer height. 
<img width="531" alt="Screenshot 2021-07-26 at 11 33 44" src="https://user-images.githubusercontent.com/44647540/126976455-bb63e4ff-e3d3-4cb3-9edd-af42436cddcd.png">
<img width="587" alt="Screenshot 2021-07-26 at 11 43 04" src="https://user-images.githubusercontent.com/44647540/126976606-65169c35-3127-4b50-ae98-5e020a4415ca.png">

