### PR TITLE
fix/tdp-760-article-divider-headline-fix

### DIFF
--- a/packages/ts-components/src/components/article-header/ArticleHeader.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleHeader.tsx
@@ -42,6 +42,15 @@ const ArticleHeader: React.FC<{
     ? Boolean(breaking.toLowerCase() === 'true')
     : false;
 
+  const decodeHeadline = (headline: string) => {
+    try{
+      return decodeURI(headline)
+    }
+    catch {
+      return headline
+    }
+  }
+
   return (
     <Container isBreaking={isBreaking && isLessThan1Hour}>
       <UpdatesContainer>
@@ -75,7 +84,7 @@ const ArticleHeader: React.FC<{
           </UpdatedDate>
         ) : null}
       </UpdatesContainer>
-      {headline && <Headline>{decodeURI(headline)}</Headline>}
+      {headline && <Headline>{decodeHeadline(headline)}</Headline>}
     </Container>
   );
 };

--- a/packages/ts-components/src/components/article-header/ArticleHeader.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleHeader.tsx
@@ -42,14 +42,13 @@ const ArticleHeader: React.FC<{
     ? Boolean(breaking.toLowerCase() === 'true')
     : false;
 
-  const decodeHeadline = (headline: string) => {
-    try{
-      return decodeURI(headline)
+  const decodeHeadline = (uri: string) => {
+    try {
+      return decodeURI(uri);
+    } catch {
+      return uri;
     }
-    catch {
-      return headline
-    }
-  }
+  };
 
   return (
     <Container isBreaking={isBreaking && isLessThan1Hour}>


### PR DESCRIPTION
Add a try catch around headline decoding as sometimes the input isn't encoded properly


