### PR TITLE
Revert "fix(TDP-3336): Allow links to render without text in articles"

### DIFF
--- a/packages/article-skeleton/__tests__/web/dropcap-util.test.js
+++ b/packages/article-skeleton/__tests__/web/dropcap-util.test.js
@@ -1,20 +1,6 @@
 import insertDropcapIntoAST from "../../src/contentModifiers/dropcap-util";
 import { isQuote } from "../../src/contentModifiers/dropcap-util-common";
 
-const childWithMarkupNoChildren = {
-  name: "paragraph",
-  children: [
-    {
-      name: "link",
-      children: [],
-      attributes: {
-        href:
-          "https://www.telegraph.co.uk/business/2023/03/05/huawei-abandons-plans-1bn-cambridge-research-campus/"
-      }
-    }
-  ]
-};
-
 const child = {
   attributes: [],
   children: [
@@ -493,15 +479,6 @@ describe("insertDropcapIntoAST", () => {
   it("should NOT insert dropcap if it belongs to the wrong template", () => {
     const template = "mainstandard";
     expect(insertDropcapIntoAST(template)([child])).toEqual([child]);
-  });
-  it("should NOT insert dropcap if the markup does not contain children even with disableDropcap true", () => {
-    const template = "indepth";
-    const isDropcapDisabled = false;
-    expect(
-      insertDropcapIntoAST(template, isDropcapDisabled)([
-        childWithMarkupNoChildren
-      ])
-    ).toEqual([childWithMarkupNoChildren]);
   });
 
   it("should NOT insert dropcap if it belongs to the right template but disableDropcap is true", () => {

--- a/packages/article-skeleton/src/article-body/article-link.js
+++ b/packages/article-skeleton/src/article-body/article-link.js
@@ -8,30 +8,15 @@ import {
 import withTrackEvents from "./article-link-tracking-events";
 
 const ArticleLink = ({ children, target, url, onPress, dropCap }) => (
-  <>
-    {children.length === 0 ? (
-      <>
-        <Link
-          responsiveLinkStyles={linkStyles}
-          target={target}
-          onPress={onPress}
-          url={url}
-        >
-          {url}
-        </Link>{" "}
-      </>
-    ) : (
-      <Link
-        underlined={!(dropCap && children[0].length === 1)}
-        responsiveLinkStyles={dropCap ? dropCapLinkStyles : linkStyles}
-        target={target}
-        url={url}
-        onPress={onPress}
-      >
-        {children}
-      </Link>
-    )}
-  </>
+  <Link
+    underlined={!(dropCap && children[0].length === 1)}
+    responsiveLinkStyles={dropCap ? dropCapLinkStyles : linkStyles}
+    target={target}
+    url={url}
+    onPress={onPress}
+  >
+    {children}
+  </Link>
 );
 
 ArticleLink.defaultProps = {

--- a/packages/article-skeleton/src/contentModifiers/dropcap-util-common.js
+++ b/packages/article-skeleton/src/contentModifiers/dropcap-util-common.js
@@ -48,9 +48,6 @@ const splitNode = node => {
       ]
     };
   }
-  if (children[0].name === "link" && children[0].children.length === 0) {
-    return null;
-  }
   const firstChild = splitNode(children[0]);
   if (firstChild.attributes.dropCap && node.name !== "paragraph") {
     const result = {


### PR DESCRIPTION
Reverts newsuk/times-components#3266

