### PR TITLE
fix(TMRX-1148): fonts displaying bold when they dont need tobe

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -425,6 +425,7 @@ exports[`full article with style 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-size: 30px;
   line-height: 33px;
   font-weight: 400;
@@ -502,6 +503,7 @@ exports[`full article with style 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;
@@ -1534,6 +1536,7 @@ exports[`full article with style in the culture magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Bold,TimesModern-Bold-fallback,serif;
   font-size: 30px;
   line-height: 33px;
@@ -1612,6 +1615,7 @@ exports[`full article with style in the culture magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;
@@ -2644,6 +2648,7 @@ exports[`full article with style in the style magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Bold,TimesModern-Bold-fallback,serif;
   font-size: 30px;
   line-height: 33px;
@@ -2723,6 +2728,7 @@ exports[`full article with style in the style magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;
@@ -3755,6 +3761,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Bold,TimesModern-Bold-fallback,serif;
   font-size: 30px;
   line-height: 33px;
@@ -3833,6 +3840,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;

--- a/packages/article-in-depth/src/styles/responsive.js
+++ b/packages/article-in-depth/src/styles/responsive.js
@@ -52,6 +52,7 @@ export const HeadlineContainer = styled.h1`
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   ${props => props.styles && props.styles}
   @media (min-width: ${breakpoints.medium}px) {
     font-size: ${fontSizes.articleHeadline}px;
@@ -104,6 +105,7 @@ export const StandfirstContainer = styled.h2`
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   ${props => props.styles && props.styles}
   @media (min-width: ${breakpoints.medium}px) {
     font-size: ${fontSizes.infoTitle}px;

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -432,6 +432,7 @@ exports[`full article with style 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-size: 30px;
   line-height: 33px;
   color: #1D1D1B;
@@ -522,6 +523,7 @@ exports[`full article with style 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;
@@ -1563,6 +1565,7 @@ exports[`full article with style in the culture magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Bold,TimesModern-Bold-fallback,serif;
   font-size: 30px;
   line-height: 33px;
@@ -1654,6 +1657,7 @@ exports[`full article with style in the culture magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;
@@ -2695,6 +2699,7 @@ exports[`full article with style in the style magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Bold,TimesModern-Bold-fallback,serif;
   font-size: 30px;
   line-height: 33px;
@@ -2787,6 +2792,7 @@ exports[`full article with style in the style magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;
@@ -3828,6 +3834,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Bold,TimesModern-Bold-fallback,serif;
   font-size: 30px;
   line-height: 33px;
@@ -3919,6 +3926,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;

--- a/packages/article-magazine-comment/src/styles/responsive.js
+++ b/packages/article-magazine-comment/src/styles/responsive.js
@@ -67,6 +67,7 @@ export const HeadlineContainer = styled.h1`
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   ${props => props.styles && props.styles}
   @media (min-width: ${breakpoints.medium}px) {
     font-size: ${fontSizes.articleHeadline}px;
@@ -121,6 +122,7 @@ export const StandfirstContainer = styled.h2`
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   ${props => props.styles && props.styles}
   @media (min-width: ${breakpoints.medium}px) {
     font-size: ${fontSizes.infoTitle}px;

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -402,6 +402,7 @@ exports[`full article with style 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-size: 30px;
   line-height: 33px;
   color: #1D1D1B;
@@ -486,6 +487,7 @@ exports[`full article with style 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;
@@ -1455,6 +1457,7 @@ exports[`full article with style in the culture magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Bold,TimesModern-Bold-fallback,serif;
   font-size: 30px;
   line-height: 33px;
@@ -1540,6 +1543,7 @@ exports[`full article with style in the culture magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;
@@ -2509,6 +2513,7 @@ exports[`full article with style in the style magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Bold,TimesModern-Bold-fallback,serif;
   font-size: 30px;
   line-height: 33px;
@@ -2595,6 +2600,7 @@ exports[`full article with style in the style magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;
@@ -3564,6 +3570,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Bold,TimesModern-Bold-fallback,serif;
   font-size: 30px;
   line-height: 33px;
@@ -3649,6 +3656,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;

--- a/packages/article-magazine-standard/src/newStyles/responsive.js
+++ b/packages/article-magazine-standard/src/newStyles/responsive.js
@@ -45,6 +45,7 @@ export const HeaderContainer = styled(TcView)`
 `;
 
 export const HeadlineContainer = styled(TcText)`
+  font-weight: 400;
   @media (min-width: ${breakpoints.medium}px) {
     font-size: ${fontSizes.articleHeadline}px;
     line-height: 50px;
@@ -90,6 +91,7 @@ export const Separator = styled(TcView)`
 `;
 
 export const StandfirstContainer = styled(TcText)`
+  font-weight: 400;
   @media (min-width: ${breakpoints.medium}px) {
     font-size: ${fontSizes.infoTitle}px;
     line-height: ${lineHeight({

--- a/packages/article-magazine-standard/src/styles/responsive.js
+++ b/packages/article-magazine-standard/src/styles/responsive.js
@@ -54,6 +54,7 @@ export const HeadlineContainer = styled.h1`
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   ${props => props.styles && props.styles}
   @media (min-width: ${breakpoints.medium}px) {
     font-size: ${fontSizes.articleHeadline}px;
@@ -108,6 +109,7 @@ export const StandfirstContainer = styled.h2`
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   ${props => props.styles && props.styles}
   @media (min-width: ${breakpoints.medium}px) {
     font-size: ${fontSizes.infoTitle}px;

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -424,6 +424,7 @@ exports[`full article with style 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Bold,TimesModern-Bold-fallback,serif;
   font-size: 30px;
   line-height: 33px;
@@ -514,6 +515,7 @@ exports[`full article with style 1`] = `
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   font-family: TimesModern-Regular,TimesModern-Regular-fallback,serif;
   font-size: 20px;
   line-height: 26px;

--- a/packages/article-main-comment/src/styles/responsive.js
+++ b/packages/article-main-comment/src/styles/responsive.js
@@ -64,6 +64,7 @@ export const HeadlineContainer = styled.h1`
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   ${props => props.styles && props.styles};
   @media (min-width: ${breakpoints.medium}px) {
     font-size: ${fontSizes.articleHeadline}px;
@@ -117,6 +118,7 @@ export const StandfirstContainer = styled.h2`
   padding: 0px;
   white-space: pre-wrap;
   overflow-wrap: break-word;
+  font-weight: 400;
   ${props => props.styles && props.styles};
   @media (min-width: ${breakpoints.medium}px) {
     font-size: ${fontSizes.infoTitle}px;


### PR DESCRIPTION
On article pages, the headline and the standfirst are displaying bold, but they don’t need to be.
![image-20230404-141122](https://user-images.githubusercontent.com/116718171/231767514-475ded16-44d1-4d2c-91af-9c513bae9cae.png)

[JIRA-1148](https://nidigitalsolutions.jira.com/browse/TMRX-1148)
From the image above, you can see the fonts on the left, without bold applied, and on the right as they currently are, but are incorrect.

Both the H1 and the H2 on the template are using the browser default stylesheet formatting of using bold for Hx tags, bold doesn’t need to be applied as it is already bold in the fonts and a font weight of normal(400) should be used.

We need to apply font-weight: 400 to both of them so they display as on the left.

Acceptance Criteria

The font-weight is applied so that the fonts are displayed correctly.

Check all article templates and apply same if needed.
