### PR TITLE
fix(te-000): Revert medal position change 

### DIFF
--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -90,13 +90,11 @@ exports[`<OlympicsSchedule> click show all 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
   color: #402f7a;
   line-height: 30px;
-  position: absolute;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-text {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
-  margin-right: 50px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_discipline {
@@ -106,12 +104,8 @@ exports[`<OlympicsSchedule> click show all 1`] = `
   margin-top: 4px;
 }
 
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
-  position: relative;
-  left: calc(100% - 65px);
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_status-live {
+  padding: 9px 20px 5px 20px;
 }
 
 .c0 .pa-schedule .pa_OdfFooter_ctr {
@@ -163,12 +157,6 @@ exports[`<OlympicsSchedule> click show all 1`] = `
 @media (min-width:1024px) {
   .c0 {
     width: 56.2%;
-  }
-}
-
-@media only screen and (min-width:321px) {
-  .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
-    left: calc(100% - 75px);
   }
 }
 
@@ -297,13 +285,11 @@ exports[`<OlympicsSchedule> render default keys 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
   color: #402f7a;
   line-height: 30px;
-  position: absolute;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-text {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
-  margin-right: 50px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_discipline {
@@ -313,12 +299,8 @@ exports[`<OlympicsSchedule> render default keys 1`] = `
   margin-top: 4px;
 }
 
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
-  position: relative;
-  left: calc(100% - 65px);
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_status-live {
+  padding: 9px 20px 5px 20px;
 }
 
 .c0 .pa-schedule .pa_OdfFooter_ctr {
@@ -370,12 +352,6 @@ exports[`<OlympicsSchedule> render default keys 1`] = `
 @media (min-width:1024px) {
   .c0 {
     width: 56.2%;
-  }
-}
-
-@media only screen and (min-width:321px) {
-  .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
-    left: calc(100% - 75px);
   }
 }
 
@@ -504,13 +480,11 @@ exports[`<OlympicsSchedule> renders 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
   color: #402f7a;
   line-height: 30px;
-  position: absolute;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-text {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
-  margin-right: 50px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_discipline {
@@ -520,12 +494,8 @@ exports[`<OlympicsSchedule> renders 1`] = `
   margin-top: 4px;
 }
 
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
-  position: relative;
-  left: calc(100% - 65px);
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_status-live {
+  padding: 9px 20px 5px 20px;
 }
 
 .c0 .pa-schedule .pa_OdfFooter_ctr {
@@ -577,12 +547,6 @@ exports[`<OlympicsSchedule> renders 1`] = `
 @media (min-width:1024px) {
   .c0 {
     width: 56.2%;
-  }
-}
-
-@media only screen and (min-width:321px) {
-  .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
-    left: calc(100% - 75px);
   }
 }
 
@@ -711,13 +675,11 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-time {
   color: #402f7a;
   line-height: 30px;
-  position: absolute;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_unit-text {
   font-family: GillSansMTStd-Medium;
   font-size: 16px;
-  margin-right: 50px;
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_discipline {
@@ -727,12 +689,8 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
   margin-top: 4px;
 }
 
-.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
-  position: relative;
-  left: calc(100% - 65px);
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
+.c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_status-live {
+  padding: 9px 20px 5px 20px;
 }
 
 .c0 .pa-schedule .pa_OdfFooter_ctr {
@@ -772,12 +730,6 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 @media only screen and (min-width:768px) {
   .c3 {
     font-size: 32px;
-  }
-}
-
-@media only screen and (min-width:321px) {
-  .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_ctr .pa_UnitListView_medal {
-    left: calc(100% - 75px);
   }
 }
 

--- a/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
+++ b/packages/ts-components/src/components/olympics/__tests__/__snapshots__/OlympicsSchedule.test.tsx.snap
@@ -105,7 +105,10 @@ exports[`<OlympicsSchedule> click show all 1`] = `
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_status-live {
-  padding: 9px 20px 5px 20px;
+  padding: 8px 20px 4px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .c0 .pa-schedule .pa_OdfFooter_ctr {
@@ -300,7 +303,10 @@ exports[`<OlympicsSchedule> render default keys 1`] = `
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_status-live {
-  padding: 9px 20px 5px 20px;
+  padding: 8px 20px 4px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .c0 .pa-schedule .pa_OdfFooter_ctr {
@@ -495,7 +501,10 @@ exports[`<OlympicsSchedule> renders 1`] = `
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_status-live {
-  padding: 9px 20px 5px 20px;
+  padding: 8px 20px 4px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .c0 .pa-schedule .pa_OdfFooter_ctr {
@@ -690,7 +699,10 @@ exports[`<OlympicsSchedule> renders outside of article 1`] = `
 }
 
 .c0 .pa-schedule .pa_LoadingOverlayContainer_ctr .pa_UnitListView_status-live {
-  padding: 9px 20px 5px 20px;
+  padding: 8px 20px 4px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .c0 .pa-schedule .pa_OdfFooter_ctr {

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -55,13 +55,11 @@ export const Container = styled.div<{
         .pa_UnitListView_unit-time {
           color: ${olympicColour};
           line-height: 30px;
-          position: absolute;
         }
 
         .pa_UnitListView_unit-text {
           font-family: ${fonts.supporting};
           font-size: 16px;
-          margin-right: 50px;
         }
 
         .pa_UnitListView_discipline {
@@ -70,15 +68,9 @@ export const Container = styled.div<{
           font-weight: 400;
           margin-top: 4px;
         }
-
-        .pa_UnitListView_medal {
-          position: relative;
-          left: calc(100% - 65px);
-          align-self: center;
-          @media only screen and (min-width: 321px) {
-            left: calc(100% - 75px);
-          }
-        }
+      }
+      .pa_UnitListView_status-live {
+        padding: 9px 20px 5px 20px;
       }
     }
 

--- a/packages/ts-components/src/components/olympics/schedule/styles.ts
+++ b/packages/ts-components/src/components/olympics/schedule/styles.ts
@@ -70,7 +70,8 @@ export const Container = styled.div<{
         }
       }
       .pa_UnitListView_status-live {
-        padding: 9px 20px 5px 20px;
+        padding: 8px 20px 4px;
+        align-self: center;
       }
     }
 


### PR DESCRIPTION
### Description
Now we can see live data on the Olympics schedule, can see that the medal in the right hand side overlaps both 'Live' status and 'finished' status so have to move it back to the original left position. 
Also the text in the 'Live' status was very high up so have centralised it. -- More styling issues in my opinion with 'Live' and 'Finished' but that can be added later. 

### Before 
<img width="533" alt="Screenshot 2021-07-29 at 09 11 06" src="https://user-images.githubusercontent.com/44647540/127459436-e16d22db-aa2b-4d11-b0d0-14a56bbb56e2.png">
### After
<img width="785" alt="Screenshot 2021-07-29 at 09 24 39" src="https://user-images.githubusercontent.com/44647540/127459492-4af3d669-0445-4a16-9759-c8b6e830a6f2.png">
<img width="785" alt="Screenshot 2021-07-29 at 09 24 42" src="https://user-images.githubusercontent.com/44647540/127459577-49f110ba-f87b-4fd2-a44b-d7c024e0ba09.png">
