### PR TITLE
Feat/tdp 2259 pointer style for inlinedialog btn

### DIFF
--- a/packages/article-comments/__tests__/web/__snapshots__/shared.web.test.js.snap
+++ b/packages/article-comments/__tests__/web/__snapshots__/shared.web.test.js.snap
@@ -125,6 +125,7 @@ exports[`User States RA Users 1`] = `
   justify-content: center;
   -webkit-text-decoration: none;
   text-decoration: none;
+  cursor: pointer;
   background-color: #008387;
   color: white;
   font-family: GillSansMTStd-Medium;

--- a/packages/ts-components/src/components/inline-dialog/__tests__/__snapshots__/InlineDialog.test.tsx.snap
+++ b/packages/ts-components/src/components/inline-dialog/__tests__/__snapshots__/InlineDialog.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`<InlineDialog> should render the component 1`] = `
         class="sc-htpNat dBfnu"
       />
       <a
-        class="sc-bxivhb bTkHyz"
+        class="sc-bxivhb buzDgg"
         href="#"
       >
         Button

--- a/packages/ts-components/src/components/inline-dialog/styles.ts
+++ b/packages/ts-components/src/components/inline-dialog/styles.ts
@@ -34,7 +34,7 @@ export const Button = styled.a`
   align-items: center;
   justify-content: center;
   text-decoration: none;
-
+  cursor: pointer;
   background-color: #008387;
   color: white;
   font-family: ${fonts.supporting};


### PR DESCRIPTION
cursor: pointer style added to InlineDialog's A tag because if there is no href but callback added only the cursor was default.