### PR TITLE
Fix/tdp 1698 layout issue for template main commment on mobile

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -502,7 +502,7 @@ exports[`full article with style 1`] = `
   overflow-wrap: break-word;
   font-family: TimesModern-Regular;
   font-size: 20px;
-  line-height: 26;
+  line-height: 26px;
   font-weight: 400;
   color: rgba(255,255,255,1);
   margin-bottom: 15px;
@@ -1659,7 +1659,7 @@ exports[`full article with style in the culture magazine 1`] = `
   overflow-wrap: break-word;
   font-family: TimesModern-Regular;
   font-size: 20px;
-  line-height: 26;
+  line-height: 26px;
   font-weight: 400;
   color: rgba(255,255,255,1);
   margin-bottom: 15px;
@@ -2817,7 +2817,7 @@ exports[`full article with style in the style magazine 1`] = `
   overflow-wrap: break-word;
   font-family: TimesModern-Regular;
   font-size: 20px;
-  line-height: 26;
+  line-height: 26px;
   font-weight: 400;
   color: rgba(255,255,255,1);
   margin-bottom: 15px;
@@ -3974,7 +3974,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   overflow-wrap: break-word;
   font-family: TimesModern-Regular;
   font-size: 20px;
-  line-height: 26;
+  line-height: 26px;
   font-weight: 400;
   color: rgba(255,255,255,1);
   margin-bottom: 15px;

--- a/packages/article-in-depth/src/article-standfirst/article-standfirst.js
+++ b/packages/article-in-depth/src/article-standfirst/article-standfirst.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { checkStylesForUnits } from "@times-components/utils";
 import { colours } from "@times-components/ts-styleguide";
 import styles from "../styles";
 import { StandfirstContainer } from "../styles/responsive";
@@ -11,7 +12,7 @@ const HeaderStandfirst = ({ standfirst, color }) => {
     <StandfirstContainer
       role="heading"
       aria-level="2"
-      styles={{ ...styles.standFirst, color }}
+      styles={{ ...checkStylesForUnits(styles.standFirst), color }}
       testID="standfirst"
     >
       {standfirst}

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -522,7 +522,7 @@ exports[`full article with style 1`] = `
   overflow-wrap: break-word;
   font-family: TimesModern-Regular;
   font-size: 20px;
-  line-height: 26;
+  line-height: 26px;
   color: #333333;
   margin-bottom: 15px;
   padding-left: 10px;
@@ -1714,7 +1714,7 @@ exports[`full article with style in the culture magazine 1`] = `
   overflow-wrap: break-word;
   font-family: TimesModern-Regular;
   font-size: 20px;
-  line-height: 26;
+  line-height: 26px;
   color: #333333;
   margin-bottom: 15px;
   padding-left: 10px;
@@ -2907,7 +2907,7 @@ exports[`full article with style in the style magazine 1`] = `
   overflow-wrap: break-word;
   font-family: TimesModern-Regular;
   font-size: 20px;
-  line-height: 26;
+  line-height: 26px;
   color: #333333;
   margin-bottom: 15px;
   padding-left: 10px;
@@ -4099,7 +4099,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   overflow-wrap: break-word;
   font-family: TimesModern-Regular;
   font-size: 20px;
-  line-height: 26;
+  line-height: 26px;
   color: #333333;
   margin-bottom: 15px;
   padding-left: 10px;

--- a/packages/article-magazine-comment/src/article-standfirst/article-standfirst.js
+++ b/packages/article-magazine-comment/src/article-standfirst/article-standfirst.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { checkStylesForUnits } from "@times-components/utils";
 import styles from "../styles";
 import { StandfirstContainer } from "../styles/responsive";
 
@@ -10,7 +11,7 @@ const HeaderStandfirst = ({ standfirst }) => {
     <StandfirstContainer
       role="heading"
       aria-level="2"
-      styles={styles.standFirst}
+      styles={checkStylesForUnits(styles.standFirst)}
       testID="standfirst"
     >
       {standfirst}

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -424,7 +424,7 @@ exports[`full article with style 1`] = `
   overflow-wrap: break-word;
   font-family: TimesModern-Bold;
   font-size: 30px;
-  line-height: 33;
+  line-height: 33px;
   color: #1D1D1B;
   margin-bottom: 10px;
   text-align: center;
@@ -515,7 +515,7 @@ exports[`full article with style 1`] = `
   overflow-wrap: break-word;
   font-family: TimesModern-Regular;
   font-size: 20px;
-  line-height: 26;
+  line-height: 26px;
   color: #333333;
   margin-bottom: 15px;
   padding-left: 10px;

--- a/packages/article-main-comment/src/article-header/article-header.js
+++ b/packages/article-main-comment/src/article-header/article-header.js
@@ -4,6 +4,7 @@ import {
   UpdatedTimeProvider
 } from "@times-components/ts-components";
 import Image from "@times-components/image";
+import { checkStylesForUnits } from "@times-components/utils";
 
 import Label from "../article-label/article-label";
 import Meta from "../article-meta/article-meta";
@@ -45,7 +46,7 @@ const ArticleHeader = ({
     <HeadlineContainer
       role="heading"
       aria-level="1"
-      styles={styles.articleHeadline}
+      styles={checkStylesForUnits(styles.articleHeadline)}
     >
       {headline}
     </HeadlineContainer>

--- a/packages/article-main-comment/src/article-standfirst/article-standfirst.js
+++ b/packages/article-main-comment/src/article-standfirst/article-standfirst.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { checkStylesForUnits } from "@times-components/utils";
 import styles from "../styles";
 import { StandfirstContainer } from "../styles/responsive";
 
@@ -10,7 +11,7 @@ const HeaderStandfirst = ({ standfirst }) => {
     <StandfirstContainer
       role="heading"
       aria-level="2"
-      styles={styles.standFirst}
+      styles={checkStylesForUnits(styles.standFirst)}
       testID="standfirst"
     >
       {standfirst}

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -366,7 +366,7 @@ exports[`full article with style 1`] = `
   line-height: 30px;
   font-family: TimesModern-Bold;
   font-size: 30px;
-  line-height: 33;
+  line-height: 33px;
   color: #1D1D1B;
   margin-bottom: 7px;
 }

--- a/packages/article-main-standard/src/article-header/article-header.js
+++ b/packages/article-main-standard/src/article-header/article-header.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/forbid-prop-types */
 import React from "react";
 import PropTypes from "prop-types";
-import { TcView } from "@times-components/utils";
+import { TcView, checkStylesForUnits } from "@times-components/utils";
 import {
   ArticleFlags,
   UpdatedTimeProvider
@@ -27,7 +27,7 @@ const ArticleHeader = ({
     <HeadlineContainer
       role="heading"
       aria-level="1"
-      styles={styles.articleHeadLineText}
+      styles={checkStylesForUnits(styles.articleHeadLineText)}
     >
       {headline}
     </HeadlineContainer>


### PR DESCRIPTION
This is a fix for incident **INC0108476** that i've attached to the old ticket where the error came as it was when we removed react-native and the styles changed slightly 


[TDP-1698](https://nidigitalsolutions.jira.com/browse/TDP-1698)