### PR TITLE
feat(TDP-1419): Remove react-native from message-bar package

### DIFF
--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -48,7 +48,7 @@ const Article = props => {
 
   return (
     <Responsive>
-      <MessageManager animate delay={3000} scale={scales.medium}>
+      <MessageManager delay={3000} scale={scales.medium}>
         <Component {...newProps} onImagePress={onImagePressArticle} />
       </MessageManager>
     </Responsive>

--- a/packages/message-bar/__tests__/message-bar.base.js
+++ b/packages/message-bar/__tests__/message-bar.base.js
@@ -4,9 +4,9 @@ import { delay } from "@times-components/test-utils";
 import { shallow } from "enzyme";
 import TestRenderer from "react-test-renderer";
 import MessageBar from "../src/message-bar";
-import { CloseButton } from '../src/styles';
+import { CloseButton } from "../src/styles";
 
-export default animate => [
+export default () => [
   {
     name: "renders correctly",
     test: async () => {

--- a/packages/message-bar/__tests__/message-bar.base.js
+++ b/packages/message-bar/__tests__/message-bar.base.js
@@ -4,7 +4,7 @@ import { scales } from "@times-components/ts-styleguide";
 import { delay } from "@times-components/test-utils";
 import { shallow } from "enzyme";
 import TestRenderer from "react-test-renderer";
-import MessageBar from "../src/message-bar";
+import MessageBar, { CloseButton } from "../src/message-bar";
 
 export default animate => [
   {
@@ -31,16 +31,15 @@ export default animate => [
       const testInstance = shallow(
         <MessageBar
           close={closed}
-          delay={1}
+          delay={10000}
           message="test message"
           scale={scales.medium}
         />
       );
-
-      const button = testInstance.find(TouchableOpacity);
-      button.simulate("press");
-      await delay(10);
-      expect(closed).toBeCalled();
+      const button = testInstance.find(CloseButton);
+      button.simulate("click");
+      await delay(300);
+      expect(closed.mock.calls.length).toEqual(1);
     }
   },
   {

--- a/packages/message-bar/__tests__/message-bar.base.js
+++ b/packages/message-bar/__tests__/message-bar.base.js
@@ -12,7 +12,6 @@ export default animate => [
     test: async () => {
       const testInstance = TestRenderer.create(
         <MessageBar
-          animate={animate}
           close={() => {}}
           delay={1}
           message="test message"
@@ -31,7 +30,6 @@ export default animate => [
       const closed = jest.fn();
       const testInstance = shallow(
         <MessageBar
-          animate={animate}
           close={closed}
           delay={1}
           message="test message"
@@ -50,7 +48,6 @@ export default animate => [
     test: async () => {
       const testInstance = shallow(
         <MessageBar
-          animate={animate}
           close={() => {}}
           delay={100}
           message="test message"
@@ -74,7 +71,6 @@ export default animate => [
     test: async () => {
       const testInstance = shallow(
         <MessageBar
-          animate={animate}
           close={() => {}}
           delay={100}
           message="test message"

--- a/packages/message-bar/__tests__/message-bar.base.js
+++ b/packages/message-bar/__tests__/message-bar.base.js
@@ -1,10 +1,10 @@
 import React from "react";
-import { TouchableOpacity } from "react-native";
 import { scales } from "@times-components/ts-styleguide";
 import { delay } from "@times-components/test-utils";
 import { shallow } from "enzyme";
 import TestRenderer from "react-test-renderer";
-import MessageBar, { CloseButton } from "../src/message-bar";
+import MessageBar from "../src/message-bar";
+import { CloseButton } from '../src/styles';
 
 export default animate => [
   {

--- a/packages/message-bar/__tests__/message-manager.base.js
+++ b/packages/message-bar/__tests__/message-manager.base.js
@@ -1,16 +1,18 @@
 import React from "react";
-import { View, Text, TouchableOpacity } from "react-native";
+import { View, Text } from "react-native";
 import TestRenderer from "react-test-renderer";
 import { scales } from "@times-components/ts-styleguide";
 import { delay } from "@times-components/test-utils";
 import MessageManager from "../src/message-manager";
-import MessageBar from "../src/message-bar";
+import MessageBar, { CloseButton } from "../src/message-bar";
 import Context from "../src/message-context";
+
+const Button = () => <button type="button" />;
 
 const TestConsumer = () => (
   <Context.Consumer>
     {({ showMessage }) => (
-      <TouchableOpacity onPress={() => showMessage("foo")} />
+      <Button onClick={() => showMessage("foo")} />
     )}
   </Context.Consumer>
 );
@@ -41,9 +43,9 @@ export default animate => [
         </MessageManager>
       );
 
-      const touchable = testInstance.root.findByType(TouchableOpacity);
+      const button = testInstance.root.findByType(Button);
 
-      touchable.props.onPress();
+      button.props.onClick();
 
       expect(testInstance.root.instance.state.message).toEqual("foo");
     }
@@ -52,21 +54,23 @@ export default animate => [
     name: "removes the message when the bar says it closed",
     test: async () => {
       const testInstance = TestRenderer.create(
-        <MessageManager delay={100} scale={scales.medium}>
+        <MessageManager delay={1000} scale={scales.medium}>
           <TestConsumer />
         </MessageManager>
       );
 
-      const touchable = testInstance.root.findByType(TouchableOpacity);
-      touchable.props.onPress();
+      const button = testInstance.root.findByType(Button);
+      button.props.onClick();
 
       delay(1);
 
       const close = testInstance.root
         .findByType(MessageBar)
-        .findByType(TouchableOpacity);
-      close.props.onPress();
+        .findByType(CloseButton);
 
+      close.props.onClick();
+
+      await delay(300);
       expect(testInstance.root.instance.state.message).toEqual(null);
     }
   }

--- a/packages/message-bar/__tests__/message-manager.base.js
+++ b/packages/message-bar/__tests__/message-manager.base.js
@@ -20,7 +20,7 @@ export default animate => [
     name: "renders correctly",
     test: async () => {
       const testInstance = TestRenderer.create(
-        <MessageManager animate={animate} delay={1} scale={scales.medium}>
+        <MessageManager delay={1} scale={scales.medium}>
           <View>
             <Text>test child content</Text>
           </View>
@@ -36,7 +36,7 @@ export default animate => [
     name: "children can show a message",
     test: async () => {
       const testInstance = TestRenderer.create(
-        <MessageManager animate={animate} delay={1} scale={scales.medium}>
+        <MessageManager delay={1} scale={scales.medium}>
           <TestConsumer />
         </MessageManager>
       );
@@ -52,7 +52,7 @@ export default animate => [
     name: "removes the message when the bar says it closed",
     test: async () => {
       const testInstance = TestRenderer.create(
-        <MessageManager animate={animate} delay={100} scale={scales.medium}>
+        <MessageManager delay={100} scale={scales.medium}>
           <TestConsumer />
         </MessageManager>
       );

--- a/packages/message-bar/__tests__/message-manager.base.js
+++ b/packages/message-bar/__tests__/message-manager.base.js
@@ -5,20 +5,18 @@ import { scales } from "@times-components/ts-styleguide";
 import { delay } from "@times-components/test-utils";
 import MessageManager from "../src/message-manager";
 import MessageBar from "../src/message-bar";
-import { CloseButton } from '../src/styles';
+import { CloseButton } from "../src/styles";
 import Context from "../src/message-context";
 
 const Button = () => <button type="button" />;
 
 const TestConsumer = () => (
   <Context.Consumer>
-    {({ showMessage }) => (
-      <Button onClick={() => showMessage("foo")} />
-    )}
+    {({ showMessage }) => <Button onClick={() => showMessage("foo")} />}
   </Context.Consumer>
 );
 
-export default animate => [
+export default () => [
   {
     name: "renders correctly",
     test: async () => {

--- a/packages/message-bar/__tests__/message-manager.base.js
+++ b/packages/message-bar/__tests__/message-manager.base.js
@@ -1,10 +1,11 @@
 import React from "react";
-import { View, Text } from "react-native";
+import { TcView, TcText } from "@times-components/utils";
 import TestRenderer from "react-test-renderer";
 import { scales } from "@times-components/ts-styleguide";
 import { delay } from "@times-components/test-utils";
 import MessageManager from "../src/message-manager";
-import MessageBar, { CloseButton } from "../src/message-bar";
+import MessageBar from "../src/message-bar";
+import { CloseButton } from '../src/styles';
 import Context from "../src/message-context";
 
 const Button = () => <button type="button" />;
@@ -23,9 +24,9 @@ export default animate => [
     test: async () => {
       const testInstance = TestRenderer.create(
         <MessageManager delay={1} scale={scales.medium}>
-          <View>
-            <Text>test child content</Text>
-          </View>
+          <TcView>
+            <TcText>test child content</TcText>
+          </TcView>
         </MessageManager>
       );
 

--- a/packages/message-bar/__tests__/shared.base.js
+++ b/packages/message-bar/__tests__/shared.base.js
@@ -2,8 +2,8 @@ import { iterator } from "@times-components/test-utils";
 import MessageBarTests from "./message-bar.base";
 import MessageManagerTests from "./message-manager.base";
 
-export default animate => {
-  const tests = [...MessageBarTests(animate), ...MessageManagerTests(animate)];
+export default () => {
+  const tests = [...MessageBarTests(), ...MessageManagerTests()];
 
   iterator(tests);
 };

--- a/packages/message-bar/__tests__/web/__snapshots__/message-bar.test.js.snap
+++ b/packages/message-bar/__tests__/web/__snapshots__/message-bar.test.js.snap
@@ -10,10 +10,10 @@ exports[`1. renders correctly 1`] = `
       <button>
         <svg
           aria-label="icon-close"
-          height="28"
+          height={28}
           role="img"
           viewBox="0 0 28 28"
-          width="28"
+          width={28}
         >
           <title>
             Close Icon

--- a/packages/message-bar/__tests__/web/__snapshots__/message-bar.test.js.snap
+++ b/packages/message-bar/__tests__/web/__snapshots__/message-bar.test.js.snap
@@ -12,12 +12,11 @@ exports[`1. renders correctly 1`] = `
           aria-label="icon-close"
           height={28}
           role="img"
+          title="Close Icon"
           viewBox="0 0 28 28"
           width={28}
         >
-          <title>
-            Close Icon
-          </title>
+          <title />
           <path
             d="M15.617 14l4.683 5.838-.462.462L14 15.617 8.162 20.3l-.462-.462L12.383 14 7.7 8.162l.462-.462L14 12.383 19.838 7.7l.462.462z"
             fill="white"

--- a/packages/message-bar/__tests__/web/__snapshots__/message-bar.test.js.snap
+++ b/packages/message-bar/__tests__/web/__snapshots__/message-bar.test.js.snap
@@ -7,27 +7,24 @@ exports[`1. renders correctly 1`] = `
       <div>
         test message
       </div>
-      <div>
-        <div
-          tabIndex="0"
+      <button>
+        <svg
+          aria-label="icon-close"
+          height="28"
+          role="img"
+          viewBox="0 0 28 28"
+          width="28"
         >
-          <svg
-            aria-label="icon-close"
-            height="28"
-            role="img"
-            title="Close Icon"
-            viewBox="0 0 28 28"
-            width="28"
-          >
-            <title />
-            <path
-              d="M15.617 14l4.683 5.838-.462.462L14 15.617 8.162 20.3l-.462-.462L12.383 14 7.7 8.162l.462-.462L14 12.383 19.838 7.7l.462.462z"
-              fill="white"
-              stroke="white"
-            />
-          </svg>
-        </div>
-      </div>
+          <title>
+            Close Icon
+          </title>
+          <path
+            d="M15.617 14l4.683 5.838-.462.462L14 15.617 8.162 20.3l-.462-.462L12.383 14 7.7 8.162l.462-.462L14 12.383 19.838 7.7l.462.462z"
+            fill="white"
+            stroke="white"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>

--- a/packages/message-bar/message-bar.showcase.js
+++ b/packages/message-bar/message-bar.showcase.js
@@ -7,7 +7,6 @@ export default {
     {
       component: () => (
         <MessageBar
-          animate
           close={() => {}}
           delay={3000}
           message="Article link copied"

--- a/packages/message-bar/package.json
+++ b/packages/message-bar/package.json
@@ -21,9 +21,7 @@
     "url": "git+https://github.com/newsuk/times-components.git"
   },
   "keywords": [
-    "react-native-web",
     "react",
-    "native",
     "web",
     "message-bar",
     "component"
@@ -49,7 +47,6 @@
     "prettier": "1.14.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-native": "0.61.5",
     "react-test-renderer": "16.9.0",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1"
@@ -60,9 +57,7 @@
   },
   "peerDependencies": {
     "react": ">=16.9",
-    "react-dom": ">=16.9",
-    "react-native": ">=0.59",
-    "react-native-web": "0.11.4"
+    "react-dom": ">=16.9"
   },
   "dependencies": {
     "@times-components/icons": "2.18.2",

--- a/packages/message-bar/package.json
+++ b/packages/message-bar/package.json
@@ -62,7 +62,7 @@
     "@times-components/icons": "2.18.2",
     "@times-components/responsive": "0.12.3",
     "@times-components/ts-styleguide": "1.36.4",
-    "@times-components/utils": "6.12.1",
+    "@times-components/utils": "6.13.0",
     "prop-types": "15.7.2",
     "styled-components": "4.3.2"
   },

--- a/packages/message-bar/package.json
+++ b/packages/message-bar/package.json
@@ -41,6 +41,7 @@
     "@times-components/jest-serializer": "3.2.30",
     "@times-components/storybook": "4.2.25",
     "@times-components/test-utils": "2.3.10",
+    "@times-components/utils": "6.12.1",
     "@times-components/webpack-configurator": "2.0.29",
     "enzyme": "3.9.0",
     "eslint": "5.9.0",

--- a/packages/message-bar/package.json
+++ b/packages/message-bar/package.json
@@ -39,7 +39,6 @@
     "@times-components/jest-serializer": "3.2.30",
     "@times-components/storybook": "4.2.25",
     "@times-components/test-utils": "2.3.10",
-    "@times-components/utils": "6.12.1",
     "@times-components/webpack-configurator": "2.0.29",
     "enzyme": "3.9.0",
     "eslint": "5.9.0",
@@ -63,7 +62,9 @@
     "@times-components/icons": "2.18.2",
     "@times-components/responsive": "0.12.3",
     "@times-components/ts-styleguide": "1.36.4",
-    "prop-types": "15.7.2"
+    "@times-components/utils": "6.12.1",
+    "prop-types": "15.7.2",
+    "styled-components": "4.3.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/message-bar/src/message-bar.js
+++ b/packages/message-bar/src/message-bar.js
@@ -56,7 +56,7 @@ class MessageBar extends Component {
           <TcView style={styles.messageBarBody}>
             <TcText style={styles.messageBarText}>{message}</TcText>
               <CloseButton style={styles.messageBarCloseButton} className={this.state.closeActive ? ' active' : ''} onClick={this.closeMessage}>
-                <CloseIcon width="28" height="28" onPress={this.closeMessage}/>
+                <CloseIcon width="28" height="28" onClick={this.closeMessage}/>
               </CloseButton>
             </TcView>
         </TcView>
@@ -88,7 +88,7 @@ const StyledAnimation = styled(TcView)`
   }
 `;
 
-const CloseButton = styled.button`
+export const CloseButton = styled.button`
   cursor: pointer;
   &.active {
     opacity: 0.5

--- a/packages/message-bar/src/message-bar.js
+++ b/packages/message-bar/src/message-bar.js
@@ -2,22 +2,21 @@ import React, { Component } from "react";
 import { TcView, TcText } from "@times-components/utils";
 import PropTypes from "prop-types";
 import { CloseIcon } from "@times-components/icons";
-import styleFactory from "./styles";
-import { CloseButton, StyledAnimation } from './styles'
+import styleFactory, { CloseButton, StyledAnimation } from "./styles";
 
 class MessageBar extends Component {
   constructor(props) {
     super(props);
     this.closeMessage = this.closeMessage.bind(this);
     this.state = {
-      closeActive: false,
-    }
+      closeActive: false
+    };
   }
 
   componentDidMount() {
     const { delay } = this.props;
     this.timeout = setTimeout(() => {
-        this.closeMessage();
+      this.closeMessage();
     }, delay);
   }
 
@@ -28,7 +27,7 @@ class MessageBar extends Component {
     if (message === newMessage) {
       clearTimeout(this.timeout);
       this.timeout = setTimeout(() => {
-          this.closeMessage();
+        this.closeMessage();
       }, delay);
     }
   }
@@ -41,24 +40,35 @@ class MessageBar extends Component {
 
   closeMessage() {
     const { close } = this.props;
-    this.setState({ closeActive: true })
+    this.setState({ closeActive: true });
     this.timeout = setTimeout(() => {
       close();
-  }, 250);
+    }, 250);
   }
 
   render() {
     const { message, scale, breakpoint } = this.props;
     const styles = styleFactory(scale, breakpoint);
+    const { closeActive } = this.state;
     return (
-      <StyledAnimation data-testid="Styled Animation" className={this.state.closeActive ? ' close' : ''}>
-        <TcView data-testid="message-bar" style={styles.messageBarBodyContainer}>
+      <StyledAnimation
+        data-testid="Styled Animation"
+        className={closeActive ? " close" : ""}
+      >
+        <TcView
+          data-testid="message-bar"
+          style={styles.messageBarBodyContainer}
+        >
           <TcView style={styles.messageBarBody}>
             <TcText style={styles.messageBarText}>{message}</TcText>
-              <CloseButton style={styles.messageBarCloseButton} className={this.state.closeActive ? ' active' : ''} onClick={this.closeMessage}>
-                <CloseIcon width={28} height={28} onClick={this.closeMessage}/>
-              </CloseButton>
-            </TcView>
+            <CloseButton
+              style={styles.messageBarCloseButton}
+              className={closeActive ? " active" : ""}
+              onClick={this.closeMessage}
+            >
+              <CloseIcon width={28} height={28} onClick={this.closeMessage} />
+            </CloseButton>
+          </TcView>
         </TcView>
       </StyledAnimation>
     );

--- a/packages/message-bar/src/message-bar.js
+++ b/packages/message-bar/src/message-bar.js
@@ -56,7 +56,7 @@ class MessageBar extends Component {
           <TcView style={styles.messageBarBody}>
             <TcText style={styles.messageBarText}>{message}</TcText>
               <CloseButton style={styles.messageBarCloseButton} className={this.state.closeActive ? ' active' : ''} onClick={this.closeMessage}>
-                <CloseIcon width="28" height="28" onClick={this.closeMessage}/>
+                <CloseIcon width={28} height={28} onClick={this.closeMessage}/>
               </CloseButton>
             </TcView>
         </TcView>

--- a/packages/message-bar/src/message-bar.js
+++ b/packages/message-bar/src/message-bar.js
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import { TouchableOpacity } from "react-native";
 import { TcView, TcText } from "@times-components/utils";
 import PropTypes from "prop-types";
 import { CloseIcon } from "@times-components/icons";
@@ -45,28 +44,27 @@ class MessageBar extends Component {
     this.setState({ closeActive: true })
     this.timeout = setTimeout(() => {
       close();
-  }, 500);
+  }, 250);
   }
 
   render() {
     const { message, scale, breakpoint } = this.props;
     const styles = styleFactory(scale, breakpoint);
     return (
-      <StyledAnimation className={this.state.closeActive ? ' close' : ''}>
+      <StyledAnimation data-testid="Styled Animation" className={this.state.closeActive ? ' close' : ''}>
         <TcView data-testid="message-bar" style={styles.messageBarBodyContainer}>
           <TcView style={styles.messageBarBody}>
             <TcText style={styles.messageBarText}>{message}</TcText>
-            <TcView style={styles.messageBarCloseButton}>
-              <TouchableOpacity onPress={this.closeMessage}>
+              <CloseButton style={styles.messageBarCloseButton} className={this.state.closeActive ? ' active' : ''} onClick={this.closeMessage}>
                 <CloseIcon width="28" height="28" onPress={this.closeMessage}/>
-              </TouchableOpacity>
+              </CloseButton>
             </TcView>
-          </TcView>
         </TcView>
-        </StyledAnimation>
+      </StyledAnimation>
     );
   }
 }
+
 
 const AnimationIn = keyframes`
   0% { transform: translateY(-51px)}
@@ -81,14 +79,24 @@ const AnimationOut = keyframes`
 
 const StyledAnimation = styled(TcView)`
   animation-name: ${AnimationIn};
-  animation-duration: 0.5s;
+  animation-duration: 0.25s;
   animation-timing-function: ease-in-out;
   &.close {
     transform: translateY(-51px);
     animation-name: ${AnimationOut};
-    animation-duration: 0.5s;
+    animation-duration: 0.25s;
   }
 `;
+
+const CloseButton = styled.button`
+  cursor: pointer;
+  &.active {
+    opacity: 0.5
+  }
+  :active { 
+    opacity: 0.5
+  }
+`
 
 MessageBar.propTypes = {
   breakpoint: PropTypes.string.isRequired,

--- a/packages/message-bar/src/message-bar.js
+++ b/packages/message-bar/src/message-bar.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
-import { View, Text, Animated, TouchableOpacity } from "react-native";
+import { Animated, TouchableOpacity } from "react-native";
+import { TcView, TcText } from "@times-components/utils";
 import PropTypes from "prop-types";
 import { CloseIcon } from "@times-components/icons";
 import styleFactory from "./styles";
@@ -74,7 +75,6 @@ class MessageBar extends Component {
     const { message, scale, animate, breakpoint } = this.props;
     const { yValue } = this.state;
     const styles = styleFactory(scale, breakpoint);
-
     return (
       <Animated.View
         style={
@@ -90,16 +90,16 @@ class MessageBar extends Component {
           }
         }
       >
-        <View data-testid="message-bar" style={styles.messageBarBodyContainer}>
-          <View style={styles.messageBarBody}>
-            <Text style={styles.messageBarText}>{message}</Text>
-            <View style={styles.messageBarCloseButton}>
+        <TcView data-testid="message-bar" style={styles.messageBarBodyContainer}>
+          <TcView style={styles.messageBarBody}>
+            <TcText style={styles.messageBarText}>{message}</TcText>
+            <TcView style={styles.messageBarCloseButton}>
               <TouchableOpacity onPress={this.close}>
-                <CloseIcon width="28" height="28" />
+                <CloseIcon width="28" height="28" onPress={this.close}/>
               </TouchableOpacity>
-            </View>
-          </View>
-        </View>
+            </TcView>
+          </TcView>
+        </TcView>
       </Animated.View>
     );
   }

--- a/packages/message-bar/src/message-bar.js
+++ b/packages/message-bar/src/message-bar.js
@@ -3,7 +3,7 @@ import { TcView, TcText } from "@times-components/utils";
 import PropTypes from "prop-types";
 import { CloseIcon } from "@times-components/icons";
 import styleFactory from "./styles";
-import styled, { keyframes } from 'styled-components';
+import { CloseButton, StyledAnimation } from './styles'
 
 class MessageBar extends Component {
   constructor(props) {
@@ -64,39 +64,6 @@ class MessageBar extends Component {
     );
   }
 }
-
-
-const AnimationIn = keyframes`
-  0% { transform: translateY(-51px)}
-  90% { transform: translateY(5px)}
-  100% { transform: translateY(0px)}
-`;
-
-const AnimationOut = keyframes`
-  0% { transform: translateY(0px)}
-  100% { transform: translateY(-51px)}
-`
-
-const StyledAnimation = styled(TcView)`
-  animation-name: ${AnimationIn};
-  animation-duration: 0.25s;
-  animation-timing-function: ease-in-out;
-  &.close {
-    transform: translateY(-51px);
-    animation-name: ${AnimationOut};
-    animation-duration: 0.25s;
-  }
-`;
-
-export const CloseButton = styled.button`
-  cursor: pointer;
-  &.active {
-    opacity: 0.5
-  }
-  :active { 
-    opacity: 0.5
-  }
-`
 
 MessageBar.propTypes = {
   breakpoint: PropTypes.string.isRequired,

--- a/packages/message-bar/src/message-manager.js
+++ b/packages/message-bar/src/message-manager.js
@@ -58,7 +58,7 @@ class MessageManager extends Component {
       : {};
     return (
       <TcView>
-        <TcView style={{...styles.messageManager, offsetStyle}}>
+        <TcView style={{ ...styles.messageManager, offsetStyle }}>
           {message && (
             <ResponsiveContext.Consumer>
               {({ editionBreakpoint }) => (
@@ -84,7 +84,7 @@ class MessageManager extends Component {
 }
 
 {
-  const { string, node, number, bool } = PropTypes;
+  const { string, node, number } = PropTypes;
   MessageManager.propTypes = {
     children: node.isRequired,
     delay: number.isRequired,

--- a/packages/message-bar/src/message-manager.js
+++ b/packages/message-bar/src/message-manager.js
@@ -46,7 +46,7 @@ class MessageManager extends Component {
   }
 
   render() {
-    const { scale, children, delay, animate } = this.props;
+    const { scale, children, delay } = this.props;
     const { message, offsetTop } = this.state;
     const styles = styleFactory(scale);
     const offsetStyle = offsetTop
@@ -56,7 +56,6 @@ class MessageManager extends Component {
           height: message ? 50 : 0
         }
       : {};
-
     return (
       <TcView>
         <TcView style={[styles.messageManager, offsetStyle]}>
@@ -64,7 +63,6 @@ class MessageManager extends Component {
             <ResponsiveContext.Consumer>
               {({ editionBreakpoint }) => (
                 <MessageBar
-                  animate={animate}
                   close={this.removeMessage}
                   delay={delay}
                   message={message}
@@ -88,7 +86,6 @@ class MessageManager extends Component {
 {
   const { string, node, number, bool } = PropTypes;
   MessageManager.propTypes = {
-    animate: bool.isRequired,
     children: node.isRequired,
     delay: number.isRequired,
     scale: string.isRequired

--- a/packages/message-bar/src/message-manager.js
+++ b/packages/message-bar/src/message-manager.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unused-state */
 import React, { Component } from "react";
-import { View } from "react-native";
+import { TcView } from "@times-components/utils";
 import PropTypes from "prop-types";
 import { ResponsiveContext } from "@times-components/responsive";
 import styleFactory from "./styles";
@@ -58,8 +58,8 @@ class MessageManager extends Component {
       : {};
 
     return (
-      <View>
-        <View style={[styles.messageManager, offsetStyle]}>
+      <TcView>
+        <TcView style={[styles.messageManager, offsetStyle]}>
           {message && (
             <ResponsiveContext.Consumer>
               {({ editionBreakpoint }) => (
@@ -74,13 +74,13 @@ class MessageManager extends Component {
               )}
             </ResponsiveContext.Consumer>
           )}
-        </View>
-        <View onLayout={this.onLayout}>
+        </TcView>
+        <TcView onLayout={this.onLayout}>
           <MessageContext.Provider value={this.state}>
             {children}
           </MessageContext.Provider>
-        </View>
-      </View>
+        </TcView>
+      </TcView>
     );
   }
 }

--- a/packages/message-bar/src/message-manager.js
+++ b/packages/message-bar/src/message-manager.js
@@ -58,7 +58,7 @@ class MessageManager extends Component {
       : {};
     return (
       <TcView>
-        <TcView style={[styles.messageManager, offsetStyle]}>
+        <TcView style={{...styles.messageManager, offsetStyle}}>
           {message && (
             <ResponsiveContext.Consumer>
               {({ editionBreakpoint }) => (

--- a/packages/message-bar/src/styles/index.js
+++ b/packages/message-bar/src/styles/index.js
@@ -1,4 +1,6 @@
 import sharedStyles from "./shared";
+import styled, { keyframes } from 'styled-components';
+import { TcView } from "@times-components/utils";
 
 const styles = (scale, breakpoint) => ({
     ...sharedStyles(scale, breakpoint),
@@ -8,5 +10,38 @@ const styles = (scale, breakpoint) => ({
       left: 0
     }
   });
+
+
+const AnimationIn = keyframes`
+0% { transform: translateY(-51px)}
+90% { transform: translateY(5px)}
+100% { transform: translateY(0px)}
+`;
+
+const AnimationOut = keyframes`
+0% { transform: translateY(0px)}
+100% { transform: translateY(-51px)}
+`
+
+export const StyledAnimation = styled(TcView)`
+animation-name: ${AnimationIn};
+animation-duration: 0.25s;
+animation-timing-function: ease-in-out;
+&.close {
+  transform: translateY(-51px);
+  animation-name: ${AnimationOut};
+  animation-duration: 0.25s;
+}
+`;
+
+export const CloseButton = styled.button`
+cursor: pointer;
+&.active {
+  opacity: 0.5
+}
+:active { 
+  opacity: 0.5
+}
+`
 
 export default styles;

--- a/packages/message-bar/src/styles/index.js
+++ b/packages/message-bar/src/styles/index.js
@@ -1,8 +1,7 @@
-import { StyleSheet } from "react-native";
 import sharedStyles from "./shared";
+import styled from 'styled-components';
 
-const styles = (scale, breakpoint) =>
-  StyleSheet.create({
+const styles = (scale, breakpoint) => ({
     ...sharedStyles(scale, breakpoint),
     messageManager: {
       ...sharedStyles(scale, breakpoint).messageManager,

--- a/packages/message-bar/src/styles/index.js
+++ b/packages/message-bar/src/styles/index.js
@@ -1,5 +1,4 @@
 import sharedStyles from "./shared";
-import styled from 'styled-components';
 
 const styles = (scale, breakpoint) => ({
     ...sharedStyles(scale, breakpoint),

--- a/packages/message-bar/src/styles/index.js
+++ b/packages/message-bar/src/styles/index.js
@@ -1,16 +1,15 @@
-import sharedStyles from "./shared";
-import styled, { keyframes } from 'styled-components';
+import styled, { keyframes } from "styled-components";
 import { TcView } from "@times-components/utils";
+import sharedStyles from "./shared";
 
 const styles = (scale, breakpoint) => ({
-    ...sharedStyles(scale, breakpoint),
-    messageManager: {
-      ...sharedStyles(scale, breakpoint).messageManager,
-      position: "fixed",
-      left: 0
-    }
-  });
-
+  ...sharedStyles(scale, breakpoint),
+  messageManager: {
+    ...sharedStyles(scale, breakpoint).messageManager,
+    position: "fixed",
+    left: 0
+  }
+});
 
 const AnimationIn = keyframes`
 0% { transform: translateY(-51px)}
@@ -21,27 +20,27 @@ const AnimationIn = keyframes`
 const AnimationOut = keyframes`
 0% { transform: translateY(0px)}
 100% { transform: translateY(-51px)}
-`
+`;
 
 export const StyledAnimation = styled(TcView)`
-animation-name: ${AnimationIn};
-animation-duration: 0.25s;
-animation-timing-function: ease-in-out;
-&.close {
-  transform: translateY(-51px);
-  animation-name: ${AnimationOut};
+  animation-name: ${AnimationIn};
   animation-duration: 0.25s;
-}
+  animation-timing-function: ease-in-out;
+  &.close {
+    transform: translateY(-51px);
+    animation-name: ${AnimationOut};
+    animation-duration: 0.25s;
+  }
 `;
 
 export const CloseButton = styled.button`
-cursor: pointer;
-&.active {
-  opacity: 0.5
-}
-:active { 
-  opacity: 0.5
-}
-`
+  cursor: pointer;
+  &.active {
+    opacity: 0.5;
+  }
+  :active {
+    opacity: 0.5;
+  }
+`;
 
 export default styles;

--- a/packages/message-bar/src/styles/shared.js
+++ b/packages/message-bar/src/styles/shared.js
@@ -21,7 +21,10 @@ const messageBarCloseButton = {
   justifyContent: "center",
   marginLeft: "auto",
   marginRight: 20,
-  width: 28
+  width: 28,
+  padding: 0,
+  display: "inherit",
+  border: "0px"
 };
 
 const messageBarText = scale => ({

--- a/packages/save-and-share-bar/save-and-share-bar.showcase.js
+++ b/packages/save-and-share-bar/save-and-share-bar.showcase.js
@@ -27,7 +27,7 @@ export default {
     {
       component: () => (
         <MockBookmarksProvider delay={1000} articleId={articleId}>
-          <MessageManager animate delay={3000} scale={scales.medium}>
+          <MessageManager delay={3000} scale={scales.medium}>
             <MessageContext.Consumer>
               {({ showMessage }) => (
                 <SaveAndShareBar

--- a/yarn.lock
+++ b/yarn.lock
@@ -3707,6 +3707,18 @@
     fs-extra "6.0.0"
     glob "7.1.2"
 
+"@times-components/link@3.10.5":
+  version "3.10.5"
+  resolved "https://registry.yarnpkg.com/@times-components/link/-/link-3.10.5.tgz#331a0f9709ab550913fdd7ac5270d505ae0edc50"
+  integrity sha512-cvYFILk9lkhYQgNVKJYK5dRknAH6dBlWGiCrEmWHx8KCMtZac0bmEM514OkhRh8xLgg2X6LgpSbrqVt/gOT4ig==
+  dependencies:
+    "@times-components/ts-styleguide" "1.36.2"
+    "@times-components/utils" "6.12.1"
+    prop-types "15.7.2"
+    react "16.9.0"
+    react-dom "16.9.0"
+    styled-components "4.3.2"
+
 "@times-components/svgs@2.7.36":
   version "2.7.36"
   resolved "https://registry.yarnpkg.com/@times-components/svgs/-/svgs-2.7.36.tgz#a7a17502f7806ce59f39b7bf037e13753edfc905"
@@ -3714,6 +3726,33 @@
   dependencies:
     prop-types "15.7.2"
     svgs "3.2.1"
+
+"@times-components/ts-styleguide@1.36.2":
+  version "1.36.2"
+  resolved "https://registry.yarnpkg.com/@times-components/ts-styleguide/-/ts-styleguide-1.36.2.tgz#90da27a8732960d3a6727b3c83979b67eee9a594"
+  integrity sha512-UhmDH5ggca+OzshMoPNUxi8rVZBdI+u61CpDCFf+psF4IOvkzpFvl1BCD1ua+3YnkexV5fXH7hzgx4ltisPP3A==
+  dependencies:
+    "@times-components/link" "3.10.5"
+    "@times-components/utils" "6.12.1"
+    react "16.9.0"
+    styled-components "4.3.2"
+
+"@times-components/utils@6.12.1":
+  version "6.12.1"
+  resolved "https://registry.yarnpkg.com/@times-components/utils/-/utils-6.12.1.tgz#557a5263af797fd5fca87496643c353a0996845c"
+  integrity sha512-zOvjPhYMhpM4FBAUKh/NP5+ktjkjqEnTM59RUn9gU/eCJNiUJaUGMpRjrqSum9woF4cf/faP3O3eH7DOg9ChwA==
+  dependencies:
+    "@times-components/schema" "0.7.1"
+    "@times-components/ts-styleguide" "1.36.2"
+    apollo-cache-inmemory "1.5.1"
+    apollo-client "2.5.1"
+    apollo-link "1.2.4"
+    apollo-link-http "1.5.14"
+    apollo-link-persisted-queries "0.2.2"
+    lodash.omitby "4.6.0"
+    prop-types "15.7.2"
+    styled-components "4.3.2"
+    unfetch "^3.0.0"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -11311,14 +11350,6 @@ flat-cache@^2.0.1:
     flatted "^2.0.0"
     rimraf "2.6.3"
     write "1.0.3"
-
-flatlist-react@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/flatlist-react/-/flatlist-react-1.5.0.tgz#96985790a3cf3dd534050bb05c0ed2a1ad39a87a"
-  integrity sha512-Ux0Pnp679sNcq+v0o+mU5pJgPBFdaOWDzxGknftZw1G4uBrwyAFRJN++gyveiEXc5bPvRL0wsE2B6OYSmdUmKg==
-  dependencies:
-    prop-types "^15.7.2"
-    warning "^4.0.3"
 
 flatted@^2.0.0:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3707,18 +3707,6 @@
     fs-extra "6.0.0"
     glob "7.1.2"
 
-"@times-components/link@3.10.5":
-  version "3.10.5"
-  resolved "https://registry.yarnpkg.com/@times-components/link/-/link-3.10.5.tgz#331a0f9709ab550913fdd7ac5270d505ae0edc50"
-  integrity sha512-cvYFILk9lkhYQgNVKJYK5dRknAH6dBlWGiCrEmWHx8KCMtZac0bmEM514OkhRh8xLgg2X6LgpSbrqVt/gOT4ig==
-  dependencies:
-    "@times-components/ts-styleguide" "1.36.2"
-    "@times-components/utils" "6.12.1"
-    prop-types "15.7.2"
-    react "16.9.0"
-    react-dom "16.9.0"
-    styled-components "4.3.2"
-
 "@times-components/svgs@2.7.36":
   version "2.7.36"
   resolved "https://registry.yarnpkg.com/@times-components/svgs/-/svgs-2.7.36.tgz#a7a17502f7806ce59f39b7bf037e13753edfc905"
@@ -3726,33 +3714,6 @@
   dependencies:
     prop-types "15.7.2"
     svgs "3.2.1"
-
-"@times-components/ts-styleguide@1.36.2":
-  version "1.36.2"
-  resolved "https://registry.yarnpkg.com/@times-components/ts-styleguide/-/ts-styleguide-1.36.2.tgz#90da27a8732960d3a6727b3c83979b67eee9a594"
-  integrity sha512-UhmDH5ggca+OzshMoPNUxi8rVZBdI+u61CpDCFf+psF4IOvkzpFvl1BCD1ua+3YnkexV5fXH7hzgx4ltisPP3A==
-  dependencies:
-    "@times-components/link" "3.10.5"
-    "@times-components/utils" "6.12.1"
-    react "16.9.0"
-    styled-components "4.3.2"
-
-"@times-components/utils@6.12.1":
-  version "6.12.1"
-  resolved "https://registry.yarnpkg.com/@times-components/utils/-/utils-6.12.1.tgz#557a5263af797fd5fca87496643c353a0996845c"
-  integrity sha512-zOvjPhYMhpM4FBAUKh/NP5+ktjkjqEnTM59RUn9gU/eCJNiUJaUGMpRjrqSum9woF4cf/faP3O3eH7DOg9ChwA==
-  dependencies:
-    "@times-components/schema" "0.7.1"
-    "@times-components/ts-styleguide" "1.36.2"
-    apollo-cache-inmemory "1.5.1"
-    apollo-client "2.5.1"
-    apollo-link "1.2.4"
-    apollo-link-http "1.5.14"
-    apollo-link-persisted-queries "0.2.2"
-    lodash.omitby "4.6.0"
-    prop-types "15.7.2"
-    styled-components "4.3.2"
-    unfetch "^3.0.0"
 
 "@tootallnate/once@1":
   version "1.1.2"


### PR DESCRIPTION
### Description 

Remove React Native from message-bar package
[TDP-1419](https://nidigitalsolutions.jira.com/browse/TDP-1419)
Due to the message bar using TouchableOpacity and Animate particularly from react-native we had to refactor the MessageBar component quite a bit to recreate the animation. 
To test the behaviour locally best component is the save-share-bar if you click the icon to copy the link you should see the message bar, and it will automatically close after 3000ms or you can click the close button and it will close. - Compare against the built component [here](https://components.thetimes.co.uk/?path=/story/composed-save-and-share-bar--save-and-share-bar)

Big thank you to @adamosborne-tnl and @DMackintosh-TNL for the assist on this one! 