### PR TITLE
chore(TLP-00): Fix string comparasion.

### DIFF
--- a/lib/publish.sh
+++ b/lib/publish.sh
@@ -8,7 +8,7 @@ TIP_COMMIT=$(git rev-parse HEAD)
 echo $(printf "CircleCI commit: %s, Head commit: %s" $CIRCLE_SHA1 $TIP_COMMIT)
 
 # make sure we only publish if we are at the head of master
-if [[ $TIP_COMMIT != $CIRCLE_SHA1 ]]
+if [[ "$TIP_COMMIT" != "$CIRCLE_SHA1" ]]
 then
   echo "Not on the tip of master!"
   exit 0


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Simple fix for string comparison in bash which was causing error in the pipeline.
```
$ sh ./lib/publish.sh
Already on 'master'
Your branch is up to date with 'origin/master'.
CircleCI commit: 92a0d600b183105d33f8c15780922bd630048793, Head commit: 92a0d600b183105d33f8c15780922bd630048793
./lib/publish.sh: 11: ./lib/publish.sh: [[: not found
```
