### PR TITLE
chore: hydrate instead of render when zephr divs are on

### DIFF
--- a/packages/ssr/src/client/article.js
+++ b/packages/ssr/src/client/article.js
@@ -44,7 +44,8 @@ if (window.nuk && window.nuk.ssr && window.nuk.article) {
     useGET: false,
     headers: {
       "x-new-topic-data-source": true
-    }
+    },
+    zephrDivs
   };
 
   runClient(article, clientOptions, data);

--- a/packages/ssr/src/lib/run-client.js
+++ b/packages/ssr/src/lib/run-client.js
@@ -86,5 +86,9 @@ module.exports = (component, clientOptions, data) => {
 
   const App = component(client, analyticsStream, data, {});
 
-  ReactDOMClient.render(App, document.getElementById(clientOptions.rootTag));
+  if (clientOptions.zephrDivs && clientOptions.zephrDivs === true) {
+    ReactDOMClient.hydrate(App, document.getElementById(clientOptions.rootTag));
+  } else {
+    ReactDOMClient.render(App, document.getElementById(clientOptions.rootTag));
+  }
 };


### PR DESCRIPTION
There's an issue with calling render on the client. When we do it with hydrate, everything works as expected so this feature flags it to see if we can get it working in production.