### PR TITLE
fix(TDP-1777): Make analytics article_flag data lower case

### DIFF
--- a/packages/article-skeleton/src/tracking/article-tracking-context.js
+++ b/packages/article-skeleton/src/tracking/article-tracking-context.js
@@ -50,7 +50,9 @@ export default Component =>
         template: get(data, "template", "Default"),
         registrationType: getRegistrationType(),
         shared: getSharedStatus(),
-        article_flag: getIsLiveOrBreakingFlag(flags) ? getIsLiveOrBreakingFlag(flags).toLowerCase() : "no flag",
+        article_flag: getIsLiveOrBreakingFlag(flags)
+          ? getIsLiveOrBreakingFlag(flags).toLowerCase()
+          : "no flag",
         article_template_name: getIsLiveOrBreakingFlag(flags)
           ? "live template"
           : "standard template"

--- a/packages/article-skeleton/src/tracking/article-tracking-context.js
+++ b/packages/article-skeleton/src/tracking/article-tracking-context.js
@@ -50,7 +50,7 @@ export default Component =>
         template: get(data, "template", "Default"),
         registrationType: getRegistrationType(),
         shared: getSharedStatus(),
-        article_flag: getIsLiveOrBreakingFlag(flags) || "no flag",
+        article_flag: getIsLiveOrBreakingFlag(flags) ? getIsLiveOrBreakingFlag(flags).toLowerCase() : "no flag",
         article_template_name: getIsLiveOrBreakingFlag(flags)
           ? "live template"
           : "standard template"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "dependencies": {
-    "@times-components/styleguide": "3.38.34"
+    "@times-components/styleguide": "3.38.35"
   },
   "devDependencies": {
     "@babel/core": "7.4.4",

--- a/packages/key-facts/src/key-facts.js
+++ b/packages/key-facts/src/key-facts.js
@@ -14,7 +14,9 @@ const KeyFacts = ({ ast, section, headline, isLiveOrBreaking }) => {
 
   const { children: keyFactsItems } = children[0];
 
-  const articleFlag = isLiveOrBreaking? isLiveOrBreaking.toLowerCase() : "no flag"
+  const articleFlag = isLiveOrBreaking
+    ? isLiveOrBreaking.toLowerCase()
+    : "no flag";
 
   return (
     <TrackingContextProvider

--- a/packages/key-facts/src/key-facts.js
+++ b/packages/key-facts/src/key-facts.js
@@ -14,7 +14,7 @@ const KeyFacts = ({ ast, section, headline, isLiveOrBreaking }) => {
 
   const { children: keyFactsItems } = children[0];
 
-  const articleFlag = isLiveOrBreaking || "no flag";
+  const articleFlag = isLiveOrBreaking? isLiveOrBreaking.toLowerCase() : "no flag"
 
   return (
     <TrackingContextProvider


### PR DESCRIPTION
The value for article_flag if a live or breaking article was coming through as uppercase. This PR changes it to lower case.
[TDP-1777](https://nidigitalsolutions.jira.com/browse/TDP-1777)