### PR TITLE
fix(TDP-2097): Fix analytics for bylines with links

### DIFF
--- a/packages/article-byline/src/article-byline-with-links.js
+++ b/packages/article-byline/src/article-byline-with-links.js
@@ -14,7 +14,7 @@ const AuthorComponent = ({ slug, className, onAuthorPress, children }) => {
   return (
     <TextLink
       className={className}
-      onClick={e => {
+      onPress={e => {
         onAuthorPress(e, { name, slug });
       }}
       style={checkStylesForUnits(styles.link)}


### PR DESCRIPTION
This PR fixes the analytics for author bylines with links by changing the `onClick ` prop to `onPress`.

[TDP-2097](https://nidigitalsolutions.jira.com/browse/TDP-2097)