### PR TITLE
feat(TMRX-1181): added lazy loading to tc_images

### DIFF
--- a/packages/article-image/__tests__/web/__snapshots__/article-image.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image.web.test.js.snap
@@ -55,11 +55,13 @@ Array [
             <responsive
               alt={null}
               isLoaded={false}
+              loading="lazy"
               src="https://img/someImage"
               zIndex={2}
             >
               <img
                 alt={null}
+                loading="lazy"
                 src="https://img/someImage"
               />
             </responsive>
@@ -162,11 +164,13 @@ Array [
             <responsive
               alt="Some caption"
               isLoaded={false}
+              loading="lazy"
               src="https://img/someImage"
               zIndex={2}
             >
               <img
                 alt="Some caption"
+                loading="lazy"
                 src="https://img/someImage"
               />
             </responsive>
@@ -254,22 +258,26 @@ Array [
             <responsive
               alt="Some caption"
               isLoaded={false}
+              loading="lazy"
               src="https://img/someImage?resize=900"
               zIndex={2}
             >
               <img
                 alt="Some caption"
+                loading="lazy"
                 src="https://img/someImage?resize=900"
               />
             </responsive>
             <responsive
               alt="Some caption"
               isLoaded={true}
+              loading="lazy"
               src="https://img/someImage?resize=50"
               zIndex={1}
             >
               <img
                 alt="Some caption"
+                loading="lazy"
                 src="https://img/someImage?resize=50"
               />
             </responsive>

--- a/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -189,6 +189,7 @@ exports[`1. a full article 1`] = `
     <article>
       <img
         alt="An image caption"
+        loading="lazy"
         src="https://image.io?resize=400&quality=3"
       />
       <svg

--- a/packages/article-list/__tests__/web/__snapshots__/article-list-error.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list-error.web.test.js.snap
@@ -6,6 +6,7 @@ exports[`1. page error 1`] = `
     <div>
       <div>
         <img
+          loading="lazy"
           src="2d7dffcd8e7f3cde3e959c364dc3d432"
         />
         <div

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -69,6 +69,7 @@ exports[`1. a full article 1`] = `
   <main>
     <img
       alt="author-image"
+      loading="lazy"
       src={null}
     />
     <svg
@@ -205,6 +206,7 @@ exports[`1. a full article 1`] = `
     <article>
       <img
         alt="An image caption"
+        loading="lazy"
         src="https://image.io?resize=400&quality=3"
       />
       <svg

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -194,6 +194,7 @@ exports[`1. a full article 1`] = `
     <article>
       <img
         alt="An image caption"
+        loading="lazy"
         src="https://image.io?resize=400&quality=3"
       />
       <svg

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -69,6 +69,7 @@ exports[`1. a full article 1`] = `
   <main>
     <img
       alt="author-image"
+      loading="lazy"
       src="https://image.io"
     />
     <svg
@@ -194,6 +195,7 @@ exports[`1. a full article 1`] = `
     <article>
       <img
         alt="An image caption"
+        loading="lazy"
         src="https://image.io?resize=400&quality=3"
       />
       <svg

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -117,6 +117,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
     <article>
       <img
         alt="An image caption"
+        loading="lazy"
         src="https://image.io?resize=400&quality=3"
       />
       <svg

--- a/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
@@ -93,7 +93,7 @@ exports[`1. card loading state 1`] = `
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "Animations__FadeIn-je5757-0",
+          "componentId": "Animations__FadeIn-w31u4-0",
           "isStatic": false,
           "lastClassName": "c0",
           "rules": Array [
@@ -128,10 +128,10 @@ exports[`1. card loading state 1`] = `
         },
         "displayName": "Animations__FadeIn",
         "foldedComponentIds": Array [
-          "TsTcView-o5ytee-0",
+          "TsTcView-sc-154dp5w-0",
         ],
         "render": [Function],
-        "styledComponentId": "Animations__FadeIn-je5757-0",
+        "styledComponentId": "Animations__FadeIn-w31u4-0",
         "target": "div",
         "toString": [Function],
         "warnTooManyClasses": [Function],
@@ -428,7 +428,7 @@ exports[`2. card with reversed loading state 1`] = `
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "Animations__FadeIn-je5757-0",
+          "componentId": "Animations__FadeIn-w31u4-0",
           "isStatic": false,
           "lastClassName": "c0",
           "rules": Array [
@@ -463,10 +463,10 @@ exports[`2. card with reversed loading state 1`] = `
         },
         "displayName": "Animations__FadeIn",
         "foldedComponentIds": Array [
-          "TsTcView-o5ytee-0",
+          "TsTcView-sc-154dp5w-0",
         ],
         "render": [Function],
-        "styledComponentId": "Animations__FadeIn-je5757-0",
+        "styledComponentId": "Animations__FadeIn-w31u4-0",
         "target": "div",
         "toString": [Function],
         "warnTooManyClasses": [Function],

--- a/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
@@ -93,7 +93,7 @@ exports[`1. card loading state 1`] = `
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "Animations__FadeIn-w31u4-0",
+          "componentId": "Animations__FadeIn-je5757-0",
           "isStatic": false,
           "lastClassName": "c0",
           "rules": Array [
@@ -128,10 +128,10 @@ exports[`1. card loading state 1`] = `
         },
         "displayName": "Animations__FadeIn",
         "foldedComponentIds": Array [
-          "TsTcView-sc-154dp5w-0",
+          "TsTcView-o5ytee-0",
         ],
         "render": [Function],
-        "styledComponentId": "Animations__FadeIn-w31u4-0",
+        "styledComponentId": "Animations__FadeIn-je5757-0",
         "target": "div",
         "toString": [Function],
         "warnTooManyClasses": [Function],
@@ -428,7 +428,7 @@ exports[`2. card with reversed loading state 1`] = `
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "Animations__FadeIn-w31u4-0",
+          "componentId": "Animations__FadeIn-je5757-0",
           "isStatic": false,
           "lastClassName": "c0",
           "rules": Array [
@@ -463,10 +463,10 @@ exports[`2. card with reversed loading state 1`] = `
         },
         "displayName": "Animations__FadeIn",
         "foldedComponentIds": Array [
-          "TsTcView-sc-154dp5w-0",
+          "TsTcView-o5ytee-0",
         ],
         "render": [Function],
-        "styledComponentId": "Animations__FadeIn-w31u4-0",
+        "styledComponentId": "Animations__FadeIn-je5757-0",
         "target": "div",
         "toString": [Function],
         "warnTooManyClasses": [Function],

--- a/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
@@ -850,9 +850,9 @@ exports[`7. card with a loading state 1`] = `
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "Animations__FadeIn-w31u4-0",
+          "componentId": "Animations__FadeIn-je5757-0",
           "isStatic": false,
-          "lastClassName": "ejSuos",
+          "lastClassName": "dazpaJ",
           "rules": Array [
             "border:0px solid black;box-sizing:border-box;display:flex;flex-direction:column;margin:",
             [Function],
@@ -885,10 +885,10 @@ exports[`7. card with a loading state 1`] = `
         },
         "displayName": "Animations__FadeIn",
         "foldedComponentIds": Array [
-          "TsTcView-sc-154dp5w-0",
+          "TsTcView-o5ytee-0",
         ],
         "render": [Function],
-        "styledComponentId": "Animations__FadeIn-w31u4-0",
+        "styledComponentId": "Animations__FadeIn-je5757-0",
         "target": "div",
         "toString": [Function],
         "warnTooManyClasses": [Function],
@@ -1055,9 +1055,9 @@ exports[`8. card with a loading state and no image 1`] = `
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "Animations__FadeIn-w31u4-0",
+          "componentId": "Animations__FadeIn-je5757-0",
           "isStatic": false,
-          "lastClassName": "ejSuos",
+          "lastClassName": "dazpaJ",
           "rules": Array [
             "border:0px solid black;box-sizing:border-box;display:flex;flex-direction:column;margin:",
             [Function],
@@ -1090,10 +1090,10 @@ exports[`8. card with a loading state and no image 1`] = `
         },
         "displayName": "Animations__FadeIn",
         "foldedComponentIds": Array [
-          "TsTcView-sc-154dp5w-0",
+          "TsTcView-o5ytee-0",
         ],
         "render": [Function],
-        "styledComponentId": "Animations__FadeIn-w31u4-0",
+        "styledComponentId": "Animations__FadeIn-je5757-0",
         "target": "div",
         "toString": [Function],
         "warnTooManyClasses": [Function],
@@ -1219,9 +1219,9 @@ exports[`9. card with reversed loading state 1`] = `
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "Animations__FadeIn-w31u4-0",
+          "componentId": "Animations__FadeIn-je5757-0",
           "isStatic": false,
-          "lastClassName": "ejSuos",
+          "lastClassName": "dazpaJ",
           "rules": Array [
             "border:0px solid black;box-sizing:border-box;display:flex;flex-direction:column;margin:",
             [Function],
@@ -1254,10 +1254,10 @@ exports[`9. card with reversed loading state 1`] = `
         },
         "displayName": "Animations__FadeIn",
         "foldedComponentIds": Array [
-          "TsTcView-sc-154dp5w-0",
+          "TsTcView-o5ytee-0",
         ],
         "render": [Function],
-        "styledComponentId": "Animations__FadeIn-w31u4-0",
+        "styledComponentId": "Animations__FadeIn-je5757-0",
         "target": "div",
         "toString": [Function],
         "warnTooManyClasses": [Function],
@@ -1424,9 +1424,9 @@ exports[`10. card with reversed loading state with no image 1`] = `
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "Animations__FadeIn-w31u4-0",
+          "componentId": "Animations__FadeIn-je5757-0",
           "isStatic": false,
-          "lastClassName": "ejSuos",
+          "lastClassName": "dazpaJ",
           "rules": Array [
             "border:0px solid black;box-sizing:border-box;display:flex;flex-direction:column;margin:",
             [Function],
@@ -1459,10 +1459,10 @@ exports[`10. card with reversed loading state with no image 1`] = `
         },
         "displayName": "Animations__FadeIn",
         "foldedComponentIds": Array [
-          "TsTcView-sc-154dp5w-0",
+          "TsTcView-o5ytee-0",
         ],
         "render": [Function],
-        "styledComponentId": "Animations__FadeIn-w31u4-0",
+        "styledComponentId": "Animations__FadeIn-je5757-0",
         "target": "div",
         "toString": [Function],
         "warnTooManyClasses": [Function],
@@ -1586,9 +1586,11 @@ exports[`11. card should not re-render when imageratio prop is changed 1`] = `
     <div>
       <div>
         <img
+          loading="lazy"
           src="https://img.io/img?resize=360"
         />
         <img
+          loading="lazy"
           src="https://img.io/img?resize=50"
         />
         <div
@@ -1631,9 +1633,11 @@ exports[`11. card should not re-render when imageratio prop is changed 2`] = `
     <div>
       <div>
         <img
+          loading="lazy"
           src="https://img.io/img?resize=360"
         />
         <img
+          loading="lazy"
           src="https://img.io/img?resize=50"
         />
         <div
@@ -1676,9 +1680,11 @@ exports[`12. card should re-render when image uri changes 1`] = `
     <div>
       <div>
         <img
+          loading="lazy"
           src="https://img.io/img?resize=360"
         />
         <img
+          loading="lazy"
           src="https://img.io/img?resize=50"
         />
         <div
@@ -1721,9 +1727,11 @@ exports[`12. card should re-render when image uri changes 2`] = `
     <div>
       <div>
         <img
+          loading="lazy"
           src="http://foo?resize=360"
         />
         <img
+          loading="lazy"
           src="http://foo?resize=50"
         />
         <div
@@ -1766,9 +1774,11 @@ exports[`13. card should re-render when low res size changes 1`] = `
     <div>
       <div>
         <img
+          loading="lazy"
           src="https://img.io/img?resize=360"
         />
         <img
+          loading="lazy"
           src="https://img.io/img?resize=50"
         />
         <div
@@ -1811,6 +1821,7 @@ exports[`13. card should re-render when low res size changes 2`] = `
     <div>
       <div>
         <img
+          loading="lazy"
           src="https://img.io/img?resize=360"
         />
         <div
@@ -1853,9 +1864,11 @@ exports[`14. card should re-render when high res size changes 1`] = `
     <div>
       <div>
         <img
+          loading="lazy"
           src="https://img.io/img?resize=360"
         />
         <img
+          loading="lazy"
           src="https://img.io/img?resize=50"
         />
         <div
@@ -1898,6 +1911,7 @@ exports[`14. card should re-render when high res size changes 2`] = `
     <div>
       <div>
         <img
+          loading="lazy"
           src="https://img.io/img?resize=50"
         />
         <div
@@ -1941,9 +1955,11 @@ exports[`15. card should re-render when loading state changes 1`] = `
       <div>
         <div>
           <img
+            loading="lazy"
             src="https://img.io/img?resize=360"
           />
           <img
+            loading="lazy"
             src="https://img.io/img?resize=50"
           />
           <div
@@ -1988,9 +2004,11 @@ exports[`15. card should re-render when loading state changes 2`] = `
     <div>
       <div>
         <img
+          loading="lazy"
           src="https://img.io/img?resize=360"
         />
         <img
+          loading="lazy"
           src="https://img.io/img?resize=50"
         />
         <div

--- a/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
@@ -850,9 +850,9 @@ exports[`7. card with a loading state 1`] = `
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "Animations__FadeIn-je5757-0",
+          "componentId": "Animations__FadeIn-w31u4-0",
           "isStatic": false,
-          "lastClassName": "dazpaJ",
+          "lastClassName": "ejSuos",
           "rules": Array [
             "border:0px solid black;box-sizing:border-box;display:flex;flex-direction:column;margin:",
             [Function],
@@ -885,10 +885,10 @@ exports[`7. card with a loading state 1`] = `
         },
         "displayName": "Animations__FadeIn",
         "foldedComponentIds": Array [
-          "TsTcView-o5ytee-0",
+          "TsTcView-sc-154dp5w-0",
         ],
         "render": [Function],
-        "styledComponentId": "Animations__FadeIn-je5757-0",
+        "styledComponentId": "Animations__FadeIn-w31u4-0",
         "target": "div",
         "toString": [Function],
         "warnTooManyClasses": [Function],
@@ -1055,9 +1055,9 @@ exports[`8. card with a loading state and no image 1`] = `
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "Animations__FadeIn-je5757-0",
+          "componentId": "Animations__FadeIn-w31u4-0",
           "isStatic": false,
-          "lastClassName": "dazpaJ",
+          "lastClassName": "ejSuos",
           "rules": Array [
             "border:0px solid black;box-sizing:border-box;display:flex;flex-direction:column;margin:",
             [Function],
@@ -1090,10 +1090,10 @@ exports[`8. card with a loading state and no image 1`] = `
         },
         "displayName": "Animations__FadeIn",
         "foldedComponentIds": Array [
-          "TsTcView-o5ytee-0",
+          "TsTcView-sc-154dp5w-0",
         ],
         "render": [Function],
-        "styledComponentId": "Animations__FadeIn-je5757-0",
+        "styledComponentId": "Animations__FadeIn-w31u4-0",
         "target": "div",
         "toString": [Function],
         "warnTooManyClasses": [Function],
@@ -1219,9 +1219,9 @@ exports[`9. card with reversed loading state 1`] = `
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "Animations__FadeIn-je5757-0",
+          "componentId": "Animations__FadeIn-w31u4-0",
           "isStatic": false,
-          "lastClassName": "dazpaJ",
+          "lastClassName": "ejSuos",
           "rules": Array [
             "border:0px solid black;box-sizing:border-box;display:flex;flex-direction:column;margin:",
             [Function],
@@ -1254,10 +1254,10 @@ exports[`9. card with reversed loading state 1`] = `
         },
         "displayName": "Animations__FadeIn",
         "foldedComponentIds": Array [
-          "TsTcView-o5ytee-0",
+          "TsTcView-sc-154dp5w-0",
         ],
         "render": [Function],
-        "styledComponentId": "Animations__FadeIn-je5757-0",
+        "styledComponentId": "Animations__FadeIn-w31u4-0",
         "target": "div",
         "toString": [Function],
         "warnTooManyClasses": [Function],
@@ -1424,9 +1424,9 @@ exports[`10. card with reversed loading state with no image 1`] = `
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "Animations__FadeIn-je5757-0",
+          "componentId": "Animations__FadeIn-w31u4-0",
           "isStatic": false,
-          "lastClassName": "dazpaJ",
+          "lastClassName": "ejSuos",
           "rules": Array [
             "border:0px solid black;box-sizing:border-box;display:flex;flex-direction:column;margin:",
             [Function],
@@ -1459,10 +1459,10 @@ exports[`10. card with reversed loading state with no image 1`] = `
         },
         "displayName": "Animations__FadeIn",
         "foldedComponentIds": Array [
-          "TsTcView-o5ytee-0",
+          "TsTcView-sc-154dp5w-0",
         ],
         "render": [Function],
-        "styledComponentId": "Animations__FadeIn-je5757-0",
+        "styledComponentId": "Animations__FadeIn-w31u4-0",
         "target": "div",
         "toString": [Function],
         "warnTooManyClasses": [Function],

--- a/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
@@ -32,6 +32,7 @@ exports[`1. default layout 1`] = `
 <div>
   <div>
     <img
+      loading="lazy"
       src="http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1000"
     />
     <div
@@ -93,6 +94,7 @@ exports[`2. default layout without uri 1`] = `
 <div>
   <div>
     <img
+      loading="lazy"
       src={null}
     />
     <div
@@ -154,6 +156,7 @@ exports[`3. default layout without aspect ratio 1`] = `
 <div>
   <div>
     <img
+      loading="lazy"
       src="http://example.com/image.jpg?crop=1016%2C677%2C0%2C0"
     />
     <div
@@ -215,6 +218,7 @@ exports[`4. rounded image 1`] = `
 <div>
   <div>
     <img
+      loading="lazy"
       src="http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800"
     />
     <div
@@ -276,6 +280,7 @@ exports[`5. with existing url params 1`] = `
 <div>
   <div>
     <img
+      loading="lazy"
       src="https://image.io?resize=1400"
     />
     <div
@@ -337,6 +342,7 @@ exports[`6. with disabled placeholder 1`] = `
 <div>
   <div>
     <img
+      loading="lazy"
       src="https://image.io?resize=1400"
     />
   </div>
@@ -385,9 +391,11 @@ exports[`7. remove the low res image after the high res image has transitioned i
 <div>
   <div>
     <img
+      loading="lazy"
       src="https://image.io?resize=1400"
     />
     <img
+      loading="lazy"
       src="https://image.io?resize=200"
     />
   </div>
@@ -426,6 +434,7 @@ exports[`7. remove the low res image after the high res image has transitioned i
 <div>
   <div>
     <img
+      loading="lazy"
       src="https://image.io?resize=1400"
     />
   </div>
@@ -464,6 +473,7 @@ exports[`8. only a low res image 1`] = `
 <div>
   <div>
     <img
+      loading="lazy"
       src="https://image.io?resize=200"
     />
     <div
@@ -525,6 +535,7 @@ exports[`9. fade in the low res image 1`] = `
 <div>
   <div>
     <img
+      loading="lazy"
       src="https://image.io?resize=200"
     />
     <div
@@ -586,6 +597,7 @@ exports[`9. fade in the low res image 2`] = `
 <div>
   <div>
     <img
+      loading="lazy"
       src="https://image.io?resize=200"
     />
   </div>
@@ -634,9 +646,11 @@ exports[`10. both high and low res sizes 1`] = `
 <div>
   <div>
     <img
+      loading="lazy"
       src="https://image.io?resize=900"
     />
     <img
+      loading="lazy"
       src="https://image.io?resize=200"
     />
     <div

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -67,6 +67,7 @@ class TimesImage extends Component {
         <StyledImage
           alt={accessibilityLabel}
           ref={this.getHighResImage}
+          loading="lazy"
           isLoaded={highResIsLoaded}
           onLoad={this.handleHighResOnLoad}
           onTransitionEnd={this.onHighResTransitionEnd}
@@ -91,6 +92,7 @@ class TimesImage extends Component {
       return (
         <StyledImage
           alt={accessibilityLabel}
+          loading="lazy"
           ref={this.getLowResImage}
           isLoaded={lowResIsLoaded}
           onLoad={this.handleLowResOnLoad}

--- a/packages/related-articles/fixtures/standard/1-article-no-byline.json
+++ b/packages/related-articles/fixtures/standard/1-article-no-byline.json
@@ -109,7 +109,7 @@
             "leadAsset": {
               "title": "The tapestry has had a purpose-built home since 1983, having once been kept at Bayeux Cathedral",
               "crop169": {
-                "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104"
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F6c7f242e-d1de-11ec-9d8b-0826aa666f4f.jpg?crop=1919%2C1080%2C134%2C281&resize=1500"
               }
             }
           },

--- a/packages/related-articles/fixtures/standard/1-article-no-label.json
+++ b/packages/related-articles/fixtures/standard/1-article-no-label.json
@@ -127,7 +127,7 @@
             "leadAsset": {
               "title": "The tapestry has had a purpose-built home since 1983, having once been kept at Bayeux Cathedral",
               "crop169": {
-                "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104"
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F6c7f242e-d1de-11ec-9d8b-0826aa666f4f.jpg?crop=1919%2C1080%2C134%2C281&resize=1500"
               }
             }
           },

--- a/packages/related-articles/fixtures/standard/1-article-video-lead.json
+++ b/packages/related-articles/fixtures/standard/1-article-video-lead.json
@@ -149,7 +149,7 @@
               "posterImage": {
                 "title": "*** BESTPIX *** TOPSHOT-SINGAPORE-US-NKOREA-DIPLOMACY-SUMMIT",
                 "crop": {
-                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F99f6424c-6e5b-11e8-bea3-bf1a5a054f3a.png?crop=1622%2C1081%2C150%2C0"
+                  "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F6c7f242e-d1de-11ec-9d8b-0826aa666f4f.jpg?crop=1919%2C1080%2C134%2C281&resize=1500"
                 }
               }
             }

--- a/packages/related-articles/fixtures/standard/1-article.js
+++ b/packages/related-articles/fixtures/standard/1-article.js
@@ -1,5 +1,5 @@
 const defaultCrop169 =
-  "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104";
+  "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F6c7f242e-d1de-11ec-9d8b-0826aa666f4f.jpg?crop=1919%2C1080%2C134%2C281&resize=1500";
 const defaultHasVideo = false;
 const defaultHeadline =
   "Now for a new battle: bringing the fragile masterpiece over safely";

--- a/packages/related-articles/fixtures/standard/2-articles.js
+++ b/packages/related-articles/fixtures/standard/2-articles.js
@@ -1,5 +1,5 @@
 const defaultFirstCrop169 =
-  "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104";
+  "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F6c7f242e-d1de-11ec-9d8b-0826aa666f4f.jpg?crop=1919%2C1080%2C134%2C281&resize=1500";
 const defaultFirstHeadline =
   "Now for a new battle: bringing the fragile masterpiece over safely";
 const defaultFirstShortHeadline =
@@ -101,7 +101,7 @@ const defaultFirstTitle =
 const defaultFirstUrl =
   "https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh";
 const defaultSecondCrop169 =
-  "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F82723c10-fb7f-11e7-a987-7fcf5e9983dc.jpg?crop=4886%2C2748%2C92%2C108";
+  "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F6c7f242e-d1de-11ec-9d8b-0826aa666f4f.jpg?crop=1919%2C1080%2C134%2C281&resize=1500";
 const defaultSecondHeadline = "Bayeux Tapestry to be displayed in Britain";
 const defaultSecondShortHeadline = "Bayeux Tapestry displayed in Britain";
 const defaultSecondLabel = "BAYEUX TAPESTRY";

--- a/packages/related-articles/fixtures/standard/3-articles.js
+++ b/packages/related-articles/fixtures/standard/3-articles.js
@@ -1,5 +1,5 @@
 const defaultFirstCrop169 =
-  "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104";
+  "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F6c7f242e-d1de-11ec-9d8b-0826aa666f4f.jpg?crop=1919%2C1080%2C134%2C281&resize=1500";
 const defaultFirstHeadline =
   "Now for a new battle: bringing the fragile masterpiece over safely";
 const defaultFirstShortHeadline =
@@ -110,7 +110,7 @@ const defaultSlug =
   "bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely";
 const defaultShortIdentifier = "2k629tpvh";
 const defaultSecondCrop169 =
-  "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F82723c10-fb7f-11e7-a987-7fcf5e9983dc.jpg?crop=4886%2C2748%2C92%2C108";
+  "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F6c7f242e-d1de-11ec-9d8b-0826aa666f4f.jpg?crop=1919%2C1080%2C134%2C281&resize=1500";
 const defaultSecondHeadline = "Bayeux Tapestry to be displayed in Britain";
 const defaultSecondShortHeadline = "Bayeux Tapestry displayed in Britain";
 const defaultSecondLabel = "BAYEUX TAPESTRY";

--- a/packages/ts-components/src/components/latest-from-section/__tests__/__snapshots__/LatestFromSection.test.tsx.snap
+++ b/packages/ts-components/src/components/latest-from-section/__tests__/__snapshots__/LatestFromSection.test.tsx.snap
@@ -76,6 +76,7 @@ exports[`<LatestFromSection> renders  1`] = `
                         >
                           <img
                             class="responsive-sc-1nnon4d-0 fwlcWP"
+                            loading="lazy"
                             src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7fca746-d8ec-11eb-8f14-0bb645f59db0.jpg?resize=200&quality=3"
                           />
                           <div
@@ -190,6 +191,7 @@ exports[`<LatestFromSection> renders  1`] = `
                         >
                           <img
                             class="responsive-sc-1nnon4d-0 fwlcWP"
+                            loading="lazy"
                             src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F65e48858-d913-11eb-b92f-5fe539a30c29.jpg?resize=200&quality=3"
                           />
                           <div
@@ -304,6 +306,7 @@ exports[`<LatestFromSection> renders  1`] = `
                         >
                           <img
                             class="responsive-sc-1nnon4d-0 fwlcWP"
+                            loading="lazy"
                             src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F798e1dce-d918-11eb-b92f-5fe539a30c29.jpg?resize=200&quality=3"
                           />
                           <div


### PR DESCRIPTION
Updated the IMG that is used for **Related Images**, **More News...** and secondary and subsequent images in articles so that it uses the HTML property `loading="lazy"`

[TMRX-1181](https://nidigitalsolutions.jira.com/browse/TMRX-1181)

[TMRX-1181]: https://nidigitalsolutions.jira.com/browse/TMRX-1181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![image](https://github.com/newsuk/times-components/assets/89213300/0242ef54-061f-44b5-8696-6bda056bd0d3)
![image](https://github.com/newsuk/times-components/assets/89213300/ff1e4ec6-e30e-4205-a081-02c0ef1ce783)
