### PR TITLE
feat(TDP-1329): Unlock related articles to users with access to full articles 

### DIFF
--- a/packages/user-state/__tests__/matchers.test.js
+++ b/packages/user-state/__tests__/matchers.test.js
@@ -6,14 +6,16 @@ import {
   isNonMeteredExpiredUser,
   isSubscriber,
   shouldShowFullArticle,
-  isLoggedInOrShared
+  isLoggedInOrShared,
+  hasAccess
 } from "../src/matchers";
 
 const defaultUserState = {
   isLoggedIn: false,
   isMetered: false,
   isMeteredExpired: false,
-  isShared: false
+  isShared: false,
+  hasAccess: false
 };
 
 describe("user state should", () => {
@@ -135,6 +137,18 @@ describe("user state should", () => {
     });
   });
 
+  describe("hasAccess", () => {
+    it("return true if userState hasAccess is true", () => {
+      const userState = { ...defaultUserState, hasAccess: true };
+      expect(hasAccess(userState)).toBe(true);
+    });
+
+    it("return false if userState hasAccess is false", () => {
+      const userState = { ...defaultUserState, hasAccess: false };
+      expect(hasAccess(userState)).toBe(false);
+    });
+  });
+
   describe("isLoggedInOrShared", () => {
     it("returns true when user is subscriber", () => {
       const userState = { ...defaultUserState, isLoggedIn: true };
@@ -188,6 +202,11 @@ describe("user state should", () => {
 
     it("returns true when user is on share token", () => {
       const userState = { ...defaultUserState, isShared: true };
+      expect(shouldShowFullArticle(userState)).toBe(true);
+    });
+
+    it("returns true when user hasAccess", () => {
+      const userState = { ...defaultUserState, hasAccess: true };
       expect(shouldShowFullArticle(userState)).toBe(true);
     });
 

--- a/packages/user-state/src/matchers.js
+++ b/packages/user-state/src/matchers.js
@@ -1,5 +1,7 @@
 export const isLoggedIn = userState => userState.isLoggedIn;
 
+export const hasAccess = userState => userState.hasAccess;
+
 export const isMeteredExpired = userState =>
   isLoggedIn(userState) && userState.isMeteredExpired;
 
@@ -15,6 +17,6 @@ export const isNonMeteredExpiredUser = user =>
   isLoggedIn(user) && !isMeteredExpired(user);
 
 export const shouldShowFullArticle = user =>
-  isShared(user) || isNonMeteredExpiredUser(user);
+  isShared(user) || isNonMeteredExpiredUser(user) || hasAccess(user);
 
 export const isLoggedInOrShared = user => isShared(user) || isLoggedIn(user);

--- a/packages/user-state/src/user-state.js
+++ b/packages/user-state/src/user-state.js
@@ -20,7 +20,8 @@ import {
   isShared,
   shouldShowFullArticle,
   isSubscriber,
-  isLoggedInOrShared
+  isLoggedInOrShared,
+  hasAccess
 } from "./matchers";
 
 function UserState({
@@ -46,6 +47,7 @@ UserState.nonMeteredExpiredUser = isNonMeteredExpiredUser;
 UserState.fullArticle = shouldShowFullArticle;
 UserState.subscriber = isSubscriber;
 UserState.loggedInOrShared = isLoggedInOrShared;
+UserState.hasAccess = hasAccess;
 
 UserState.propTypes = {
   state: PropTypes.func.isRequired,


### PR DESCRIPTION
### Description

In this PR we add `hasAccess` to `userState` and we check it to `matchers` when we see if we `shouldShowFullArticle`
[TDP-1329](https://nidigitalsolutions.jira.com/browse/TDP-1329)
