### PR TITLE
feat(TMST-726): Text on puzzle cards jumps when image loads

### DIFF
--- a/packages/ts-newskit/src/components/puzzles/cards-container/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/cards-container/__tests__/__snapshots__/index.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -268,7 +268,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -397,7 +397,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -526,7 +526,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -655,7 +655,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -784,7 +784,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -913,7 +913,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -1042,7 +1042,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -1212,7 +1212,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -1341,7 +1341,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -1470,7 +1470,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -1599,7 +1599,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -1728,7 +1728,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -1857,7 +1857,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -1986,7 +1986,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"
@@ -2115,7 +2115,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-kjwcwf"
           >
             <div
-              class="css-17csqz3"
+              class="css-1bse6cu"
             >
               <div
                 class="css-1kwj960"

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/__tests__/PuzzleCard.test.tsx
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/__tests__/PuzzleCard.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import { render } from '../../../../utils/test-utils';
 import { puzzles } from '../fixtures/data.json';
 import { PuzzleCard } from '../index';
+import { NewsKitPuzzlePlaceholder } from '../assets';
 
 const renderComponent = () => render(<PuzzleCard data={puzzles.list[0]} />);
 
@@ -26,5 +27,14 @@ describe('Puzzle Card', () => {
       const placeholder = getByTestId('puzzle-placeholder');
       expect(placeholder).toBeInTheDocument();
     }
+  });
+
+  it('renders NewsKitPuzzlePlaceholder component', () => {
+    const { container } = render(<NewsKitPuzzlePlaceholder />);
+
+    expect(container).toBeInTheDocument();
+
+    const svgElement = container.querySelector('svg');
+    expect(svgElement).toBeInTheDocument();
   });
 });

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/__tests__/__snapshots__/PuzzleCard.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/__tests__/__snapshots__/PuzzleCard.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Puzzle Card should render Puzzle Card 1`] = `
     class="css-kjwcwf"
   >
     <div
-      class="css-17csqz3"
+      class="css-1bse6cu"
     >
       <div
         class="css-1kwj960"

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/styles.ts
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/styles.ts
@@ -1,4 +1,10 @@
-import { styled, Block, getColorCssFromTheme, CardComposable } from 'newskit';
+import {
+  styled,
+  Block,
+  getColorCssFromTheme,
+  CardComposable,
+  getMediaQueryFromTheme
+} from 'newskit';
 import { NewsKitPuzzlePlaceholder } from './assets';
 
 export const Wrap = styled(Block)`
@@ -16,6 +22,20 @@ export const PuzzleCardImgWrapper = styled(Block)`
   justify-content: center;
   align-items: center;
   align-self: flex-start;
+  min-height: 50%;
+
+  ${getMediaQueryFromTheme('sm')} {
+    min-height: 51%;
+  }
+  ${getMediaQueryFromTheme('md')} {
+    min-height: 55%;
+  }
+  ${getMediaQueryFromTheme('lg')} {
+    min-height: 68%;
+  }
+  ${getMediaQueryFromTheme('xl')} {
+    min-height: 74%;
+  }
 `;
 
 export const StyledNewsKitPuzzlePlaceholder = styled(NewsKitPuzzlePlaceholder)`


### PR DESCRIPTION
Release-1 feedback: Text on puzzle cards jumps when image loads [TMST-726](https://nidigitalsolutions.jira.com/jira/software/c/projects/TMST/boards/1608?modal=detail&selectedIssue=TMST-726)

- Added minimum height for puzzle card image wrapper so that it occupies the same space before the image loads.
- Added test case for puzzle card placeholder coverage

[TMST-726]: https://nidigitalsolutions.jira.com/browse/TMST-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ