### PR TITLE
fix (TDP-2233): get user details from local storage instead of openweb

### DIFF
--- a/packages/article-comments/__tests__/web/__snapshots__/shared.web.test.js.snap
+++ b/packages/article-comments/__tests__/web/__snapshots__/shared.web.test.js.snap
@@ -553,7 +553,6 @@ exports[`single comment 1`] = `
 exports[`window listeners added all listeners added 1`] = `
 Array [
   "spot-im-current-user-typing-start",
-  "spot-im-user-auth-success",
   "spot-im-current-user-sent-message",
   "spot-im-notification-drop-down-link",
   "spot-im-user-up-vote-click",

--- a/packages/article-comments/__tests__/web/utils.test.js
+++ b/packages/article-comments/__tests__/web/utils.test.js
@@ -1,7 +1,52 @@
-import { userShouldUpdateName } from "../../src/utils";
+/* global window */
+
+import {
+  userShouldUpdateName,
+  getDisplayNameFromLocalStorage
+} from "../../src/utils";
 
 const unmockedFetch = global.fetch;
 let mockFetchResponse = {};
+
+const localStorageMock = (function() {
+  const store = {};
+  return {
+    getItem(key) {
+      return store[key];
+    },
+    setItem(key, value) {
+      store[key] = value.toString();
+    }
+  };
+})();
+
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
+describe("", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+});
+describe("getDisplayNameFromLocalStorage()", () => {
+  it("should return false if user it not signed in", () => {
+    expect(getDisplayNameFromLocalStorage()).toEqual(false);
+  });
+
+  it("should return false if there is no display name", () => {
+    window.localStorage.setItem(
+      "SPOTIM_CURRENT_USER",
+      '{"data":{"id":"u_sgCrqrs7KNLv","imageId":"#Grey-Cactus","username":"JohnSmith750","isRegistered":true,"isCommunityModerator":false,"isJournalist":false,"isModerator":false,"isAdmin":false,"isSuperAdmin":false,"reputation":{"total":1},"ssoData":{},"email":"","isEmailVerified":false}}'
+    );
+    expect(getDisplayNameFromLocalStorage()).toEqual(false);
+  });
+  it.only("should return the display name ", () => {
+    window.localStorage.setItem(
+      "SPOTIM_CURRENT_USER",
+      '{"data":{"id":"u_sgCrqrs7KNLv","displayName":"John Smith","imageId":"#Grey-Cactus","username":"JohnSmith750","isRegistered":true,"isCommunityModerator":false,"isJournalist":false,"isModerator":false,"isAdmin":false,"isSuperAdmin":false,"reputation":{"total":1},"ssoData":{},"email":"","isEmailVerified":false}}'
+    );
+    expect(getDisplayNameFromLocalStorage()).toEqual("John Smith");
+  });
+});
 
 describe("userShouldUpdateName()", () => {
   beforeAll(() => {

--- a/packages/article-comments/__tests__/web/utils.test.js
+++ b/packages/article-comments/__tests__/web/utils.test.js
@@ -27,58 +27,58 @@ describe("utils", () => {
     jest.clearAllMocks();
   });
 
-describe("getDisplayNameFromLocalStorage()", () => {
-  it("should return false if user it not signed in", () => {
-    expect(getDisplayNameFromLocalStorage()).toEqual(false);
+  describe("getDisplayNameFromLocalStorage()", () => {
+    it("should return false if user it not signed in", () => {
+      expect(getDisplayNameFromLocalStorage()).toEqual(false);
+    });
+
+    it("should return false if there is no display name", () => {
+      window.localStorage.setItem(
+        "SPOTIM_CURRENT_USER",
+        '{"data":{"id":"u_sgCrqrs7KNLv","imageId":"#Grey-Cactus","username":"JohnSmith750","isRegistered":true}}'
+      );
+      expect(getDisplayNameFromLocalStorage()).toEqual(false);
+    });
+    it("should return the display name ", () => {
+      window.localStorage.setItem(
+        "SPOTIM_CURRENT_USER",
+        '{"data":{"id":"u_sgCrqrs7KNLv","displayName":"John Smith","imageId":"#Grey-Cactus","username":"JohnSmith750","isRegistered":true}}'
+      );
+      expect(getDisplayNameFromLocalStorage()).toEqual("John Smith");
+    });
   });
 
-  it("should return false if there is no display name", () => {
-    window.localStorage.setItem(
-      "SPOTIM_CURRENT_USER",
-      '{"data":{"id":"u_sgCrqrs7KNLv","imageId":"#Grey-Cactus","username":"JohnSmith750","isRegistered":true}}'
-    );
-    expect(getDisplayNameFromLocalStorage()).toEqual(false);
+  describe("userShouldUpdateName()", () => {
+    beforeAll(() => {
+      global.fetch = () =>
+        Promise.resolve({
+          json: () => Promise.resolve(mockFetchResponse)
+        });
+    });
+
+    afterAll(() => {
+      global.fetch = unmockedFetch;
+    });
+    it("it should return false if no username", async () => {
+      const result = await userShouldUpdateName();
+
+      expect(result).toEqual(false);
+    });
+
+    it("it should return false if the username is valid", async () => {
+      mockFetchResponse = { isPseudonym: false };
+
+      const result = await userShouldUpdateName("john");
+
+      expect(result).toEqual(false);
+    });
+
+    it("should set local storage values if they do not already exist and the user is on the banned list", async () => {
+      mockFetchResponse = { isPseudonym: true };
+
+      const result = await userShouldUpdateName("MockBannedName");
+
+      expect(result).toEqual(true);
+    });
   });
-  it("should return the display name ", () => {
-    window.localStorage.setItem(
-      "SPOTIM_CURRENT_USER",
-      '{"data":{"id":"u_sgCrqrs7KNLv","displayName":"John Smith","imageId":"#Grey-Cactus","username":"JohnSmith750","isRegistered":true}}'
-    );
-    expect(getDisplayNameFromLocalStorage()).toEqual("John Smith");
-  });
-});
-
-describe("userShouldUpdateName()", () => {
-  beforeAll(() => {
-    global.fetch = () =>
-      Promise.resolve({
-        json: () => Promise.resolve(mockFetchResponse)
-      });
-  });
-
-  afterAll(() => {
-    global.fetch = unmockedFetch;
-  });
-  it("it should return false if no username", async () => {
-    const result = await userShouldUpdateName();
-
-    expect(result).toEqual(false);
-  });
-
-  it("it should return false if the username is valid", async () => {
-    mockFetchResponse = { isPseudonym: false };
-
-    const result = await userShouldUpdateName("john");
-
-    expect(result).toEqual(false);
-  });
-
-  it("should set local storage values if they do not already exist and the user is on the banned list", async () => {
-    mockFetchResponse = { isPseudonym: true };
-
-    const result = await userShouldUpdateName("MockBannedName");
-
-    expect(result).toEqual(true);
-  });
-});
 });

--- a/packages/article-comments/__tests__/web/utils.test.js
+++ b/packages/article-comments/__tests__/web/utils.test.js
@@ -39,7 +39,7 @@ describe("getDisplayNameFromLocalStorage()", () => {
     );
     expect(getDisplayNameFromLocalStorage()).toEqual(false);
   });
-  it.only("should return the display name ", () => {
+  it("should return the display name ", () => {
     window.localStorage.setItem(
       "SPOTIM_CURRENT_USER",
       '{"data":{"id":"u_sgCrqrs7KNLv","displayName":"John Smith","imageId":"#Grey-Cactus","username":"JohnSmith750","isRegistered":true}}'

--- a/packages/article-comments/__tests__/web/utils.test.js
+++ b/packages/article-comments/__tests__/web/utils.test.js
@@ -22,11 +22,11 @@ const localStorageMock = (function() {
 
 Object.defineProperty(window, "localStorage", { value: localStorageMock });
 
-describe("", () => {
+describe("utils", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-});
+
 describe("getDisplayNameFromLocalStorage()", () => {
   it("should return false if user it not signed in", () => {
     expect(getDisplayNameFromLocalStorage()).toEqual(false);
@@ -80,4 +80,5 @@ describe("userShouldUpdateName()", () => {
 
     expect(result).toEqual(true);
   });
+});
 });

--- a/packages/article-comments/__tests__/web/utils.test.js
+++ b/packages/article-comments/__tests__/web/utils.test.js
@@ -35,14 +35,14 @@ describe("getDisplayNameFromLocalStorage()", () => {
   it("should return false if there is no display name", () => {
     window.localStorage.setItem(
       "SPOTIM_CURRENT_USER",
-      '{"data":{"id":"u_sgCrqrs7KNLv","imageId":"#Grey-Cactus","username":"JohnSmith750","isRegistered":true,"isCommunityModerator":false,"isJournalist":false,"isModerator":false,"isAdmin":false,"isSuperAdmin":false,"reputation":{"total":1},"ssoData":{},"email":"","isEmailVerified":false}}'
+      '{"data":{"id":"u_sgCrqrs7KNLv","imageId":"#Grey-Cactus","username":"JohnSmith750","isRegistered":true}}'
     );
     expect(getDisplayNameFromLocalStorage()).toEqual(false);
   });
   it.only("should return the display name ", () => {
     window.localStorage.setItem(
       "SPOTIM_CURRENT_USER",
-      '{"data":{"id":"u_sgCrqrs7KNLv","displayName":"John Smith","imageId":"#Grey-Cactus","username":"JohnSmith750","isRegistered":true,"isCommunityModerator":false,"isJournalist":false,"isModerator":false,"isAdmin":false,"isSuperAdmin":false,"reputation":{"total":1},"ssoData":{},"email":"","isEmailVerified":false}}'
+      '{"data":{"id":"u_sgCrqrs7KNLv","displayName":"John Smith","imageId":"#Grey-Cactus","username":"JohnSmith750","isRegistered":true}}'
     );
     expect(getDisplayNameFromLocalStorage()).toEqual("John Smith");
   });

--- a/packages/article-comments/src/comments.js
+++ b/packages/article-comments/src/comments.js
@@ -5,16 +5,12 @@ import PropTypes from "prop-types";
 import { CommentContainer } from "./styles/responsive";
 import executeSSOtransaction from "./comment-login";
 import withTrackEvents from "./tracking/with-track-events";
-import { userShouldUpdateName } from "./utils";
+import { userShouldUpdateName, getDisplayNameFromLocalStorage } from "./utils";
 
 class Comments extends Component {
   constructor() {
     super();
     this.container = null;
-
-    this.state = {
-      displayName: ""
-    };
   }
 
   componentDidMount() {
@@ -99,7 +95,9 @@ class Comments extends Component {
         onCommentStart(event);
 
         if (isFeatureFlagEnabled) {
-          const { displayName } = this.state;
+          const displayName = getDisplayNameFromLocalStorage();
+
+          if (!displayName) return;
 
           const shouldShowBanner = await userShouldUpdateName(displayName);
           if (shouldShowBanner) {
@@ -111,14 +109,6 @@ class Comments extends Component {
       },
       { once: true }
     );
-
-    document.addEventListener("spot-im-user-auth-success", async event => {
-      if (isFeatureFlagEnabled) {
-        const { displayName } = event.detail;
-
-        this.setState({ displayName });
-      }
-    });
 
     document.addEventListener(
       "spot-im-current-user-sent-message",

--- a/packages/article-comments/src/utils.js
+++ b/packages/article-comments/src/utils.js
@@ -29,6 +29,19 @@ export const userShouldUpdateName = async username => {
   return isPseudonym;
 };
 
+export const getDisplayNameFromLocalStorage = () => {
+  const spotimUserDetails = window.localStorage.getItem("SPOTIM_CURRENT_USER");
+
+  if (!spotimUserDetails) return false;
+
+  const spotimUserDetailsJSON =
+    spotimUserDetails && JSON.parse(spotimUserDetails);
+
+  const { displayName } = spotimUserDetailsJSON.data;
+
+  return displayName || false;
+};
+
 export default () => {
   const region =
     // eslint-disable-next-line no-undef


### PR DESCRIPTION
When a user initially logs into an article page, dummy user details are used which means an incorrect display name is passed which will not trigger the functionality of the smart banner.

The issue of the dummy data is initially resolved and the correct values are stored into local storage. This pr simply reads the local storage data as a source of truth rather than data we get back from spotim which is dummy data.

https://nidigitalsolutions.jira.com/jira/software/c/projects/TDP/boards/1491?modal=detail&selectedIssue=TDP-2233