### PR TITLE
fix(TDP-2179): Fix article_flag bug

### DIFF
--- a/packages/article-skeleton/__tests__/web/data-helper.test.js
+++ b/packages/article-skeleton/__tests__/web/data-helper.test.js
@@ -12,7 +12,7 @@ describe("Data helper", () => {
       const flags = [
         {
           type: "LIVE",
-          expiryTime: null,
+          expiryTime: null
         }
       ];
       expect(getActiveArticleFlags(flags)).toEqual("live");

--- a/packages/article-skeleton/__tests__/web/data-helper.test.js
+++ b/packages/article-skeleton/__tests__/web/data-helper.test.js
@@ -6,7 +6,17 @@ import {
 describe("Data helper", () => {
   const active = "2050-03-13T13:00:00.000Z";
   const expired = "2000-03-13T13:00:00.000Z";
+
   describe("getActiveArticleFlags", () => {
+    it("Returns the value of the flag if the expiry time is not set -- null", () => {
+      const flags = [
+        {
+          type: "LIVE",
+          expiryTime: null,
+        }
+      ];
+      expect(getActiveArticleFlags(flags)).toEqual("live");
+    });
     it("Returns the lower case value of a flag is a flag is active", () => {
       const flags = [
         {

--- a/packages/article-skeleton/src/data-helper.js
+++ b/packages/article-skeleton/src/data-helper.js
@@ -96,7 +96,9 @@ export const getActiveArticleFlags = flags => {
     return [];
   }
   const findFlag = flags.find(
-    flag => flag.expiryTime === null || new Date().getTime() < new Date(flag.expiryTime).getTime()
+    flag =>
+      flag.expiryTime === null ||
+      new Date().getTime() < new Date(flag.expiryTime).getTime()
   );
   return findFlag && findFlag.type && findFlag.type.toLowerCase();
 };

--- a/packages/article-skeleton/src/data-helper.js
+++ b/packages/article-skeleton/src/data-helper.js
@@ -96,7 +96,7 @@ export const getActiveArticleFlags = flags => {
     return [];
   }
   const findFlag = flags.find(
-    flag => new Date().getTime() < new Date(flag.expiryTime).getTime()
+    flag => flag.expiryTime === null || new Date().getTime() < new Date(flag.expiryTime).getTime()
   );
   return findFlag && findFlag.type && findFlag.type.toLowerCase();
 };


### PR DESCRIPTION
## Description

[TDP-2179](https://nidigitalsolutions.jira.com/browse/TDP-2179)

@DMackintosh-TNL has written some good documentation on the problem we were having [here](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/4013850689?atlOrigin=eyJpIjoiNjU5ZGNjMmFiN2E3NGMxMGE0ZWU5MzA2N2ZmZTA5OTkiLCJwIjoiY29uZmx1ZW5jZS1jaGF0cy1pbnQifQ).

But to summarise this PR - Editorial want to be able to set an active flag either by using an expiry time, but also for cases where they don't know how long the piece will run for ahead of time they also want to not set an expiry and later manually expire the flag. This means that the data we receive could be either a date/time or a null value for when the flag is meant to be live.  - For this reason I have added a check for a null value in the function getActiveArticleFlags. 

