### PR TITLE
feat(TMST-751): removed puzzle card unecesary components

### DIFF
--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/PuzzleCard.stories.mdx
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/PuzzleCard.stories.mdx
@@ -31,10 +31,6 @@ export const PuzzleCardStory = ({data}) => (
 
 <Story
   name="PuzzleCard"
-  argTypes={{
-    publishedAt: { control: 'date' },
-    status: { control: "select", options: ["COMPLETE", "IN PROGRESS"] }
-  }}
   args={{ data: puzzles.list[0] }}
 >
   {PuzzleCardStory.bind({})}

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/__tests__/__snapshots__/PuzzleCard.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/__tests__/__snapshots__/PuzzleCard.test.tsx.snap
@@ -22,6 +22,20 @@ exports[`Puzzle Card should render Puzzle Card 1`] = `
           />
         </picture>
       </div>
+      <div
+        class="css-593iq0"
+      >
+        <div
+          class="css-7el6ft"
+          data-testid="flag"
+        >
+          <span
+            class="css-1x1ve0y"
+          >
+            COMPLETE
+          </span>
+        </div>
+      </div>
     </div>
     <div
       class="css-5p0hht"

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/fixtures/data.json
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/fixtures/data.json
@@ -9,7 +9,7 @@
                 "title": "Polygon",
                 "type": "WordPuzzles",
                 "publishedAt": "Sat Mar 04 2023 00:00:00 GMT+0100 (Central European Standard Time)",
-                "status": "",
+                "status": "COMPLETE",
                 "gameLevel": "Jumbo",
                 "url": "https://www.newskit.co.uk/components/accordion/",
                 "image": {


### PR DESCRIPTION
Puzzle card - controls not working in story book [TMST-751](https://nidigitalsolutions.jira.com/browse/TMST-751)

- removed controls for date and status because these parameters are now passed trough data object

[TMST-751]: https://nidigitalsolutions.jira.com/browse/TMST-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ