### PR TITLE
fix(TDP-2238): remove id from ad container

### DIFF
--- a/packages/ad/__tests__/web/__snapshots__/ad-container.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-container.web.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ad-container header ad 1`] = `
-<div
-  id="header"
->
+<div>
   <div
     id="ad-header"
   />
@@ -11,9 +9,7 @@ exports[`ad-container header ad 1`] = `
 `;
 
 exports[`ad-container inline ad 1`] = `
-<div
-  id="inline-ad"
->
+<div>
   <div
     id="ad-article-inline"
   />
@@ -21,9 +17,7 @@ exports[`ad-container inline ad 1`] = `
 `;
 
 exports[`ad-container pixel ad 1`] = `
-<div
-  id="pixel"
->
+<div>
   <div
     id="ad-pixel"
   />
@@ -31,9 +25,7 @@ exports[`ad-container pixel ad 1`] = `
 `;
 
 exports[`ad-container pixelskin ad 1`] = `
-<div
-  id="pixelskin"
->
+<div>
   <div
     id="ad-pixelskin"
   />
@@ -41,9 +33,7 @@ exports[`ad-container pixelskin ad 1`] = `
 `;
 
 exports[`ad-container pixelteads ad 1`] = `
-<div
-  id="pixelteads"
->
+<div>
   <div
     id="ad-pixelteads"
   />

--- a/packages/ad/src/ad-container.js
+++ b/packages/ad/src/ad-container.js
@@ -18,7 +18,7 @@ const AdContainer = ({ slotName, style }) => {
   };
 
   return (
-    <TcView id={slotName} style={{ ...styles.container, ...style }}>
+    <TcView style={{ ...styles.container, ...style }}>
       <div id={`${adMap[slotName]}`} />
     </TcView>
   );


### PR DESCRIPTION
This PR removes the id from the ad-container, which is causing issues with ads appearing correctly.
