### PR TITLE
feat(tdp-1712): updated jest configurator

### DIFF
--- a/packages/jest-configurator-web/src/jest-configurator.js
+++ b/packages/jest-configurator-web/src/jest-configurator.js
@@ -25,7 +25,6 @@ export default (cwd, options = {}) => {
       "node_modules/redbox-react/node_modules/react/",
       "node_modules/@storybook/"
     ],
-    preset: "react",
     rootDir,
     setupFiles: [
       path.resolve(__dirname, "../setup-jest.js"),


### PR DESCRIPTION
have removed the preset from the jest.config as was previously needed for react-native, but don't think it's needed for vanilla react
