### PR TITLE
Update styles of heading in olympic widgets

### DIFF
--- a/packages/ts-components/src/components/olympics/__tests__/OlympicsMedalTable.test.tsx
+++ b/packages/ts-components/src/components/olympics/__tests__/OlympicsMedalTable.test.tsx
@@ -34,11 +34,7 @@ describe('<OlympicsMedalTable>', () => {
 
   it('click show all', async () => {
     const { asFragment, getByText, findByText } = render(
-      <OlympicsMedalTable
-        keys={keys}
-        highlighted="AND"
-        sectionColor="sectionColor"
-      />
+      <OlympicsMedalTable keys={keys} highlighted="AND" />
     );
     fireEvent.click(getByText('Show All'));
     await findByText('Collapse');

--- a/packages/ts-components/src/components/olympics/__tests__/OlympicsSchedule.test.tsx
+++ b/packages/ts-components/src/components/olympics/__tests__/OlympicsSchedule.test.tsx
@@ -31,7 +31,7 @@ describe('<OlympicsSchedule>', () => {
   });
   it('click show all', async () => {
     const { asFragment, getByText, findByText } = render(
-      <OlympicsSchedule keys={keys} sectionColor="sectionColor" />
+      <OlympicsSchedule keys={keys} />
     );
     fireEvent.click(getByText('Show All'));
     await findByText('Collapse');

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsMedalTable.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsMedalTable.test.tsx.snap
@@ -2,7 +2,49 @@
 
 exports[`<OlympicsMedalTable> click show all 1`] = `
 <DocumentFragment>
-  .c0 {
+  .c1 {
+  background: #F9F9F9;
+  padding: 20px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.c4 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c4:hover {
+  background-color: #e4e4e4;
+}
+
+.c2 {
+  font-size: 12px;
+  line-height: 14px;
+  color: #402f7a;
+  font-family: GillSansMTStd-Medium;
+  font-weight: normal;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.c3 {
+  font-size: 24px;
+  line-height: 18px;
+  font-family: TimesModern-Bold;
+  margin: 14px 0 10px 0;
+}
+
+.c0 {
   border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
@@ -84,47 +126,10 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
   height: 0;
 }
 
-.c1 {
-  background: #F9F9F9;
-  padding: 20px 0;
-  text-align: center;
-  margin: 0px;
-}
-
-.c4 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-  cursor: pointer;
-}
-
-.c4:hover {
-  background-color: #e4e4e4;
-}
-
-.c2 {
-  font-size: 12px;
-  line-height: 14px;
-  color: #402f7a;
-  font-family: GillSansMTStd-Medium;
-  font-weight: normal;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-}
-
-.c3 {
-  font-size: 24px;
-  line-height: 18px;
-  font-family: TimesModern-Bold;
-  margin: 14px 0 10px 0;
-  font-weight: normal;
+@media only screen and (min-width:768px) {
+  .c3 {
+    font-size: 32px;
+  }
 }
 
 @media (min-width:768px) {
@@ -139,12 +144,6 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
   }
 }
 
-@media only screen and (min-width:768px) {
-  .c3 {
-    font-size: 32px;
-  }
-}
-
 <div
     class="c0"
   >
@@ -156,11 +155,11 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
       >
         Tokyo 2020
       </span>
-      <h2
+      <div
         class="c3"
       >
         Olympic Medal Count
-      </h2>
+      </div>
     </div>
     <div
       class="pa-medaltable"
@@ -184,7 +183,49 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
 
 exports[`<OlympicsMedalTable> renders 1`] = `
 <DocumentFragment>
-  .c0 {
+  .c1 {
+  background: #F9F9F9;
+  padding: 20px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.c4 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c4:hover {
+  background-color: #e4e4e4;
+}
+
+.c2 {
+  font-size: 12px;
+  line-height: 14px;
+  color: #402f7a;
+  font-family: GillSansMTStd-Medium;
+  font-weight: normal;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.c3 {
+  font-size: 24px;
+  line-height: 18px;
+  font-family: TimesModern-Bold;
+  margin: 14px 0 10px 0;
+}
+
+.c0 {
   border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
@@ -266,47 +307,10 @@ exports[`<OlympicsMedalTable> renders 1`] = `
   height: 0;
 }
 
-.c1 {
-  background: #F9F9F9;
-  padding: 20px 0;
-  text-align: center;
-  margin: 0px;
-}
-
-.c4 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-  cursor: pointer;
-}
-
-.c4:hover {
-  background-color: #e4e4e4;
-}
-
-.c2 {
-  font-size: 12px;
-  line-height: 14px;
-  color: #402f7a;
-  font-family: GillSansMTStd-Medium;
-  font-weight: normal;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-}
-
-.c3 {
-  font-size: 24px;
-  line-height: 18px;
-  font-family: TimesModern-Bold;
-  margin: 14px 0 10px 0;
-  font-weight: normal;
+@media only screen and (min-width:768px) {
+  .c3 {
+    font-size: 32px;
+  }
 }
 
 @media (min-width:768px) {
@@ -321,12 +325,6 @@ exports[`<OlympicsMedalTable> renders 1`] = `
   }
 }
 
-@media only screen and (min-width:768px) {
-  .c3 {
-    font-size: 32px;
-  }
-}
-
 <div
     class="c0"
   >
@@ -338,11 +336,11 @@ exports[`<OlympicsMedalTable> renders 1`] = `
       >
         Tokyo 2020
       </span>
-      <h2
+      <div
         class="c3"
       >
         Olympic Medal Count
-      </h2>
+      </div>
     </div>
     <div
       class="pa-medaltable"
@@ -366,7 +364,49 @@ exports[`<OlympicsMedalTable> renders 1`] = `
 
 exports[`<OlympicsMedalTable> renders outside of article 1`] = `
 <DocumentFragment>
-  .c0 {
+  .c1 {
+  background: #F9F9F9;
+  padding: 20px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.c4 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c4:hover {
+  background-color: #e4e4e4;
+}
+
+.c2 {
+  font-size: 12px;
+  line-height: 14px;
+  color: #402f7a;
+  font-family: GillSansMTStd-Medium;
+  font-weight: normal;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.c3 {
+  font-size: 24px;
+  line-height: 18px;
+  font-family: TimesModern-Bold;
+  margin: 14px 0 10px 0;
+}
+
+.c0 {
   border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
@@ -448,49 +488,6 @@ exports[`<OlympicsMedalTable> renders outside of article 1`] = `
   height: 0;
 }
 
-.c1 {
-  background: #F9F9F9;
-  padding: 20px 0;
-  text-align: center;
-  margin: 0px;
-}
-
-.c4 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-  cursor: pointer;
-}
-
-.c4:hover {
-  background-color: #e4e4e4;
-}
-
-.c2 {
-  font-size: 12px;
-  line-height: 14px;
-  color: #402f7a;
-  font-family: GillSansMTStd-Medium;
-  font-weight: normal;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-}
-
-.c3 {
-  font-size: 24px;
-  line-height: 18px;
-  font-family: TimesModern-Bold;
-  margin: 14px 0 10px 0;
-  font-weight: normal;
-}
-
 @media only screen and (min-width:768px) {
   .c3 {
     font-size: 32px;
@@ -508,11 +505,11 @@ exports[`<OlympicsMedalTable> renders outside of article 1`] = `
       >
         Tokyo 2020
       </span>
-      <h2
+      <div
         class="c3"
       >
         Olympic Medal Count
-      </h2>
+      </div>
     </div>
     <div
       class="pa-medaltable"

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsMedalTable.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsMedalTable.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<OlympicsMedalTable> click show all 1`] = `
 <DocumentFragment>
   .c0 {
-  border-top: 2px solid sectionColor;
+  border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
 }
@@ -60,7 +60,7 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
 
 .c0 .pa-medaltable .pa_MedalTableView_medaltable tbody tr td:first-child {
   font-family: GillSansMTStd-Medium;
-  color: sectionColor;
+  color: #402f7a;
 }
 
 .c0 .pa-medaltable .pa_MedalTableView_medaltable tbody tr:nth-child(n + 8) {
@@ -109,7 +109,7 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
 .c2 {
   font-size: 12px;
   line-height: 14px;
-  color: sectionColor;
+  color: #402f7a;
   font-family: GillSansMTStd-Medium;
   font-weight: normal;
   text-transform: uppercase;
@@ -120,10 +120,11 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
 }
 
 .c3 {
-  font-size: 18px;
+  font-size: 24px;
   line-height: 18px;
-  font-family: TimesModern-Regular;
-  margin: 6px 0 0 0;
+  font-family: TimesModern-Bold;
+  margin: 14px 0 10px 0;
+  font-weight: normal;
 }
 
 @media (min-width:768px) {
@@ -138,6 +139,12 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
   }
 }
 
+@media only screen and (min-width:768px) {
+  .c3 {
+    font-size: 32px;
+  }
+}
+
 <div
     class="c0"
   >
@@ -147,12 +154,12 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
       <span
         class="c2"
       >
-        Olympics Tokyo 2020
+        Tokyo 2020
       </span>
       <h2
         class="c3"
       >
-        Medal Table
+        Olympic Medal Count
       </h2>
     </div>
     <div
@@ -178,7 +185,7 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
 exports[`<OlympicsMedalTable> renders 1`] = `
 <DocumentFragment>
   .c0 {
-  border-top: 2px solid #008347;
+  border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
 }
@@ -235,7 +242,7 @@ exports[`<OlympicsMedalTable> renders 1`] = `
 
 .c0 .pa-medaltable .pa_MedalTableView_medaltable tbody tr td:first-child {
   font-family: GillSansMTStd-Medium;
-  color: #008347;
+  color: #402f7a;
 }
 
 .c0 .pa-medaltable .pa_MedalTableView_medaltable tbody tr:nth-child(n + 8) {
@@ -284,7 +291,7 @@ exports[`<OlympicsMedalTable> renders 1`] = `
 .c2 {
   font-size: 12px;
   line-height: 14px;
-  color: #008347;
+  color: #402f7a;
   font-family: GillSansMTStd-Medium;
   font-weight: normal;
   text-transform: uppercase;
@@ -295,10 +302,11 @@ exports[`<OlympicsMedalTable> renders 1`] = `
 }
 
 .c3 {
-  font-size: 18px;
+  font-size: 24px;
   line-height: 18px;
-  font-family: TimesModern-Regular;
-  margin: 6px 0 0 0;
+  font-family: TimesModern-Bold;
+  margin: 14px 0 10px 0;
+  font-weight: normal;
 }
 
 @media (min-width:768px) {
@@ -313,6 +321,12 @@ exports[`<OlympicsMedalTable> renders 1`] = `
   }
 }
 
+@media only screen and (min-width:768px) {
+  .c3 {
+    font-size: 32px;
+  }
+}
+
 <div
     class="c0"
   >
@@ -322,12 +336,12 @@ exports[`<OlympicsMedalTable> renders 1`] = `
       <span
         class="c2"
       >
-        Olympics Tokyo 2020
+        Tokyo 2020
       </span>
       <h2
         class="c3"
       >
-        Medal Table
+        Olympic Medal Count
       </h2>
     </div>
     <div
@@ -353,7 +367,7 @@ exports[`<OlympicsMedalTable> renders 1`] = `
 exports[`<OlympicsMedalTable> renders outside of article 1`] = `
 <DocumentFragment>
   .c0 {
-  border-top: 2px solid #008347;
+  border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
 }
@@ -410,7 +424,7 @@ exports[`<OlympicsMedalTable> renders outside of article 1`] = `
 
 .c0 .pa-medaltable .pa_MedalTableView_medaltable tbody tr td:first-child {
   font-family: GillSansMTStd-Medium;
-  color: #008347;
+  color: #402f7a;
 }
 
 .c0 .pa-medaltable .pa_MedalTableView_medaltable tbody tr:nth-child(n + 8) {
@@ -459,7 +473,7 @@ exports[`<OlympicsMedalTable> renders outside of article 1`] = `
 .c2 {
   font-size: 12px;
   line-height: 14px;
-  color: #008347;
+  color: #402f7a;
   font-family: GillSansMTStd-Medium;
   font-weight: normal;
   text-transform: uppercase;
@@ -470,10 +484,17 @@ exports[`<OlympicsMedalTable> renders outside of article 1`] = `
 }
 
 .c3 {
-  font-size: 18px;
+  font-size: 24px;
   line-height: 18px;
-  font-family: TimesModern-Regular;
-  margin: 6px 0 0 0;
+  font-family: TimesModern-Bold;
+  margin: 14px 0 10px 0;
+  font-weight: normal;
+}
+
+@media only screen and (min-width:768px) {
+  .c3 {
+    font-size: 32px;
+  }
 }
 
 <div
@@ -485,12 +506,12 @@ exports[`<OlympicsMedalTable> renders outside of article 1`] = `
       <span
         class="c2"
       >
-        Olympics Tokyo 2020
+        Tokyo 2020
       </span>
       <h2
         class="c3"
       >
-        Medal Table
+        Olympic Medal Count
       </h2>
     </div>
     <div

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsMedalTable.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsMedalTable.test.tsx.snap
@@ -91,6 +91,21 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
   margin: 0px;
 }
 
+.c4 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c4:hover {
+  background-color: #e4e4e4;
+}
+
 .c2 {
   font-size: 12px;
   line-height: 14px;
@@ -105,18 +120,10 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
 }
 
 .c3 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-  cursor: pointer;
-}
-
-.c3:hover {
-  background-color: #e4e4e4;
+  font-size: 18px;
+  line-height: 18px;
+  font-family: TimesModern-Regular;
+  margin: 6px 0 0 0;
 }
 
 @media (min-width:768px) {
@@ -134,15 +141,20 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
 <div
     class="c0"
   >
-    <h2
+    <div
       class="c1"
     >
-      <div
+      <span
         class="c2"
       >
-        Medal Table - Olympics Tokyo 2020
-      </div>
-    </h2>
+        Olympics Tokyo 2020
+      </span>
+      <h2
+        class="c3"
+      >
+        Medal Table
+      </h2>
+    </div>
     <div
       class="pa-medaltable"
       data-auth-token="token"
@@ -154,7 +166,7 @@ exports[`<OlympicsMedalTable> click show all 1`] = `
       class="buttonContainer"
     >
       <button
-        class="c3"
+        class="c4"
       >
         Collapse
       </button>
@@ -254,6 +266,21 @@ exports[`<OlympicsMedalTable> renders 1`] = `
   margin: 0px;
 }
 
+.c4 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c4:hover {
+  background-color: #e4e4e4;
+}
+
 .c2 {
   font-size: 12px;
   line-height: 14px;
@@ -268,18 +295,10 @@ exports[`<OlympicsMedalTable> renders 1`] = `
 }
 
 .c3 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-  cursor: pointer;
-}
-
-.c3:hover {
-  background-color: #e4e4e4;
+  font-size: 18px;
+  line-height: 18px;
+  font-family: TimesModern-Regular;
+  margin: 6px 0 0 0;
 }
 
 @media (min-width:768px) {
@@ -297,15 +316,20 @@ exports[`<OlympicsMedalTable> renders 1`] = `
 <div
     class="c0"
   >
-    <h2
+    <div
       class="c1"
     >
-      <div
+      <span
         class="c2"
       >
-        Medal Table - Olympics Tokyo 2020
-      </div>
-    </h2>
+        Olympics Tokyo 2020
+      </span>
+      <h2
+        class="c3"
+      >
+        Medal Table
+      </h2>
+    </div>
     <div
       class="pa-medaltable"
       data-auth-token="token"
@@ -317,7 +341,7 @@ exports[`<OlympicsMedalTable> renders 1`] = `
       class="buttonContainer"
     >
       <button
-        class="c3"
+        class="c4"
       >
         Show All
       </button>
@@ -417,6 +441,21 @@ exports[`<OlympicsMedalTable> renders outside of article 1`] = `
   margin: 0px;
 }
 
+.c4 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c4:hover {
+  background-color: #e4e4e4;
+}
+
 .c2 {
   font-size: 12px;
   line-height: 14px;
@@ -431,32 +470,29 @@ exports[`<OlympicsMedalTable> renders outside of article 1`] = `
 }
 
 .c3 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-  cursor: pointer;
-}
-
-.c3:hover {
-  background-color: #e4e4e4;
+  font-size: 18px;
+  line-height: 18px;
+  font-family: TimesModern-Regular;
+  margin: 6px 0 0 0;
 }
 
 <div
     class="c0"
   >
-    <h2
+    <div
       class="c1"
     >
-      <div
+      <span
         class="c2"
       >
-        Medal Table - Olympics Tokyo 2020
-      </div>
-    </h2>
+        Olympics Tokyo 2020
+      </span>
+      <h2
+        class="c3"
+      >
+        Medal Table
+      </h2>
+    </div>
     <div
       class="pa-medaltable"
       data-auth-token="token"
@@ -468,7 +504,7 @@ exports[`<OlympicsMedalTable> renders outside of article 1`] = `
       class="buttonContainer"
     >
       <button
-        class="c3"
+        class="c4"
       >
         Show All
       </button>

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<OlympicsSchedule> click show all 1`] = `
 <DocumentFragment>
   .c0 {
-  border-top: 2px solid sectionColor;
+  border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
 }
@@ -46,7 +46,7 @@ exports[`<OlympicsSchedule> click show all 1`] = `
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
-  color: sectionColor;
+  color: #402f7a;
   line-height: 30px;
   position: absolute;
 }
@@ -131,7 +131,7 @@ exports[`<OlympicsSchedule> click show all 1`] = `
 .c2 {
   font-size: 12px;
   line-height: 14px;
-  color: sectionColor;
+  color: #402f7a;
   font-family: GillSansMTStd-Medium;
   font-weight: normal;
   text-transform: uppercase;
@@ -142,10 +142,11 @@ exports[`<OlympicsSchedule> click show all 1`] = `
 }
 
 .c3 {
-  font-size: 18px;
+  font-size: 24px;
   line-height: 18px;
-  font-family: TimesModern-Regular;
-  margin: 6px 0 0 0;
+  font-family: TimesModern-Bold;
+  margin: 14px 0 10px 0;
+  font-weight: normal;
 }
 
 @media (min-width:768px) {
@@ -166,6 +167,12 @@ exports[`<OlympicsSchedule> click show all 1`] = `
   }
 }
 
+@media only screen and (min-width:768px) {
+  .c3 {
+    font-size: 32px;
+  }
+}
+
 <div
     class="c0"
   >
@@ -175,7 +182,7 @@ exports[`<OlympicsSchedule> click show all 1`] = `
       <span
         class="c2"
       >
-        Olympics Tokyo 2020
+        Tokyo 2020
       </span>
       <h2
         class="c3"
@@ -204,7 +211,7 @@ exports[`<OlympicsSchedule> click show all 1`] = `
 exports[`<OlympicsSchedule> renders 1`] = `
 <DocumentFragment>
   .c0 {
-  border-top: 2px solid #008347;
+  border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
 }
@@ -247,7 +254,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
-  color: #008347;
+  color: #402f7a;
   line-height: 30px;
   position: absolute;
 }
@@ -332,7 +339,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
 .c2 {
   font-size: 12px;
   line-height: 14px;
-  color: #008347;
+  color: #402f7a;
   font-family: GillSansMTStd-Medium;
   font-weight: normal;
   text-transform: uppercase;
@@ -343,10 +350,11 @@ exports[`<OlympicsSchedule> renders 1`] = `
 }
 
 .c3 {
-  font-size: 18px;
+  font-size: 24px;
   line-height: 18px;
-  font-family: TimesModern-Regular;
-  margin: 6px 0 0 0;
+  font-family: TimesModern-Bold;
+  margin: 14px 0 10px 0;
+  font-weight: normal;
 }
 
 @media (min-width:768px) {
@@ -367,6 +375,12 @@ exports[`<OlympicsSchedule> renders 1`] = `
   }
 }
 
+@media only screen and (min-width:768px) {
+  .c3 {
+    font-size: 32px;
+  }
+}
+
 <div
     class="c0"
   >
@@ -376,7 +390,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
       <span
         class="c2"
       >
-        Olympics Tokyo 2020
+        Tokyo 2020
       </span>
       <h2
         class="c3"
@@ -405,7 +419,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
 exports[`<OlympicsSchedule> renders outside of article 1`] = `
 <DocumentFragment>
   .c0 {
-  border-top: 2px solid #008347;
+  border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
 }
@@ -448,7 +462,7 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
-  color: #008347;
+  color: #402f7a;
   line-height: 30px;
   position: absolute;
 }
@@ -533,7 +547,7 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 .c2 {
   font-size: 12px;
   line-height: 14px;
-  color: #008347;
+  color: #402f7a;
   font-family: GillSansMTStd-Medium;
   font-weight: normal;
   text-transform: uppercase;
@@ -544,15 +558,22 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 }
 
 .c3 {
-  font-size: 18px;
+  font-size: 24px;
   line-height: 18px;
-  font-family: TimesModern-Regular;
-  margin: 6px 0 0 0;
+  font-family: TimesModern-Bold;
+  margin: 14px 0 10px 0;
+  font-weight: normal;
 }
 
 @media only screen and (min-width:321px) {
   .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
     left: calc(100% - 75px);
+  }
+}
+
+@media only screen and (min-width:768px) {
+  .c3 {
+    font-size: 32px;
   }
 }
 
@@ -565,7 +586,7 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
       <span
         class="c2"
       >
-        Olympics Tokyo 2020
+        Tokyo 2020
       </span>
       <h2
         class="c3"

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -2,7 +2,49 @@
 
 exports[`<OlympicsSchedule> click show all 1`] = `
 <DocumentFragment>
-  .c0 {
+  .c1 {
+  background: #F9F9F9;
+  padding: 20px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.c4 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c4:hover {
+  background-color: #e4e4e4;
+}
+
+.c2 {
+  font-size: 12px;
+  line-height: 14px;
+  color: #402f7a;
+  font-family: GillSansMTStd-Medium;
+  font-weight: normal;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.c3 {
+  font-size: 24px;
+  line-height: 18px;
+  font-family: TimesModern-Bold;
+  margin: 14px 0 10px 0;
+}
+
+.c0 {
   border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
@@ -106,47 +148,10 @@ exports[`<OlympicsSchedule> click show all 1`] = `
   background-color: #EDEDED;
 }
 
-.c1 {
-  background: #F9F9F9;
-  padding: 20px 0;
-  text-align: center;
-  margin: 0px;
-}
-
-.c4 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-  cursor: pointer;
-}
-
-.c4:hover {
-  background-color: #e4e4e4;
-}
-
-.c2 {
-  font-size: 12px;
-  line-height: 14px;
-  color: #402f7a;
-  font-family: GillSansMTStd-Medium;
-  font-weight: normal;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-}
-
-.c3 {
-  font-size: 24px;
-  line-height: 18px;
-  font-family: TimesModern-Bold;
-  margin: 14px 0 10px 0;
-  font-weight: normal;
+@media only screen and (min-width:768px) {
+  .c3 {
+    font-size: 32px;
+  }
 }
 
 @media (min-width:768px) {
@@ -167,12 +172,6 @@ exports[`<OlympicsSchedule> click show all 1`] = `
   }
 }
 
-@media only screen and (min-width:768px) {
-  .c3 {
-    font-size: 32px;
-  }
-}
-
 <div
     class="c0"
   >
@@ -184,11 +183,11 @@ exports[`<OlympicsSchedule> click show all 1`] = `
       >
         Tokyo 2020
       </span>
-      <h2
+      <div
         class="c3"
       >
         Event Schedule
-      </h2>
+      </div>
     </div>
     <div
       class="pa-schedule"
@@ -210,7 +209,49 @@ exports[`<OlympicsSchedule> click show all 1`] = `
 
 exports[`<OlympicsSchedule> renders 1`] = `
 <DocumentFragment>
-  .c0 {
+  .c1 {
+  background: #F9F9F9;
+  padding: 20px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.c4 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c4:hover {
+  background-color: #e4e4e4;
+}
+
+.c2 {
+  font-size: 12px;
+  line-height: 14px;
+  color: #402f7a;
+  font-family: GillSansMTStd-Medium;
+  font-weight: normal;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.c3 {
+  font-size: 24px;
+  line-height: 18px;
+  font-family: TimesModern-Bold;
+  margin: 14px 0 10px 0;
+}
+
+.c0 {
   border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
@@ -314,47 +355,10 @@ exports[`<OlympicsSchedule> renders 1`] = `
   background-color: #EDEDED;
 }
 
-.c1 {
-  background: #F9F9F9;
-  padding: 20px 0;
-  text-align: center;
-  margin: 0px;
-}
-
-.c4 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-  cursor: pointer;
-}
-
-.c4:hover {
-  background-color: #e4e4e4;
-}
-
-.c2 {
-  font-size: 12px;
-  line-height: 14px;
-  color: #402f7a;
-  font-family: GillSansMTStd-Medium;
-  font-weight: normal;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-}
-
-.c3 {
-  font-size: 24px;
-  line-height: 18px;
-  font-family: TimesModern-Bold;
-  margin: 14px 0 10px 0;
-  font-weight: normal;
+@media only screen and (min-width:768px) {
+  .c3 {
+    font-size: 32px;
+  }
 }
 
 @media (min-width:768px) {
@@ -375,12 +379,6 @@ exports[`<OlympicsSchedule> renders 1`] = `
   }
 }
 
-@media only screen and (min-width:768px) {
-  .c3 {
-    font-size: 32px;
-  }
-}
-
 <div
     class="c0"
   >
@@ -392,11 +390,11 @@ exports[`<OlympicsSchedule> renders 1`] = `
       >
         Tokyo 2020
       </span>
-      <h2
+      <div
         class="c3"
       >
         Event Schedule
-      </h2>
+      </div>
     </div>
     <div
       class="pa-schedule"
@@ -418,7 +416,49 @@ exports[`<OlympicsSchedule> renders 1`] = `
 
 exports[`<OlympicsSchedule> renders outside of article 1`] = `
 <DocumentFragment>
-  .c0 {
+  .c1 {
+  background: #F9F9F9;
+  padding: 20px 0;
+  text-align: center;
+  margin: 0px;
+}
+
+.c4 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c4:hover {
+  background-color: #e4e4e4;
+}
+
+.c2 {
+  font-size: 12px;
+  line-height: 14px;
+  color: #402f7a;
+  font-family: GillSansMTStd-Medium;
+  font-weight: normal;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.c3 {
+  font-size: 24px;
+  line-height: 18px;
+  font-family: TimesModern-Bold;
+  margin: 14px 0 10px 0;
+}
+
+.c0 {
   border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
@@ -522,58 +562,15 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
   background-color: #EDEDED;
 }
 
-.c1 {
-  background: #F9F9F9;
-  padding: 20px 0;
-  text-align: center;
-  margin: 0px;
-}
-
-.c4 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-  cursor: pointer;
-}
-
-.c4:hover {
-  background-color: #e4e4e4;
-}
-
-.c2 {
-  font-size: 12px;
-  line-height: 14px;
-  color: #402f7a;
-  font-family: GillSansMTStd-Medium;
-  font-weight: normal;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-}
-
-.c3 {
-  font-size: 24px;
-  line-height: 18px;
-  font-family: TimesModern-Bold;
-  margin: 14px 0 10px 0;
-  font-weight: normal;
+@media only screen and (min-width:768px) {
+  .c3 {
+    font-size: 32px;
+  }
 }
 
 @media only screen and (min-width:321px) {
   .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
     left: calc(100% - 75px);
-  }
-}
-
-@media only screen and (min-width:768px) {
-  .c3 {
-    font-size: 32px;
   }
 }
 
@@ -588,11 +585,11 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
       >
         Tokyo 2020
       </span>
-      <h2
+      <div
         class="c3"
       >
         Event Schedule
-      </h2>
+      </div>
     </div>
     <div
       class="pa-schedule"

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -38,6 +38,13 @@ exports[`<OlympicsSchedule> click show all 1`] = `
   display: block;
 }
 
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
   color: sectionColor;
   line-height: 30px;
@@ -54,7 +61,7 @@ exports[`<OlympicsSchedule> click show all 1`] = `
   font-family: TimesModern-Bold;
   text-transform: capitalize;
   font-weight: 400;
-  padding-bottom: 4px;
+  margin-top: 4px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
@@ -106,6 +113,21 @@ exports[`<OlympicsSchedule> click show all 1`] = `
   margin: 0px;
 }
 
+.c4 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c4:hover {
+  background-color: #e4e4e4;
+}
+
 .c2 {
   font-size: 12px;
   line-height: 14px;
@@ -120,18 +142,10 @@ exports[`<OlympicsSchedule> click show all 1`] = `
 }
 
 .c3 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-  cursor: pointer;
-}
-
-.c3:hover {
-  background-color: #e4e4e4;
+  font-size: 18px;
+  line-height: 18px;
+  font-family: TimesModern-Regular;
+  margin: 6px 0 0 0;
 }
 
 @media (min-width:768px) {
@@ -155,15 +169,20 @@ exports[`<OlympicsSchedule> click show all 1`] = `
 <div
     class="c0"
   >
-    <h2
+    <div
       class="c1"
     >
-      <div
+      <span
         class="c2"
       >
-        Event Schedule - Olympics Tokyo 2020
-      </div>
-    </h2>
+        Olympics Tokyo 2020
+      </span>
+      <h2
+        class="c3"
+      >
+        Event Schedule
+      </h2>
+    </div>
     <div
       class="pa-schedule"
       data-auth-token="token"
@@ -173,7 +192,7 @@ exports[`<OlympicsSchedule> click show all 1`] = `
       class="buttonContainer"
     >
       <button
-        class="c3"
+        class="c4"
       >
         Collapse
       </button>
@@ -220,6 +239,13 @@ exports[`<OlympicsSchedule> renders 1`] = `
   display: none;
 }
 
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
   color: #008347;
   line-height: 30px;
@@ -236,7 +262,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
   font-family: TimesModern-Bold;
   text-transform: capitalize;
   font-weight: 400;
-  padding-bottom: 4px;
+  margin-top: 4px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
@@ -288,6 +314,21 @@ exports[`<OlympicsSchedule> renders 1`] = `
   margin: 0px;
 }
 
+.c4 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c4:hover {
+  background-color: #e4e4e4;
+}
+
 .c2 {
   font-size: 12px;
   line-height: 14px;
@@ -302,18 +343,10 @@ exports[`<OlympicsSchedule> renders 1`] = `
 }
 
 .c3 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-  cursor: pointer;
-}
-
-.c3:hover {
-  background-color: #e4e4e4;
+  font-size: 18px;
+  line-height: 18px;
+  font-family: TimesModern-Regular;
+  margin: 6px 0 0 0;
 }
 
 @media (min-width:768px) {
@@ -337,15 +370,20 @@ exports[`<OlympicsSchedule> renders 1`] = `
 <div
     class="c0"
   >
-    <h2
+    <div
       class="c1"
     >
-      <div
+      <span
         class="c2"
       >
-        Event Schedule - Olympics Tokyo 2020
-      </div>
-    </h2>
+        Olympics Tokyo 2020
+      </span>
+      <h2
+        class="c3"
+      >
+        Event Schedule
+      </h2>
+    </div>
     <div
       class="pa-schedule"
       data-auth-token="token"
@@ -355,7 +393,7 @@ exports[`<OlympicsSchedule> renders 1`] = `
       class="buttonContainer"
     >
       <button
-        class="c3"
+        class="c4"
       >
         Show All
       </button>
@@ -402,6 +440,13 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
   display: none;
 }
 
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
   color: #008347;
   line-height: 30px;
@@ -418,7 +463,7 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
   font-family: TimesModern-Bold;
   text-transform: capitalize;
   font-weight: 400;
-  padding-bottom: 4px;
+  margin-top: 4px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
@@ -470,6 +515,21 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
   margin: 0px;
 }
 
+.c4 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 14px 16px;
+  border: 1px solid #DBDBDB;
+  top: -80px;
+  position: relative;
+  cursor: pointer;
+}
+
+.c4:hover {
+  background-color: #e4e4e4;
+}
+
 .c2 {
   font-size: 12px;
   line-height: 14px;
@@ -484,18 +544,10 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 }
 
 .c3 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 14px 16px;
-  border: 1px solid #DBDBDB;
-  top: -80px;
-  position: relative;
-  cursor: pointer;
-}
-
-.c3:hover {
-  background-color: #e4e4e4;
+  font-size: 18px;
+  line-height: 18px;
+  font-family: TimesModern-Regular;
+  margin: 6px 0 0 0;
 }
 
 @media only screen and (min-width:321px) {
@@ -507,15 +559,20 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 <div
     class="c0"
   >
-    <h2
+    <div
       class="c1"
     >
-      <div
+      <span
         class="c2"
       >
-        Event Schedule - Olympics Tokyo 2020
-      </div>
-    </h2>
+        Olympics Tokyo 2020
+      </span>
+      <h2
+        class="c3"
+      >
+        Event Schedule
+      </h2>
+    </div>
     <div
       class="pa-schedule"
       data-auth-token="token"
@@ -525,7 +582,7 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
       class="buttonContainer"
     >
       <button
-        class="c3"
+        class="c4"
       >
         Show All
       </button>

--- a/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.tsx
+++ b/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useEffect, useState } from 'react';
-import { colours } from '@times-components/styleguide';
 import { Container } from './styles';
 import { HeadingContainer, Heading, Button, Label } from '../shared-styles';
 import { OlympicsKeys } from '../types';
@@ -8,12 +7,10 @@ import { injectScript } from '../../../helpers/widgets/inject-script';
 export const OlympicsMedalTable: FC<{
   highlighted?: string;
   keys: OlympicsKeys;
-  sectionColor?: string;
   inArticle?: boolean;
 }> = ({
   keys: { endpoint, authToken, gamesCode },
   highlighted = 'GBR',
-  sectionColor = colours.section.sport,
   inArticle = true
 }) => {
   const [showAll, setShowAll] = useState(false);
@@ -25,14 +22,10 @@ export const OlympicsMedalTable: FC<{
   }, []);
 
   return (
-    <Container
-      sectionColour={sectionColor}
-      showAll={showAll}
-      inArticle={inArticle}
-    >
+    <Container showAll={showAll} inArticle={inArticle}>
       <HeadingContainer>
-        <Label sectionColour={sectionColor}>Olympics Tokyo 2020</Label>
-        <Heading>Medal Table</Heading>
+        <Label>Tokyo 2020</Label>
+        <Heading>Olympic Medal Count</Heading>
       </HeadingContainer>
       <div
         className="pa-medaltable"

--- a/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.tsx
+++ b/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
 import { colours } from '@times-components/styleguide';
 import { Container } from './styles';
-import { HeadingContainer, Heading, Button } from '../shared-styles';
+import { HeadingContainer, Heading, Button, Label } from '../shared-styles';
 import { OlympicsKeys } from '../types';
 import { injectScript } from '../../../helpers/widgets/inject-script';
 
@@ -31,8 +31,9 @@ export const OlympicsMedalTable: FC<{
       inArticle={inArticle}
     >
       <HeadingContainer>
-        <Heading sectionColour={sectionColor}>
-          Medal Table - Olympics Tokyo 2020
+        <Label sectionColour={sectionColor}>Olympics Tokyo 2020</Label>
+        <Heading>
+          Medal Table
         </Heading>
       </HeadingContainer>
       <div

--- a/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.tsx
+++ b/packages/ts-components/src/components/olympics/medal-table/OlympicsMedalTable.tsx
@@ -32,9 +32,7 @@ export const OlympicsMedalTable: FC<{
     >
       <HeadingContainer>
         <Label sectionColour={sectionColor}>Olympics Tokyo 2020</Label>
-        <Heading>
-          Medal Table
-        </Heading>
+        <Heading>Medal Table</Heading>
       </HeadingContainer>
       <div
         className="pa-medaltable"

--- a/packages/ts-components/src/components/olympics/medal-table/styles.ts
+++ b/packages/ts-components/src/components/olympics/medal-table/styles.ts
@@ -3,11 +3,10 @@ import { breakpoints, colours, fonts } from '@times-components/styleguide';
 
 const highlightColour = '#e4e4e4';
 export const Container = styled.div<{
-  sectionColour: string;
   showAll: boolean;
   inArticle: boolean;
 }>`
-  border-top: 2px solid ${({ sectionColour }) => sectionColour};
+  border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
 
@@ -69,7 +68,7 @@ export const Container = styled.div<{
 
           td:first-child {
             font-family: ${fonts.supporting};
-            color: ${({ sectionColour }) => sectionColour};
+            color: #402f7a;
           }
 
           &:nth-child(n + 8) {

--- a/packages/ts-components/src/components/olympics/medal-table/styles.ts
+++ b/packages/ts-components/src/components/olympics/medal-table/styles.ts
@@ -1,12 +1,13 @@
 import styled from 'styled-components';
 import { breakpoints, colours, fonts } from '@times-components/styleguide';
+import { olympicColour } from '../shared-styles';
 
 const highlightColour = '#e4e4e4';
 export const Container = styled.div<{
   showAll: boolean;
   inArticle: boolean;
 }>`
-  border-top: 2px solid #402f7a;
+  border-top: 2px solid ${olympicColour};
   position: relative;
   margin: 0 auto 20px auto;
 
@@ -68,7 +69,7 @@ export const Container = styled.div<{
 
           td:first-child {
             font-family: ${fonts.supporting};
-            color: #402f7a;
+            color: ${olympicColour};
           }
 
           &:nth-child(n + 8) {

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.stories.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.stories.tsx
@@ -17,7 +17,7 @@ storiesOf('Typescript Component/Olympics', module)
         staging: 'https://olympics-embed-staging.pamedia.io',
         prod: 'https://olympics-embed.pamedia.io'
       },
-      'https://olympics-embed-staging.pamedia.io'
+      '.'
     );
     const authToken = text('Auth Token', '6i3DuEwbVhr2Fht6');
     const gamesCode = text('Games Code', 'OG2020-TR2');

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.stories.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.stories.tsx
@@ -17,7 +17,7 @@ storiesOf('Typescript Component/Olympics', module)
         staging: 'https://olympics-embed-staging.pamedia.io',
         prod: 'https://olympics-embed.pamedia.io'
       },
-      '.'
+      'https://olympics-embed-staging.pamedia.io'
     );
     const authToken = text('Auth Token', '6i3DuEwbVhr2Fht6');
     const gamesCode = text('Games Code', 'OG2020-TR2');

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
 
 import { Container } from './styles';
-import { HeadingContainer, Heading, Button } from '../shared-styles';
+import { HeadingContainer, Label, Button, Heading } from '../shared-styles';
 import { colours } from '@times-components/styleguide';
 
 import { OlympicsKeys } from '../types';
@@ -49,8 +49,9 @@ export const OlympicsSchedule: FC<{
       showAll={showAll}
     >
       <HeadingContainer>
-        <Heading sectionColour={sectionColor}>
-          Event Schedule - Olympics Tokyo 2020
+        <Label sectionColour={sectionColor}>Olympics Tokyo 2020</Label>
+        <Heading>
+          Event Schedule
         </Heading>
       </HeadingContainer>
       <div

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -50,9 +50,7 @@ export const OlympicsSchedule: FC<{
     >
       <HeadingContainer>
         <Label sectionColour={sectionColor}>Olympics Tokyo 2020</Label>
-        <Heading>
-          Event Schedule
-        </Heading>
+        <Heading>Event Schedule</Heading>
       </HeadingContainer>
       <div
         className="pa-schedule"

--- a/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
+++ b/packages/ts-components/src/components/olympics/schedule/OlympicsSchedule.tsx
@@ -2,20 +2,14 @@ import React, { FC, useEffect, useState } from 'react';
 
 import { Container } from './styles';
 import { HeadingContainer, Label, Button, Heading } from '../shared-styles';
-import { colours } from '@times-components/styleguide';
 
 import { OlympicsKeys } from '../types';
 import { injectScript } from '../../../helpers/widgets/inject-script';
 
 export const OlympicsSchedule: FC<{
   keys: OlympicsKeys;
-  sectionColor?: string;
   inArticle?: boolean;
-}> = ({
-  keys: { endpoint, authToken, gamesCode },
-  sectionColor = colours.section.sport,
-  inArticle = true
-}) => {
+}> = ({ keys: { endpoint, authToken, gamesCode }, inArticle = true }) => {
   useEffect(() => {
     injectScript(`${endpoint}/static/schedule.js`);
   }, []);
@@ -43,13 +37,9 @@ export const OlympicsSchedule: FC<{
   };
 
   return (
-    <Container
-      sectionColour={sectionColor}
-      inArticle={inArticle}
-      showAll={showAll}
-    >
+    <Container inArticle={inArticle} showAll={showAll}>
       <HeadingContainer>
-        <Label sectionColour={sectionColor}>Olympics Tokyo 2020</Label>
+        <Label>Tokyo 2020</Label>
         <Heading>Event Schedule</Heading>
       </HeadingContainer>
       <div

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -2,11 +2,10 @@ import styled from 'styled-components';
 import { breakpoints, colours, fonts } from '@times-components/styleguide';
 
 export const Container = styled.div<{
-  sectionColour: string;
   showAll: boolean;
   inArticle: boolean;
 }>`
-  border-top: 2px solid ${({ sectionColour }) => sectionColour};
+  border-top: 2px solid #402f7a;
   position: relative;
   margin: 0 auto 20px auto;
 
@@ -53,7 +52,7 @@ export const Container = styled.div<{
         }
 
         .pa_UnitListView_unit-time {
-          color: ${({ sectionColour }) => sectionColour};
+          color: #402f7a;
           line-height: 30px;
           position: absolute;
         }

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 import { breakpoints, colours, fonts } from '@times-components/styleguide';
+import { olympicColour } from '../shared-styles';
 
 export const Container = styled.div<{
   showAll: boolean;
   inArticle: boolean;
 }>`
-  border-top: 2px solid #402f7a;
+  border-top: 2px solid ${olympicColour};
   position: relative;
   margin: 0 auto 20px auto;
 
@@ -52,7 +53,7 @@ export const Container = styled.div<{
         }
 
         .pa_UnitListView_unit-time {
-          color: #402f7a;
+          color: ${olympicColour};
           line-height: 30px;
           position: absolute;
         }

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -48,6 +48,10 @@ export const Container = styled.div<{
           border-bottom: 1px solid ${colours.functional.keyline};
         }
 
+        .pa_UnitListView_unit {
+          align-items: center;
+        }
+
         .pa_UnitListView_unit-time {
           color: ${({ sectionColour }) => sectionColour};
           line-height: 30px;
@@ -64,7 +68,7 @@ export const Container = styled.div<{
           font-family: ${fonts.headline};
           text-transform: capitalize;
           font-weight: 400;
-          padding-bottom: 4px;
+          margin-top: 4px;
         }
 
         .pa_UnitListView_medal {

--- a/packages/ts-components/src/components/olympics/shared-styles.ts
+++ b/packages/ts-components/src/components/olympics/shared-styles.ts
@@ -26,10 +26,10 @@ export const Button = styled.button`
   }
 `;
 
-export const Label = styled.span<{ sectionColour: string }>`
+export const Label = styled.span`
   font-size: 12px;
   line-height: 14px;
-  color: ${({ sectionColour }) => sectionColour};
+  color: #402f7a;
   font-family: ${fonts.supporting};
   font-weight: normal;
   text-transform: uppercase;
@@ -37,8 +37,12 @@ export const Label = styled.span<{ sectionColour: string }>`
 `;
 
 export const Heading = styled.h2`
-  font-size: 18px;
+  font-size: 24px;
   line-height: 18px;
-  font-family: ${fonts.headlineRegular};
-  margin: 6px 0 0 0;
+  font-family: ${fonts.headline};
+  margin: 14px 0 10px 0;
+  font-weight: normal;
+  @media only screen and (min-width: 768px) {
+    font-size: 32px;
+  }
 `;

--- a/packages/ts-components/src/components/olympics/shared-styles.ts
+++ b/packages/ts-components/src/components/olympics/shared-styles.ts
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import { colours, fonts } from '@times-components/styleguide';
 
 const highlightColour = '#e4e4e4';
+export const olympicColour = '#402f7a';
+
 export const HeadingContainer = styled.div`
   background: ${colours.functional.backgroundPrimary};
   padding: 20px 0;
@@ -29,19 +31,18 @@ export const Button = styled.button`
 export const Label = styled.span`
   font-size: 12px;
   line-height: 14px;
-  color: #402f7a;
+  color: ${olympicColour};
   font-family: ${fonts.supporting};
   font-weight: normal;
   text-transform: uppercase;
   letter-spacing: 1px;
 `;
 
-export const Heading = styled.h2`
+export const Heading = styled.div`
   font-size: 24px;
   line-height: 18px;
   font-family: ${fonts.headline};
   margin: 14px 0 10px 0;
-  font-weight: normal;
   @media only screen and (min-width: 768px) {
     font-size: 32px;
   }

--- a/packages/ts-components/src/components/olympics/shared-styles.ts
+++ b/packages/ts-components/src/components/olympics/shared-styles.ts
@@ -2,21 +2,11 @@ import styled from 'styled-components';
 import { colours, fonts } from '@times-components/styleguide';
 
 const highlightColour = '#e4e4e4';
-export const HeadingContainer = styled.h2`
+export const HeadingContainer = styled.div`
   background: ${colours.functional.backgroundPrimary};
   padding: 20px 0;
   text-align: center;
   margin: 0px;
-`;
-
-export const Heading = styled.div<{ sectionColour: string }>`
-  font-size: 12px;
-  line-height: 14px;
-  color: ${({ sectionColour }) => sectionColour};
-  font-family: ${fonts.supporting};
-  font-weight: normal;
-  text-transform: uppercase;
-  letter-spacing: 1px;
 `;
 
 export const Button = styled.button`
@@ -34,4 +24,21 @@ export const Button = styled.button`
   &:hover {
     background-color: ${highlightColour};
   }
+`;
+
+export const Label = styled.span<{ sectionColour: string }>`
+  font-size: 12px;
+  line-height: 14px;
+  color: ${({ sectionColour }) => sectionColour};
+  font-family: ${fonts.supporting};
+  font-weight: normal;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+`;
+
+export const Heading = styled.h2`
+  font-size: 18px;
+  line-height: 18px;
+  font-family: ${fonts.headlineRegular};
+  margin: 6px 0 0 0;
 `;


### PR DESCRIPTION
Styling updates: 
1: Heading - Add a larger heading and separate from the label
2: Centralise spacing of items in the schedule list.
3: Change colour of border, label and time on schedule to the olympic purple as requested by Anthony. 

### Screenshots 
<img width="766" alt="Screenshot 2021-07-27 at 16 29 04" src="https://user-images.githubusercontent.com/44647540/127183755-a638f270-0f34-47f8-be1a-cb8e8f5034e6.png">
<img width="766" alt="Screenshot 2021-07-27 at 16 29 01" src="https://user-images.githubusercontent.com/44647540/127183761-f625ee84-d8ab-4986-964c-6f70eb08a75b.png">
<img width="766" alt="Screenshot 2021-07-27 at 16 28 55" src="https://user-images.githubusercontent.com/44647540/127183762-0ee7ca4b-6331-4476-a1f3-52f2fa04fd6f.png">

<img width="766" alt="Screenshot 2021-07-27 at 16 27 13" src="https://user-images.githubusercontent.com/44647540/127183766-0672b586-0270-4b12-8675-c58542a71c60.png">
<img width="766" alt="Screenshot 2021-07-27 at 16 27 10" src="https://user-images.githubusercontent.com/44647540/127183768-d574a063-8182-48df-b302-6b3a9cfc24af.png">
<img width="766" alt="Screenshot 2021-07-27 at 16 27 05" src="https://user-images.githubusercontent.com/44647540/127183769-a99335b3-6968-4a2f-a95a-822d642e98e4.png">
