### PR TITLE
feat(TDP-1747):  commented out message so an override cant display it…

### DIFF
--- a/packages/article-comments/__tests__/web/__snapshots__/shared.web.test.js.snap
+++ b/packages/article-comments/__tests__/web/__snapshots__/shared.web.test.js.snap
@@ -6,64 +6,6 @@ exports[`Render comments label, when comments are loaded 1`] = `
   display: none;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  margin-top: 50px;
-}
-
-.c2.info {
-  background-color: #bedeed;
-  border-left: 4px solid #1573a2;
-}
-
-.c2.info svg {
-  fill: #1573a2;
-}
-
-.c2.warning {
-  background-color: #ffeecc;
-  border-left: 4px solid #ffa300;
-}
-
-.c2.warning svg {
-  fill: #ffa300;
-}
-
-.c2.error {
-  background-color: #ffd6d6;
-  border-left: 4px solid #df0000;
-}
-
-.c2.error svg {
-  fill: #df0000;
-}
-
-.c3 {
-  margin: 12px 0 45px 12px;
-}
-
-.c4 {
-  margin: 12px;
-}
-
-.c5 {
-  font-family: GillSansMTStd-Medium;
-  font-weight: 700;
-  font-size: 16px;
-  line-height: 16px;
-  margin-bottom: 6px;
-}
-
-.c6 {
-  font-family: GillSansMTStd-Medium;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
 .c0 {
   margin-left: auto;
   margin-right: auto;
@@ -86,49 +28,7 @@ exports[`Render comments label, when comments are loaded 1`] = `
   >
     <div
       class="comment-banner c1"
-    >
-      <div
-        class="info c2"
-      >
-        <div
-          class="c3"
-        >
-          <svg
-            fill="none"
-            height="20"
-            viewBox="0 0 20 20"
-            width="20"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM9 15V9H11V15H9ZM9 5V7H11V5H9Z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </div>
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            Real-name Commenting
-          </div>
-          <div
-            class="c6"
-          >
-            We've changed our policy and from now on commenters will need to use their real names. If you've been using a pseudonym, please edit your screen name 
-            <a
-              href="https://home.thetimes.co.uk/"
-            >
-              here
-            </a>
-            . We believe this will ensure true debate.
-          </div>
-        </div>
-      </div>
-    </div>
+    />
   </div>
   .c0 {
   margin-left: auto;
@@ -276,64 +176,6 @@ exports[`User States enabled comments 1`] = `
   display: none;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  margin-top: 50px;
-}
-
-.c2.info {
-  background-color: #bedeed;
-  border-left: 4px solid #1573a2;
-}
-
-.c2.info svg {
-  fill: #1573a2;
-}
-
-.c2.warning {
-  background-color: #ffeecc;
-  border-left: 4px solid #ffa300;
-}
-
-.c2.warning svg {
-  fill: #ffa300;
-}
-
-.c2.error {
-  background-color: #ffd6d6;
-  border-left: 4px solid #df0000;
-}
-
-.c2.error svg {
-  fill: #df0000;
-}
-
-.c3 {
-  margin: 12px 0 45px 12px;
-}
-
-.c4 {
-  margin: 12px;
-}
-
-.c5 {
-  font-family: GillSansMTStd-Medium;
-  font-weight: 700;
-  font-size: 16px;
-  line-height: 16px;
-  margin-bottom: 6px;
-}
-
-.c6 {
-  font-family: GillSansMTStd-Medium;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
 .c0 {
   margin-left: auto;
   margin-right: auto;
@@ -356,49 +198,7 @@ exports[`User States enabled comments 1`] = `
   >
     <div
       class="comment-banner c1"
-    >
-      <div
-        class="info c2"
-      >
-        <div
-          class="c3"
-        >
-          <svg
-            fill="none"
-            height="20"
-            viewBox="0 0 20 20"
-            width="20"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM9 15V9H11V15H9ZM9 5V7H11V5H9Z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </div>
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            Real-name Commenting
-          </div>
-          <div
-            class="c6"
-          >
-            We've changed our policy and from now on commenters will need to use their real names. If you've been using a pseudonym, please edit your screen name 
-            <a
-              href="https://home.thetimes.co.uk/"
-            >
-              here
-            </a>
-            . We believe this will ensure true debate.
-          </div>
-        </div>
-      </div>
-    </div>
+    />
   </div>
   .c0 {
   margin-left: auto;
@@ -689,64 +489,6 @@ exports[`single comment 1`] = `
   display: none;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  margin-top: 50px;
-}
-
-.c2.info {
-  background-color: #bedeed;
-  border-left: 4px solid #1573a2;
-}
-
-.c2.info svg {
-  fill: #1573a2;
-}
-
-.c2.warning {
-  background-color: #ffeecc;
-  border-left: 4px solid #ffa300;
-}
-
-.c2.warning svg {
-  fill: #ffa300;
-}
-
-.c2.error {
-  background-color: #ffd6d6;
-  border-left: 4px solid #df0000;
-}
-
-.c2.error svg {
-  fill: #df0000;
-}
-
-.c3 {
-  margin: 12px 0 45px 12px;
-}
-
-.c4 {
-  margin: 12px;
-}
-
-.c5 {
-  font-family: GillSansMTStd-Medium;
-  font-weight: 700;
-  font-size: 16px;
-  line-height: 16px;
-  margin-bottom: 6px;
-}
-
-.c6 {
-  font-family: GillSansMTStd-Medium;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
 .c0 {
   margin-left: auto;
   margin-right: auto;
@@ -769,49 +511,7 @@ exports[`single comment 1`] = `
   >
     <div
       class="comment-banner c1"
-    >
-      <div
-        class="info c2"
-      >
-        <div
-          class="c3"
-        >
-          <svg
-            fill="none"
-            height="20"
-            viewBox="0 0 20 20"
-            width="20"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM9 15V9H11V15H9ZM9 5V7H11V5H9Z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </div>
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            Real-name Commenting
-          </div>
-          <div
-            class="c6"
-          >
-            We've changed our policy and from now on commenters will need to use their real names. If you've been using a pseudonym, please edit your screen name 
-            <a
-              href="https://home.thetimes.co.uk/"
-            >
-              here
-            </a>
-            . We believe this will ensure true debate.
-          </div>
-        </div>
-      </div>
-    </div>
+    />
   </div>
   .c0 {
   margin-left: auto;
@@ -870,64 +570,6 @@ exports[`zero comments 1`] = `
   display: none;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  margin-top: 50px;
-}
-
-.c2.info {
-  background-color: #bedeed;
-  border-left: 4px solid #1573a2;
-}
-
-.c2.info svg {
-  fill: #1573a2;
-}
-
-.c2.warning {
-  background-color: #ffeecc;
-  border-left: 4px solid #ffa300;
-}
-
-.c2.warning svg {
-  fill: #ffa300;
-}
-
-.c2.error {
-  background-color: #ffd6d6;
-  border-left: 4px solid #df0000;
-}
-
-.c2.error svg {
-  fill: #df0000;
-}
-
-.c3 {
-  margin: 12px 0 45px 12px;
-}
-
-.c4 {
-  margin: 12px;
-}
-
-.c5 {
-  font-family: GillSansMTStd-Medium;
-  font-weight: 700;
-  font-size: 16px;
-  line-height: 16px;
-  margin-bottom: 6px;
-}
-
-.c6 {
-  font-family: GillSansMTStd-Medium;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-}
-
 .c0 {
   margin-left: auto;
   margin-right: auto;
@@ -950,49 +592,7 @@ exports[`zero comments 1`] = `
   >
     <div
       class="comment-banner c1"
-    >
-      <div
-        class="info c2"
-      >
-        <div
-          class="c3"
-        >
-          <svg
-            fill="none"
-            height="20"
-            viewBox="0 0 20 20"
-            width="20"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM9 15V9H11V15H9ZM9 5V7H11V5H9Z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </div>
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            Real-name Commenting
-          </div>
-          <div
-            class="c6"
-          >
-            We've changed our policy and from now on commenters will need to use their real names. If you've been using a pseudonym, please edit your screen name 
-            <a
-              href="https://home.thetimes.co.uk/"
-            >
-              here
-            </a>
-            . We believe this will ensure true debate.
-          </div>
-        </div>
-      </div>
-    </div>
+    />
   </div>
   .c0 {
   margin-left: auto;

--- a/packages/article-comments/__tests__/web/shared.web.test.js
+++ b/packages/article-comments/__tests__/web/shared.web.test.js
@@ -69,7 +69,7 @@ describe("User States", () => {
   });
 });
 
-it("pre-switchover comments", () => {
+xit("pre-switchover comments", () => {
   const { asFragment, baseElement } = renderComments({
     count: 123,
     enabled: true,

--- a/packages/article-comments/src/article-comments.js
+++ b/packages/article-comments/src/article-comments.js
@@ -35,13 +35,13 @@ const ArticleComments = ({
       <UserState state={UserState.subscriber}>
         <CommentContainer>
           <HiddenDiv className="comment-banner">
-            <InlineMessage title="Real-name Commenting" type="info">
+            {/* <InlineMessage title="Real-name Commenting" type="info">
               We&apos;ve changed our policy and from now on commenters will need
               to use their real names. If you&apos;ve been using a pseudonym,
               please edit your screen name{" "}
               <a href="https://home.thetimes.co.uk/">here</a>. We believe this
               will ensure true debate.
-            </InlineMessage>
+            </InlineMessage> */}
           </HiddenDiv>
         </CommentContainer>
         <Comments

--- a/packages/article-comments/src/article-comments.js
+++ b/packages/article-comments/src/article-comments.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import UserState from "@times-components/user-state";
 import {
   InlineDialog,
-  InlineMessage,
+  // InlineMessage,
   HiddenDiv
 } from "@times-components/ts-components";
 

--- a/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -391,27 +391,6 @@ exports[`1. a full article 1`] = `
           r="14"
         />
       </svg>
-      <svg
-        height="20"
-        viewBox="0 0 20 20"
-        width="20"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clip-rule="evenodd"
-          d="a4e230906ee0051a9ddc27f81fc43cb2"
-          fill-rule="evenodd"
-        />
-      </svg>
-      Real-name Commenting
-      We've changed our policy and from now on commenters will need to use their real names. If you've been using a pseudonym, please edit your screen name
-       
-      <a
-        href="https://home.thetimes.co.uk/"
-      >
-        here
-      </a>
-      . We believe this will ensure true debate.
     </article>
   </main>
 </article>

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -407,27 +407,6 @@ exports[`1. a full article 1`] = `
           r="14"
         />
       </svg>
-      <svg
-        height="20"
-        viewBox="0 0 20 20"
-        width="20"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clip-rule="evenodd"
-          d="a4e230906ee0051a9ddc27f81fc43cb2"
-          fill-rule="evenodd"
-        />
-      </svg>
-      Real-name Commenting
-      We've changed our policy and from now on commenters will need to use their real names. If you've been using a pseudonym, please edit your screen name
-       
-      <a
-        href="https://home.thetimes.co.uk/"
-      >
-        here
-      </a>
-      . We believe this will ensure true debate.
     </article>
   </main>
 </article>

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -396,27 +396,6 @@ exports[`1. a full article 1`] = `
           r="14"
         />
       </svg>
-      <svg
-        height="20"
-        viewBox="0 0 20 20"
-        width="20"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clip-rule="evenodd"
-          d="a4e230906ee0051a9ddc27f81fc43cb2"
-          fill-rule="evenodd"
-        />
-      </svg>
-      Real-name Commenting
-      We've changed our policy and from now on commenters will need to use their real names. If you've been using a pseudonym, please edit your screen name
-       
-      <a
-        href="https://home.thetimes.co.uk/"
-      >
-        here
-      </a>
-      . We believe this will ensure true debate.
     </article>
   </main>
 </article>

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -396,27 +396,6 @@ exports[`1. a full article 1`] = `
           r="14"
         />
       </svg>
-      <svg
-        height="20"
-        viewBox="0 0 20 20"
-        width="20"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clip-rule="evenodd"
-          d="a4e230906ee0051a9ddc27f81fc43cb2"
-          fill-rule="evenodd"
-        />
-      </svg>
-      Real-name Commenting
-      We've changed our policy and from now on commenters will need to use their real names. If you've been using a pseudonym, please edit your screen name
-       
-      <a
-        href="https://home.thetimes.co.uk/"
-      >
-        here
-      </a>
-      . We believe this will ensure true debate.
     </article>
   </main>
 </article>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -417,27 +417,6 @@ exports[`1. a full article with an image as the lead asset 1`] = `
           r="14"
         />
       </svg>
-      <svg
-        height="20"
-        viewBox="0 0 20 20"
-        width="20"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clip-rule="evenodd"
-          d="a4e230906ee0051a9ddc27f81fc43cb2"
-          fill-rule="evenodd"
-        />
-      </svg>
-      Real-name Commenting
-      We've changed our policy and from now on commenters will need to use their real names. If you've been using a pseudonym, please edit your screen name
-       
-      <a
-        href="https://home.thetimes.co.uk/"
-      >
-        here
-      </a>
-      . We believe this will ensure true debate.
     </article>
   </main>
 </article>


### PR DESCRIPTION
… before it's ready

Commented out the Real Name Commenting Message, but left it in the code, so that it can be uncommented when it's needed. It seems that the display:none on the hidden div wasn't sufficient as an unknown override has displayed it to a customer, maybe optomizely 
