### PR TITLE
 feat(TMST-722): limited puzzle and story images sizes

### DIFF
--- a/packages/ts-newskit/src/components/puzzles/cards-container/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/cards-container/__tests__/__snapshots__/index.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -174,7 +174,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -268,7 +268,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -303,7 +303,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -397,7 +397,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -432,7 +432,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -526,7 +526,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -561,7 +561,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -655,7 +655,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -690,7 +690,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -784,7 +784,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -819,7 +819,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -913,7 +913,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -948,7 +948,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -1042,7 +1042,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -1077,7 +1077,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -1212,7 +1212,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -1247,7 +1247,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -1341,7 +1341,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -1376,7 +1376,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -1470,7 +1470,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -1505,7 +1505,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -1599,7 +1599,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -1634,7 +1634,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -1728,7 +1728,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -1763,7 +1763,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -1857,7 +1857,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -1892,7 +1892,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -1986,7 +1986,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -2021,7 +2021,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>
@@ -2115,7 +2115,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1jtzw40"
             >
               <div
                 class="css-1kwj960"
@@ -2150,7 +2150,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                   </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1qgqq71"
+                    class="css-1km3pto"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
                   />
                 </picture>

--- a/packages/ts-newskit/src/components/puzzles/cards-container/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/cards-container/__tests__/__snapshots__/index.test.tsx.snap
@@ -146,36 +146,12 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -275,36 +251,12 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -404,36 +356,12 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -533,36 +461,12 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -662,36 +566,12 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -791,36 +671,12 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -920,36 +776,12 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -1049,36 +881,12 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -1219,36 +1027,12 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -1348,36 +1132,12 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -1477,36 +1237,12 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -1606,36 +1342,12 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -1735,36 +1447,12 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -1864,36 +1552,12 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -1993,36 +1657,12 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -2122,36 +1762,12 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 data-testid="puzzle-image"
               >
                 <picture
-                  class="css-2pubdt"
+                  class="css-om84o6"
                 >
-                  <div
-                    class="css-5pczz7"
-                  >
-                    <div
-                      class="css-1q2lbmy"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                        fill="currentColor"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
                   <img
                     alt="Puzzle Name"
-                    class="css-1km3pto"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+                    class="css-1955ygm"
+                    loading="lazy"
                   />
                 </picture>
               </div>

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/__tests__/__snapshots__/PuzzleCard.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/__tests__/__snapshots__/PuzzleCard.test.tsx.snap
@@ -13,36 +13,12 @@ exports[`Puzzle Card should render Puzzle Card 1`] = `
         data-testid="puzzle-image"
       >
         <picture
-          class="css-2pubdt"
+          class="css-om84o6"
         >
-          <div
-            class="css-5pczz7"
-          >
-            <div
-              class="css-1q2lbmy"
-            >
-              <svg
-                aria-hidden="true"
-                class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                fill="currentColor"
-                focusable="false"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M0 0h24v24H0V0z"
-                  fill="none"
-                />
-                <path
-                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                />
-              </svg>
-            </div>
-          </div>
           <img
             alt="Polygon"
-            class="css-1km3pto"
-            src="https://www.uat-thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
+            class="css-1955ygm"
+            loading="lazy"
           />
         </picture>
       </div>

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/__tests__/__snapshots__/PuzzleCard.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/__tests__/__snapshots__/PuzzleCard.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Puzzle Card should render Puzzle Card 1`] = `
     class="css-kjwcwf"
   >
     <div
-      class="css-17csqz3"
+      class="css-1jtzw40"
     >
       <div
         class="css-1kwj960"
@@ -41,7 +41,7 @@ exports[`Puzzle Card should render Puzzle Card 1`] = `
           </div>
           <img
             alt="Polygon"
-            class="css-1qgqq71"
+            class="css-1km3pto"
             src="https://www.uat-thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0"
           />
         </picture>

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/index.tsx
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/index.tsx
@@ -48,6 +48,7 @@ export const PuzzleCard = ({ data }: PuzzleCardProps) => {
               alt: data.title || 'Puzzle thumbnail',
               src: imageUrl,
               placeholderIcon: true,
+              fit: 'cover',
               overrides: {
                 stylePreset: 'puzzleCardMedia'
               }

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/index.tsx
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/index.tsx
@@ -49,6 +49,7 @@ export const PuzzleCard = ({ data }: PuzzleCardProps) => {
               src: imageUrl,
               placeholderIcon: true,
               fit: 'cover',
+              loading: 'lazy',
               overrides: {
                 stylePreset: 'puzzleCardMedia'
               }

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/styles.ts
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/styles.ts
@@ -16,6 +16,10 @@ export const PuzzleCardImgWrapper = styled(Block)`
   justify-content: center;
   align-items: center;
   align-self: flex-start;
+
+  img {
+    aspect-ratio: 3/2;
+  }
 `;
 
 export const StyledNewsKitPuzzlePlaceholder = styled(NewsKitPuzzlePlaceholder)`

--- a/packages/ts-newskit/src/components/puzzles/story-card-listing/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/story-card-listing/__tests__/__snapshots__/index.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
           class="css-9fndha"
         >
           <div
-            class="css-1kwj960"
+            class="css-1lxmnox"
           >
             <picture
               class="css-zp0elg"
@@ -73,7 +73,7 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
               </div>
               <img
                 alt="ChatGPT invents Sudoku-style puzzle to keep the humans busy"
-                class="css-1qgqq71"
+                class="css-1km3pto"
                 src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F086a8da2-dec6-11ed-9cc2-0f7e26ed83eb.jpg?crop=3995%2C2247%2C0%2C208&resize=498"
               />
             </picture>
@@ -178,7 +178,7 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
           class="css-11l110t"
         >
           <div
-            class="css-1kwj960"
+            class="css-1lxmnox"
           >
             <picture
               class="css-zp0elg"
@@ -209,7 +209,7 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
               </div>
               <img
                 alt="Early birds from across globe make camp in The Mall"
-                class="css-1qgqq71"
+                class="css-1km3pto"
                 src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F086a8da2-dec6-11ed-9cc2-0f7e26ed83eb.jpg?crop=3995%2C2247%2C0%2C208&resize=498"
               />
             </picture>
@@ -314,7 +314,7 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
           class="css-11l110t"
         >
           <div
-            class="css-1kwj960"
+            class="css-1lxmnox"
           >
             <picture
               class="css-zp0elg"
@@ -345,7 +345,7 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
               </div>
               <img
                 alt="A dish best served cold: Rees-Mogg takes revenge on quiche"
-                class="css-1qgqq71"
+                class="css-1km3pto"
                 src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F086a8da2-dec6-11ed-9cc2-0f7e26ed83eb.jpg?crop=3995%2C2247%2C0%2C208&resize=498"
               />
             </picture>
@@ -450,7 +450,7 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
           class="css-11l110t"
         >
           <div
-            class="css-1kwj960"
+            class="css-1lxmnox"
           >
             <picture
               class="css-zp0elg"
@@ -481,7 +481,7 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
               </div>
               <img
                 alt="Hour-by-hour guide to a day of remarkable ceremony"
-                class="css-1qgqq71"
+                class="css-1km3pto"
                 src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F086a8da2-dec6-11ed-9cc2-0f7e26ed83eb.jpg?crop=3995%2C2247%2C0%2C208&resize=498"
               />
             </picture>

--- a/packages/ts-newskit/src/components/puzzles/story-card-listing/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/story-card-listing/__tests__/__snapshots__/index.test.tsx.snap
@@ -45,36 +45,12 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
             class="css-1lxmnox"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              >
-                <div
-                  class="css-1q2lbmy"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0 0h24v24H0V0z"
-                      fill="none"
-                    />
-                    <path
-                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                    />
-                  </svg>
-                </div>
-              </div>
               <img
                 alt="ChatGPT invents Sudoku-style puzzle to keep the humans busy"
-                class="css-1km3pto"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F086a8da2-dec6-11ed-9cc2-0f7e26ed83eb.jpg?crop=3995%2C2247%2C0%2C208&resize=498"
+                class="css-1955ygm"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -181,36 +157,12 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
             class="css-1lxmnox"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              >
-                <div
-                  class="css-1q2lbmy"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0 0h24v24H0V0z"
-                      fill="none"
-                    />
-                    <path
-                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                    />
-                  </svg>
-                </div>
-              </div>
               <img
                 alt="Early birds from across globe make camp in The Mall"
-                class="css-1km3pto"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F086a8da2-dec6-11ed-9cc2-0f7e26ed83eb.jpg?crop=3995%2C2247%2C0%2C208&resize=498"
+                class="css-1955ygm"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -317,36 +269,12 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
             class="css-1lxmnox"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              >
-                <div
-                  class="css-1q2lbmy"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0 0h24v24H0V0z"
-                      fill="none"
-                    />
-                    <path
-                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                    />
-                  </svg>
-                </div>
-              </div>
               <img
                 alt="A dish best served cold: Rees-Mogg takes revenge on quiche"
-                class="css-1km3pto"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F086a8da2-dec6-11ed-9cc2-0f7e26ed83eb.jpg?crop=3995%2C2247%2C0%2C208&resize=498"
+                class="css-1955ygm"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -453,36 +381,12 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
             class="css-1lxmnox"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              >
-                <div
-                  class="css-1q2lbmy"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0 0h24v24H0V0z"
-                      fill="none"
-                    />
-                    <path
-                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                    />
-                  </svg>
-                </div>
-              </div>
               <img
                 alt="Hour-by-hour guide to a day of remarkable ceremony"
-                class="css-1km3pto"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F086a8da2-dec6-11ed-9cc2-0f7e26ed83eb.jpg?crop=3995%2C2247%2C0%2C208&resize=498"
+                class="css-1955ygm"
+                loading="lazy"
               />
             </picture>
           </div>

--- a/packages/ts-newskit/src/components/puzzles/storyCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/storyCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -24,36 +24,12 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
           class="css-1lxmnox"
         >
           <picture
-            class="css-zp0elg"
+            class="css-l4lngz"
           >
-            <div
-              class="css-5pczz7"
-            >
-              <div
-                class="css-1q2lbmy"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="css-2xpd25-EmotionIconBase ex0cdmw0"
-                  fill="currentColor"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M0 0h24v24H0V0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z"
-                  />
-                </svg>
-              </div>
-            </div>
             <img
               alt="Some alt text"
-              class="css-1km3pto"
-              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F086a8da2-dec6-11ed-9cc2-0f7e26ed83eb.jpg?crop=3995%2C2247%2C0%2C208&resize=498"
+              class="css-1955ygm"
+              loading="lazy"
             />
           </picture>
         </div>

--- a/packages/ts-newskit/src/components/puzzles/storyCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/storyCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
         class="css-9fndha"
       >
         <div
-          class="css-1kwj960"
+          class="css-1lxmnox"
         >
           <picture
             class="css-zp0elg"
@@ -52,7 +52,7 @@ exports[`Render puzzles story card should render a snapshot 1`] = `
             </div>
             <img
               alt="Some alt text"
-              class="css-1qgqq71"
+              class="css-1km3pto"
               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F086a8da2-dec6-11ed-9cc2-0f7e26ed83eb.jpg?crop=3995%2C2247%2C0%2C208&resize=498"
             />
           </picture>

--- a/packages/ts-newskit/src/components/puzzles/storyCard/index.tsx
+++ b/packages/ts-newskit/src/components/puzzles/storyCard/index.tsx
@@ -52,7 +52,8 @@ export const StoryCard: FC<StoryCardProps> = ({
                 alt: altText || title,
                 src: image,
                 placeholderIcon: true,
-                fit: 'cover'
+                fit: 'cover',
+                loading: 'lazy'
               }}
             />
           ) : (

--- a/packages/ts-newskit/src/components/puzzles/storyCard/index.tsx
+++ b/packages/ts-newskit/src/components/puzzles/storyCard/index.tsx
@@ -8,11 +8,11 @@ import {
   Visible,
   CardLink,
   Headline,
-  CardMedia,
   GridLayout,
   Divider
 } from 'newskit';
 
+import { ImgWrap } from './styles';
 export interface StoryCardProps {
   image?: string;
   altText?: string;
@@ -46,12 +46,13 @@ export const StoryCard: FC<StoryCardProps> = ({
       <CardComposable>
         <Visible xs={!imgHiddenMobile} sm={!imgHiddenMobile} md lg xl>
           {image ? (
-            <CardMedia
+            <ImgWrap
               media={{
                 loadingAspectRatio: '3:2',
                 alt: altText || title,
                 src: image,
-                placeholderIcon: true
+                placeholderIcon: true,
+                fit: 'cover'
               }}
             />
           ) : (

--- a/packages/ts-newskit/src/components/puzzles/storyCard/styles.ts
+++ b/packages/ts-newskit/src/components/puzzles/storyCard/styles.ts
@@ -1,0 +1,7 @@
+import { styled, CardMedia } from 'newskit';
+
+export const ImgWrap = styled(CardMedia)`
+  img {
+    aspect-ratio: 3/2;
+  }
+`;


### PR DESCRIPTION
Release-1 feedback: Text on puzzle cards jumps when image loads [TMST-726](https://nidigitalsolutions.jira.com/jira/software/c/projects/TMST/boards/1608?modal=detail&selectedIssue=TMST-726)

- added limit for aspect ration on puzzle card and story card images
- if images is different aspect ration then 3/2, it will be readjusted to 3/2 ratio
- added lazy loading for images

![image](https://github.com/newsuk/times-components/assets/129039019/71d4ceba-1c70-4a13-a21b-bbf22deb3441)


[TMST-726]: https://nidigitalsolutions.jira.com/browse/TMST-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ