### PR TITLE
fix(tdp-1829): update flag tracking

### DIFF
--- a/packages/article-magazine-standard/fixtures/full-article.js
+++ b/packages/article-magazine-standard/fixtures/full-article.js
@@ -2160,7 +2160,6 @@ export const testFixture = {
       name: "paragraph"
     }
   ],
-  flags: ["NEW"],
   hasVideo: false,
   headline: "Some Headline",
   label: "Some Label",

--- a/packages/article-skeleton/__tests__/web/__snapshots__/tracking.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/tracking.web.test.js.snap
@@ -8,7 +8,7 @@ Array [
       "article_locked_status": "locked",
       "attrs": Object {
         "articleId": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
-        "article_flag": "no flag",
+        "article_flag": "new",
         "article_template_name": "standard template",
         "article_topic_tags": Array [
           "Football",
@@ -47,7 +47,7 @@ Array [
       "article_locked_status": "locked",
       "attrs": Object {
         "articleId": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
-        "article_flag": "no flag",
+        "article_flag": "new",
         "article_template_name": "standard template",
         "article_topic_tags": Array [
           "Football",
@@ -86,7 +86,7 @@ Array [
       "article_locked_status": "locked",
       "attrs": Object {
         "articleId": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
-        "article_flag": "no flag",
+        "article_flag": "new",
         "article_template_name": "standard template",
         "article_topic_tags": Array [
           "Football",
@@ -125,7 +125,7 @@ Array [
       "article_locked_status": "locked",
       "attrs": Object {
         "articleId": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
-        "article_flag": "no flag",
+        "article_flag": "new",
         "article_template_name": "standard template",
         "article_topic_tags": Array [
           "Football",

--- a/packages/article-skeleton/__tests__/web/data-helper.test.js
+++ b/packages/article-skeleton/__tests__/web/data-helper.test.js
@@ -1,83 +1,84 @@
-import { getActiveArticleFlags, getIsLiveOrBreakingFlag } from '../../src/data-helper';
+import {
+  getActiveArticleFlags,
+  getIsLiveOrBreakingFlag
+} from "../../src/data-helper";
 
-describe('Data helper', () => {
-  const active = "2050-03-13T13:00:00.000Z"
-  const expired = "2000-03-13T13:00:00.000Z"
-  describe('getActiveArticleFlags', () => {
-    it('Returns the lower case value of a flag is a flag is active', () => {
+describe("Data helper", () => {
+  const active = "2050-03-13T13:00:00.000Z";
+  const expired = "2000-03-13T13:00:00.000Z";
+  describe("getActiveArticleFlags", () => {
+    it("Returns the lower case value of a flag is a flag is active", () => {
       const flags = [
         {
-          "type": "BREAKING",
-          "expiryTime": active
+          type: "BREAKING",
+          expiryTime: active
         }
       ];
-      expect(getActiveArticleFlags(flags)).toEqual('breaking');
+      expect(getActiveArticleFlags(flags)).toEqual("breaking");
     });
-    it('Returns undefined if there are no flags', () => {
+    it("Returns undefined if there are no flags", () => {
+      const flags = [];
+      expect(getActiveArticleFlags(flags)).toEqual(undefined);
+    });
+    it("Returns undefined if the flag has expired", () => {
       const flags = [
+        {
+          type: "BREAKING",
+          expiryTime: expired
+        }
       ];
       expect(getActiveArticleFlags(flags)).toEqual(undefined);
     });
-    it('Returns undefined if the flag has expired', () => {
-      const flags = [
-        {
-          "type": "BREAKING",
-          "expiryTime": expired
-        }
-      ];
-      expect(getActiveArticleFlags(flags)).toEqual(undefined);
-    })
   });
-  describe('getIsLiveOrBreakingFlag', () => {
-    it('Returns LIVE if the flag is live and active', () => {
+  describe("getIsLiveOrBreakingFlag", () => {
+    it("Returns LIVE if the flag is live and active", () => {
       const flags = [
         {
-          "type": "LIVE",
-          "expiryTime": active
+          type: "LIVE",
+          expiryTime: active
         }
       ];
-      expect(getIsLiveOrBreakingFlag(flags)).toEqual('LIVE')
+      expect(getIsLiveOrBreakingFlag(flags)).toEqual("LIVE");
     });
-    it('Returns LIVE if the flag is live and expired', () => {
+    it("Returns LIVE if the flag is live and expired", () => {
       const flags = [
         {
-          "type": "LIVE",
-          "expiryTime": expired
+          type: "LIVE",
+          expiryTime: expired
         }
       ];
-      expect(getIsLiveOrBreakingFlag(flags)).toEqual('LIVE')
+      expect(getIsLiveOrBreakingFlag(flags)).toEqual("LIVE");
     });
-    it('Returns BREAKING if the flag is breaking and active', () => {
+    it("Returns BREAKING if the flag is breaking and active", () => {
       const flags = [
         {
-          "type": "BREAKING",
-          "expiryTime": active
+          type: "BREAKING",
+          expiryTime: active
         }
       ];
-      expect(getIsLiveOrBreakingFlag(flags)).toEqual('BREAKING')
+      expect(getIsLiveOrBreakingFlag(flags)).toEqual("BREAKING");
     });
-    it('Returns BREAKING if the flag is breaking and expired', () => {
+    it("Returns BREAKING if the flag is breaking and expired", () => {
       const flags = [
         {
-          "type": "BREAKING",
-          "expiryTime": expired
+          type: "BREAKING",
+          expiryTime: expired
         }
       ];
-      expect(getIsLiveOrBreakingFlag(flags)).toEqual('BREAKING')
+      expect(getIsLiveOrBreakingFlag(flags)).toEqual("BREAKING");
     });
-    it('Returns undefined if there are no flags', () => {
-      const flags = [
-      ];
-      expect(getIsLiveOrBreakingFlag(flags)).toEqual(undefined)
+    it("Returns undefined if there are no flags", () => {
+      const flags = [];
+      expect(getIsLiveOrBreakingFlag(flags)).toEqual(undefined);
     });
-    it('Returns undefined if the flag is not live or breaking', () => {
+    it("Returns undefined if the flag is not live or breaking", () => {
       const flags = [
         {
-          "type": "UPDATED",
-          "expiryTime": active
+          type: "UPDATED",
+          expiryTime: active
         }
       ];
-      expect(getIsLiveOrBreakingFlag(flags)).toEqual(undefined)
+      expect(getIsLiveOrBreakingFlag(flags)).toEqual(undefined);
     });
-  })
-})
+  });
+});

--- a/packages/article-skeleton/__tests__/web/data-helper.test.js
+++ b/packages/article-skeleton/__tests__/web/data-helper.test.js
@@ -1,0 +1,83 @@
+import { getActiveArticleFlags, getIsLiveOrBreakingFlag } from '../../src/data-helper';
+
+describe('Data helper', () => {
+  const active = "2050-03-13T13:00:00.000Z"
+  const expired = "2000-03-13T13:00:00.000Z"
+  describe('getActiveArticleFlags', () => {
+    it('Returns the lower case value of a flag is a flag is active', () => {
+      const flags = [
+        {
+          "type": "BREAKING",
+          "expiryTime": active
+        }
+      ];
+      expect(getActiveArticleFlags(flags)).toEqual('breaking');
+    });
+    it('Returns undefined if there are no flags', () => {
+      const flags = [
+      ];
+      expect(getActiveArticleFlags(flags)).toEqual(undefined);
+    });
+    it('Returns undefined if the flag has expired', () => {
+      const flags = [
+        {
+          "type": "BREAKING",
+          "expiryTime": expired
+        }
+      ];
+      expect(getActiveArticleFlags(flags)).toEqual(undefined);
+    })
+  });
+  describe('getIsLiveOrBreakingFlag', () => {
+    it('Returns LIVE if the flag is live and active', () => {
+      const flags = [
+        {
+          "type": "LIVE",
+          "expiryTime": active
+        }
+      ];
+      expect(getIsLiveOrBreakingFlag(flags)).toEqual('LIVE')
+    });
+    it('Returns LIVE if the flag is live and expired', () => {
+      const flags = [
+        {
+          "type": "LIVE",
+          "expiryTime": expired
+        }
+      ];
+      expect(getIsLiveOrBreakingFlag(flags)).toEqual('LIVE')
+    });
+    it('Returns BREAKING if the flag is breaking and active', () => {
+      const flags = [
+        {
+          "type": "BREAKING",
+          "expiryTime": active
+        }
+      ];
+      expect(getIsLiveOrBreakingFlag(flags)).toEqual('BREAKING')
+    });
+    it('Returns BREAKING if the flag is breaking and expired', () => {
+      const flags = [
+        {
+          "type": "BREAKING",
+          "expiryTime": expired
+        }
+      ];
+      expect(getIsLiveOrBreakingFlag(flags)).toEqual('BREAKING')
+    });
+    it('Returns undefined if there are no flags', () => {
+      const flags = [
+      ];
+      expect(getIsLiveOrBreakingFlag(flags)).toEqual(undefined)
+    });
+    it('Returns undefined if the flag is not live or breaking', () => {
+      const flags = [
+        {
+          "type": "UPDATED",
+          "expiryTime": active
+        }
+      ];
+      expect(getIsLiveOrBreakingFlag(flags)).toEqual(undefined)
+    });
+  })
+})

--- a/packages/article-skeleton/__tests__/web/tracking.web.test.js
+++ b/packages/article-skeleton/__tests__/web/tracking.web.test.js
@@ -68,13 +68,6 @@ describe("helper functions", () => {
     expect(getSharedStatus()).toEqual("no");
   });
 
-  it("getIsLiveOrBreakingFlag helper function", () => {
-    expect(getIsLiveOrBreakingFlag([{ type: "LIVE" }])).toEqual("LIVE");
-  });
-
-  it("getIsLiveOrBreakingFlag helper function", () => {
-    expect(getIsLiveOrBreakingFlag(["LIVE"])).toEqual("LIVE");
-  });
 });
 
 it("should track ArticleLink clicks in analytics", () => {

--- a/packages/article-skeleton/__tests__/web/tracking.web.test.js
+++ b/packages/article-skeleton/__tests__/web/tracking.web.test.js
@@ -12,8 +12,7 @@ import ArticleLink from "../../src/article-body/article-link";
 import articleSkeletonProps from "../shared-article-skeleton-props";
 import {
   getRegistrationType,
-  getSharedStatus,
-  getIsLiveOrBreakingFlag
+  getSharedStatus
 } from "../../src/data-helper";
 import shared from "../shared-tracking";
 

--- a/packages/article-skeleton/__tests__/web/tracking.web.test.js
+++ b/packages/article-skeleton/__tests__/web/tracking.web.test.js
@@ -10,10 +10,7 @@ import ArticleSkeleton from "../../src/article-skeleton";
 import articleFixture from "../../fixtures/full-article";
 import ArticleLink from "../../src/article-body/article-link";
 import articleSkeletonProps from "../shared-article-skeleton-props";
-import {
-  getRegistrationType,
-  getSharedStatus
-} from "../../src/data-helper";
+import { getRegistrationType, getSharedStatus } from "../../src/data-helper";
 import shared from "../shared-tracking";
 
 beforeEach(() => {
@@ -66,7 +63,6 @@ describe("helper functions", () => {
   it("getSharedStatus helper function", () => {
     expect(getSharedStatus()).toEqual("no");
   });
-
 });
 
 it("should track ArticleLink clicks in analytics", () => {

--- a/packages/article-skeleton/src/data-helper.js
+++ b/packages/article-skeleton/src/data-helper.js
@@ -90,7 +90,7 @@ export const getIsLiveOrBreakingFlag = flags => {
        liveOrBreaking.includes(flag.type.toUpperCase())
     );
 
-  return findFlag && findFlag.type && findFlag.type;
+  return findFlag && findFlag.type
 };
 
 export const getActiveArticleFlags = flags => {

--- a/packages/article-skeleton/src/data-helper.js
+++ b/packages/article-skeleton/src/data-helper.js
@@ -83,20 +83,25 @@ export const getSharedStatus = () => {
 
 export const getIsLiveOrBreakingFlag = flags => {
   const liveOrBreaking = ["LIVE", "BREAKING"];
-  let isObject;
 
   const findFlag =
     flags &&
-    flags.find(flag => {
-      if (typeof flag === "string") {
-        isObject = false;
-        return liveOrBreaking.includes(flag.toUpperCase());
-      }
-      isObject = true;
-      return flag.type && liveOrBreaking.includes(flag.type.toUpperCase());
-    });
+    flags.find(flag => 
+       liveOrBreaking.includes(flag.type.toUpperCase())
+    );
 
-  return isObject && findFlag ? findFlag.type : findFlag;
+  return findFlag && findFlag.type && findFlag.type;
+};
+
+export const getActiveArticleFlags = flags => {
+  if (!flags) {
+    return [];
+  }
+  const findFlag = flags.find(
+    flag =>
+      new Date().getTime() < new Date(flag.expiryTime).getTime()
+  );
+  return findFlag && findFlag.type && findFlag.type.toLowerCase();
 };
 
 export default prepareDataForListView;

--- a/packages/article-skeleton/src/data-helper.js
+++ b/packages/article-skeleton/src/data-helper.js
@@ -86,11 +86,9 @@ export const getIsLiveOrBreakingFlag = flags => {
 
   const findFlag =
     flags &&
-    flags.find(flag => 
-       liveOrBreaking.includes(flag.type.toUpperCase())
-    );
+    flags.find(flag => liveOrBreaking.includes(flag.type.toUpperCase()));
 
-  return findFlag && findFlag.type
+  return findFlag && findFlag.type;
 };
 
 export const getActiveArticleFlags = flags => {
@@ -98,8 +96,7 @@ export const getActiveArticleFlags = flags => {
     return [];
   }
   const findFlag = flags.find(
-    flag =>
-      new Date().getTime() < new Date(flag.expiryTime).getTime()
+    flag => new Date().getTime() < new Date(flag.expiryTime).getTime()
   );
   return findFlag && findFlag.type && findFlag.type.toLowerCase();
 };

--- a/packages/article-skeleton/src/tracking/article-tracking-context.js
+++ b/packages/article-skeleton/src/tracking/article-tracking-context.js
@@ -3,14 +3,15 @@ import { withTrackingContext } from "@times-components/tracking";
 import {
   getRegistrationType,
   getSharedStatus,
-  getIsLiveOrBreakingFlag
+  getIsLiveOrBreakingFlag,
+  getActiveArticleFlags
 } from "../data-helper";
 
 export default Component =>
   withTrackingContext(Component, {
     getAttrs: ({ data, pageSection, navigationMode, referralUrl = "" }) => {
       let editionType = "";
-      const flags = data.expirableFlags || data.flags;
+      const flags = data.expirableFlags;
 
       if (navigationMode) {
         const { isMyArticles, isPastSixDays } = navigationMode;
@@ -50,8 +51,8 @@ export default Component =>
         template: get(data, "template", "Default"),
         registrationType: getRegistrationType(),
         shared: getSharedStatus(),
-        article_flag: getIsLiveOrBreakingFlag(flags)
-          ? getIsLiveOrBreakingFlag(flags).toLowerCase()
+        article_flag: getActiveArticleFlags(flags)
+          ? getActiveArticleFlags(flags)
           : "no flag",
         article_template_name: getIsLiveOrBreakingFlag(flags)
           ? "live template"

--- a/packages/responsive/package.json
+++ b/packages/responsive/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "dependencies": {
-    "@times-components/styleguide": "3.38.45",
+    "@times-components/styleguide": "3.38.46",
     "@times-components/utils": "6.11.0",
     "prop-types": "15.7.2"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@times-components/schema": "0.7.1",
-    "@times-components/styleguide": "3.38.45",
+    "@times-components/styleguide": "3.38.46",
     "apollo-cache-inmemory": "1.5.1",
     "apollo-client": "2.5.1",
     "apollo-link": "1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3707,6 +3707,14 @@
     fs-extra "6.0.0"
     glob "7.1.2"
 
+"@times-components/styleguide@3.38.45":
+  version "3.38.45"
+  resolved "https://registry.yarnpkg.com/@times-components/styleguide/-/styleguide-3.38.45.tgz#8c116be7c052891dab96ce3b50b8aeab4267905f"
+  integrity sha512-E9DSBnD9vg5I6XSVEH2lGeEPTz0dbvTbe6MjhGY5SL6BCs98vC11wqm9rBi/SDDsSeAorCO8QI5OwLtyVrTf5w==
+  dependencies:
+    prop-types "15.7.2"
+    styled-components "4.3.2"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3707,14 +3707,6 @@
     fs-extra "6.0.0"
     glob "7.1.2"
 
-"@times-components/styleguide@3.38.45":
-  version "3.38.45"
-  resolved "https://registry.yarnpkg.com/@times-components/styleguide/-/styleguide-3.38.45.tgz#8c116be7c052891dab96ce3b50b8aeab4267905f"
-  integrity sha512-E9DSBnD9vg5I6XSVEH2lGeEPTz0dbvTbe6MjhGY5SL6BCs98vC11wqm9rBi/SDDsSeAorCO8QI5OwLtyVrTf5w==
-  dependencies:
-    prop-types "15.7.2"
-    styled-components "4.3.2"
-
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
## Description 

[TDP-1829](https://nidigitalsolutions.jira.com/browse/TDP-1829)
Remove reference to the deprecated "flags" data - we don't query for it, so no longer need to code against it. 
Update article_flag tracking to check for ACTIVE flags, if they are active the value will be the lower case of the flag name, if they don't exist or are expired it will be "no flag".
