### PR TITLE
feat(TMRX-1225): update leadStory component to accommodate slice

### DIFF
--- a/packages/ts-newskit/src/components/slices/lead-story/LeadStory.stories.mdx
+++ b/packages/ts-newskit/src/components/slices/lead-story/LeadStory.stories.mdx
@@ -23,9 +23,9 @@ This takes in a series of props, as below, to display the part of the slices.
 ## View Component
 Please click the 'Canvas' tab for a better viewing experience, where you can update the props and review at the different breakpoints by clicking the preview icon and selecting from our list of pre-defined breakpoints (XS, SM, MD, LG and XL).
 
-export const HeaderStory = ({headline, color, readingTime, summary, bylines, subHeadline, caption, image, url, articleType}) => (
+export const HeaderStory = ({headline, color, readingTime, summary, bylines, subHeadline, caption, image, url, articleType, hasTagOrTimeToRead, isBukcet1}) => (
   <NewsKitProvider theme={TimesWebLightTheme}>
-    <LeadStory {...{headline, color, readingTime, summary, bylines, subHeadline, caption, image, url, articleType}} />
+    <LeadStory {...{headline, color, readingTime, summary, bylines, subHeadline, caption, image, url, articleType, hasTagOrTimeToRead, isBukcet1}} />
   </NewsKitProvider>
 );
 

--- a/packages/ts-newskit/src/components/slices/lead-story/LeadStory.stories.mdx
+++ b/packages/ts-newskit/src/components/slices/lead-story/LeadStory.stories.mdx
@@ -23,9 +23,9 @@ This takes in a series of props, as below, to display the part of the slices.
 ## View Component
 Please click the 'Canvas' tab for a better viewing experience, where you can update the props and review at the different breakpoints by clicking the preview icon and selecting from our list of pre-defined breakpoints (XS, SM, MD, LG and XL).
 
-export const HeaderStory = ({headline, color, readingTime, summary, bylines, subHeadline, caption, image, url, articleType, hasTagOrTimeToRead, isBukcet1}) => (
+export const HeaderStory = ({headline, color, readingTime, summary, bylines, subHeadline, caption, image, url, articleType, hasTagOrTimeToRead, isBucket1}) => (
   <NewsKitProvider theme={TimesWebLightTheme}>
-    <LeadStory {...{headline, color, readingTime, summary, bylines, subHeadline, caption, image, url, articleType, hasTagOrTimeToRead, isBukcet1}} />
+    <LeadStory {...{headline, color, readingTime, summary, bylines, subHeadline, caption, image, url, articleType, hasTagOrTimeToRead, isBucket1}} />
   </NewsKitProvider>
 );
 

--- a/packages/ts-newskit/src/components/slices/lead-story/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-story/__tests__/index.test.tsx
@@ -3,20 +3,32 @@ import '@testing-library/jest-dom';
 import { render } from '../../../../utils/test-utils';
 import { LeadStory } from '../index';
 import { leadStory } from '../../../../slices/fixtures/data.json';
+import { useBreakpointKey } from 'newskit';
+
+jest.mock('newskit', () => ({
+  ...jest.requireActual('newskit'),
+  useBreakpointKey: jest.fn().mockReturnValue('xs')
+}));
 
 const leadStoryData = {
   ...leadStory,
   subHeadline: 'TAG'
 };
 
-const renderComponent = () => render(<LeadStory {...leadStoryData} />);
+const renderComponent = () =>
+  render(
+    <LeadStory
+      {...leadStoryData}
+      hasTagOrTimeToRead={false}
+      isBukcet1={false}
+    />
+  );
 
 describe('Render Component one', () => {
   it('should render a snapshot', () => {
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
-
   it('should render correct headline', () => {
     const { getByText } = renderComponent();
     const headlineText = getByText(leadStory.headline);
@@ -46,5 +58,25 @@ describe('Render Component one', () => {
 
     const subHeadline = getByText('TAG');
     expect(subHeadline).toBeInTheDocument();
+  });
+
+  it('should not render articleType if hasTagOrTimeToRead is false', () => {
+    (useBreakpointKey as any).mockReturnValue('xs');
+    const { queryByText } = renderComponent();
+    const articleType = queryByText(leadStory.articleType);
+    expect(articleType).not.toBeVisible();
+  });
+
+  it('should render articleType if hasTagOrTimeToRead is false', () => {
+    (useBreakpointKey as any).mockReturnValue('xs');
+    const { queryByText } = render(
+      <LeadStory
+        {...leadStoryData}
+        hasTagOrTimeToRead={true}
+        isBukcet1={true}
+      />
+    );
+    const articleType = queryByText(leadStory.articleType);
+    expect(articleType).toBeVisible();
   });
 });

--- a/packages/ts-newskit/src/components/slices/lead-story/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-story/__tests__/index.test.tsx
@@ -20,7 +20,7 @@ const renderComponent = () =>
     <LeadStory
       {...leadStoryData}
       hasTagOrTimeToRead={false}
-      isBukcet1={false}
+      isBucket1={false}
     />
   );
 
@@ -73,7 +73,7 @@ describe('Render Component one', () => {
       <LeadStory
         {...leadStoryData}
         hasTagOrTimeToRead={true}
-        isBukcet1={true}
+        isBucket1={true}
       />
     );
     const articleType = queryByText(leadStory.articleType);

--- a/packages/ts-newskit/src/components/slices/lead-story/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-story/index.tsx
@@ -25,8 +25,9 @@ export interface LeadStoryProps {
   image: string;
   url: string;
   articleType?: string;
+  hasTagOrTimeToRead?: boolean;
+  isBukcet1?: boolean;
 }
-
 export const LeadStory = ({
   headline,
   color,
@@ -36,7 +37,9 @@ export const LeadStory = ({
   caption,
   image,
   url,
-  articleType
+  articleType,
+  hasTagOrTimeToRead,
+  isBukcet1
 }: LeadStoryProps) => {
   const stylePresets = {
     typographyPreset: 'utilityButton010',
@@ -92,7 +95,9 @@ export const LeadStory = ({
           expand
           href={url}
           overrides={{
-            typographyPreset: 'editorialHeadline040',
+            typographyPreset: isBukcet1
+              ? { xs: 'editorialHeadline040', md: 'editorialHeadline030' }
+              : 'editorialHeadline040',
             paddingBlockStart: 'space050'
           }}
           external={false}
@@ -109,7 +114,7 @@ export const LeadStory = ({
         >
           {summary}
         </TextBlock>
-        <Visible md lg xl>
+        <Visible xs={hasTagOrTimeToRead} sm={hasTagOrTimeToRead} md lg xl>
           <ColouredText
             size="small"
             overrides={{

--- a/packages/ts-newskit/src/components/slices/lead-story/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-story/index.tsx
@@ -62,7 +62,7 @@ export const LeadStory = ({
           : `content media`
       }}
       columnGap="space040"
-      columns={isBukcet1 ? { md: '1fr' } : { md: '3fr 5fr' }}
+      columns={{ md: isBukcet1 ? '1fr' : '3fr 5fr' }}
     >
       <Block>
         <FullWidthCardMediaMob

--- a/packages/ts-newskit/src/components/slices/lead-story/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-story/index.tsx
@@ -26,7 +26,7 @@ export interface LeadStoryProps {
   url: string;
   articleType?: string;
   hasTagOrTimeToRead?: boolean;
-  isBukcet1?: boolean;
+  isBucket1?: boolean;
 }
 export const LeadStory = ({
   headline,
@@ -39,7 +39,7 @@ export const LeadStory = ({
   url,
   articleType,
   hasTagOrTimeToRead,
-  isBukcet1
+  isBucket1
 }: LeadStoryProps) => {
   const stylePresets = {
     typographyPreset: 'utilityButton010',
@@ -56,13 +56,13 @@ export const LeadStory = ({
       areas={{
         xs: `media 
              content`,
-        md: isBukcet1
+        md: isBucket1
           ? `media 
              content`
           : `content media`
       }}
       columnGap="space040"
-      columns={{ md: isBukcet1 ? '1fr' : '3fr 5fr' }}
+      columns={{ md: isBucket1 ? '1fr' : '3fr 5fr' }}
     >
       <Block>
         <FullWidthCardMediaMob
@@ -80,7 +80,7 @@ export const LeadStory = ({
         </TextBlock>
       </Block>
       <CardContent alignContent="start">
-        {!isBukcet1 && (
+        {!isBucket1 && (
           <StyledDivider overrides={{ stylePreset: 'dashedDivider' }} />
         )}
         <Visible md lg xl>
@@ -100,7 +100,7 @@ export const LeadStory = ({
           expand
           href={url}
           overrides={{
-            typographyPreset: isBukcet1
+            typographyPreset: isBucket1
               ? { xs: 'editorialHeadline040', md: 'editorialHeadline030' }
               : 'editorialHeadline040',
             paddingBlockStart: 'space050'

--- a/packages/ts-newskit/src/components/slices/lead-story/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-story/index.tsx
@@ -56,10 +56,13 @@ export const LeadStory = ({
       areas={{
         xs: `media 
              content`,
-        md: `content media`
+        md: isBukcet1
+          ? `media 
+             content`
+          : `content media`
       }}
       columnGap="space040"
-      columns={{ md: '3fr 5fr' }}
+      columns={isBukcet1 ? { md: '1fr' } : { md: '3fr 5fr' }}
     >
       <Block>
         <FullWidthCardMediaMob
@@ -77,7 +80,9 @@ export const LeadStory = ({
         </TextBlock>
       </Block>
       <CardContent alignContent="start">
-        <StyledDivider overrides={{ stylePreset: 'dashedDivider' }} />
+        {!isBukcet1 && (
+          <StyledDivider overrides={{ stylePreset: 'dashedDivider' }} />
+        )}
         <Visible md lg xl>
           {subHeadline && (
             <ColouredText

--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                   class="css-17x5lw"
                 >
                   <span
-                    class="css-174i6ea"
+                    class="css-13ln2fu"
                   >
                     Sarcacens an inclusive club? They didnt look out for me
                   </span>
@@ -138,7 +138,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                 Lyon lock Joel Kpoku tells Will Kelleher that he’s fired up to face old team — and urges more English stars to move to France
               </p>
               <div
-                class="css-9fndha"
+                class="css-11l110t"
               >
                 <div
                   class="css-1j46hv8"

--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                   class="css-17x5lw"
                 >
                   <span
-                    class="css-13ln2fu"
+                    class="css-174i6ea"
                   >
                     Sarcacens an inclusive club? They didnt look out for me
                   </span>
@@ -138,7 +138,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                 Lyon lock Joel Kpoku tells Will Kelleher that he’s fired up to face old team — and urges more English stars to move to France
               </p>
               <div
-                class="css-11l110t"
+                class="css-9fndha"
               >
                 <div
                   class="css-1j46hv8"

--- a/packages/ts-newskit/src/slices/fixtures/data.json
+++ b/packages/ts-newskit/src/slices/fixtures/data.json
@@ -11,7 +11,7 @@
     "url": "https://www.thetimes.co.uk",
     "articleType": "Review",
     "hasTagOrTimeToRead": false,
-    "isBukcet1": false
+    "isBucket1": false
   },
   "articles": [
     {

--- a/packages/ts-newskit/src/slices/fixtures/data.json
+++ b/packages/ts-newskit/src/slices/fixtures/data.json
@@ -9,7 +9,9 @@
     "caption": "Credit",
     "image": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0",
     "url": "https://www.thetimes.co.uk",
-    "articleType": "Review"
+    "articleType": "Review",
+    "hasTagOrTimeToRead": false,
+    "isBukcet1": false
   },
   "articles": [
     {


### PR DESCRIPTION
- Allow for content to be placed below image
- Allow for different Headline sizes
 
[TMRX-1225](https://nidigitalsolutions.jira.com/browse/TMRX-1225)


[TMRX-1225]: https://nidigitalsolutions.jira.com/browse/TMRX-1225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ