### PR TITLE
Fix/add headings to olympic widgets

### DIFF
--- a/packages/ts-components/src/components/olympics/__tests__/OlympicsSchedule.test.tsx
+++ b/packages/ts-components/src/components/olympics/__tests__/OlympicsSchedule.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import 'regenerator-runtime';
 import 'jest-styled-components';
@@ -27,6 +27,15 @@ describe('<OlympicsSchedule>', () => {
     const { asFragment } = render(
       <OlympicsSchedule keys={keys} inArticle={false} />
     );
+    expect(asFragment()).toMatchSnapshot();
+  });
+  it('click show all', async () => {
+    const { asFragment, getByText, findByText } = render(
+      <OlympicsSchedule keys={keys} sectionColor="sectionColor" />
+    );
+    fireEvent.click(getByText('Show All'));
+    await findByText('Collapse');
+
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsMedalTable.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsMedalTable.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<OlympicsMedalTable> click show all 1`] = `
 <DocumentFragment>
   .c0 {
+  border-top: 2px solid sectionColor;
   position: relative;
   margin: 0 auto 20px auto;
 }
@@ -84,6 +85,26 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
 }
 
 .c1 {
+  background: #F9F9F9;
+  padding: 20px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.c2 {
+  font-size: 12px;
+  line-height: 14px;
+  color: sectionColor;
+  font-family: GillSansMTStd-Medium;
+  font-weight: normal;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.c3 {
   font-family: GillSansMTStd-Medium;
   font-size: 14px;
   line-height: 20px;
@@ -94,7 +115,7 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
   cursor: pointer;
 }
 
-.c1:hover {
+.c3:hover {
   background-color: #e4e4e4;
 }
 
@@ -113,6 +134,15 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
 <div
     class="c0"
   >
+    <h2
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        Medal Table - Olympics Tokyo 2020
+      </div>
+    </h2>
     <div
       class="pa-medaltable"
       data-auth-token="token"
@@ -124,7 +154,7 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
       class="buttonContainer"
     >
       <button
-        class="c1"
+        class="c3"
       >
         Collapse
       </button>
@@ -136,6 +166,7 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
 exports[`<OlympicsMedalTable> renders 1`] = `
 <DocumentFragment>
   .c0 {
+  border-top: 2px solid #008347;
   position: relative;
   margin: 0 auto 20px auto;
 }
@@ -217,6 +248,26 @@ exports[`<OlympicsMedalTable> renders 1`] = `
 }
 
 .c1 {
+  background: #F9F9F9;
+  padding: 20px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.c2 {
+  font-size: 12px;
+  line-height: 14px;
+  color: #008347;
+  font-family: GillSansMTStd-Medium;
+  font-weight: normal;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.c3 {
   font-family: GillSansMTStd-Medium;
   font-size: 14px;
   line-height: 20px;
@@ -227,7 +278,7 @@ exports[`<OlympicsMedalTable> renders 1`] = `
   cursor: pointer;
 }
 
-.c1:hover {
+.c3:hover {
   background-color: #e4e4e4;
 }
 
@@ -246,6 +297,15 @@ exports[`<OlympicsMedalTable> renders 1`] = `
 <div
     class="c0"
   >
+    <h2
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        Medal Table - Olympics Tokyo 2020
+      </div>
+    </h2>
     <div
       class="pa-medaltable"
       data-auth-token="token"
@@ -257,7 +317,7 @@ exports[`<OlympicsMedalTable> renders 1`] = `
       class="buttonContainer"
     >
       <button
-        class="c1"
+        class="c3"
       >
         Show All
       </button>
@@ -269,6 +329,7 @@ exports[`<OlympicsMedalTable> renders 1`] = `
 exports[`<OlympicsMedalTable> renders outside of article 1`] = `
 <DocumentFragment>
   .c0 {
+  border-top: 2px solid #008347;
   position: relative;
   margin: 0 auto 20px auto;
 }
@@ -350,6 +411,26 @@ exports[`<OlympicsMedalTable> renders outside of article 1`] = `
 }
 
 .c1 {
+  background: #F9F9F9;
+  padding: 20px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.c2 {
+  font-size: 12px;
+  line-height: 14px;
+  color: #008347;
+  font-family: GillSansMTStd-Medium;
+  font-weight: normal;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.c3 {
   font-family: GillSansMTStd-Medium;
   font-size: 14px;
   line-height: 20px;
@@ -360,13 +441,22 @@ exports[`<OlympicsMedalTable> renders outside of article 1`] = `
   cursor: pointer;
 }
 
-.c1:hover {
+.c3:hover {
   background-color: #e4e4e4;
 }
 
 <div
     class="c0"
   >
+    <h2
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        Medal Table - Olympics Tokyo 2020
+      </div>
+    </h2>
     <div
       class="pa-medaltable"
       data-auth-token="token"
@@ -378,7 +468,7 @@ exports[`<OlympicsMedalTable> renders outside of article 1`] = `
       class="buttonContainer"
     >
       <button
-        class="c1"
+        class="c3"
       >
         Show All
       </button>

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
+  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
@@ -122,6 +123,7 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
+  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
 }
 
 .c0 .pa-schedule .pa_UnitListView_ctr {
-  max-height: 400px;
+  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
@@ -140,7 +140,7 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 }
 
 .c0 .pa-schedule .pa_UnitListView_ctr {
-  max-height: 400px;
+  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -24,9 +24,10 @@ exports[`<OlympicsSchedule> renders 1`] = `
   height: 400px;
 }
 
-exports[`<OlympicsSchedule> renders 1`] = `
+exports[`<OlympicsSchedule> click show all 1`] = `
 <DocumentFragment>
   .c0 {
+  border-top: 2px solid sectionColor;
   position: relative;
   margin: 0 auto 20px auto;
 }
@@ -45,10 +46,6 @@ exports[`<OlympicsSchedule> renders 1`] = `
   font-size: 16px;
 }
 
-.c0 .pa-schedule .pa_UnitListView_ctr {
-  height: 400px;
-}
-
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
@@ -57,28 +54,46 @@ exports[`<OlympicsSchedule> renders 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
   background-color: #F9F9F9;
   color: #1D1D1B;
+  padding: 10px 6px 8px 10px;
   border-bottom: 1px solid #DBDBDB;
 }
 
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li:nth-child(n + 8) {
+  display: block;
+}
+
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
-  color: #008347;
+  color: sectionColor;
   line-height: 30px;
+  position: absolute;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-text {
   font-family: GillSansMTStd-Medium;
-  font-size: 14px;
+  font-size: 16px;
+  margin-right: 50px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_discipline {
   font-family: TimesModern-Bold;
   text-transform: capitalize;
   font-weight: 400;
+  padding-bottom: 4px;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
+  position: relative;
+  left: calc(100% - 65px);
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .c0 .pa-schedule .pa_OdfFooter_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
+  top: 60px;
+  position: relative;
 }
 
 .c0 .pa-schedule .pa_UnitListView_message {
@@ -88,10 +103,59 @@ exports[`<OlympicsSchedule> renders 1`] = `
 
 .c0 .pa-schedule .pa_Schedule_ctr {
   background: #EDEDED;
+  padding-bottom: 60px;
 }
 
 .c0 .pa-schedule .pa_ErrorMessage_ctr {
   background: #ededed;
+}
+
+.c0 .buttonContainer {
+  text-align: center;
+  height: 0;
+}
+
+.c0 .buttonContainer button {
+  background-color: #F9F9F9;
+}
+
+.c0 .buttonContainer button:hover {
+  background-color: #EDEDED;
+}
+
+.c1 {
+  background: #F9F9F9;
+  padding: 20px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.c2 {
+  font-size: 12px;
+  line-height: 14px;
+  color: sectionColor;
+  font-family: GillSansMTStd-Medium;
+  font-weight: normal;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.c3 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c3:hover {
+  background-color: #e4e4e4;
 }
 
 @media (min-width:768px) {
@@ -106,21 +170,46 @@ exports[`<OlympicsSchedule> renders 1`] = `
   }
 }
 
+@media only screen and (min-width:321px) {
+  .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
+    left: calc(100% - 75px);
+  }
+}
+
 <div
     class="c0"
   >
+    <h2
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        Event Schedule - Olympics Tokyo 2020
+      </div>
+    </h2>
     <div
       class="pa-schedule"
       data-auth-token="token"
       data-games-code="OG1896"
     />
+    <div
+      class="buttonContainer"
+    >
+      <button
+        class="c3"
+      >
+        Collapse
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
-exports[`<OlympicsSchedule> renders outside of article 1`] = `
+exports[`<OlympicsSchedule> renders 1`] = `
 <DocumentFragment>
   .c0 {
+  border-top: 2px solid #008347;
   position: relative;
   margin: 0 auto 20px auto;
 }
@@ -139,8 +228,186 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
   font-size: 16px;
 }
 
-.c0 .pa-schedule .pa_UnitListView_ctr {
-  height: 400px;
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
+  font-family: GillSansMTStd-Medium;
+  font-size: 16px;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
+  background-color: #F9F9F9;
+  color: #1D1D1B;
+  padding: 10px 6px 8px 10px;
+  border-bottom: 1px solid #DBDBDB;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li:nth-child(n + 8) {
+  display: none;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
+  color: #008347;
+  line-height: 30px;
+  position: absolute;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-text {
+  font-family: GillSansMTStd-Medium;
+  font-size: 16px;
+  margin-right: 50px;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_discipline {
+  font-family: TimesModern-Bold;
+  text-transform: capitalize;
+  font-weight: 400;
+  padding-bottom: 4px;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
+  position: relative;
+  left: calc(100% - 65px);
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c0 .pa-schedule .pa_OdfFooter_ctr {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  top: 60px;
+  position: relative;
+}
+
+.c0 .pa-schedule .pa_UnitListView_message {
+  min-height: 70px;
+  background-color: #F9F9F9;
+}
+
+.c0 .pa-schedule .pa_Schedule_ctr {
+  background: #EDEDED;
+  padding-bottom: 60px;
+}
+
+.c0 .pa-schedule .pa_ErrorMessage_ctr {
+  background: #ededed;
+}
+
+.c0 .buttonContainer {
+  text-align: center;
+  height: 0;
+}
+
+.c0 .buttonContainer button {
+  background-color: #F9F9F9;
+}
+
+.c0 .buttonContainer button:hover {
+  background-color: #EDEDED;
+}
+
+.c1 {
+  background: #F9F9F9;
+  padding: 20px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.c2 {
+  font-size: 12px;
+  line-height: 14px;
+  color: #008347;
+  font-family: GillSansMTStd-Medium;
+  font-weight: normal;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.c3 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c3:hover {
+  background-color: #e4e4e4;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    width: 80.8%;
+  }
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    width: 56.2%;
+  }
+}
+
+@media only screen and (min-width:321px) {
+  .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
+    left: calc(100% - 75px);
+  }
+}
+
+<div
+    class="c0"
+  >
+    <h2
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        Event Schedule - Olympics Tokyo 2020
+      </div>
+    </h2>
+    <div
+      class="pa-schedule"
+      data-auth-token="token"
+      data-games-code="OG1896"
+    />
+    <div
+      class="buttonContainer"
+    >
+      <button
+        class="c3"
+      >
+        Show All
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<OlympicsSchedule> renders outside of article 1`] = `
+<DocumentFragment>
+  .c0 {
+  border-top: 2px solid #008347;
+  position: relative;
+  margin: 0 auto 20px auto;
+}
+
+.c0 .pa-schedule .pa_ScheduleHeader_header {
+  color: #1D1D1B;
+  font-family: GillSansMTStd-Medium;
+  font-size: 18px;
+  background: #EDEDED;
+}
+
+.c0 .pa-schedule .pa_ScheduleHeader_filterbar {
+  color: #1D1D1B;
+  font-family: GillSansMTStd-Medium;
+  background: #EDEDED;
+  font-size: 16px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
@@ -151,28 +418,46 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
   background-color: #F9F9F9;
   color: #1D1D1B;
+  padding: 10px 6px 8px 10px;
   border-bottom: 1px solid #DBDBDB;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li:nth-child(n + 8) {
+  display: none;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
   color: #008347;
   line-height: 30px;
+  position: absolute;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-text {
   font-family: GillSansMTStd-Medium;
-  font-size: 14px;
+  font-size: 16px;
+  margin-right: 50px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_discipline {
   font-family: TimesModern-Bold;
   text-transform: capitalize;
   font-weight: 400;
+  padding-bottom: 4px;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
+  position: relative;
+  left: calc(100% - 65px);
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .c0 .pa-schedule .pa_OdfFooter_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 12px;
+  top: 60px;
+  position: relative;
 }
 
 .c0 .pa-schedule .pa_UnitListView_message {
@@ -182,20 +467,93 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 
 .c0 .pa-schedule .pa_Schedule_ctr {
   background: #EDEDED;
+  padding-bottom: 60px;
 }
 
 .c0 .pa-schedule .pa_ErrorMessage_ctr {
   background: #ededed;
 }
 
+.c0 .buttonContainer {
+  text-align: center;
+  height: 0;
+}
+
+.c0 .buttonContainer button {
+  background-color: #F9F9F9;
+}
+
+.c0 .buttonContainer button:hover {
+  background-color: #EDEDED;
+}
+
+.c1 {
+  background: #F9F9F9;
+  padding: 20px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.c2 {
+  font-size: 12px;
+  line-height: 14px;
+  color: #008347;
+  font-family: GillSansMTStd-Medium;
+  font-weight: normal;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.c3 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c3:hover {
+  background-color: #e4e4e4;
+}
+
+@media only screen and (min-width:321px) {
+  .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
+    left: calc(100% - 75px);
+  }
+}
+
 <div
     class="c0"
   >
+    <h2
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        Event Schedule - Olympics Tokyo 2020
+      </div>
+    </h2>
     <div
       class="pa-schedule"
       data-auth-token="token"
       data-games-code="OG1896"
     />
+    <div
+      class="buttonContainer"
+    >
+      <button
+        class="c3"
+      >
+        Show All
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -25,16 +25,144 @@ exports[`<OlympicsSchedule> renders 1`] = `
   height: 400px;
 }
 
+<<<<<<< HEAD
+=======
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
+  background-color: #F9F9F9;
+  color: #1D1D1B;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li:nth-child(n + 8) {
+  display: block;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
+  color: sectionColor;
+  line-height: 30px;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-text {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+}
+
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_discipline {
+  font-family: TimesModern-Bold;
+  text-transform: capitalize;
+  font-weight: 400;
+}
+
+.c0 .pa-schedule .pa_OdfFooter_ctr {
+  font-family: GillSansMTStd-Medium;
+  top: 60px;
+  position: relative;
+  font-size: 12px;
+}
+
+.c0 .pa-schedule .pa_UnitListView_message {
+  min-height: 70px;
+  background-color: #F9F9F9;
+}
+
+.c0 .pa-schedule .pa_Schedule_ctr {
+  padding-bottom: 60px;
+  background: #EDEDED;
+}
+
+.c0 .pa-schedule .pa_ErrorMessage_ctr {
+  background: #ededed;
+}
+
+.c0 .buttonContainer {
+  text-align: center;
+  height: 0;
+}
+
+.c0 .buttonContainer button {
+  background-color: #F9F9F9;
+}
+
+.c1 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    width: 80.8%;
+  }
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    width: 56.2%;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="pa-schedule"
+      data-auth-token="token"
+      data-games-code="OG1896"
+    />
+    <div
+      class="buttonContainer"
+    >
+      <button
+        class="c1"
+      >
+        Collapse
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<OlympicsSchedule> renders 1`] = `
+<DocumentFragment>
+  .c0 {
+  position: relative;
+  margin: 0 auto 20px auto;
+}
+
+.c0 .pa-schedule .pa_ScheduleHeader_header {
+  color: #1D1D1B;
+  font-family: GillSansMTStd-Medium;
+  font-size: 18px;
+  background: #EDEDED;
+}
+
+.c0 .pa-schedule .pa_ScheduleHeader_filterbar {
+  color: #1D1D1B;
+  font-family: GillSansMTStd-Medium;
+  background: #EDEDED;
+  font-size: 16px;
+}
+
+.c0 .pa-schedule .pa_UnitListView_ctr {
+  height: 400px;
+}
+
+>>>>>>> Fix linting and tests
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
-  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
   background-color: #F9F9F9;
   color: #1D1D1B;
+<<<<<<< HEAD
   border-bottom: 1px solid #DBDBDB;
+=======
+>>>>>>> Fix linting and tests
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
@@ -123,13 +251,15 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
-  height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
   background-color: #F9F9F9;
   color: #1D1D1B;
+<<<<<<< HEAD
   border-bottom: 1px solid #DBDBDB;
+=======
+>>>>>>> Fix linting and tests
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
@@ -166,6 +296,21 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
   background: #ededed;
 }
 
+<<<<<<< HEAD
+=======
+@media (min-width:768px) {
+  .c0 {
+    width: 80.8%;
+  }
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    width: 56.2%;
+  }
+}
+
+>>>>>>> Fix linting and tests
 <div
     class="c0"
   >

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-
 exports[`<OlympicsSchedule> renders 1`] = `
 <DocumentFragment>
   .c0 {
@@ -25,106 +24,6 @@ exports[`<OlympicsSchedule> renders 1`] = `
   height: 400px;
 }
 
-<<<<<<< HEAD
-=======
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
-  background-color: #F9F9F9;
-  color: #1D1D1B;
-}
-
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li:nth-child(n + 8) {
-  display: block;
-}
-
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
-  color: sectionColor;
-  line-height: 30px;
-}
-
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-text {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-}
-
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_discipline {
-  font-family: TimesModern-Bold;
-  text-transform: capitalize;
-  font-weight: 400;
-}
-
-.c0 .pa-schedule .pa_OdfFooter_ctr {
-  font-family: GillSansMTStd-Medium;
-  top: 60px;
-  position: relative;
-  font-size: 12px;
-}
-
-.c0 .pa-schedule .pa_UnitListView_message {
-  min-height: 70px;
-  background-color: #F9F9F9;
-}
-
-.c0 .pa-schedule .pa_Schedule_ctr {
-  padding-bottom: 60px;
-  background: #EDEDED;
-}
-
-.c0 .pa-schedule .pa_ErrorMessage_ctr {
-  background: #ededed;
-}
-
-.c0 .buttonContainer {
-  text-align: center;
-  height: 0;
-}
-
-.c0 .buttonContainer button {
-  background-color: #F9F9F9;
-}
-
-.c1 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    width: 80.8%;
-  }
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    width: 56.2%;
-  }
-}
-
-<div
-    class="c0"
-  >
-    <div
-      class="pa-schedule"
-      data-auth-token="token"
-      data-games-code="OG1896"
-    />
-    <div
-      class="buttonContainer"
-    >
-      <button
-        class="c1"
-      >
-        Collapse
-      </button>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`<OlympicsSchedule> renders 1`] = `
 <DocumentFragment>
   .c0 {
@@ -147,7 +46,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
 }
 
 .c0 .pa-schedule .pa_UnitListView_ctr {
-  height: 400px;
+  max-height: 400px;
 }
 
 >>>>>>> Fix linting and tests
@@ -245,7 +144,7 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 }
 
 .c0 .pa-schedule .pa_UnitListView_ctr {
-  height: 400px;
+  max-height: 400px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
@@ -256,10 +155,7 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
   background-color: #F9F9F9;
   color: #1D1D1B;
-<<<<<<< HEAD
   border-bottom: 1px solid #DBDBDB;
-=======
->>>>>>> Fix linting and tests
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
@@ -296,21 +192,6 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
   background: #ededed;
 }
 
-<<<<<<< HEAD
-=======
-@media (min-width:768px) {
-  .c0 {
-    width: 80.8%;
-  }
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    width: 56.2%;
-  }
-}
-
->>>>>>> Fix linting and tests
 <div
     class="c0"
   >

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -1,28 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-exports[`<OlympicsSchedule> renders 1`] = `
-<DocumentFragment>
-  .c0 {
-  position: relative;
-  margin: 0 auto 20px auto;
-}
-
-.c0 .pa-schedule .pa_ScheduleHeader_header {
-  color: #1D1D1B;
-  font-family: GillSansMTStd-Medium;
-  font-size: 18px;
-  background: #EDEDED;
-}
-
-.c0 .pa-schedule .pa_ScheduleHeader_filterbar {
-  color: #1D1D1B;
-  font-family: GillSansMTStd-Medium;
-  background: #EDEDED;
-  font-size: 16px;
-}
-
-.c0 .pa-schedule .pa_UnitListView_ctr {
-  height: 400px;
-}
 
 exports[`<OlympicsSchedule> click show all 1`] = `
 <DocumentFragment>

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -49,7 +49,6 @@ exports[`<OlympicsSchedule> renders 1`] = `
   max-height: 400px;
 }
 
->>>>>>> Fix linting and tests
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
@@ -58,10 +57,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr ul.pa_UnitListView_list li {
   background-color: #F9F9F9;
   color: #1D1D1B;
-<<<<<<< HEAD
   border-bottom: 1px solid #DBDBDB;
-=======
->>>>>>> Fix linting and tests
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {

--- a/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.tsx
+++ b/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
 import { colours } from '@times-components/styleguide';
-import { Container, Button } from './styles';
-import { Heading, Span } from '../shared-styles';
+import { Container } from './styles';
+import { HeadingContainer, Heading, Button } from '../shared-styles';
 import { OlympicsKeys } from '../types';
 import { injectScript } from '../../../helpers/widgets/inject-script';
 
@@ -30,7 +30,11 @@ export const OlympicsMedalTable: FC<{
       showAll={showAll}
       inArticle={inArticle}
     >
-      <Heading><Span sectionColour={sectionColor}>Olympics Tokyo 2020 - Medal Table</Span></Heading>
+      <HeadingContainer>
+        <Heading sectionColour={sectionColor}>
+          Medal Table - Olympics Tokyo 2020
+        </Heading>
+      </HeadingContainer>
       <div
         className="pa-medaltable"
         data-auth-token={authToken}

--- a/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.tsx
+++ b/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
 import { colours } from '@times-components/styleguide';
 import { Container, Button } from './styles';
+import { Heading, Span } from '../shared-styles';
 import { OlympicsKeys } from '../types';
 import { injectScript } from '../../../helpers/widgets/inject-script';
 
@@ -29,6 +30,7 @@ export const OlympicsMedalTable: FC<{
       showAll={showAll}
       inArticle={inArticle}
     >
+      <Heading><Span sectionColour={sectionColor}>Olympics Tokyo 2020 - Medal Table</Span></Heading>
       <div
         className="pa-medaltable"
         data-auth-token={authToken}

--- a/packages/ts-components/src/components/olympics/medal-table/styles.ts
+++ b/packages/ts-components/src/components/olympics/medal-table/styles.ts
@@ -95,20 +95,3 @@ export const Container = styled.div<{
     height: 0;
   }
 `;
-
-export const Button = styled.button`
-  font-family: ${fonts.supporting};
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid ${colours.functional.keyline};
-
-  top: -80px;
-  position: relative;
-
-  cursor: pointer;
-
-  &:hover {
-    background-color: ${highlightColour};
-  }
-`;

--- a/packages/ts-components/src/components/olympics/medal-table/styles.ts
+++ b/packages/ts-components/src/components/olympics/medal-table/styles.ts
@@ -7,6 +7,7 @@ export const Container = styled.div<{
   showAll: boolean;
   inArticle: boolean;
 }>`
+  border-top: 2px solid ${({ sectionColour }) => sectionColour};
   position: relative;
   margin: 0 auto 20px auto;
 

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.stories.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.stories.tsx
@@ -17,7 +17,7 @@ storiesOf('Typescript Component/Olympics', module)
         staging: 'https://olympics-embed-staging.pamedia.io',
         prod: 'https://olympics-embed.pamedia.io'
       },
-      'https://olympics-embed-staging.pamedia.io/'
+      'https://olympics-embed-staging.pamedia.io'
     );
     const authToken = text('Auth Token', '6i3DuEwbVhr2Fht6');
     const gamesCode = text('Games Code', 'OG2020-TR2');

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.stories.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.stories.tsx
@@ -17,7 +17,7 @@ storiesOf('Typescript Component/Olympics', module)
         staging: 'https://olympics-embed-staging.pamedia.io',
         prod: 'https://olympics-embed.pamedia.io'
       },
-      'https://olympics-embed-staging.pamedia.io'
+      'https://olympics-embed-staging.pamedia.io/'
     );
     const authToken = text('Auth Token', '6i3DuEwbVhr2Fht6');
     const gamesCode = text('Games Code', 'OG2020-TR2');

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useEffect } from 'react';
 import { Container } from './styles';
+import { Heading, Span } from '../shared-styles';
 import { colours } from '@times-components/styleguide';
 
 import { OlympicsKeys } from '../types';
@@ -54,11 +55,13 @@ export const OlympicsSchedule: FC<{
 
   return (
     <Container sectionColour={sectionColor} inArticle={inArticle}>
+      <Heading><Span sectionColour={sectionColor}>Olympics Tokyo 2020 - Event Schedule</Span></Heading>
       <div
         className="pa-schedule"
         data-auth-token={authToken}
         data-games-code={gamesCode}
-      />
+      >
+        </div>
     </Container>
   );
 };

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -1,8 +1,4 @@
 import React, { FC, useEffect } from 'react';
-<<<<<<< HEAD
-
-=======
->>>>>>> Remove show all buttons
 import { Container } from './styles';
 import { colours } from '@times-components/styleguide';
 
@@ -18,10 +14,6 @@ export const OlympicsSchedule: FC<{
   sectionColor = colours.section.sport,
   inArticle = true
 }) => {
-<<<<<<< HEAD
-=======
-
->>>>>>> Remove show all buttons
   useEffect(() => {
     injectScript(`${endpoint}/static/schedule.js`);
   }, []);
@@ -44,11 +36,7 @@ export const OlympicsSchedule: FC<{
   }, []);
 
   return (
-<<<<<<< HEAD
     <Container sectionColour={sectionColor} inArticle={inArticle}>
-=======
-    <Container sectionColour={sectionColor}>
->>>>>>> Remove show all buttons
       <div
         className="pa-schedule"
         data-auth-token={authToken}

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -1,5 +1,8 @@
 import React, { FC, useEffect } from 'react';
+<<<<<<< HEAD
 
+=======
+>>>>>>> Remove show all buttons
 import { Container } from './styles';
 import { colours } from '@times-components/styleguide';
 
@@ -15,6 +18,10 @@ export const OlympicsSchedule: FC<{
   sectionColor = colours.section.sport,
   inArticle = true
 }) => {
+<<<<<<< HEAD
+=======
+
+>>>>>>> Remove show all buttons
   useEffect(() => {
     injectScript(`${endpoint}/static/schedule.js`);
   }, []);
@@ -37,7 +44,11 @@ export const OlympicsSchedule: FC<{
   }, []);
 
   return (
+<<<<<<< HEAD
     <Container sectionColour={sectionColor} inArticle={inArticle}>
+=======
+    <Container sectionColour={sectionColor}>
+>>>>>>> Remove show all buttons
       <div
         className="pa-schedule"
         data-auth-token={authToken}

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -1,6 +1,7 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC, useEffect, useState } from 'react';
+
 import { Container } from './styles';
-import { Heading, Span } from '../shared-styles';
+import { HeadingContainer, Heading, Button } from '../shared-styles';
 import { colours } from '@times-components/styleguide';
 
 import { OlympicsKeys } from '../types';
@@ -36,32 +37,32 @@ export const OlympicsSchedule: FC<{
     );
   }, []);
 
-  useEffect(() => {
-    window.addEventListener(
-      'wheel',
-      event => {
-        if (
-          event
-            .composedPath()
-            // @ts-ignore
-            .includes(document.querySelector('.pa_UnitListView_ctr'))
-        ) {
-          event.stopImmediatePropagation();
-        }
-      },
-      true
-    );
-  }, []);
+  const [showAll, setShowAll] = useState(false);
+  const handleShowAll = () => {
+    setShowAll(!showAll);
+  };
 
   return (
-    <Container sectionColour={sectionColor} inArticle={inArticle}>
-      <Heading><Span sectionColour={sectionColor}>Olympics Tokyo 2020 - Event Schedule</Span></Heading>
+    <Container
+      sectionColour={sectionColor}
+      inArticle={inArticle}
+      showAll={showAll}
+    >
+      <HeadingContainer>
+        <Heading sectionColour={sectionColor}>
+          Event Schedule - Olympics Tokyo 2020
+        </Heading>
+      </HeadingContainer>
       <div
         className="pa-schedule"
         data-auth-token={authToken}
         data-games-code={gamesCode}
-      >
-        </div>
+      />
+      <div className="buttonContainer">
+        <Button onClick={handleShowAll}>
+          {showAll ? 'Collapse' : 'Show All'}
+        </Button>
+      </div>
     </Container>
   );
 };

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -16,6 +16,9 @@ export const OlympicsSchedule: FC<{
 }) => {
   useEffect(() => {
     injectScript(`${endpoint}/static/schedule.js`);
+  }, []);
+
+  useEffect(() => {
     window.addEventListener(
       'wheel',
       event => {
@@ -29,7 +32,7 @@ export const OlympicsSchedule: FC<{
         }
       },
       true
-    )
+    );
   }, []);
 
   useEffect(() => {

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -16,6 +16,20 @@ export const OlympicsSchedule: FC<{
 }) => {
   useEffect(() => {
     injectScript(`${endpoint}/static/schedule.js`);
+    window.addEventListener(
+      'wheel',
+      event => {
+        if (
+          event
+            .composedPath()
+            // @ts-ignore
+            .includes(document.querySelector('.pa_UnitListView_ctr'))
+        ) {
+          event.stopImmediatePropagation();
+        }
+      },
+      true
+    )
   }, []);
 
   useEffect(() => {

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -39,6 +39,7 @@ export const Container = styled.div<{
       .pa_UnitListView_ctr {
         font-family: ${fonts.supporting};
         font-size: 16px;
+        height: 400px;
 
         ul.pa_UnitListView_list li {
           background-color: ${colours.functional.backgroundPrimary};

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -3,6 +3,7 @@ import { breakpoints, colours, fonts } from '@times-components/styleguide';
 
 export const Container = styled.div<{
   sectionColour: string;
+  showAll: boolean;
   inArticle: boolean;
 }>`
   border-top: 2px solid ${({ sectionColour }) => sectionColour};
@@ -32,14 +33,6 @@ export const Container = styled.div<{
       font-size: 16px;
     }
 
-    .pa_UnitListView_ctr {
-      height: 400px;
-    }
-
-    .pa_UnitListView_ctr {
-      height: 400px;
-    }
-
     .pa_LoadingOverlayContainer_ctr {
       .pa_UnitListView_ctr {
         font-family: ${fonts.supporting};
@@ -48,23 +41,39 @@ export const Container = styled.div<{
         ul.pa_UnitListView_list li {
           background-color: ${colours.functional.backgroundPrimary};
           color: ${colours.functional.brandColour};
+          padding: 10px 6px 8px 10px;
+          &:nth-child(n + 8) {
+            display: ${({ showAll }) => (showAll ? 'block' : 'none')};
+          }
           border-bottom: 1px solid ${colours.functional.keyline};
         }
 
         .pa_UnitListView_unit-time {
           color: ${({ sectionColour }) => sectionColour};
           line-height: 30px;
+          position: absolute;
         }
 
         .pa_UnitListView_unit-text {
           font-family: ${fonts.supporting};
-          font-size: 14px;
+          font-size: 16px;
+          margin-right: 50px;
         }
 
         .pa_UnitListView_discipline {
           font-family: ${fonts.headline};
           text-transform: capitalize;
           font-weight: 400;
+          padding-bottom: 4px;
+        }
+
+        .pa_UnitListView_medal {
+          position: relative;
+          left: calc(100% - 65px);
+          align-self: center;
+          @media only screen and (min-width: 321px) {
+            left: calc(100% - 75px);
+          }
         }
       }
     }
@@ -72,6 +81,8 @@ export const Container = styled.div<{
     .pa_OdfFooter_ctr {
       font-family: ${fonts.supporting};
       font-size: 12px;
+      top: 60px;
+      position: relative;
     }
 
     .pa_UnitListView_message {
@@ -81,10 +92,21 @@ export const Container = styled.div<{
 
     .pa_Schedule_ctr {
       background: ${colours.functional.backgroundSecondary};
+      padding-bottom: 60px;
     }
 
     .pa_ErrorMessage_ctr {
       background: #ededed;
+    }
+  }
+  .buttonContainer {
+    text-align: center;
+    height: 0;
+    button {
+      background-color: ${colours.functional.backgroundPrimary};
+      :hover {
+        background-color: ${colours.functional.backgroundSecondary};
+      }
     }
   }
 `;

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -30,6 +30,10 @@ export const Container = styled.div<{
       background: ${colours.functional.backgroundSecondary};
       font-size: 16px;
     }
+    
+    .pa_UnitListView_ctr {
+      height: 400px;
+    }
 
     .pa_UnitListView_ctr {
       height: 400px;
@@ -39,7 +43,6 @@ export const Container = styled.div<{
       .pa_UnitListView_ctr {
         font-family: ${fonts.supporting};
         font-size: 16px;
-        height: 400px;
 
         ul.pa_UnitListView_list li {
           background-color: ${colours.functional.backgroundPrimary};

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -5,6 +5,7 @@ export const Container = styled.div<{
   sectionColour: string;
   inArticle: boolean;
 }>`
+  border-top: 2px solid ${({ sectionColour }) => sectionColour};
   position: relative;
   margin: 0 auto 20px auto;
 

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -32,7 +32,7 @@ export const Container = styled.div<{
     }
 
     .pa_UnitListView_ctr {
-      max-height: 400px;
+      height: 400px;
     }
 
     .pa_UnitListView_ctr {

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -30,7 +30,7 @@ export const Container = styled.div<{
       background: ${colours.functional.backgroundSecondary};
       font-size: 16px;
     }
-    
+
     .pa_UnitListView_ctr {
       height: 400px;
     }

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -32,7 +32,7 @@ export const Container = styled.div<{
     }
 
     .pa_UnitListView_ctr {
-      height: 400px;
+      max-height: 400px;
     }
 
     .pa_UnitListView_ctr {

--- a/packages/ts-components/src/components/olympics/shared-styles.ts
+++ b/packages/ts-components/src/components/olympics/shared-styles.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+import { colours, fonts } from '@times-components/styleguide';
+
+export const Heading = styled.h2`
+  background: ${colours.functional.backgroundPrimary};
+  padding: 20px 0 10px 0;
+  text-align: center;
+  margin: 0px;
+`;
+
+export const Span = styled.span<{ sectionColour: string }>`
+    font-size: 12px;
+    line-height: 14px;
+    color: ${({ sectionColour }) => sectionColour};
+    font-family: ${fonts.supporting};
+    font-weight: normal;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+`;

--- a/packages/ts-components/src/components/olympics/shared-styles.ts
+++ b/packages/ts-components/src/components/olympics/shared-styles.ts
@@ -1,19 +1,37 @@
 import styled from 'styled-components';
 import { colours, fonts } from '@times-components/styleguide';
 
-export const Heading = styled.h2`
+const highlightColour = '#e4e4e4';
+export const HeadingContainer = styled.h2`
   background: ${colours.functional.backgroundPrimary};
-  padding: 20px 0 10px 0;
+  padding: 20px 0;
   text-align: center;
   margin: 0px;
 `;
 
-export const Span = styled.span<{ sectionColour: string }>`
-    font-size: 12px;
-    line-height: 14px;
-    color: ${({ sectionColour }) => sectionColour};
-    font-family: ${fonts.supporting};
-    font-weight: normal;
-    text-transform: uppercase;
-    letter-spacing: 1px;
+export const Heading = styled.div<{ sectionColour: string }>`
+  font-size: 12px;
+  line-height: 14px;
+  color: ${({ sectionColour }) => sectionColour};
+  font-family: ${fonts.supporting};
+  font-weight: normal;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+`;
+
+export const Button = styled.button`
+  font-family: ${fonts.supporting};
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid ${colours.functional.keyline};
+
+  top: -80px;
+  position: relative;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${highlightColour};
+  }
 `;


### PR DESCRIPTION
Add headings like those in the football widgets to the olympics widgets. 
Change styling of schedule back to show all buttons, and move medals to the right hand side of the table. 
Other small styling tweaks. 

### Screenshots of headers
<img width="528" alt="Screenshot 2021-07-27 at 11 57 03" src="https://user-images.githubusercontent.com/44647540/127142877-80c2ae07-69cf-400a-ba46-b27125672e52.png">
<img width="528" alt="Screenshot 2021-07-27 at 11 56 49" src="https://user-images.githubusercontent.com/44647540/127142882-8f5e4fba-a9cd-4053-b91c-dc63a7f511e2.png">

### Screenshots of other changes, mainly medal change 
<img width="773" alt="Screenshot 2021-07-27 at 11 51 00" src="https://user-images.githubusercontent.com/44647540/127142922-c904246e-58bc-4d35-b93c-93d1d7b1ea6d.png">
<img width="773" alt="Screenshot 2021-07-27 at 11 50 40" src="https://user-images.githubusercontent.com/44647540/127142936-eaf9a11b-33eb-4b81-9b20-2856f37dfd87.png">
<img width="773" alt="Screenshot 2021-07-27 at 11 50 37" src="https://user-images.githubusercontent.com/44647540/127142940-ff4fb177-b2f5-48e3-a453-a3393c8e720c.png">
<img width="773" alt="Screenshot 2021-07-27 at 11 50 34" src="https://user-images.githubusercontent.com/44647540/127142944-a3daef23-eb55-4ef4-9c77-0eb5558210b8.png">
<img width="773" alt="Screenshot 2021-07-27 at 11 50 30" src="https://user-images.githubusercontent.com/44647540/127142946-9dfc6ac9-7ba0-47a6-a103-94a37f753782.png">

