### PR TITLE
fix(TDP-3079): remove section name from page meta title

### DIFF
--- a/packages/article-skeleton/src/head.js
+++ b/packages/article-skeleton/src/head.js
@@ -382,10 +382,7 @@ function Head({
         jsonLD.mainEntityOfPage["@id"] = makeArticleUrl(article);
         return (
           <Helmet encodeSpecialCharacters={false}>
-            <title>
-              {title} | {sectionname ? `${sectionname} | ` : ""}
-              {publication}
-            </title>
+            <title>{title}</title>
             <meta name="robots" content="max-image-preview:large" />
             <meta content={title} name="article:title" />
             <meta content={publication} name="article:publication" />


### PR DESCRIPTION
We’d like to remove the page section name which is appended to page meta titles

Hypothesis that this will improve the UX for readers presented with a link to our content when using Google

Context to request and example of page meta title:

User story:

Given I’m a web user
When I’m using Google
And I’m presented with a link to content from The Times
Then The meta title doesn’t include the section name

[JIRA-3079](https://nidigitalsolutions.jira.com/browse/TDP-3079)

