### PR TITLE
feat(TMST-632): Flag component

### DIFF
--- a/packages/ts-newskit/src/components/puzzles/flag/Flag.stories.mdx
+++ b/packages/ts-newskit/src/components/puzzles/flag/Flag.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Props } from '@storybook/addon-docs'
-import { TCThemeProvider } from '../../../utils/index.tsx';
 import { PuzzlesFlag } from './index.tsx';
+import { NewsKitProvider } from 'newskit';
+import { PuzzlesWebLightTheme } from '../../../theme';
 
 <Meta
   title="Newskit Components/Puzzles/Flag"
@@ -22,9 +23,9 @@ This takes in a status prop, as below, to display the status of the puzzle game.
 Please click the 'Canvas' tab for a better viewing experience, where you can update the props and review at the different breakpoints by clicking the preview icon and selecting from our list of pre-defined breakpoints (XS, SM, MD, LG and XL).
 
 export const FlagStory = ({ status }) => (
-  <TCThemeProvider>
+  <NewsKitProvider theme={PuzzlesWebLightTheme}>
     <PuzzlesFlag {...{ status }} />
-  </TCThemeProvider>
+  </NewsKitProvider>
 );
 
 


### PR DESCRIPTION
[TMST-632](https://nidigitalsolutions.jira.com/browse/TMST-632)

**Description**

- Updated the component to use new 'puzzle-web-light' theme instead of 'times-web-light'.

<img width="871" alt="image" src="https://user-images.githubusercontent.com/105289286/235892369-1d660b12-7388-453f-910b-43b15a3fc1e7.png">
<img width="877" alt="image" src="https://user-images.githubusercontent.com/105289286/235892424-b8f57cdb-dbfc-4fb0-8793-599f2ced3f6a.png">





[TMST-632]: https://nidigitalsolutions.jira.com/browse/TMST-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ