### PR TITLE
fix(TDP-1580): Add dateModified to liveBlogUpdate

### DIFF
--- a/packages/article-skeleton/src/head.js
+++ b/packages/article-skeleton/src/head.js
@@ -170,6 +170,7 @@ const getLiveBlogUpdates = (article, publisher, author) => {
               "@type": "BlogPosting",
               headline: attributes.headline,
               datePublished: attributes.updated,
+              dateModified: attributes.updated,
               publisher,
               url: `${article.url}#${anchorString(
                 attributes.updated,


### PR DESCRIPTION
Add dateModified to the live blog updates. 
From Grace "Date modified and published will be the same for each update, unless editors go in and tweak the update, in which case the modified date would be different - it's unlikely they'd do this though, they'd probably just add a new update."
