### PR TITLE
fix(TDP-760): Fix article heading divider spacing

### DIFF
--- a/packages/ts-components/src/components/article-header/ArticleHeader.stories.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleHeader.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { date, select } from '@storybook/addon-knobs';
+import { date, select, text } from '@storybook/addon-knobs';
 
 import { ArticleHarness } from '../../fixtures/article-harness/ArticleHarness';
 import ArticleHeader from './ArticleHeader';
@@ -9,7 +9,7 @@ storiesOf('Typescript Component/Article Header', module)
   .addDecorator((storyFn: () => React.ReactNode) => (
     <ArticleHarness>{storyFn()}</ArticleHarness>
   ))
-  .add('Basic Article Header', () => {
+  .add('Article Header with headline', () => {
     const label = 'Updated Date/Time';
     const defaultValue = new Date();
     const groupId = 'Options';
@@ -18,13 +18,33 @@ storiesOf('Typescript Component/Article Header', module)
       True: 'true',
       False: undefined
     };
-
     const updated = new Date(value).toISOString();
+
+    const headline = text('Headline', 'This is the headline', groupId);
+
     return (
       <ArticleHeader
         updated={updated}
         breaking={select('Breaking', breakingOptions, undefined, groupId)}
-        headline="This%20is%20the%20headline"
+        headline={encodeURIComponent(headline)}
+      />
+    );
+  })
+  .add('Article Header without headline', () => {
+    const label = 'Updated Date/Time';
+    const defaultValue = new Date();
+    const groupId = 'Options';
+    const value = date(label, defaultValue, groupId);
+    const breakingOptions = {
+      True: 'true',
+      False: undefined
+    };
+    const updated = new Date(value).toISOString();
+
+    return (
+      <ArticleHeader
+        updated={updated}
+        breaking={select('Breaking', breakingOptions, undefined, groupId)}
       />
     );
   });

--- a/packages/ts-components/src/components/article-header/__tests__/__snapshots__/ArticleHeader.test.tsx.snap
+++ b/packages/ts-components/src/components/article-header/__tests__/__snapshots__/ArticleHeader.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ArticleHeader In one calendar day Within the first minute of update - B
 <body>
   <div>
     <div
-      class="sc-bdVaJa loTniz"
+      class="sc-bdVaJa cQBRMp"
     >
       <div
         class="sc-bwzfXH htoLMg"
@@ -41,7 +41,7 @@ exports[`ArticleHeader In one calendar day Within the first minute of update - B
         </div>
       </div>
       <h2
-        class="sc-htoDjs dBHFtk"
+        class="sc-htoDjs ccbbfo"
       >
         This is the headline
       </h2>
@@ -54,7 +54,7 @@ exports[`ArticleHeader In one calendar day Within the first minute of update - N
 <body>
   <div>
     <div
-      class="sc-bdVaJa keGbcB"
+      class="sc-bdVaJa fLcQHz"
     >
       <div
         class="sc-bwzfXH htoLMg"
@@ -79,7 +79,7 @@ exports[`ArticleHeader In one calendar day Within the first minute of update - N
 <body>
   <div>
     <div
-      class="sc-bdVaJa keGbcB"
+      class="sc-bdVaJa fLcQHz"
     >
       <div
         class="sc-bwzfXH htoLMg"
@@ -96,7 +96,7 @@ exports[`ArticleHeader In one calendar day Within the first minute of update - N
         </div>
       </div>
       <h2
-        class="sc-htoDjs dBHFtk"
+        class="sc-htoDjs ccbbfo"
       >
         This is the headline
       </h2>

--- a/packages/ts-components/src/components/article-header/styles.ts
+++ b/packages/ts-components/src/components/article-header/styles.ts
@@ -5,18 +5,18 @@ export const Container = styled.div<{ isBreaking: boolean }>`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin: 48px 10px 0 10px;
+  margin: 48px 10px 24px 10px;
   padding-top: ${({ isBreaking }) => (isBreaking ? '8px' : '5px')};
   border-top: 2px solid #9f0000;
 
   @media (min-width: ${breakpoints.medium}px) {
     width: 80.8%;
-    margin: 64px 0 0 10%;
+    margin: 64px 0 24px 10%;
   }
 
   @media (min-width: ${breakpoints.wide}px) {
     width: 56.2%;
-    margin: 64px 0 0 22%;
+    margin: 64px 0 24px 22%;
   }
 `;
 
@@ -72,12 +72,14 @@ export const Headline = styled.h2`
   font-size: 28px;
   line-height: 28px;
   margin-top: 22px;
+  margin-bottom: 0px;
   font-weight: 400;
 
   @media (min-width: ${breakpoints.medium}px) {
     font-size: 36px;
     line-height: 36px;
     margin-top: 20px;
+    margin-bottom: 0px;
   }
 `;
 


### PR DESCRIPTION
### Description 

The spacing below the article divider component was previously being handled by the bottom of the headline - However given the headline is an optional property in the case of no headline the component squished against the top of the following paragraph/component. This change passes the spacing to the component container instead.
Also added a story without a headline.

[Storybook](https://26857-93151110-gh.circle-artifacts.com/0/Storybook/index.html?path=/story/typescript-component-article-header--article-header-without-headline)

## Before 
<img width="1185" alt="Screenshot 2022-02-22 at 14 56 46" src="https://user-images.githubusercontent.com/44647540/155158970-4561f298-0917-47ec-b55f-a637a1e5229e.png">


## After
<img width="1185" alt="Screenshot 2022-02-22 at 14 58 26" src="https://user-images.githubusercontent.com/44647540/155159006-7b5b526e-a0a7-4caa-9f64-ae508ebc4740.png">

