### PR TITLE
fix(TMRX-0000): apply design feedback

### DIFF
--- a/packages/ts-newskit/src/components/slices/article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/article/index.tsx
@@ -114,7 +114,9 @@ export const Article = ({
         </GridLayoutItem>
       )}
 
-      {image && !hideImage && <CardMediaComponent {...cardImage} />}
+      {image &&
+        image.src !== '' &&
+        !hideImage && <CardMediaComponent {...cardImage} />}
       <CardContent>
         {image &&
           !imageRight &&

--- a/packages/ts-newskit/src/components/slices/article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/article/index.tsx
@@ -139,13 +139,11 @@ export const Article = ({
           >
             {title}
           </CardHeadlineLink>
-          {(tag || flag) && (
-            <TagAndFlag
-              tag={tag}
-              flag={flag}
-              marginBlockStart={tagAndFlagMarginBlockStart}
-            />
-          )}
+          <TagAndFlag
+            tag={tag}
+            flag={flag}
+            marginBlockStart={tagAndFlagMarginBlockStart}
+          />
         </Layout>
       </CardContent>
     </CardComposable>

--- a/packages/ts-newskit/src/components/slices/article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/article/index.tsx
@@ -72,6 +72,8 @@ export const Article = ({
   const titleMarginBlockStart =
     imageRight || hideImage ? 'space000' : articleTitleMarginTop;
 
+  const hasImage = image && image.src !== '';
+
   const Layout: React.FC<LayoutProps> = ({ children }) => {
     return imageRight ? <Block>{children}</Block> : <>{children}</>;
   };
@@ -114,9 +116,7 @@ export const Article = ({
         </GridLayoutItem>
       )}
 
-      {image &&
-        image.src !== '' &&
-        !hideImage && <CardMediaComponent {...cardImage} />}
+      {hasImage && !hideImage && <CardMediaComponent {...cardImage} />}
       <CardContent>
         {image &&
           !imageRight &&

--- a/packages/ts-newskit/src/components/slices/lead-article/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/lead-article/__tests__/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Render Component one should render a snapshot 1`] = `
             class="css-5pczz7"
           />
           <img
-            alt="Sarcacens an inclusive club? They didnt look out for me"
+            alt="This is ALT Text"
             class="css-1qgqq71"
             src="/assets/main_01.jpg"
           />

--- a/packages/ts-newskit/src/components/slices/lead-article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-article/index.tsx
@@ -47,7 +47,7 @@ export interface LeadArticleProps {
   loadingAspectRatio?: string;
   marginBlockStart?: string;
   textBlockMarginBlockStart?: string;
-  tagAndFlagBlockMarginBlockStart?: string;
+  tagAndFlagMarginBlockStart?: string;
   listData?: ListData[];
   showTagL1?: boolean;
   hideImage?: boolean;
@@ -69,7 +69,7 @@ export const LeadArticle = ({
   loadingAspectRatio,
   marginBlockStart,
   textBlockMarginBlockStart = 'space040',
-  tagAndFlagBlockMarginBlockStart = 'space040',
+  tagAndFlagMarginBlockStart = 'space040',
   listData,
   showTagL1,
   hideImage
@@ -179,7 +179,7 @@ export const LeadArticle = ({
         <TagAndFlag
           tag={tag}
           flag={flag}
-          marginBlockStart={tagAndFlagBlockMarginBlockStart}
+          marginBlockStart={tagAndFlagMarginBlockStart}
         />
         <UnorderedListItems listData={listData} />
       </CardContent>

--- a/packages/ts-newskit/src/components/slices/lead-article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-article/index.tsx
@@ -4,9 +4,7 @@ import {
   CardContent,
   CardComposable,
   Divider,
-  Hidden,
-  UnorderedList,
-  LinkInline
+  Hidden
 } from 'newskit';
 import React from 'react';
 import {
@@ -15,9 +13,16 @@ import {
   TextLink
 } from '../shared-styles';
 import { TagAndFlag } from '../shared/tag-and-flag';
+import { UnorderedListItems } from './unorderedList';
 type ListData = {
   label: string;
   href: string;
+};
+
+type ImageProps = {
+  src: string;
+  alt?: string;
+  credit?: string;
 };
 export interface LeadArticleProps {
   headline: string;
@@ -28,7 +33,7 @@ export interface LeadArticleProps {
     href: string;
   };
   caption?: string;
-  image?: string;
+  image?: ImageProps;
   url: string;
   tag?: {
     label: string;
@@ -45,6 +50,7 @@ export interface LeadArticleProps {
   tagAndFlagBlockMarginBlockStart?: string;
   listData?: ListData[];
   showTagL1?: boolean;
+  hideImage?: boolean;
 }
 export const LeadArticle = ({
   headline,
@@ -62,11 +68,29 @@ export const LeadArticle = ({
   typographyPreset,
   loadingAspectRatio,
   marginBlockStart,
-  textBlockMarginBlockStart,
-  tagAndFlagBlockMarginBlockStart,
+  textBlockMarginBlockStart = 'space040',
+  tagAndFlagBlockMarginBlockStart = 'space040',
   listData,
-  showTagL1
+  showTagL1,
+  hideImage
 }: LeadArticleProps) => {
+  const cardImage = image &&
+    image.src !== '' && {
+      media: {
+        src: image.src,
+        alt: image.alt || headline,
+        loadingAspectRatio: loadingAspectRatio || '3:2'
+      }
+    };
+
+  const hasImage = image && image.src !== '';
+  const hasCaption = caption && caption !== '';
+  const headlineTypography = typographyPreset
+    ? typographyPreset
+    : imageTop
+      ? { xs: 'editorialHeadline040', md: 'editorialHeadline030' }
+      : 'editorialHeadline040';
+
   return (
     <CardComposable
       areas={{
@@ -83,66 +107,57 @@ export const LeadArticle = ({
       columnGap="space040"
       columns={{ md: imageTop ? '100%' : `${contentWidth || '260px'} auto` }}
     >
-      {image && (
-        <Block
-          marginBlockEnd={imageTop ? 'space050' : 'space000'}
-          marginBlockStart={marginBlockStart || 'space000'}
-        >
-          <FullWidthCardMediaMob
-            media={{
-              src: image,
-              alt: headline,
-              loadingAspectRatio: loadingAspectRatio || '3:2'
-            }}
-          />
-          <TextBlock
-            marginBlockStart="space020"
-            typographyPreset="utilityMeta010"
+      {hasImage &&
+        !hideImage && (
+          <Block
+            marginBlockEnd={imageTop ? 'space050' : 'space000'}
+            marginBlockStart={marginBlockStart || 'space000'}
           >
-            {caption}
-          </TextBlock>
-        </Block>
-      )}
+            <FullWidthCardMediaMob {...cardImage} />
+            {hasCaption && (
+              <TextBlock
+                marginBlockStart="space020"
+                typographyPreset="utilityMeta010"
+              >
+                {caption}
+              </TextBlock>
+            )}
+          </Block>
+        )}
 
       <CardContent
         alignContent="start"
         overrides={{ marginBlockEnd: contentTop ? 'space040' : 'space000' }}
       >
         {hasTopBorder && (
-          <>
-            {!imageTop && (
-              <Divider
-                overrides={{
-                  stylePreset: 'dashedDivider',
-                  marginBlockEnd: 'space050'
-                }}
-              />
-            )}
-          </>
+          <Divider
+            overrides={{
+              stylePreset: 'dashedDivider',
+              marginBlockEnd: 'space050'
+            }}
+          />
         )}
 
-        {tagL1 && (
-          <Hidden xs={showTagL1} sm={showTagL1}>
-            <TextLink
-              overrides={{
-                typographyPreset: 'utilityButton010',
-                stylePreset: 'inkBrand010',
-                marginBlockEnd: 'space040'
-              }}
-              href={tagL1.href}
-            >
-              {tagL1.label}
-            </TextLink>
-          </Hidden>
-        )}
+        {tagL1 &&
+          tagL1.label !== '' && (
+            <Hidden xs={showTagL1} sm={showTagL1}>
+              <TextLink
+                overrides={{
+                  typographyPreset: 'utilityButton010',
+                  stylePreset: 'inkBrand010',
+                  marginBlockEnd: 'space040'
+                }}
+                href={tagL1.href}
+              >
+                {tagL1.label}
+              </TextLink>
+            </Hidden>
+          )}
+
         <CardHeadlineLink
           href={url}
           overrides={{
-            typographyPreset: typographyPreset
-              ? typographyPreset
-              : imageTop
-                ? { xs: 'editorialHeadline040', md: 'editorialHeadline030' }
-                : 'editorialHeadline040'
+            typographyPreset: headlineTypography
           }}
           external={false}
           expand={!tag}
@@ -155,7 +170,7 @@ export const LeadArticle = ({
               xs: 'editorialParagraph020',
               md: 'editorialParagraph010'
             }}
-            marginBlockStart={textBlockMarginBlockStart || 'space040'}
+            marginBlockStart={textBlockMarginBlockStart}
             as="p"
           >
             {summary}
@@ -164,40 +179,9 @@ export const LeadArticle = ({
         <TagAndFlag
           tag={tag}
           flag={flag}
-          marginBlockStart={tagAndFlagBlockMarginBlockStart || 'space040'}
+          marginBlockStart={tagAndFlagBlockMarginBlockStart}
         />
-        {listData && (
-          <UnorderedList
-            overrides={{
-              marker: {
-                size: 'iconSize005',
-                spaceInline: 'space020',
-                stylePreset: 'inkContrast'
-              },
-              marginBlockStart: 'space050',
-              content: {
-                typographyPreset: 'utilityBody010'
-              }
-            }}
-          >
-            {listData.map(({ label, href }, index) => {
-              const hasHref = !!href;
-              return hasHref ? (
-                <LinkInline
-                  overrides={{
-                    stylePreset: 'inkContrast'
-                  }}
-                  key={index}
-                  href={href}
-                >
-                  {label}
-                </LinkInline>
-              ) : (
-                <>{label}</>
-              );
-            })}
-          </UnorderedList>
-        )}
+        <UnorderedListItems listData={listData} />
       </CardContent>
     </CardComposable>
   );

--- a/packages/ts-newskit/src/components/slices/lead-article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-article/index.tsx
@@ -43,9 +43,9 @@ export interface LeadArticleProps {
   hasTopBorder?: boolean;
   contentTop?: boolean;
   contentWidth?: string;
-  typographyPreset?: string;
+  headlineTypographyPreset?: string;
   loadingAspectRatio?: string;
-  marginBlockStart?: string;
+  imageMarginBlockStart?: string;
   textBlockMarginBlockStart?: string;
   tagAndFlagMarginBlockStart?: string;
   listData?: ListData[];
@@ -65,9 +65,9 @@ export const LeadArticle = ({
   hasTopBorder = true,
   contentTop,
   contentWidth,
-  typographyPreset,
+  headlineTypographyPreset,
   loadingAspectRatio,
-  marginBlockStart,
+  imageMarginBlockStart = 'space000',
   textBlockMarginBlockStart = 'space040',
   tagAndFlagMarginBlockStart = 'space040',
   listData,
@@ -85,8 +85,8 @@ export const LeadArticle = ({
 
   const hasImage = image && image.src !== '';
   const hasCaption = caption && caption !== '';
-  const headlineTypography = typographyPreset
-    ? typographyPreset
+  const headlineTypography = headlineTypographyPreset
+    ? headlineTypographyPreset
     : imageTop
       ? { xs: 'editorialHeadline040', md: 'editorialHeadline030' }
       : 'editorialHeadline040';
@@ -111,7 +111,7 @@ export const LeadArticle = ({
         !hideImage && (
           <Block
             marginBlockEnd={imageTop ? 'space050' : 'space000'}
-            marginBlockStart={marginBlockStart || 'space000'}
+            marginBlockStart={imageMarginBlockStart}
           >
             <FullWidthCardMediaMob {...cardImage} />
             {hasCaption && (

--- a/packages/ts-newskit/src/components/slices/lead-article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-article/index.tsx
@@ -161,13 +161,11 @@ export const LeadArticle = ({
             {summary}
           </TextBlock>
         )}
-        {(tag || flag) && (
-          <TagAndFlag
-            tag={tag}
-            flag={flag}
-            marginBlockStart={tagAndFlagBlockMarginBlockStart || 'space040'}
-          />
-        )}
+        <TagAndFlag
+          tag={tag}
+          flag={flag}
+          marginBlockStart={tagAndFlagBlockMarginBlockStart || 'space040'}
+        />
         {listData && (
           <UnorderedList
             overrides={{

--- a/packages/ts-newskit/src/components/slices/lead-article/unorderedList.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-article/unorderedList.tsx
@@ -1,0 +1,50 @@
+import React, { Fragment } from 'react';
+import { UnorderedList, LinkInline } from 'newskit';
+
+type ListData = {
+  label: string;
+  href: string;
+};
+
+export interface ListDataProps {
+  listData?: ListData[];
+}
+
+export const UnorderedListItems = ({ listData }: ListDataProps) => {
+  if (!listData || listData.length === 0) {
+    return null;
+  }
+
+  return (
+    <UnorderedList
+      overrides={{
+        marker: {
+          size: 'iconSize005',
+          spaceInline: 'space020',
+          stylePreset: 'inkContrast'
+        },
+        marginBlockStart: 'space050',
+        content: {
+          typographyPreset: 'utilityBody010'
+        }
+      }}
+    >
+      {listData.map(({ label, href }, index) => {
+        const hasHref = !!href;
+        return hasHref ? (
+          <LinkInline
+            overrides={{
+              stylePreset: 'inkContrast'
+            }}
+            key={index}
+            href={href}
+          >
+            {label}
+          </LinkInline>
+        ) : (
+          <Fragment key={index}>{label}</Fragment>
+        );
+      })}
+    </UnorderedList>
+  );
+};

--- a/packages/ts-newskit/src/components/slices/shared/grouped-article.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/grouped-article.tsx
@@ -16,8 +16,9 @@ export interface GroupedArticleProps {
 export const GroupedArticle = ({ articles, tagL1 }: GroupedArticleProps) => {
   const modifiedGroupedArticles = articles.map(article => ({
     ...article,
-    imageTop: true,
-    typographyPreset: 'editorialHeadline020'
+    hasTopBorder: false,
+    typographyPreset: 'editorialHeadline020',
+    hideImage: true
   }));
 
   return (

--- a/packages/ts-newskit/src/components/slices/shared/grouped-article.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/grouped-article.tsx
@@ -17,7 +17,7 @@ export const GroupedArticle = ({ articles, tagL1 }: GroupedArticleProps) => {
   const modifiedGroupedArticles = articles.map(article => ({
     ...article,
     hasTopBorder: false,
-    typographyPreset: 'editorialHeadline020',
+    headlineTypographyPreset: 'editorialHeadline020',
     hideImage: true
   }));
 

--- a/packages/ts-newskit/src/components/slices/shared/tag-and-flag.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/tag-and-flag.tsx
@@ -14,7 +14,7 @@ export interface TagAndFlagProps {
 export const TagAndFlag = ({
   flag,
   tag,
-  marginBlockStart
+  marginBlockStart = 'space000'
 }: TagAndFlagProps) => {
   const hasTag = tag && tag.label;
   const hasFlag = flag && flag !== '';
@@ -24,10 +24,7 @@ export const TagAndFlag = ({
   }
 
   return (
-    <Block
-      marginBlockStart={marginBlockStart || 'space000'}
-      data-testid="tag-and-flag"
-    >
+    <Block marginBlockStart={marginBlockStart} data-testid="tag-and-flag">
       {tag && (
         <TextLink
           overrides={{

--- a/packages/ts-newskit/src/components/slices/shared/tag-and-flag.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/tag-and-flag.tsx
@@ -16,6 +16,13 @@ export const TagAndFlag = ({
   tag,
   marginBlockStart
 }: TagAndFlagProps) => {
+  const hasTag = tag && tag.label;
+  const hasFlag = flag && flag !== '';
+
+  if (!hasTag && !hasFlag) {
+    return null;
+  }
+
   return (
     <Block
       marginBlockStart={marginBlockStart || 'space000'}
@@ -34,6 +41,8 @@ export const TagAndFlag = ({
       )}
 
       {tag &&
+        Object.keys(tag).length > 0 &&
+        tag.label !== '' &&
         flag && (
           <ContainerInline>
             <Divider

--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                   class="css-5pczz7"
                 />
                 <img
-                  alt="Sarcacens an inclusive club? They didnt look out for me"
+                  alt="This is ALT Text"
                   class="css-1qgqq71"
                   src="/assets/main_01.jpg"
                 />
@@ -698,7 +698,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                   class="css-5pczz7"
                 />
                 <img
-                  alt="Sarcacens an inclusive club? They didnt look out for me"
+                  alt="This is ALT Text"
                   class="css-1qgqq71"
                   src="/assets/main_01.jpg"
                 />

--- a/packages/ts-newskit/src/slices/content-bucket-1/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-1/index.tsx
@@ -34,10 +34,12 @@ export const ContentBucket1 = ({
   articles
 }: ContentBucket1Props) => {
   const breakpointKey = useBreakpointKey();
+  const isMobile = ['xs', 'sm'].includes(breakpointKey);
 
   const modifiedLeadArticle = {
     ...leadArticle,
-    imageTop: breakpointKey === 'xs' || breakpointKey === 'sm' ? true : false
+    imageTop: isMobile,
+    hasTopBorder: !isMobile
   };
 
   return (

--- a/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -153,7 +153,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -197,7 +197,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div

--- a/packages/ts-newskit/src/slices/content-bucket-2/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-2/index.tsx
@@ -1,11 +1,11 @@
-import { Divider, GridLayout, useBreakpointKey } from 'newskit';
+import { GridLayout, useBreakpointKey } from 'newskit';
 import React from 'react';
 import {
   SliceHeader,
   SliceHeaderProps
 } from '../../components/slices/slice-header';
 import { Article, ArticleProps } from '../../components/slices/article';
-import { StackItem } from '../shared-styles';
+import { StackItem, StyledDivider } from '../shared-styles';
 import { CustomStackLayout } from '../shared';
 import { FullWidthBlock } from '../../components/slices/shared-styles';
 
@@ -38,7 +38,10 @@ export const ContentBucket2 = ({ section, articles }: ContentBucket2Props) => {
           {articles.map((article: ArticleProps, articleIndex, articleArr) => {
             const articleBorder = articleIndex < articleArr.length - 1 &&
               !isMob && (
-                <Divider overrides={{ stylePreset: 'lightDivider' }} vertical />
+                <StyledDivider
+                  overrides={{ stylePreset: 'lightDivider' }}
+                  vertical
+                />
               );
 
             const isAfterFirstArticle = isMob && articleIndex > 0;

--- a/packages/ts-newskit/src/slices/fixtures/data.json
+++ b/packages/ts-newskit/src/slices/fixtures/data.json
@@ -4,13 +4,17 @@
     "headline": "Sarcacens an inclusive club? They didnt look out for me",
     "summary": "Lyon lock Joel Kpoku tells Will Kelleher that he’s fired up to face old team — and urges more English stars to move to France",
     "caption": "Credit",
-    "image": "/assets/main_01.jpg",
+    "image": {
+      "src": "/assets/main_01.jpg",
+      "alt": "This is ALT Text"
+    },
     "url": "https://www.thetimes.co.uk",
     "tag": {
       "label": "Review",
       "href": "/"
     },
-    "flag": "4 min read"
+    "flag": "4 min read",
+    "listData": []
   },
   "articles": [
     {
@@ -20,7 +24,6 @@
       },
       "title": "European cup winner Mihajlovic dies aged 53 after battle with leukaemia",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -34,7 +37,6 @@
       },
       "title": "‘American owners pose threat to English pyramid’",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -48,7 +50,6 @@
       },
       "title": "£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -62,7 +63,6 @@
       },
       "title": "Blow for rebel clubs as court says Uefa can block Super League",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -78,7 +78,6 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -92,7 +91,6 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -106,7 +104,6 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -120,7 +117,6 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -134,7 +130,6 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -148,7 +143,6 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -162,7 +156,6 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -176,8 +169,6 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
-
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -212,7 +203,6 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -226,8 +216,6 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "imageRight": false,
-
         "tag": {
           "label": "",
           "href": ""
@@ -241,7 +229,6 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -263,7 +250,6 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -277,8 +263,6 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "imageRight": false,
-
         "tag": {
           "label": "",
           "href": ""
@@ -292,7 +276,6 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -314,7 +297,6 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -328,8 +310,6 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "imageRight": false,
-
         "tag": {
           "label": "",
           "href": ""
@@ -343,7 +323,6 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -365,7 +344,6 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -379,7 +357,6 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -393,7 +370,6 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""

--- a/packages/ts-newskit/src/slices/fixtures/data.json
+++ b/packages/ts-newskit/src/slices/fixtures/data.json
@@ -1,6 +1,10 @@
 {
   "section": { "title": "Rugby Union", "href": "https://www.thetimes.co.uk/" },
   "leadArticle": {
+    "tagL1": {
+      "label": "",
+      "href": ""
+    },
     "headline": "Sarcacens an inclusive club? They didnt look out for me",
     "summary": "Lyon lock Joel Kpoku tells Will Kelleher that he’s fired up to face old team — and urges more English stars to move to France",
     "caption": "Credit",

--- a/packages/ts-newskit/src/slices/fixtures/data.json
+++ b/packages/ts-newskit/src/slices/fixtures/data.json
@@ -19,7 +19,12 @@
         "alt": "This is ALT Text"
       },
       "title": "European cup winner Mihajlovic dies aged 53 after battle with leukaemia",
-      "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+      "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "tag": {
+        "label": "",
+        "href": ""
+      },
+      "flag": ""
     },
     {
       "image": {
@@ -27,7 +32,12 @@
         "alt": "This is ALT Text"
       },
       "title": "‘American owners pose threat to English pyramid’",
-      "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+      "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "tag": {
+        "label": "",
+        "href": ""
+      },
+      "flag": ""
     },
     {
       "image": {
@@ -35,7 +45,12 @@
         "alt": "This is ALT Text"
       },
       "title": "£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid",
-      "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+      "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "tag": {
+        "label": "",
+        "href": ""
+      },
+      "flag": ""
     },
     {
       "image": {
@@ -43,7 +58,12 @@
         "alt": "This is ALT Text"
       },
       "title": "Blow for rebel clubs as court says Uefa can block Super League",
-      "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+      "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "tag": {
+        "label": "",
+        "href": ""
+      },
+      "flag": ""
     }
   ],
   "stackedModule1Articles": [
@@ -57,7 +77,8 @@
       "tag": {
         "label": "Tag",
         "href": "/"
-      }
+      },
+      "flag": ""
     },
     {
       "image": {
@@ -82,7 +103,8 @@
       "tag": {
         "label": "Tag",
         "href": "/"
-      }
+      },
+      "flag": ""
     },
     {
       "image": {
@@ -107,7 +129,8 @@
       "tag": {
         "label": "Tag",
         "href": "/"
-      }
+      },
+      "flag": ""
     },
     {
       "image": {
@@ -132,7 +155,8 @@
       "tag": {
         "label": "Tag",
         "href": "/"
-      }
+      },
+      "flag": ""
     },
     {
       "image": {
@@ -174,7 +198,12 @@
           "alt": "This is ALT Text"
         },
         "title": "Short title of the card describing the main content",
-        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "tag": {
+          "label": "",
+          "href": ""
+        },
+        "flag": ""
       },
       {
         "image": {
@@ -182,7 +211,12 @@
           "alt": "This is ALT Text"
         },
         "title": "Short title of the card describing the main content",
-        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "tag": {
+          "label": "",
+          "href": ""
+        },
+        "flag": ""
       },
       {
         "image": {
@@ -190,7 +224,12 @@
           "alt": "This is ALT Text"
         },
         "title": "Short title of the card describing the main content",
-        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "tag": {
+          "label": "",
+          "href": ""
+        },
+        "flag": ""
       }
     ]
   },
@@ -206,7 +245,12 @@
           "alt": "This is ALT Text"
         },
         "title": "Short title of the card describing the main content",
-        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "tag": {
+          "label": "",
+          "href": ""
+        },
+        "flag": ""
       },
       {
         "image": {
@@ -214,7 +258,12 @@
           "alt": "This is ALT Text"
         },
         "title": "Short title of the card describing the main content",
-        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "tag": {
+          "label": "",
+          "href": ""
+        },
+        "flag": ""
       },
       {
         "image": {
@@ -222,7 +271,12 @@
           "alt": "This is ALT Text"
         },
         "title": "Short title of the card describing the main content",
-        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "tag": {
+          "label": "",
+          "href": ""
+        },
+        "flag": ""
       }
     ]
   },
@@ -238,7 +292,12 @@
           "alt": "This is ALT Text"
         },
         "title": "Short title of the card describing the main content",
-        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "tag": {
+          "label": "",
+          "href": ""
+        },
+        "flag": ""
       },
       {
         "image": {
@@ -246,7 +305,12 @@
           "alt": "This is ALT Text"
         },
         "title": "Short title of the card describing the main content",
-        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "tag": {
+          "label": "",
+          "href": ""
+        },
+        "flag": ""
       },
       {
         "image": {
@@ -254,7 +318,9 @@
           "alt": "This is ALT Text"
         },
         "title": "Short title of the card describing the main content",
-        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "tag": {},
+        "flag": ""
       }
     ]
   },
@@ -270,7 +336,9 @@
           "alt": "This is ALT Text"
         },
         "title": "Short title of the card describing the main content",
-        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "tag": {},
+        "flag": ""
       },
       {
         "image": {
@@ -278,7 +346,9 @@
           "alt": "This is ALT Text"
         },
         "title": "Short title of the card describing the main content",
-        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "tag": {},
+        "flag": ""
       },
       {
         "image": {
@@ -286,7 +356,9 @@
           "alt": "This is ALT Text"
         },
         "title": "Short title of the card describing the main content",
-        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
+        "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "tag": {},
+        "flag": ""
       }
     ]
   }

--- a/packages/ts-newskit/src/slices/fixtures/data.json
+++ b/packages/ts-newskit/src/slices/fixtures/data.json
@@ -20,6 +20,7 @@
       },
       "title": "European cup winner Mihajlovic dies aged 53 after battle with leukaemia",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -33,6 +34,7 @@
       },
       "title": "‘American owners pose threat to English pyramid’",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -46,6 +48,7 @@
       },
       "title": "£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -59,6 +62,7 @@
       },
       "title": "Blow for rebel clubs as court says Uefa can block Super League",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -74,6 +78,7 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -87,6 +92,7 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -100,6 +106,7 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -113,6 +120,7 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -126,6 +134,7 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -139,6 +148,7 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -152,6 +162,7 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -165,6 +176,8 @@
       },
       "title": "Short title of the card describing the main content",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+      "imageRight": false,
+
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -199,6 +212,7 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -212,6 +226,8 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "imageRight": false,
+
         "tag": {
           "label": "",
           "href": ""
@@ -225,6 +241,7 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -246,6 +263,7 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -259,6 +277,8 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "imageRight": false,
+
         "tag": {
           "label": "",
           "href": ""
@@ -272,6 +292,7 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -293,6 +314,7 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "imageRight": false,
         "tag": {
           "label": "",
           "href": ""
@@ -306,6 +328,8 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
+        "imageRight": false,
+
         "tag": {
           "label": "",
           "href": ""
@@ -319,7 +343,11 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "tag": {},
+        "imageRight": false,
+        "tag": {
+          "label": "",
+          "href": ""
+        },
         "flag": ""
       }
     ]
@@ -337,7 +365,11 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "tag": {},
+        "imageRight": false,
+        "tag": {
+          "label": "",
+          "href": ""
+        },
         "flag": ""
       },
       {
@@ -347,7 +379,11 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "tag": {},
+        "imageRight": false,
+        "tag": {
+          "label": "",
+          "href": ""
+        },
         "flag": ""
       },
       {
@@ -357,7 +393,11 @@
         },
         "title": "Short title of the card describing the main content",
         "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-        "tag": {},
+        "imageRight": false,
+        "tag": {
+          "label": "",
+          "href": ""
+        },
         "flag": ""
       }
     ]

--- a/packages/ts-newskit/src/slices/fixtures/lead-story.json
+++ b/packages/ts-newskit/src/slices/fixtures/lead-story.json
@@ -1,5 +1,9 @@
 {
   "leadArticle": {
+    "tagL1": {
+      "label": "",
+      "href": ""
+    },
     "headline": "Sarcacens an inclusive club? They didnt look out for me",
     "summary": "Lyon lock Joel Kpoku tells Will Kelleher that he’s fired up to face old team — and urges more English stars to move to France",
     "caption": "Credit",
@@ -122,6 +126,10 @@
     },
     "articles": [
       {
+        "tagL1": {
+          "label": "",
+          "href": ""
+        },
         "image": {
           "src": "/assets/small_04.jpg",
           "alt": "This is ALT Text"
@@ -137,6 +145,10 @@
         "listData": []
       },
       {
+        "tagL1": {
+          "label": "",
+          "href": ""
+        },
         "image": {
           "src": "/assets/small_04.jpg",
           "alt": "This is ALT Text"
@@ -184,6 +196,10 @@
 
   "verticalArticles": [
     {
+      "tagL1": {
+        "label": "",
+        "href": ""
+      },
       "image": {
         "src": "/assets/main_01.jpg",
         "alt": "This is ALT Text"
@@ -200,6 +216,10 @@
       "listData": []
     },
     {
+      "tagL1": {
+        "label": "",
+        "href": ""
+      },
       "image": {
         "src": "/assets/main_01.jpg",
         "alt": "This is ALT Text"
@@ -218,6 +238,10 @@
   ],
   "horizontalArticles": [
     {
+      "tagL1": {
+        "label": "",
+        "href": ""
+      },
       "image": {
         "src": "",
         "alt": ""
@@ -234,6 +258,10 @@
       "listData": []
     },
     {
+      "tagL1": {
+        "label": "",
+        "href": ""
+      },
       "image": {
         "src": "",
         "alt": ""

--- a/packages/ts-newskit/src/slices/fixtures/lead-story.json
+++ b/packages/ts-newskit/src/slices/fixtures/lead-story.json
@@ -34,7 +34,12 @@
       },
       "title": "American owners pose threat to English pyramid",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false
+      "imageRight": false,
+      "tag": {
+        "label": "",
+        "href": ""
+      },
+      "flag": ""
     },
     {
       "image": {
@@ -47,7 +52,8 @@
       "tag": {
         "label": "Tag",
         "href": "/"
-      }
+      },
+      "flag": ""
     },
     {
       "image": {
@@ -92,7 +98,12 @@
   },
   "singleArticle": {
     "title": "Short title of the card describing the main content 2",
-    "url": "#"
+    "url": "#",
+    "tag": {
+      "label": "",
+      "href": ""
+    },
+    "flag": ""
   },
   "groupedArticles": {
     "tagL1": {
@@ -103,12 +114,22 @@
       {
         "headline": "Short title of the card describing the main content",
         "summary": "Short paragraph description of the article, outlining main story and focus.",
-        "url": "#"
+        "url": "#",
+        "tag": {
+          "label": "",
+          "href": ""
+        },
+        "flag": ""
       },
       {
         "headline": "Short title of the card describing the main content 2",
         "summary": "Short paragraph description of the article, outlining main story and focus.",
-        "url": "#"
+        "url": "#",
+        "tag": {
+          "label": "",
+          "href": ""
+        },
+        "flag": ""
       }
     ]
   },
@@ -121,6 +142,10 @@
       "title": "European cup winner Mihajlovic dies aged 53 after battle with leukaemia",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
       "imageRight": false,
+      "tag": {
+        "label": "",
+        "href": ""
+      },
       "flag": "Flag"
     },
     {
@@ -131,6 +156,10 @@
       "title": "‘American owners pose threat to English pyramid’",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
       "imageRight": false,
+      "tag": {
+        "label": "",
+        "href": ""
+      },
       "flag": ""
     }
   ],

--- a/packages/ts-newskit/src/slices/fixtures/lead-story.json
+++ b/packages/ts-newskit/src/slices/fixtures/lead-story.json
@@ -63,6 +63,10 @@
       "title": "Blow for rebel clubs as court says Uefa can block Super League",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
       "imageRight": false,
+      "tag": {
+        "label": "",
+        "href": ""
+      },
       "flag": "Flag4"
     },
     {
@@ -97,8 +101,13 @@
     "listData": [{ "label": "Unordered list item", "href": "/" }]
   },
   "singleArticle": {
-    "title": "Short title of the card describing the main content 2",
+    "image": {
+      "src": "",
+      "alt": ""
+    },
+    "title": "Short title of the card describing the main content 3",
     "url": "#",
+    "imageRight": null,
     "tag": {
       "label": "",
       "href": ""

--- a/packages/ts-newskit/src/slices/fixtures/lead-story.json
+++ b/packages/ts-newskit/src/slices/fixtures/lead-story.json
@@ -3,14 +3,17 @@
     "headline": "Sarcacens an inclusive club? They didnt look out for me",
     "summary": "Lyon lock Joel Kpoku tells Will Kelleher that he’s fired up to face old team — and urges more English stars to move to France",
     "caption": "Credit",
-    "image": "/assets/main_01.jpg",
+    "image": {
+      "src": "/assets/main_01.jpg",
+      "alt": "This is ALT Text"
+    },
     "url": "https://www.thetimes.co.uk",
     "tag": {
       "label": "Tag",
       "href": "/"
     },
     "flag": "4 min read",
-    "imageTop": true
+    "listData": []
   },
   "articles": [
     {
@@ -20,7 +23,6 @@
       },
       "title": "European cup winner Mihajlovic dies aged 53 after battle with leukaemia",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -34,7 +36,6 @@
       },
       "title": "American owners pose threat to English pyramid",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -48,7 +49,6 @@
       },
       "title": "£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -62,7 +62,6 @@
       },
       "title": "Blow for rebel clubs as court says Uefa can block Super League",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -76,7 +75,6 @@
       },
       "title": "Blow for rebel clubs as court says Uefa can block Super League 2",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -89,6 +87,10 @@
     "tagL1": {
       "label": "TAG",
       "href": "/"
+    },
+    "image": {
+      "src": "",
+      "alt": ""
     },
     "headline": "Short title of the card describing the main content",
     "summary": "Short paragraph description of the article, outlining main story and focus.",
@@ -107,7 +109,6 @@
     },
     "title": "Short title of the card describing the main content 3",
     "url": "#",
-    "imageRight": null,
     "tag": {
       "label": "",
       "href": ""
@@ -121,6 +122,10 @@
     },
     "articles": [
       {
+        "image": {
+          "src": "/assets/small_04.jpg",
+          "alt": "This is ALT Text"
+        },
         "headline": "Short title of the card describing the main content",
         "summary": "Short paragraph description of the article, outlining main story and focus.",
         "url": "#",
@@ -128,9 +133,14 @@
           "label": "",
           "href": ""
         },
-        "flag": ""
+        "flag": "",
+        "listData": []
       },
       {
+        "image": {
+          "src": "/assets/small_04.jpg",
+          "alt": "This is ALT Text"
+        },
         "headline": "Short title of the card describing the main content 2",
         "summary": "Short paragraph description of the article, outlining main story and focus.",
         "url": "#",
@@ -138,7 +148,8 @@
           "label": "",
           "href": ""
         },
-        "flag": ""
+        "flag": "",
+        "listData": []
       }
     ]
   },
@@ -150,7 +161,6 @@
       },
       "title": "European cup winner Mihajlovic dies aged 53 after battle with leukaemia",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -164,7 +174,6 @@
       },
       "title": "‘American owners pose threat to English pyramid’",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -175,32 +184,44 @@
 
   "verticalArticles": [
     {
+      "image": {
+        "src": "/assets/main_01.jpg",
+        "alt": "This is ALT Text"
+      },
       "headline": "Short title of the card describing the main content",
       "summary": "Short paragraph description of the article, outlining main story and focus.",
       "caption": "Credit",
-      "image": "/assets/main_01.jpg",
       "url": "https://www.thetimes.co.uk",
       "tag": {
         "label": "Tag",
         "href": "/"
       },
-      "flag": "4 min read"
+      "flag": "4 min read",
+      "listData": []
     },
     {
+      "image": {
+        "src": "/assets/main_01.jpg",
+        "alt": "This is ALT Text"
+      },
       "headline": "Short title of the card describing the main content 2",
       "summary": "Short paragraph description of the article, outlining main story and focus.",
       "caption": "Credit",
-      "image": "/assets/main_01.jpg",
       "url": "https://www.thetimes.co.uk",
       "tag": {
         "label": "Tag",
         "href": "/"
       },
-      "flag": "4 min read"
+      "flag": "4 min read",
+      "listData": []
     }
   ],
   "horizontalArticles": [
     {
+      "image": {
+        "src": "",
+        "alt": ""
+      },
       "headline": "Short title of the card describing the main content",
       "summary": "Short paragraph description of the article, outlining main story and focus.",
       "caption": "Credit",
@@ -209,9 +230,14 @@
         "label": "Tag",
         "href": "/"
       },
-      "flag": "4 min read"
+      "flag": "4 min read",
+      "listData": []
     },
     {
+      "image": {
+        "src": "",
+        "alt": ""
+      },
       "headline": "Short title of the card describing the main content 2",
       "summary": "Short paragraph description of the article, outlining main story and focus.",
       "caption": "Credit",
@@ -220,7 +246,8 @@
         "label": "Tag",
         "href": "/"
       },
-      "flag": "4 min read"
+      "flag": "4 min read",
+      "listData": []
     }
   ]
 }

--- a/packages/ts-newskit/src/slices/fixtures/lead-story3.json
+++ b/packages/ts-newskit/src/slices/fixtures/lead-story3.json
@@ -7,7 +7,6 @@
       },
       "title": "European cup winner Mihajlovic dies aged 53 after battle with leukaemia",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -21,7 +20,6 @@
       },
       "title": "American owners pose threat to English pyramid",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -35,7 +33,6 @@
       },
       "title": "£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -49,7 +46,6 @@
       },
       "title": "Blow for rebel clubs as court says Uefa can block Super League",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "",
         "href": ""
@@ -63,7 +59,6 @@
       },
       "title": "Blow for rebel clubs as court says Uefa can block Super League",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false,
       "tag": {
         "label": "Tag",
         "href": "/"
@@ -74,6 +69,10 @@
 
   "leadArticles": [
     {
+      "image": {
+        "src": "",
+        "alt": ""
+      },
       "headline": "Short title of the card describing the main content",
       "summary": "Short paragraph description of the article, outlining main story and focus.",
       "caption": "Credit",
@@ -82,9 +81,14 @@
         "label": "Tag",
         "href": "/"
       },
-      "flag": "4 min read 1"
+      "flag": "4 min read 1",
+      "listData": []
     },
     {
+      "image": {
+        "src": "",
+        "alt": ""
+      },
       "headline": "Short title of the card describing the main content",
       "summary": "Short paragraph description of the article, outlining main story and focus.",
       "caption": "Credit",
@@ -93,9 +97,14 @@
         "label": "Tag",
         "href": "/"
       },
-      "flag": "4 min read 2"
+      "flag": "4 min read 2",
+      "listData": []
     },
     {
+      "image": {
+        "src": "",
+        "alt": ""
+      },
       "headline": "Short title of the card describing the main content",
       "summary": "Short paragraph description of the article, outlining main story and focus.",
       "caption": "Credit",
@@ -104,9 +113,14 @@
         "label": "Tag",
         "href": "/"
       },
-      "flag": "4 min read 3"
+      "flag": "4 min read 3",
+      "listData": []
     },
     {
+      "image": {
+        "src": "",
+        "alt": ""
+      },
       "headline": "Short title of the card describing the main content",
       "summary": "Short paragraph description of the article, outlining main story and focus.",
       "caption": "Credit",
@@ -115,18 +129,23 @@
         "label": "Tag",
         "href": "/"
       },
-      "flag": "4 min read 4"
+      "flag": "4 min read 4",
+      "listData": []
     }
   ],
   "leadArticle": {
+    "image": {
+      "src": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7c246bf4-fa83-11ed-9be0-622d8a105167.jpg?crop=1200%2C1500%2C0%2C0&resize=747",
+      "alt": "This is ALT Text"
+    },
     "headline": "Short title of the card describing the main content",
-    "image": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7c246bf4-fa83-11ed-9be0-622d8a105167.jpg?crop=1200%2C1500%2C0%2C0&resize=747",
     "caption": "Credit",
     "url": "https://www.thetimes.co.uk",
     "tag": {
       "label": "Tag",
       "href": "/"
     },
-    "flag": "4 min read 1"
+    "flag": "4 min read 1",
+    "listData": []
   }
 }

--- a/packages/ts-newskit/src/slices/fixtures/lead-story3.json
+++ b/packages/ts-newskit/src/slices/fixtures/lead-story3.json
@@ -21,7 +21,12 @@
       },
       "title": "American owners pose threat to English pyramid",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
-      "imageRight": false
+      "imageRight": false,
+      "tag": {
+        "label": "",
+        "href": ""
+      },
+      "flag": ""
     },
     {
       "image": {
@@ -34,7 +39,8 @@
       "tag": {
         "label": "Tag",
         "href": "/"
-      }
+      },
+      "flag": ""
     },
     {
       "image": {
@@ -44,6 +50,10 @@
       "title": "Blow for rebel clubs as court says Uefa can block Super League",
       "url": "/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m",
       "imageRight": false,
+      "tag": {
+        "label": "",
+        "href": ""
+      },
       "flag": "Flag4"
     },
     {

--- a/packages/ts-newskit/src/slices/fixtures/lead-story3.json
+++ b/packages/ts-newskit/src/slices/fixtures/lead-story3.json
@@ -69,6 +69,10 @@
 
   "leadArticles": [
     {
+      "tagL1": {
+        "label": "",
+        "href": ""
+      },
       "image": {
         "src": "",
         "alt": ""
@@ -85,6 +89,10 @@
       "listData": []
     },
     {
+      "tagL1": {
+        "label": "",
+        "href": ""
+      },
       "image": {
         "src": "",
         "alt": ""
@@ -101,6 +109,10 @@
       "listData": []
     },
     {
+      "tagL1": {
+        "label": "",
+        "href": ""
+      },
       "image": {
         "src": "",
         "alt": ""
@@ -117,6 +129,10 @@
       "listData": []
     },
     {
+      "tagL1": {
+        "label": "",
+        "href": ""
+      },
       "image": {
         "src": "",
         "alt": ""
@@ -134,6 +150,10 @@
     }
   ],
   "leadArticle": {
+    "tagL1": {
+      "label": "",
+      "href": ""
+    },
     "image": {
       "src": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7c246bf4-fa83-11ed-9be0-622d8a105167.jpg?crop=1200%2C1500%2C0%2C0&resize=747",
       "alt": "This is ALT Text"

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/article-stack.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/article-stack.test.tsx.snap
@@ -239,6 +239,18 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               class="css-1atazsr"
               data-testid="tag-and-flag"
             >
+              <a
+                class="css-10d4t8c"
+                href=""
+              >
+                <span
+                  class="css-17x5lw"
+                >
+                  <span
+                    class="css-zhtub2"
+                  />
+                </span>
+              </a>
               <span
                 class="css-1vzvkql"
               >
@@ -511,6 +523,18 @@ exports[`Render Lead Story 1 Slice small Aricle Stack 1`] = `
             class="css-1atazsr"
             data-testid="tag-and-flag"
           >
+            <a
+              class="css-10d4t8c"
+              href=""
+            >
+              <span
+                class="css-17x5lw"
+              >
+                <span
+                  class="css-zhtub2"
+                />
+              </span>
+            </a>
             <span
               class="css-1vzvkql"
             >

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/article-stack.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/article-stack.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -132,7 +132,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -195,7 +195,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -249,7 +249,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -1645,7 +1645,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -1689,7 +1689,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -2477,7 +2477,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -2521,7 +2521,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -2584,7 +2584,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -2638,7 +2638,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -3469,7 +3469,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -3513,7 +3513,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -3576,7 +3576,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -3630,7 +3630,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
         >
           <hr
             aria-hidden="true"
-            class="css-5znksa"
+            class="css-1rbgup8"
             data-testid="divider"
           />
         </div>
@@ -167,7 +167,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 <span
                   class="css-65zrxz"
                 >
-                  Short title of the card describing the main content 2
+                  Short title of the card describing the main content 3
                 </span>
               </span>
             </a>
@@ -792,6 +792,18 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 class="css-1atazsr"
                 data-testid="tag-and-flag"
               >
+                <a
+                  class="css-10d4t8c"
+                  href=""
+                >
+                  <span
+                    class="css-17x5lw"
+                  >
+                    <span
+                      class="css-zhtub2"
+                    />
+                  </span>
+                </a>
                 <span
                   class="css-1vzvkql"
                 >
@@ -952,6 +964,18 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       class="css-1atazsr"
                       data-testid="tag-and-flag"
                     >
+                      <a
+                        class="css-10d4t8c"
+                        href=""
+                      >
+                        <span
+                          class="css-17x5lw"
+                        >
+                          <span
+                            class="css-zhtub2"
+                          />
+                        </span>
+                      </a>
                       <span
                         class="css-1vzvkql"
                       >
@@ -1201,7 +1225,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
         >
           <hr
             aria-hidden="true"
-            class="css-5znksa"
+            class="css-1rbgup8"
             data-testid="divider"
           />
         </div>
@@ -1222,7 +1246,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 <span
                   class="css-65zrxz"
                 >
-                  Short title of the card describing the main content 2
+                  Short title of the card describing the main content 3
                 </span>
               </span>
             </a>
@@ -1821,6 +1845,18 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     class="css-1atazsr"
                     data-testid="tag-and-flag"
                   >
+                    <a
+                      class="css-10d4t8c"
+                      href=""
+                    >
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-zhtub2"
+                        />
+                      </span>
+                    </a>
                     <span
                       class="css-1vzvkql"
                     >
@@ -2049,7 +2085,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
         >
           <hr
             aria-hidden="true"
-            class="css-5znksa"
+            class="css-1rbgup8"
             data-testid="divider"
           />
         </div>
@@ -2070,7 +2106,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 <span
                   class="css-65zrxz"
                 >
-                  Short title of the card describing the main content 2
+                  Short title of the card describing the main content 3
                 </span>
               </span>
             </a>
@@ -2664,6 +2700,18 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="css-1atazsr"
                   data-testid="tag-and-flag"
                 >
+                  <a
+                    class="css-10d4t8c"
+                    href=""
+                  >
+                    <span
+                      class="css-17x5lw"
+                    >
+                      <span
+                        class="css-zhtub2"
+                      />
+                    </span>
+                  </a>
                   <span
                     class="css-1vzvkql"
                   >
@@ -2814,6 +2862,18 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     class="css-1atazsr"
                     data-testid="tag-and-flag"
                   >
+                    <a
+                      class="css-10d4t8c"
+                      href=""
+                    >
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-zhtub2"
+                        />
+                      </span>
+                    </a>
                     <span
                       class="css-1vzvkql"
                     >
@@ -3053,7 +3113,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
         >
           <hr
             aria-hidden="true"
-            class="css-5znksa"
+            class="css-1rbgup8"
             data-testid="divider"
           />
         </div>
@@ -3074,7 +3134,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 <span
                   class="css-65zrxz"
                 >
-                  Short title of the card describing the main content 2
+                  Short title of the card describing the main content 3
                 </span>
               </span>
             </a>
@@ -3668,6 +3728,18 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="css-1atazsr"
                   data-testid="tag-and-flag"
                 >
+                  <a
+                    class="css-10d4t8c"
+                    href=""
+                  >
+                    <span
+                      class="css-17x5lw"
+                    >
+                      <span
+                        class="css-zhtub2"
+                      />
+                    </span>
+                  </a>
                   <span
                     class="css-1vzvkql"
                   >
@@ -3818,6 +3890,18 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     class="css-1atazsr"
                     data-testid="tag-and-flag"
                   >
+                    <a
+                      class="css-10d4t8c"
+                      href=""
+                    >
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-zhtub2"
+                        />
+                      </span>
+                    </a>
                     <span
                       class="css-1vzvkql"
                     >

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
       class="css-1polam9"
     >
       <div
-        class="css-6wqjuf"
+        class="css-19qmu5v"
       >
         <div
           class="css-gpke1l"
@@ -204,7 +204,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
           class="css-e0a604"
         >
           <div
-            class="css-6wqjuf"
+            class="css-19qmu5v"
           >
             <div
               class="css-gpke1l"
@@ -240,7 +240,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
             />
           </div>
           <div
-            class="css-6wqjuf"
+            class="css-19qmu5v"
           >
             <div
               class="css-gpke1l"
@@ -316,7 +316,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     class="css-5pczz7"
                   />
                   <img
-                    alt="Sarcacens an inclusive club? They didnt look out for me"
+                    alt="This is ALT Text"
                     class="css-1qgqq71"
                     src="/assets/main_01.jpg"
                   />
@@ -1088,7 +1088,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
       class="css-1polam9"
     >
       <div
-        class="css-6wqjuf"
+        class="css-19qmu5v"
       >
         <div
           class="css-gpke1l"
@@ -1283,7 +1283,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
           class="css-e0a604"
         >
           <div
-            class="css-6wqjuf"
+            class="css-19qmu5v"
           >
             <div
               class="css-gpke1l"
@@ -1319,7 +1319,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
             />
           </div>
           <div
-            class="css-6wqjuf"
+            class="css-19qmu5v"
           >
             <div
               class="css-gpke1l"
@@ -1395,7 +1395,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     class="css-5pczz7"
                   />
                   <img
-                    alt="Sarcacens an inclusive club? They didnt look out for me"
+                    alt="This is ALT Text"
                     class="css-1qgqq71"
                     src="/assets/main_01.jpg"
                   />
@@ -1948,7 +1948,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
       class="css-1polam9"
     >
       <div
-        class="css-6wqjuf"
+        class="css-19qmu5v"
       >
         <div
           class="css-gpke1l"
@@ -2143,7 +2143,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
           class="css-e0a604"
         >
           <div
-            class="css-6wqjuf"
+            class="css-19qmu5v"
           >
             <div
               class="css-gpke1l"
@@ -2179,7 +2179,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
             />
           </div>
           <div
-            class="css-6wqjuf"
+            class="css-19qmu5v"
           >
             <div
               class="css-gpke1l"
@@ -2255,7 +2255,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     class="css-5pczz7"
                   />
                   <img
-                    alt="Sarcacens an inclusive club? They didnt look out for me"
+                    alt="This is ALT Text"
                     class="css-1qgqq71"
                     src="/assets/main_01.jpg"
                   />
@@ -2976,7 +2976,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
       class="css-1polam9"
     >
       <div
-        class="css-6wqjuf"
+        class="css-19qmu5v"
       >
         <div
           class="css-gpke1l"
@@ -3171,7 +3171,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
           class="css-e0a604"
         >
           <div
-            class="css-6wqjuf"
+            class="css-19qmu5v"
           >
             <div
               class="css-gpke1l"
@@ -3207,7 +3207,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
             />
           </div>
           <div
-            class="css-6wqjuf"
+            class="css-19qmu5v"
           >
             <div
               class="css-gpke1l"
@@ -3283,7 +3283,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     class="css-5pczz7"
                   />
                   <img
-                    alt="Sarcacens an inclusive club? They didnt look out for me"
+                    alt="This is ALT Text"
                     class="css-1qgqq71"
                     src="/assets/main_01.jpg"
                   />

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -339,7 +339,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   class="css-17x5lw"
                 >
                   <span
-                    class="css-1tplk7g"
+                    class="css-1qa0j03"
                   >
                     Sarcacens an inclusive club? They didnt look out for me
                   </span>
@@ -1418,7 +1418,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="css-17x5lw"
                 >
                   <span
-                    class="css-1tplk7g"
+                    class="css-1qa0j03"
                   >
                     Sarcacens an inclusive club? They didnt look out for me
                   </span>
@@ -2278,7 +2278,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="css-17x5lw"
                 >
                   <span
-                    class="css-1tplk7g"
+                    class="css-8gj81n"
                   >
                     Sarcacens an inclusive club? They didnt look out for me
                   </span>
@@ -3306,7 +3306,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="css-17x5lw"
                 >
                   <span
-                    class="css-1tplk7g"
+                    class="css-8gj81n"
                   >
                     Sarcacens an inclusive club? They didnt look out for me
                   </span>

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -210,7 +210,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
               class="css-gpke1l"
             >
               <a
-                class="css-gull0f"
+                class="css-10h0i3c"
                 href="#"
               >
                 <span
@@ -246,7 +246,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
               class="css-gpke1l"
             >
               <a
-                class="css-gull0f"
+                class="css-10h0i3c"
                 href="#"
               >
                 <span
@@ -447,6 +447,18 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   class="css-1atazsr"
                   data-testid="tag-and-flag"
                 >
+                  <a
+                    class="css-10d4t8c"
+                    href=""
+                  >
+                    <span
+                      class="css-17x5lw"
+                    >
+                      <span
+                        class="css-zhtub2"
+                      />
+                    </span>
+                  </a>
                   <span
                     class="css-1vzvkql"
                   >
@@ -1253,7 +1265,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
               class="css-gpke1l"
             >
               <a
-                class="css-gull0f"
+                class="css-10h0i3c"
                 href="#"
               >
                 <span
@@ -1289,7 +1301,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
               class="css-gpke1l"
             >
               <a
-                class="css-gull0f"
+                class="css-10h0i3c"
                 href="#"
               >
                 <span
@@ -1490,6 +1502,18 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="css-1atazsr"
                   data-testid="tag-and-flag"
                 >
+                  <a
+                    class="css-10d4t8c"
+                    href=""
+                  >
+                    <span
+                      class="css-17x5lw"
+                    >
+                      <span
+                        class="css-zhtub2"
+                      />
+                    </span>
+                  </a>
                   <span
                     class="css-1vzvkql"
                   >
@@ -2089,7 +2113,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
               class="css-gpke1l"
             >
               <a
-                class="css-gull0f"
+                class="css-10h0i3c"
                 href="#"
               >
                 <span
@@ -2125,7 +2149,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
               class="css-gpke1l"
             >
               <a
-                class="css-gull0f"
+                class="css-10h0i3c"
                 href="#"
               >
                 <span
@@ -2323,6 +2347,18 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="css-1atazsr"
                   data-testid="tag-and-flag"
                 >
+                  <a
+                    class="css-10d4t8c"
+                    href=""
+                  >
+                    <span
+                      class="css-17x5lw"
+                    >
+                      <span
+                        class="css-zhtub2"
+                      />
+                    </span>
+                  </a>
                   <span
                     class="css-1vzvkql"
                   >
@@ -3081,7 +3117,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
               class="css-gpke1l"
             >
               <a
-                class="css-gull0f"
+                class="css-10h0i3c"
                 href="#"
               >
                 <span
@@ -3117,7 +3153,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
               class="css-gpke1l"
             >
               <a
-                class="css-gull0f"
+                class="css-10h0i3c"
                 href="#"
               >
                 <span
@@ -3315,6 +3351,18 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="css-1atazsr"
                   data-testid="tag-and-flag"
                 >
+                  <a
+                    class="css-10d4t8c"
+                    href=""
+                  >
+                    <span
+                      class="css-17x5lw"
+                    >
+                      <span
+                        class="css-zhtub2"
+                      />
+                    </span>
+                  </a>
                   <span
                     class="css-1vzvkql"
                   >

--- a/packages/ts-newskit/src/slices/lead-story-1/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-1/index.tsx
@@ -43,6 +43,7 @@ export const LeadStory1 = ({
   articlesWithListItems
 }: LeadStory1Props) => {
   const breakpointKey = useBreakpointKey();
+  const screenXsAndSm = breakpointKey === 'xs' || breakpointKey === 'sm';
 
   const modifedArticles =
     breakpointKey === 'xl'
@@ -56,7 +57,7 @@ export const LeadStory1 = ({
     ...articlesWithListItems,
     hasTopBorder: false,
     textBlockMarginBlockStart: 'space050',
-    typographyPreset:
+    headlineTypographyPreset:
       breakpointKey === 'xs'
         ? 'editorialHeadline040'
         : breakpointKey === 'sm'
@@ -68,10 +69,12 @@ export const LeadStory1 = ({
   const modifedLeadArticle = {
     ...leadArticle,
     hasTopBorder: false,
-    imageTop: true
+    imageTop: true,
+    headlineTypographyPreset: screenXsAndSm
+      ? 'editorialHeadline040'
+      : 'editorialHeadline030'
   };
 
-  const screenXsAndSm = breakpointKey === 'xs' || breakpointKey === 'sm';
   const marginTop = singleArticle
     ? 'space040'
     : !!articlesWithListItems.listData

--- a/packages/ts-newskit/src/slices/lead-story-1/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-1/index.tsx
@@ -100,7 +100,11 @@ export const LeadStory1 = ({
                   stylePreset: 'dashedDivider',
                   marginBlockStart: !!articlesWithListItems.listData
                     ? 'space020'
-                    : 'space040'
+                    : 'space040',
+                  marginBlockEnd:
+                    singleArticle.image && singleArticle.image.src !== ''
+                      ? 'space040'
+                      : 'space000'
                 }}
               />
             </FullWidthBlock>

--- a/packages/ts-newskit/src/slices/lead-story-1/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-1/index.tsx
@@ -54,7 +54,7 @@ export const LeadStory1 = ({
 
   const modifiedArticlesWithUnorderedList = {
     ...articlesWithListItems,
-    imageTop: true,
+    hasTopBorder: false,
     textBlockMarginBlockStart: 'space050',
     typographyPreset:
       breakpointKey === 'xs'
@@ -63,6 +63,12 @@ export const LeadStory1 = ({
           ? 'editorialHeadline050'
           : 'editorialHeadline060',
     showTagL1: false
+  };
+
+  const modifedLeadArticle = {
+    ...leadArticle,
+    hasTopBorder: false,
+    imageTop: true
   };
 
   const screenXsAndSm = breakpointKey === 'xs' || breakpointKey === 'sm';
@@ -159,7 +165,7 @@ export const LeadStory1 = ({
             />
           </Visible>
           <LeadStoryLayout>
-            <LeadArticle {...leadArticle} />
+            <LeadArticle {...modifedLeadArticle} />
           </LeadStoryLayout>
           <Visible md lg xl>
             <LeadStoryDivider

--- a/packages/ts-newskit/src/slices/lead-story-1/lead-story-1.stories.mdx
+++ b/packages/ts-newskit/src/slices/lead-story-1/lead-story-1.stories.mdx
@@ -23,7 +23,7 @@ This takes in a series of props, as below, to display the part of the slices.
 ## View Component
 Please click the 'Canvas' tab for a better viewing experience, where you can update the props and review at the different breakpoints by clicking the preview icon and selecting from our list of pre-defined breakpoints (XS, SM, MD, LG and XL).
 
-export const ContentBucket1Story = ({ leadArticle,articles,theme,smallArticles,groupedArticles,singleArticle,articlesWithListItems,gridOverlay}) => (
+export const LeadStory1Story = ({ leadArticle,articles,theme,smallArticles,groupedArticles,singleArticle,articlesWithListItems,gridOverlay}) => (
   <TCThemeProvider theme={theme}>
     <>
       <GridOverlay show={gridOverlay} />
@@ -31,7 +31,7 @@ export const ContentBucket1Story = ({ leadArticle,articles,theme,smallArticles,g
     </>
   </TCThemeProvider>
 );
-ContentBucket1Story.args = {
+LeadStory1Story.args = {
   theme: 'TimesWebLightTheme',
 };
 
@@ -56,5 +56,5 @@ ContentBucket1Story.args = {
     },
   }}
 >
-  {ContentBucket1Story.bind({})}
+  {LeadStory1Story.bind({})}
 </Story>

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/article-stacks.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/article-stacks.test.tsx.snap
@@ -205,7 +205,7 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                     class="css-5pczz7"
                   />
                   <img
-                    alt="Short title of the card describing the main content"
+                    alt="This is ALT Text"
                     class="css-1qgqq71"
                     src="/assets/main_01.jpg"
                   />
@@ -312,7 +312,7 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                     class="css-5pczz7"
                   />
                   <img
-                    alt="Short title of the card describing the main content 2"
+                    alt="This is ALT Text"
                     class="css-1qgqq71"
                     src="/assets/main_01.jpg"
                   />
@@ -593,7 +593,7 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                     class="css-5pczz7"
                   />
                   <img
-                    alt="Short title of the card describing the main content"
+                    alt="This is ALT Text"
                     class="css-1qgqq71"
                     src="/assets/main_01.jpg"
                   />
@@ -700,7 +700,7 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                     class="css-5pczz7"
                   />
                   <img
-                    alt="Short title of the card describing the main content 2"
+                    alt="This is ALT Text"
                     class="css-1qgqq71"
                     src="/assets/main_01.jpg"
                   />

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -1621,7 +1621,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -1665,7 +1665,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -2438,7 +2438,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -2482,7 +2482,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -2545,7 +2545,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -2599,7 +2599,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -3415,7 +3415,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -3459,7 +3459,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -3522,7 +3522,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -3576,7 +3576,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   class="css-5pczz7"
                 />
                 <img
-                  alt="Sarcacens an inclusive club? They didnt look out for me"
+                  alt="This is ALT Text"
                   class="css-1qgqq71"
                   src="/assets/main_01.jpg"
                 />
@@ -313,7 +313,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           class="css-5pczz7"
                         />
                         <img
-                          alt="Short title of the card describing the main content"
+                          alt="This is ALT Text"
                           class="css-1qgqq71"
                           src="/assets/main_01.jpg"
                         />
@@ -420,7 +420,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           class="css-5pczz7"
                         />
                         <img
-                          alt="Short title of the card describing the main content 2"
+                          alt="This is ALT Text"
                           class="css-1qgqq71"
                           src="/assets/main_01.jpg"
                         />
@@ -1091,7 +1091,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   class="css-5pczz7"
                 />
                 <img
-                  alt="Sarcacens an inclusive club? They didnt look out for me"
+                  alt="This is ALT Text"
                   class="css-1qgqq71"
                   src="/assets/main_01.jpg"
                 />
@@ -1368,7 +1368,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           class="css-5pczz7"
                         />
                         <img
-                          alt="Short title of the card describing the main content"
+                          alt="This is ALT Text"
                           class="css-1qgqq71"
                           src="/assets/main_01.jpg"
                         />
@@ -1475,7 +1475,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           class="css-5pczz7"
                         />
                         <img
-                          alt="Short title of the card describing the main content 2"
+                          alt="This is ALT Text"
                           class="css-1qgqq71"
                           src="/assets/main_01.jpg"
                         />
@@ -1927,7 +1927,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   class="css-5pczz7"
                 />
                 <img
-                  alt="Sarcacens an inclusive club? They didnt look out for me"
+                  alt="This is ALT Text"
                   class="css-1qgqq71"
                   src="/assets/main_01.jpg"
                 />
@@ -2196,7 +2196,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-5pczz7"
                       />
                       <img
-                        alt="Short title of the card describing the main content"
+                        alt="This is ALT Text"
                         class="css-1qgqq71"
                         src="/assets/main_01.jpg"
                       />
@@ -2298,7 +2298,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-5pczz7"
                       />
                       <img
-                        alt="Short title of the card describing the main content 2"
+                        alt="This is ALT Text"
                         class="css-1qgqq71"
                         src="/assets/main_01.jpg"
                       />
@@ -2928,7 +2928,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   class="css-5pczz7"
                 />
                 <img
-                  alt="Sarcacens an inclusive club? They didnt look out for me"
+                  alt="This is ALT Text"
                   class="css-1qgqq71"
                   src="/assets/main_01.jpg"
                 />
@@ -3197,7 +3197,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-5pczz7"
                       />
                       <img
-                        alt="Short title of the card describing the main content"
+                        alt="This is ALT Text"
                         class="css-1qgqq71"
                         src="/assets/main_01.jpg"
                       />
@@ -3299,7 +3299,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-5pczz7"
                       />
                       <img
-                        alt="Short title of the card describing the main content 2"
+                        alt="This is ALT Text"
                         class="css-1qgqq71"
                         src="/assets/main_01.jpg"
                       />

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -768,6 +768,18 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                 class="css-1atazsr"
                 data-testid="tag-and-flag"
               >
+                <a
+                  class="css-10d4t8c"
+                  href=""
+                >
+                  <span
+                    class="css-17x5lw"
+                  >
+                    <span
+                      class="css-zhtub2"
+                    />
+                  </span>
+                </a>
                 <span
                   class="css-1vzvkql"
                 >
@@ -928,6 +940,18 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       class="css-1atazsr"
                       data-testid="tag-and-flag"
                     >
+                      <a
+                        class="css-10d4t8c"
+                        href=""
+                      >
+                        <span
+                          class="css-17x5lw"
+                        >
+                          <span
+                            class="css-zhtub2"
+                          />
+                        </span>
+                      </a>
                       <span
                         class="css-1vzvkql"
                       >
@@ -1773,6 +1797,18 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     class="css-1atazsr"
                     data-testid="tag-and-flag"
                   >
+                    <a
+                      class="css-10d4t8c"
+                      href=""
+                    >
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-zhtub2"
+                        />
+                      </span>
+                    </a>
                     <span
                       class="css-1vzvkql"
                     >
@@ -2589,6 +2625,18 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   class="css-1atazsr"
                   data-testid="tag-and-flag"
                 >
+                  <a
+                    class="css-10d4t8c"
+                    href=""
+                  >
+                    <span
+                      class="css-17x5lw"
+                    >
+                      <span
+                        class="css-zhtub2"
+                      />
+                    </span>
+                  </a>
                   <span
                     class="css-1vzvkql"
                   >
@@ -2739,6 +2787,18 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     class="css-1atazsr"
                     data-testid="tag-and-flag"
                   >
+                    <a
+                      class="css-10d4t8c"
+                      href=""
+                    >
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-zhtub2"
+                        />
+                      </span>
+                    </a>
                     <span
                       class="css-1vzvkql"
                     >
@@ -3566,6 +3626,18 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   class="css-1atazsr"
                   data-testid="tag-and-flag"
                 >
+                  <a
+                    class="css-10d4t8c"
+                    href=""
+                  >
+                    <span
+                      class="css-17x5lw"
+                    >
+                      <span
+                        class="css-zhtub2"
+                      />
+                    </span>
+                  </a>
                   <span
                     class="css-1vzvkql"
                   >
@@ -3716,6 +3788,18 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     class="css-1atazsr"
                     data-testid="tag-and-flag"
                   >
+                    <a
+                      class="css-10d4t8c"
+                      href=""
+                    >
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-zhtub2"
+                        />
+                      </span>
+                    </a>
                     <span
                       class="css-1vzvkql"
                     >

--- a/packages/ts-newskit/src/slices/lead-story-2/article-stacks.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-2/article-stacks.tsx
@@ -28,14 +28,14 @@ export const ArticleStack = ({
   const modifiedVerticalArticles = verticalArticles.map(item => ({
     ...item,
     imageTop: true,
-    typographyPreset: 'editorialHeadline020',
+    headlineTypographyPreset: 'editorialHeadline020',
     hasTopBorder: false
   }));
 
   const modifiredHorizontalArticles = horizontalArticles.map(item => ({
     ...item,
     imageTop: true,
-    typographyPreset: 'editorialHeadline020',
+    headlineTypographyPreset: 'editorialHeadline020',
     hasTopBorder: false
   }));
   const articleGridVertical = (

--- a/packages/ts-newskit/src/slices/lead-story-2/article-stacks.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-2/article-stacks.tsx
@@ -28,13 +28,15 @@ export const ArticleStack = ({
   const modifiedVerticalArticles = verticalArticles.map(item => ({
     ...item,
     imageTop: true,
-    typographyPreset: 'editorialHeadline020'
+    typographyPreset: 'editorialHeadline020',
+    hasTopBorder: false
   }));
 
   const modifiredHorizontalArticles = horizontalArticles.map(item => ({
     ...item,
     imageTop: true,
-    typographyPreset: 'editorialHeadline020'
+    typographyPreset: 'editorialHeadline020',
+    hasTopBorder: false
   }));
   const articleGridVertical = (
     <GridLayout

--- a/packages/ts-newskit/src/slices/lead-story-2/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-2/index.tsx
@@ -40,7 +40,7 @@ export const LeadStory2 = ({
     imageTop: !!screenXsAndSm,
     hasTopBorder: false,
     textBlockMarginBlockStart: 'space050',
-    typographyPreset:
+    headlineTypographyPreset:
       breakpointKey === 'xs'
         ? 'editorialHeadline040'
         : breakpointKey === 'sm'

--- a/packages/ts-newskit/src/slices/lead-story-2/lead-story-2.stories.mdx
+++ b/packages/ts-newskit/src/slices/lead-story-2/lead-story-2.stories.mdx
@@ -23,7 +23,7 @@ This takes in a series of props, as below, to display the part of the slices.
 ## View Component
 Please click the 'Canvas' tab for a better viewing experience, where you can update the props and review at the different breakpoints by clicking the preview icon and selecting from our list of pre-defined breakpoints (XS, SM, MD, LG and XL).
 
-export const ContentBucket2Story = ({ leadArticle, articles, theme, verticalArticles, horizontalArticles, gridOverlay }) => (
+export const LeadStory2Story = ({ leadArticle, articles, theme, verticalArticles, horizontalArticles, gridOverlay }) => (
   <TCThemeProvider theme={theme}>
     <>
      <GridOverlay show={gridOverlay} />
@@ -31,7 +31,7 @@ export const ContentBucket2Story = ({ leadArticle, articles, theme, verticalArti
     </>
   </TCThemeProvider>
 );
-ContentBucket2Story.args = {
+LeadStory2Story.args = {
   theme: 'TimesWebLightTheme',
 };
 
@@ -54,6 +54,6 @@ ContentBucket2Story.args = {
     },
   }}
 >
-  {ContentBucket2Story.bind({})}
+  {LeadStory2Story.bind({})}
 </Story>
 

--- a/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -343,7 +343,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     class="css-5pczz7"
                   />
                   <img
-                    alt="Short title of the card describing the main content"
+                    alt="This is ALT Text"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7c246bf4-fa83-11ed-9be0-622d8a105167.jpg?crop=1200%2C1500%2C0%2C0&resize=747"
                   />
@@ -1322,7 +1322,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="css-5pczz7"
                   />
                   <img
-                    alt="Short title of the card describing the main content"
+                    alt="This is ALT Text"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7c246bf4-fa83-11ed-9be0-622d8a105167.jpg?crop=1200%2C1500%2C0%2C0&resize=747"
                   />
@@ -2082,7 +2082,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="css-5pczz7"
                   />
                   <img
-                    alt="Short title of the card describing the main content"
+                    alt="This is ALT Text"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7c246bf4-fa83-11ed-9be0-622d8a105167.jpg?crop=1200%2C1500%2C0%2C0&resize=747"
                   />
@@ -3021,7 +3021,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="css-5pczz7"
                   />
                   <img
-                    alt="Short title of the card describing the main content"
+                    alt="This is ALT Text"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7c246bf4-fa83-11ed-9be0-622d8a105167.jpg?crop=1200%2C1500%2C0%2C0&resize=747"
                   />

--- a/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -692,6 +692,18 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                 class="css-1atazsr"
                 data-testid="tag-and-flag"
               >
+                <a
+                  class="css-10d4t8c"
+                  href=""
+                >
+                  <span
+                    class="css-17x5lw"
+                  >
+                    <span
+                      class="css-zhtub2"
+                    />
+                  </span>
+                </a>
                 <span
                   class="css-1vzvkql"
                 >
@@ -852,6 +864,18 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       class="css-1atazsr"
                       data-testid="tag-and-flag"
                     >
+                      <a
+                        class="css-10d4t8c"
+                        href=""
+                      >
+                        <span
+                          class="css-17x5lw"
+                        >
+                          <span
+                            class="css-zhtub2"
+                          />
+                        </span>
+                      </a>
                       <span
                         class="css-1vzvkql"
                       >
@@ -1621,6 +1645,18 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="css-1atazsr"
                     data-testid="tag-and-flag"
                   >
+                    <a
+                      class="css-10d4t8c"
+                      href=""
+                    >
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-zhtub2"
+                        />
+                      </span>
+                    </a>
                     <span
                       class="css-1vzvkql"
                     >
@@ -2375,6 +2411,18 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-1atazsr"
                   data-testid="tag-and-flag"
                 >
+                  <a
+                    class="css-10d4t8c"
+                    href=""
+                  >
+                    <span
+                      class="css-17x5lw"
+                    >
+                      <span
+                        class="css-zhtub2"
+                      />
+                    </span>
+                  </a>
                   <span
                     class="css-1vzvkql"
                   >
@@ -2525,6 +2573,18 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="css-1atazsr"
                     data-testid="tag-and-flag"
                   >
+                    <a
+                      class="css-10d4t8c"
+                      href=""
+                    >
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-zhtub2"
+                        />
+                      </span>
+                    </a>
                     <span
                       class="css-1vzvkql"
                     >
@@ -3290,6 +3350,18 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-1atazsr"
                   data-testid="tag-and-flag"
                 >
+                  <a
+                    class="css-10d4t8c"
+                    href=""
+                  >
+                    <span
+                      class="css-17x5lw"
+                    >
+                      <span
+                        class="css-zhtub2"
+                      />
+                    </span>
+                  </a>
                   <span
                     class="css-1vzvkql"
                   >
@@ -3440,6 +3512,18 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="css-1atazsr"
                     data-testid="tag-and-flag"
                   >
+                    <a
+                      class="css-10d4t8c"
+                      href=""
+                    >
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-zhtub2"
+                        />
+                      </span>
+                    </a>
                     <span
                       class="css-1vzvkql"
                     >

--- a/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -1469,7 +1469,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -1513,7 +1513,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -2224,7 +2224,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -2268,7 +2268,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -2331,7 +2331,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -2385,7 +2385,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -3139,7 +3139,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -3183,7 +3183,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -3246,7 +3246,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div
@@ -3300,7 +3300,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
             </div>
             <hr
               aria-hidden="true"
-              class="css-13rcg9f"
+              class="css-5iyysz"
               data-testid="divider"
             />
             <div

--- a/packages/ts-newskit/src/slices/lead-story-3/article-stack.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-3/article-stack.tsx
@@ -30,7 +30,7 @@ export const ArticleStack = ({
               ? {
                   ...modifiedArticle,
                   textBlockMarginBlockStart: 'space050',
-                  typographyPreset:
+                  headlineTypographyPreset:
                     breakpointKey === 'xs'
                       ? 'editorialHeadline040'
                       : breakpointKey === 'sm'
@@ -39,7 +39,7 @@ export const ArticleStack = ({
                 }
               : {
                   ...modifiedArticle,
-                  typographyPreset: 'editorialHeadline020'
+                  headlineTypographyPreset: 'editorialHeadline020'
                 };
           return (
             <>

--- a/packages/ts-newskit/src/slices/lead-story-3/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-3/index.tsx
@@ -36,7 +36,7 @@ export const LeadStory3 = ({
 
   const modifedLeadArticle = {
     ...leadArticle,
-    typographyPreset: 'editorialHeadline040',
+    headlineTypographyPreset: 'editorialHeadline040',
     imageTop: true,
     hasTopBorder: false,
     loadingAspectRatio: '4:5'

--- a/packages/ts-newskit/src/slices/lead-story-3/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-3/index.tsx
@@ -34,13 +34,18 @@ export const LeadStory3 = ({
 
   const screenXsAndSm = breakpointKey === 'xs' || breakpointKey === 'sm';
 
-  const modifedLeadArticles = {
+  const modifedLeadArticle = {
     ...leadArticle,
     typographyPreset: 'editorialHeadline040',
     imageTop: true,
+    hasTopBorder: false,
     loadingAspectRatio: '4:5'
   };
 
+  const modifedLeadArticles = leadArticles.map(article => ({
+    ...article,
+    hasTopBorder: false
+  }));
   const LeadStoryLayout: React.FC = ({ children }) => {
     return (
       <Block marginBlockEnd={{ xs: 'space040', md: 'space000' }}>
@@ -74,7 +79,7 @@ export const LeadStory3 = ({
         }}
       >
         <ArticleStack
-          leadArticles={leadArticles}
+          leadArticles={modifedLeadArticles}
           breakpointKey={breakpointKey}
         />
       </StackItem>
@@ -104,7 +109,7 @@ export const LeadStory3 = ({
         </Hidden>
         <Block>
           <LeadStoryLayout>
-            <LeadArticle {...modifedLeadArticles} />
+            <LeadArticle {...modifedLeadArticle} />
           </LeadStoryLayout>
         </Block>
       </StackItem>

--- a/packages/ts-newskit/src/slices/shared-styles/index.ts
+++ b/packages/ts-newskit/src/slices/shared-styles/index.ts
@@ -25,6 +25,10 @@ export const AvatarDivider = styled(Divider)`
   }
 `;
 
+export const StyledDivider = styled(Divider)`
+  height: auto;
+`;
+
 export const StackItem = styled(Stack)<{
   $width?: { xs?: string; sm?: string; md?: string; lg?: string; xl?: string };
 }>`

--- a/packages/ts-newskit/src/slices/shared/article-stacks.tsx
+++ b/packages/ts-newskit/src/slices/shared/article-stacks.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Block, BreakpointKeys, Divider, GridLayout, Scroll } from 'newskit';
 import { Article, ArticleProps } from '../../components/slices/article';
-import { StackItem } from '../shared-styles';
+import { StackItem, StyledDivider } from '../shared-styles';
 import { ComposedArticleStack } from './composed-article-stack';
 
 export const ArticleStackLarge = ({
@@ -28,7 +28,10 @@ export const ArticleStackLarge = ({
         const articleBorder = breakpoint !== 'lg' &&
           breakpoint !== 'xl' &&
           articleIndex < articleArr.length - 1 && (
-            <Divider overrides={{ stylePreset: 'lightDivider' }} vertical />
+            <StyledDivider
+              overrides={{ stylePreset: 'lightDivider' }}
+              vertical
+            />
           );
         const topArticle = articleIndex === 0;
         const articleTopBorder =

--- a/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -162,7 +162,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -225,7 +225,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -370,7 +370,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -431,7 +431,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -478,7 +478,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -633,7 +633,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -710,7 +710,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -773,7 +773,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -918,7 +918,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -979,7 +979,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div
@@ -1026,7 +1026,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
         </div>
         <hr
           aria-hidden="true"
-          class="css-13rcg9f"
+          class="css-5iyysz"
           data-testid="divider"
         />
         <div

--- a/packages/ts-newskit/src/slices/stacked-module-1/index.tsx
+++ b/packages/ts-newskit/src/slices/stacked-module-1/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Article, ArticleProps } from '../../components/slices/article';
 import { FullWidthBlock } from '../../components/slices/shared-styles';
 import { CustomStackLayout } from '../shared';
-import { StackItem } from '../shared-styles';
+import { StackItem, StyledDivider } from '../shared-styles';
 
 export interface StackModule1Props {
   articles: ArticleProps[];
@@ -51,7 +51,10 @@ const articleStack = ({
           const articleBorder = articleIndex < articleArr.length - 1 &&
             !isMob &&
             articleIndex !== 3 && (
-              <Divider overrides={{ stylePreset: 'lightDivider' }} vertical />
+              <StyledDivider
+                overrides={{ stylePreset: 'lightDivider' }}
+                vertical
+              />
             );
 
           const hasImage = isMob && articleIndex > 0;


### PR DESCRIPTION
This PR addresses an issue with the height of the divider component on the Safari browser. Previously, the divider had a fixed height of 100% as the default, which caused rendering issues specifically on Safari. To resolve this issue, I have made a modification by adding height: auto to the divider component.