### PR TITLE
fix(TDP-1520): add articleSection to live articles

### DIFF
--- a/packages/article-skeleton/src/head.js
+++ b/packages/article-skeleton/src/head.js
@@ -380,7 +380,8 @@ function Head({
     },
     publisher: publisherSchema,
     author: authorSchema,
-    liveBlogUpdate: liveBlogUpdateSchema
+    liveBlogUpdate: liveBlogUpdateSchema,
+    articleSection: checkIsCurrentEdition()
   };
   return (
     <Context.Consumer>


### PR DESCRIPTION
This PR adds the `articleSection` property to the JSON LD of live articles (`articleSection` was previously added to the JSON LD of articles but not of live articles)

[TDP-1520](https://nidigitalsolutions.jira.com/browse/TDP-1520)
