### PR TITLE
Revert "fix(TMRX-1314): Try to fix breakpoint key issue"

### DIFF
--- a/packages/ts-newskit/src/slices/lead-story-2/article-stacks.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-2/article-stacks.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import {
   Block,
+  BreakpointKeys,
   Divider,
   GridLayout,
   Stack,
-  Visible,
-  BreakpointKeys
+  Visible
 } from 'newskit';
 import {
   LeadArticle,

--- a/packages/ts-newskit/src/slices/lead-story-2/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-2/index.tsx
@@ -1,12 +1,5 @@
-import {
-  Block,
-  Divider,
-  Stack,
-  useBreakpointKey,
-  Visible,
-  BreakpointKeys
-} from 'newskit';
-import React, { useState, useEffect } from 'react';
+import { Block, Divider, Stack, useBreakpointKey, Visible } from 'newskit';
+import React from 'react';
 import {
   LeadArticle,
   LeadArticleProps
@@ -30,25 +23,17 @@ export const LeadStory2 = ({
   verticalArticles,
   horizontalArticles
 }: LeadStory2Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xs');
   const breakpointKey = useBreakpointKey();
-  useEffect(
-    () => {
-      setBreakpoint(breakpointKey);
-    },
-    [breakpointKey]
-  );
 
   const modifedArticles =
-    currentBreakpoint === 'xl'
+    breakpointKey === 'xl'
       ? articles.map(article => ({
           ...article,
           imageRight: true
         }))
       : articles;
 
-  const screenXsAndSm =
-    currentBreakpoint === 'xs' || currentBreakpoint === 'sm';
+  const screenXsAndSm = breakpointKey === 'xs' || breakpointKey === 'sm';
 
   const modifiedLeadArticle = {
     ...leadArticle,
@@ -56,9 +41,9 @@ export const LeadStory2 = ({
     hasTopBorder: false,
     textBlockMarginBlockStart: 'space050',
     headlineTypographyPreset:
-      currentBreakpoint === 'xs'
+      breakpointKey === 'xs'
         ? 'editorialHeadline040'
-        : currentBreakpoint === 'sm'
+        : breakpointKey === 'sm'
           ? 'editorialHeadline050'
           : 'editorialHeadline060'
   };
@@ -93,7 +78,7 @@ export const LeadStory2 = ({
             />
           </Visible>
           <LeadArticle
-            contentWidth={currentBreakpoint === 'xl' ? '274px' : '246px'}
+            contentWidth={breakpointKey === 'xl' ? '274px' : '246px'}
             {...modifiedLeadArticle}
           />
           {screenXsAndSm ? (
@@ -116,10 +101,10 @@ export const LeadStory2 = ({
           )}
           <ArticleStack
             verticalArticles={verticalArticles}
-            breakpoint={currentBreakpoint}
+            breakpoint={breakpointKey}
             horizontalArticles={horizontalArticles}
             horizontalArticleContentWidth={
-              currentBreakpoint === 'xl' ? '258px' : '230px'
+              breakpointKey === 'xl' ? '258px' : '230px'
             }
           />
         </Block>
@@ -128,14 +113,14 @@ export const LeadStory2 = ({
         <BlockItem marginBlockStart="space040">
           <ComposedArticleStack
             articles={modifedArticles}
-            breakpoint={currentBreakpoint}
+            breakpoint={breakpointKey}
           />
         </BlockItem>
       ) : (
         <ArticleStackLeadStory
           mdWidth="722px"
           modifedArticles={modifedArticles}
-          breakpoint={currentBreakpoint}
+          breakpoint={breakpointKey}
         />
       )}
     </Stack>

--- a/packages/ts-newskit/src/slices/shared/article-stacks.tsx
+++ b/packages/ts-newskit/src/slices/shared/article-stacks.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Block, Divider, GridLayout, BreakpointKeys } from 'newskit';
+import { Block, BreakpointKeys, Divider, GridLayout } from 'newskit';
 import { Article, ArticleProps } from '../../components/slices/article';
 import { StackItem, StyledDivider, ScrollContainer } from '../shared-styles';
 import { ComposedArticleStack } from './composed-article-stack';


### PR DESCRIPTION
Reverts newsuk/times-components#3440 :( Didn't work. Seems to be a problem with useBreakpointKey hook - doesn't run until you resize and defaults to 'xs' which is why we get a weird view.