### PR TITLE
fix(TDP-3107): Simplify hooks and remove from conditional logic

### DIFF
--- a/packages/ts-newskit/src/components/global-nav/hamburger-menu/HamburgerMenu.tsx
+++ b/packages/ts-newskit/src/components/global-nav/hamburger-menu/HamburgerMenu.tsx
@@ -10,20 +10,9 @@ const HamburgerMenu: React.FC<{
   data: NavigationData;
 }> = ({ isLoggedIn, data }) => {
   const mainNavigation = 'Sections';
-  const secondaryNavigation = 'My account';
 
   const [expandedL1, setExpandedL1] = useState<string>('');
-  const [selected, setSelected] = useState(mainNavigation);
-
-  const onExpand = (slug: string) => setExpandedL1(slug);
-
-  const clickHandler = (title: string) => {
-    if (title === mainNavigation) {
-      return setSelected(mainNavigation);
-    } else {
-      return setSelected(secondaryNavigation);
-    }
-  };
+  const [selected, setSelected] = useState('Sections');
 
   return (
     <HamburgerMenuNav
@@ -35,7 +24,7 @@ const HamburgerMenu: React.FC<{
       <Visible xs sm>
         <NavButtonSection
           loggedIn={isLoggedIn}
-          handleClick={clickHandler}
+          setSelected={setSelected}
           selected={selected}
         />
       </Visible>
@@ -45,7 +34,7 @@ const HamburgerMenu: React.FC<{
             ? data.mainMenuItems
             : data.accountMenuItems
         }
-        onExpand={onExpand}
+        onExpand={setExpandedL1}
         expandedL1={expandedL1}
       />
       {selected === mainNavigation ? (

--- a/packages/ts-newskit/src/components/global-nav/hamburger-menu/LoggedInMenuItem.tsx
+++ b/packages/ts-newskit/src/components/global-nav/hamburger-menu/LoggedInMenuItem.tsx
@@ -4,8 +4,8 @@ import { Button } from 'newskit';
 const LoggedInMenuItem: React.FC<{
   title: string;
   selected: string;
-  handleClick: (title: string) => void;
-}> = ({ title, handleClick, selected }) => {
+  setSelected: (title: string) => void;
+}> = ({ title, setSelected, selected }) => {
   const isSelected = selected === title ? true : false;
 
   return (
@@ -17,7 +17,7 @@ const LoggedInMenuItem: React.FC<{
           isSelected ? 'loggedInMenuItemActive' : 'loggedInMenuItem'
         }`
       }}
-      onClick={() => handleClick(title)}
+      onClick={() => setSelected(title)}
     >
       {title}
     </Button>

--- a/packages/ts-newskit/src/components/global-nav/hamburger-menu/NavButtons.tsx
+++ b/packages/ts-newskit/src/components/global-nav/hamburger-menu/NavButtons.tsx
@@ -32,9 +32,9 @@ export const LoggedOutNavButtons = () => (
 );
 
 export const LoggedInNavButtons: React.FC<{
-  handleClick: (title: string) => void;
+  setSelected: (title: string) => void;
   selected: string;
-}> = ({ handleClick, selected }) => (
+}> = ({ setSelected, selected }) => (
   <>
     <Block
       paddingInline="space040"
@@ -47,12 +47,12 @@ export const LoggedInNavButtons: React.FC<{
     <HamburgerStyledMenu role="region" aria-label="Navigation Menu">
       <LoggedInMenuItem
         title="Sections"
-        handleClick={handleClick}
+        setSelected={setSelected}
         selected={selected}
       />
       <LoggedInMenuItem
         title="My account"
-        handleClick={handleClick}
+        setSelected={setSelected}
         selected={selected}
       />
     </HamburgerStyledMenu>
@@ -61,11 +61,11 @@ export const LoggedInNavButtons: React.FC<{
 
 const NavButtonSection: React.FC<{
   loggedIn?: boolean;
-  handleClick: (title: string) => void;
+  setSelected: (title: string) => void;
   selected: string;
-}> = ({ loggedIn, handleClick, selected }) =>
+}> = ({ loggedIn, setSelected, selected }) =>
   loggedIn ? (
-    <LoggedInNavButtons handleClick={handleClick} selected={selected} />
+    <LoggedInNavButtons setSelected={setSelected} selected={selected} />
   ) : (
     <LoggedOutNavButtons />
   );


### PR DESCRIPTION
### Description

Importing the GlobalNav component into render is returning errors, in the console some of these refer to maybe breaking the rules of hooks. I have simplified the HamburgerMenu hooks so that they are not within any conditional logic and called from within the component in the hopes of fixing this issue. 