### PR TITLE
feat(TDP-2429): Remove feature flag from real name commenting smart banner

### DIFF
--- a/packages/article-comments/src/comments.js
+++ b/packages/article-comments/src/comments.js
@@ -79,8 +79,6 @@ class Comments extends Component {
       "spot-im-current-user-typing-start",
       async event => {
         onCommentStart(event);
-
-        if (window.location.search.includes("enableRealNameCommenting")) {
           const displayName = getDisplayNameFromLocalStorage();
           if (!displayName) return;
 
@@ -90,7 +88,6 @@ class Comments extends Component {
               new CustomEvent("SHOW_REAL_NAME_COMMENTING_BANNER", {})
             );
           }
-        }
       },
       { once: true }
     );

--- a/packages/article-comments/src/comments.js
+++ b/packages/article-comments/src/comments.js
@@ -79,15 +79,15 @@ class Comments extends Component {
       "spot-im-current-user-typing-start",
       async event => {
         onCommentStart(event);
-          const displayName = getDisplayNameFromLocalStorage();
-          if (!displayName) return;
+        const displayName = getDisplayNameFromLocalStorage();
+        if (!displayName) return;
 
-          const shouldShowBanner = await userShouldUpdateName(displayName);
-          if (shouldShowBanner) {
-            window.dispatchEvent(
-              new CustomEvent("SHOW_REAL_NAME_COMMENTING_BANNER", {})
-            );
-          }
+        const shouldShowBanner = await userShouldUpdateName(displayName);
+        if (shouldShowBanner) {
+          window.dispatchEvent(
+            new CustomEvent("SHOW_REAL_NAME_COMMENTING_BANNER", {})
+          );
+        }
       },
       { once: true }
     );


### PR DESCRIPTION
This PR removes the feature flag from the real name commenting smart banner. There will be another ticket in Render for the timer function to show the smart banner on 29 December, which is during the code freeze.

[TDP-2429](https://nidigitalsolutions.jira.com/browse/TDP-2429)
