### PR TITLE
chore(TMRX-0000): added export for newskit themes

### DIFF
--- a/packages/ts-newskit/src/index.ts
+++ b/packages/ts-newskit/src/index.ts
@@ -1,6 +1,10 @@
 export { TCThemeProvider } from './utils/TCThemeProvider';
 export { InArticleAudio } from './components/article-audio';
 
+//THEMES
+export { TimesWebLightTheme } from './theme/times-web-light';
+export { TimesWebLightSportTheme } from './theme/times-web-light-sport';
+
 // NAVIGATION
 export { Breadcrumb } from './components/navigation/breadcrumb';
 export { GlobalNav } from './components/navigation/global-nav';

--- a/packages/ts-newskit/src/index.ts
+++ b/packages/ts-newskit/src/index.ts
@@ -1,7 +1,7 @@
 export { TCThemeProvider } from './utils/TCThemeProvider';
 export { InArticleAudio } from './components/article-audio';
 
-//THEMES
+// THEMES
 export { TimesWebLightTheme } from './theme/times-web-light';
 export { TimesWebLightSportTheme } from './theme/times-web-light-sport';
 


### PR DESCRIPTION
Just added the export for the Times themes for newskit 7
