### PR TITLE
feat(TDP-1417): remove react-native prop types from button

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -21,10 +21,7 @@
     "url": "git+https://github.com/newsuk/times-components.git"
   },
   "keywords": [
-    "react-native-web",
     "react",
-    "native",
-    "web",
     "button",
     "component"
   ],
@@ -53,7 +50,6 @@
     "react": "16.9.0",
     "react-art": "16.6.3",
     "react-dom": "16.9.0",
-    "react-native": "0.61.5",
     "react-native-web": "0.11.4",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"
@@ -69,9 +65,7 @@
   },
   "peerDependencies": {
     "react": ">=16.9",
-    "react-dom": ">=16.9",
-    "react-native": ">=0.59",
-    "react-native-web": "0.11.4"
+    "react-dom": ">=16.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/button/src/button-prop-types.js
+++ b/packages/button/src/button-prop-types.js
@@ -1,15 +1,12 @@
-import { ViewPropTypes, Text } from "react-native";
 import PropTypes from "prop-types";
-
-const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 export const propTypes = {
   fontSize: PropTypes.number,
   lineHeight: PropTypes.number,
   onPress: PropTypes.func.isRequired,
-  style: ViewPropTypesStyle,
+  style: PropTypes.object,
   title: PropTypes.string,
-  textStyle: Text.propTypes.style,
+  textStyle: PropTypes.string,
   underlayColor: PropTypes.string
 };
 


### PR DESCRIPTION
Removed react-native components Text & ViewPropTypes and replaced with PropTypes as only used for style props
