### PR TITLE
feat(TMST-695): Hide the 'See all' links from view

### DIFF
--- a/packages/ts-newskit/src/components/puzzles/cards-container/ScrollControls.tsx
+++ b/packages/ts-newskit/src/components/puzzles/cards-container/ScrollControls.tsx
@@ -5,7 +5,7 @@ import { NewskitIconBack, NewskitIconForward } from '../../../assets';
 interface ScrollControlsProps {
   scrollRef: React.RefObject<HTMLDivElement>;
   cardRef: React.RefObject<HTMLDivElement>;
-  seeAllLink: string;
+  seeAllLink?: string;
 }
 
 export const ScrollControls = ({
@@ -29,18 +29,20 @@ export const ScrollControls = ({
   };
   return (
     <Stack flow="horizontal-center">
-      <Button
-        href={seeAllLink}
-        overrides={{
-          stylePreset: 'inkBrand010',
-          marginInlineEnd: 'space030',
-          typographyPreset: 'utilityLabel010',
-          paddingInline: 'space000',
-          minWidth: 'unset'
-        }}
-      >
-        SEE ALL
-      </Button>
+      {seeAllLink && (
+        <Button
+          href={seeAllLink}
+          overrides={{
+            stylePreset: 'inkBrand010',
+            marginInlineEnd: 'space030',
+            typographyPreset: 'utilityLabel010',
+            paddingInline: 'space000',
+            minWidth: 'unset'
+          }}
+        >
+          SEE ALL
+        </Button>
+      )}
       <IconButton
         overrides={{
           stylePreset: 'iconButtonOutlinedSecondary',

--- a/packages/ts-newskit/src/components/puzzles/cards-container/index.tsx
+++ b/packages/ts-newskit/src/components/puzzles/cards-container/index.tsx
@@ -9,7 +9,7 @@ interface CardsContainerProps {
   cards: Puzzle[];
   title?: string;
   isScrollable?: boolean;
-  seeAllLink: string;
+  seeAllLink?: string;
 }
 
 export const CardsContainer = ({


### PR DESCRIPTION
[TMST-695](https://nidigitalsolutions.jira.com/jira/software/c/projects/TMST/boards/1608?modal=detail&selectedIssue=TMST-695)

- Made the 'See All' link optional in the cards container component.

<img width="1592" alt="image" src="https://github.com/newsuk/times-components/assets/105289286/19775083-48de-4aae-b428-76e660d8e882">


[TMST-695]: https://nidigitalsolutions.jira.com/browse/TMST-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ