### PR TITLE
chore: add an ssr only component to the article body for zephr

### DIFF
--- a/packages/article-main-comment/src/article-main-comment.js
+++ b/packages/article-main-comment/src/article-main-comment.js
@@ -54,7 +54,6 @@ class ArticlePage extends Component {
   }
 
   render() {
-    console.log('rendering main article')
     const {
       article,
       analyticsStream,

--- a/packages/article-main-comment/src/article-main-comment.js
+++ b/packages/article-main-comment/src/article-main-comment.js
@@ -54,6 +54,7 @@ class ArticlePage extends Component {
   }
 
   render() {
+    console.log('rendering main article')
     const {
       article,
       analyticsStream,
@@ -65,7 +66,8 @@ class ArticlePage extends Component {
       commentingConfig,
       paidContentClassName,
       isPreview,
-      swgProductId
+      swgProductId,
+      zephrDivs
     } = this.props;
 
     if (error || isLoading) {
@@ -84,6 +86,7 @@ class ArticlePage extends Component {
         paidContentClassName={paidContentClassName}
         isPreview={isPreview}
         swgProductId={swgProductId}
+        zephrDivs={zephrDivs}
       />
     );
   }

--- a/packages/article-main-comment/src/article-prop-types/article-prop-types.base.js
+++ b/packages/article-main-comment/src/article-prop-types/article-prop-types.base.js
@@ -12,7 +12,8 @@ const articlePagePropTypes = {
   }),
   isLoading: PropTypes.bool,
   onImagePress: PropTypes.func,
-  receiveChildList: PropTypes.func.isRequired
+  receiveChildList: PropTypes.func.isRequired,
+  zephrDivs: PropTypes.bool
 };
 
 const articlePageDefaultProps = {

--- a/packages/article-main-standard/src/article-main-standard.js
+++ b/packages/article-main-standard/src/article-main-standard.js
@@ -86,7 +86,8 @@ class ArticlePage extends Component {
       paidContentClassName,
       isPreview,
       swgProductId,
-      getFallbackThumbnailUrl169
+      getFallbackThumbnailUrl169,
+      zephrDivs
     } = this.props;
 
     if (error || isLoading) {
@@ -106,6 +107,7 @@ class ArticlePage extends Component {
           paidContentClassName={paidContentClassName}
           isPreview={isPreview}
           swgProductId={swgProductId}
+          zephrDivs={zephrDivs}
         />
       </ArticleMainStandardContainer>
     );

--- a/packages/article-main-standard/src/article-prop-types/article-prop-types.js
+++ b/packages/article-main-standard/src/article-prop-types/article-prop-types.js
@@ -11,7 +11,8 @@ const articlePropTypes = {
     // Could have more here
   }),
   receiveChildList: PropTypes.func,
-  navigationMode: PropTypes.shape({}).isRequired
+  navigationMode: PropTypes.shape({}).isRequired,
+  zephrDivs: PropTypes.bool
 };
 
 const articleDefaultProps = {

--- a/packages/article-skeleton/__tests__/shared.base.js
+++ b/packages/article-skeleton/__tests__/shared.base.js
@@ -46,6 +46,7 @@ export const renderArticle = (data, header = null) => (
       onTwitterLinkPress={() => {}}
       onVideoPress={() => {}}
       commentingConfig={{ account: "dummiy-spotim-id" }}
+      zephrDivs
     />
   </ContextProviderWithDefaults>
 );

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -45,6 +45,14 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <p>
           <span>
             T
@@ -475,6 +483,14 @@ exports[`2. an article with interactives 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <div>
           <div
             id="d2f83305-d558-4f78-f582-32115c659355"
@@ -649,6 +665,14 @@ exports[`3. an article with no content 1`] = `
       </div>
       <article>
         <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
+        <div
           id="paywall-portal-article-footer"
         />
         <ArticleExtras
@@ -779,6 +803,14 @@ exports[`4. an article with no content if content is set as null 1`] = `
       </div>
       <article>
         <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
+        <div
           id="paywall-portal-article-footer"
         />
         <ArticleExtras
@@ -908,6 +940,14 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <p>
           <span>
             <b>
@@ -1015,6 +1055,14 @@ exports[`6. an article with heading tags 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <h2>
           This is heading 2
         </h2>
@@ -1164,6 +1212,14 @@ exports[`7. an article with link 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <p>
           <Link
             underlined={true}
@@ -1316,6 +1372,14 @@ exports[`8. an article with italic link 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <p>
           In his 2015 book on the tournaments, 
           <Link
@@ -1471,6 +1535,14 @@ exports[`9. an article with bold text followed by bold link 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <p>
           <b>
             2 
@@ -1625,6 +1697,14 @@ exports[`10. an article with italic and normal text link 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <p>
           Family Action is one of two charities being supported by 
           <Link
@@ -1781,6 +1861,14 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <p>
           <b>
             <i>
@@ -1931,6 +2019,14 @@ exports[`12. an article with text wrapped in inline element 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <p>
           <span>
             They may have been improved by the controversy that ensued when Watson appeared on the cover of Vanity Fair to promote it, wearing a top that partially exposed her breasts. She rejected criticism that the pose was at odds with her claim to be a feminist. “Feminism is not a stick with which to beat other women. It’s about liberation. It’s about equality,” she said, adding: “I really don’t know what my tits have to do with it.” 
@@ -2079,6 +2175,14 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <p>
           20. 
           <span>
@@ -2228,6 +2332,14 @@ exports[`14. an article with inline inside a bold tag 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <p>
           <b>
             <span>
@@ -2378,6 +2490,14 @@ exports[`15. an article starting with single quote 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <p>
           <span>
             ‘S
@@ -2527,6 +2647,14 @@ exports[`16. an article starting with double quote 1`] = `
         </div>
       </div>
       <article>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div id=\\"nu-zephr-article-target-body\\">&nbsp;</div>",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
         <p>
           <span>
             “S

--- a/packages/article-skeleton/src/article-body/article-body.js
+++ b/packages/article-skeleton/src/article-body/article-body.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { AdContainer } from "@times-components/ad";
 import LazyLoad from "@times-components/lazy-load";
 import ArticleImage from "@times-components/article-image";
+import StaticContent from '../static-content';
 
 import ArticleParagraph, {
   DropCapView
@@ -64,43 +65,6 @@ import {
 } from "../styles/article-body/responsive";
 
 const deckApiUrl = "https://gobble.timesdev.tools/deck/api/deck-post-action/";
-
-function useStaticContent() {
-    const ref = useRef(null);
-    const [render, setRender] = useState(typeof window === 'undefined');
-
-    useEffect(() => {
-        const isEmpty = ref.current.innerHTML === '';
-        if (isEmpty) {
-            setRender(true);
-        }
-    }, []);
-
-    return [render, ref];
-}
-
-export default function StaticContent({
-    children,
-    element = 'div',
-    html,
-    ...props
-}) {
-    const [shouldRender, ref] = useStaticContent();
-
-    if (shouldRender) {
-        return createElement(element, {
-            ...props,
-            children,
-        });
-    }
-
-    return createElement(element, {
-        ...props,
-        ref,
-        suppressHydrationWarning: true,
-        dangerouslySetInnerHTML: { __html: html },
-    });
-}
 
 export const responsiveDisplayWrapper = displayType => {
   switch (displayType) {
@@ -524,13 +488,11 @@ const renderers = ({
   },
   paywall(key, attributes, children) {
     return (
-        <div>
-      <span className={paidContentClassName} key={key}>
-        {children}
-      </span>
-      <StaticContent
-            html={"<div id='zephr-target-pw'>Here's static emptiness</div>"}/>
-        </div>
+      <div>
+        <span className={paidContentClassName} key={key}>
+          {children}
+        </span>
+      </div>
     );
   },
   pullQuote(

--- a/packages/article-skeleton/src/article-body/article-body.js
+++ b/packages/article-skeleton/src/article-body/article-body.js
@@ -65,6 +65,43 @@ import {
 
 const deckApiUrl = "https://gobble.timesdev.tools/deck/api/deck-post-action/";
 
+function useStaticContent() {
+    const ref = useRef(null);
+    const [render, setRender] = useState(typeof window === 'undefined');
+
+    useEffect(() => {
+        const isEmpty = ref.current.innerHTML === '';
+        if (isEmpty) {
+            setRender(true);
+        }
+    }, []);
+
+    return [render, ref];
+}
+
+export default function StaticContent({
+    children,
+    element = 'div',
+    html,
+    ...props
+}) {
+    const [shouldRender, ref] = useStaticContent();
+
+    if (shouldRender) {
+        return createElement(element, {
+            ...props,
+            children,
+        });
+    }
+
+    return createElement(element, {
+        ...props,
+        ref,
+        suppressHydrationWarning: true,
+        dangerouslySetInnerHTML: { __html: html },
+    });
+}
+
 export const responsiveDisplayWrapper = displayType => {
   switch (displayType) {
     case "secondary":
@@ -487,9 +524,13 @@ const renderers = ({
   },
   paywall(key, attributes, children) {
     return (
+        <div>
       <span className={paidContentClassName} key={key}>
         {children}
       </span>
+      <StaticContent
+            html={"<div id='zephr-target-pw'>Here's static emptiness</div>"}/>
+        </div>
     );
   },
   pullQuote(

--- a/packages/article-skeleton/src/article-body/article-body.js
+++ b/packages/article-skeleton/src/article-body/article-body.js
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 import { AdContainer } from "@times-components/ad";
 import LazyLoad from "@times-components/lazy-load";
 import ArticleImage from "@times-components/article-image";
-import StaticContent from '../static-content';
 
 import ArticleParagraph, {
   DropCapView

--- a/packages/article-skeleton/src/article-body/article-body.js
+++ b/packages/article-skeleton/src/article-body/article-body.js
@@ -487,11 +487,9 @@ const renderers = ({
   },
   paywall(key, attributes, children) {
     return (
-      <div>
         <span className={paidContentClassName} key={key}>
           {children}
         </span>
-      </div>
     );
   },
   pullQuote(

--- a/packages/article-skeleton/src/article-body/article-body.js
+++ b/packages/article-skeleton/src/article-body/article-body.js
@@ -487,9 +487,9 @@ const renderers = ({
   },
   paywall(key, attributes, children) {
     return (
-        <span className={paidContentClassName} key={key}>
-          {children}
-        </span>
+      <span className={paidContentClassName} key={key}>
+        {children}
+      </span>
     );
   },
   pullQuote(

--- a/packages/article-skeleton/src/article-skeleton-prop-types.js
+++ b/packages/article-skeleton/src/article-skeleton-prop-types.js
@@ -10,7 +10,8 @@ const articleSkeletonPropTypes = {
   commentingConfig: PropTypes.shape({
     account: PropTypes.string.isRequired
   }).isRequired,
-  swgProductId: PropTypes.string
+  swgProductId: PropTypes.string,
+  zephrDivs: PropTypes.bool
 };
 
 const articleSkeletonDefaultProps = {
@@ -18,7 +19,8 @@ const articleSkeletonDefaultProps = {
   data: { content: [] },
   Header: () => null,
   receiveChildList: () => {},
-  swgProductId: null
+  swgProductId: null,
+  zephrDivs: false
 };
 
 export { articleSkeletonPropTypes, articleSkeletonDefaultProps };

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -50,7 +50,8 @@ const ArticleSkeleton = ({
   paidContentClassName,
   isPreview,
   swgProductId,
-  getFallbackThumbnailUrl169
+  getFallbackThumbnailUrl169,
+  zephrDivs
 }) => {
   const {
     commentsEnabled,
@@ -176,9 +177,11 @@ const ArticleSkeleton = ({
                 ) : null}
               </HeaderContainer>
               <BodyContainer>
-                <StaticContent
-                  html={'<div id="zephr-article-target-body"></div>'}
-                />
+                {!!zephrDivs && (
+                  <StaticContent
+                    html={'<div id="nu-zephr-article-target-body">&nbsp;</div>'}
+                  />
+                )}
                 {newContent && (
                   <ArticleBody
                     analyticsStream={analyticsStream}

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -176,7 +176,9 @@ const ArticleSkeleton = ({
                 ) : null}
               </HeaderContainer>
               <BodyContainer>
-                <StaticContent html={'<div id="zephr-article-target-body"></div>'} />
+                <StaticContent
+                  html={'<div id="zephr-article-target-body"></div>'}
+                />
                 {newContent && (
                   <ArticleBody
                     analyticsStream={analyticsStream}

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -176,9 +176,7 @@ const ArticleSkeleton = ({
                 ) : null}
               </HeaderContainer>
               <BodyContainer>
-                <StaticContent
-                  html={
-                    '<div id="zephr-article-target-body">'} />
+                <StaticContent html={'<div id="zephr-article-target-body">'} />
                 {newContent && (
                   <ArticleBody
                     analyticsStream={analyticsStream}

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -176,7 +176,7 @@ const ArticleSkeleton = ({
                 ) : null}
               </HeaderContainer>
               <BodyContainer>
-                <StaticContent html={'<div id="zephr-article-target-body">'} />
+                <StaticContent html={'<div id="zephr-article-target-body"></div>'} />
                 {newContent && (
                   <ArticleBody
                     analyticsStream={analyticsStream}

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -9,6 +9,7 @@ import { TrackingContextProvider } from "@times-components/ts-components";
 import { spacing } from "@times-components/ts-styleguide";
 import UserState from "@times-components/user-state";
 import { MessageContext } from "@times-components/message-bar";
+import  StaticContent  from './static-content';
 
 import ArticleBody, { ArticleLink } from "./article-body/article-body";
 import {
@@ -140,6 +141,8 @@ const ArticleSkeleton = ({
           data-article-sectionname={section}
           data-article-template={template}
         >
+          <StaticContent
+            html={'<div id="zephr-article-target">Here is static emptiness'} />
           <Head
             article={article}
             logoUrl={logoUrl}
@@ -175,6 +178,9 @@ const ArticleSkeleton = ({
                 ) : null}
               </HeaderContainer>
               <BodyContainer>
+
+          <StaticContent
+            html={'<div id="zephr-article-target-body">Here is static emptiness'} />
                 {newContent && (
                   <ArticleBody
                     analyticsStream={analyticsStream}

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -9,7 +9,7 @@ import { TrackingContextProvider } from "@times-components/ts-components";
 import { spacing } from "@times-components/ts-styleguide";
 import UserState from "@times-components/user-state";
 import { MessageContext } from "@times-components/message-bar";
-import  StaticContent  from './static-content';
+import StaticContent from "./static-content";
 
 import ArticleBody, { ArticleLink } from "./article-body/article-body";
 import {
@@ -141,8 +141,6 @@ const ArticleSkeleton = ({
           data-article-sectionname={section}
           data-article-template={template}
         >
-          <StaticContent
-            html={'<div id="zephr-article-target">Here is static emptiness'} />
           <Head
             article={article}
             logoUrl={logoUrl}
@@ -178,9 +176,9 @@ const ArticleSkeleton = ({
                 ) : null}
               </HeaderContainer>
               <BodyContainer>
-
-          <StaticContent
-            html={'<div id="zephr-article-target-body">Here is static emptiness'} />
+                <StaticContent
+                  html={
+                    '<div id="zephr-article-target-body">'} />
                 {newContent && (
                   <ArticleBody
                     analyticsStream={analyticsStream}

--- a/packages/article-skeleton/src/static-content.js
+++ b/packages/article-skeleton/src/static-content.js
@@ -5,7 +5,7 @@ function useStaticContent() {
   const [render, setRender] = useState(typeof window === "undefined");
 
   useEffect(() => {
-    const isEmpty = ref.current.innerHTML === "";
+    const isEmpty = !!ref.current && ref.current.innerHTML === "";
     if (isEmpty) {
       setRender(true);
     }

--- a/packages/article-skeleton/src/static-content.js
+++ b/packages/article-skeleton/src/static-content.js
@@ -1,0 +1,39 @@
+import { useEffect, createElement, useRef, useState } from 'react';
+
+function useStaticContent() {
+
+  const ref = useRef(null);
+  const [render, setRender] = useState(typeof window === "undefined");
+
+  useEffect(() => {
+    const isEmpty = ref.current.innerHTML === "";
+    if (isEmpty) {
+      setRender(true);
+    }
+  }, []);
+
+  return [render, ref];
+}
+
+export default function StaticContent({
+  children,
+  element = "div",
+  html,
+  ...props
+}) {
+  const [shouldRender, ref] = useStaticContent();
+
+  if (shouldRender) {
+    return createElement(element, {
+      ...props,
+      children
+    });
+  }
+
+  return createElement(element, {
+    ...props,
+    ref,
+    suppressHydrationWarning: true,
+    dangerouslySetInnerHTML: { __html: html }
+  });
+}

--- a/packages/article-skeleton/src/static-content.js
+++ b/packages/article-skeleton/src/static-content.js
@@ -1,7 +1,6 @@
-import { useEffect, createElement, useRef, useState } from 'react';
+import { useEffect, createElement, useRef, useState } from "react";
 
 function useStaticContent() {
-
   const ref = useRef(null);
   const [render, setRender] = useState(typeof window === "undefined");
 

--- a/packages/ssr/src/client/article.js
+++ b/packages/ssr/src/client/article.js
@@ -14,7 +14,8 @@ if (window.nuk && window.nuk.ssr && window.nuk.article) {
     userState,
     isPreview,
     swgProductId,
-    commentCount
+    commentCount,
+    zephrDivs
   } = window.nuk.article;
   const { getCookieValue } = window.nuk;
 
@@ -30,7 +31,8 @@ if (window.nuk && window.nuk.ssr && window.nuk.article) {
     userState,
     isPreview,
     swgProductId,
-    commentCount
+    commentCount,
+    zephrDivs
   };
 
   const clientOptions = {

--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -30,7 +30,8 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
     paidContentClassName,
     isPreview,
     swgProductId,
-    getFallbackThumbnailUrl169
+    getFallbackThumbnailUrl169,
+    zephrDivs
   } = data;
 
   return React.createElement(
@@ -87,7 +88,8 @@ module.exports = (client, analyticsStream, data, helmetContext) => {
               paidContentClassName,
               isPreview,
               swgProductId,
-              getFallbackThumbnailUrl169
+              getFallbackThumbnailUrl169,
+              zephrDivs
             })
           );
         }

--- a/packages/ssr/src/server/article.js
+++ b/packages/ssr/src/server/article.js
@@ -22,7 +22,8 @@ module.exports = (
     isPreview,
     swgProductId,
     getFallbackThumbnailUrl169,
-    commentCount
+    commentCount,
+    zephrDivs
   },
   userState
 ) => {
@@ -72,7 +73,8 @@ module.exports = (
       paidContentClassName,
       isPreview,
       swgProductId,
-      commentCount
+      commentCount,
+      zephrDivs
     },
     name: "article"
   };


### PR DESCRIPTION

This PR adds a static component to test if we can use it to allow Zephr to make changes to the page without React overwriting those things on the client side. This is behind a feature flag so won't display unless the flag is set.

If the flag is set, it just adds a div with no content with an id that we can use in Zephr to target and add content. If this is successful then we could markup the content with such divs and use Zephr to target them for transformations. 