### PR TITLE
fix(TDP-759): Fix links in key-facts

### DIFF
--- a/packages/key-facts/__tests__/web/__snapshots__/key-facts.web.test.js.snap
+++ b/packages/key-facts/__tests__/web/__snapshots__/key-facts.web.test.js.snap
@@ -17,6 +17,7 @@ exports[`1. key facts with title 1`] = `
       An example 
       <a
         data-testid="KeyFactTextLink"
+        href="https://example.io"
       >
         link
       </a>
@@ -57,6 +58,7 @@ exports[`2. key facts without title 1`] = `
       An example 
       <a
         data-testid="KeyFactTextLink"
+        href="https://example.io"
       >
         link
       </a>

--- a/packages/key-facts/src/key-facts-text.js
+++ b/packages/key-facts/src/key-facts-text.js
@@ -24,7 +24,7 @@ const KeyFactsText = ({ item, listIndex, onLinkPress }) => (
                     url
                   })
                 }
-                url={url}
+                href={url}
               >
                 {renderedChildren}
               </KeyFactTextLink>

--- a/packages/key-facts/src/styles.js
+++ b/packages/key-facts/src/styles.js
@@ -8,6 +8,7 @@ import {
 } from "@times-components/styleguide";
 
 export const KeyFactTextLink = styled.a`
+  color: inherit;
   cursor: pointer;
   text-decoration: underline;
   &:hover {


### PR DESCRIPTION
The links in the Key Facts component was not working after converting Key Facts away from React Native. This change fixes that.
