### PR TITLE
fix(TMRX-1314): Replace props so that current slices not affected by summary formatting

### DIFF
--- a/packages/ts-newskit/src/components/slices/lead-article/LeadArticle.stories.mdx
+++ b/packages/ts-newskit/src/components/slices/lead-article/LeadArticle.stories.mdx
@@ -23,9 +23,9 @@ This takes in a series of props, as below, to display the part of the slices.
 ## View Component
 Please click the 'Canvas' tab for a better viewing experience, where you can update the props and review at the different breakpoints by clicking the preview icon and selecting from our list of pre-defined breakpoints (XS, SM, MD, LG and XL).
 
-export const LeadArticleStory = ({headline, color, flag, summary, bylines, tagL1, caption, images, url, tag, imageTop}) => (
+export const LeadArticleStory = ({headline, color, flag, standfirst, bylines, tagL1, caption, images, url, tag, imageTop}) => (
   <NewsKitProvider theme={TimesWebLightTheme}>
-    <LeadArticle {...{headline, color, flag, summary, bylines, tagL1, caption, images, url, tag, imageTop}} />
+    <LeadArticle {...{headline, color, flag, standfirst, bylines, tagL1, caption, images, url, tag, imageTop}} />
   </NewsKitProvider>
 );
 

--- a/packages/ts-newskit/src/components/slices/lead-article/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-article/__tests__/index.test.tsx
@@ -28,11 +28,11 @@ describe('Render Component one', () => {
     expect(headlineText).toBeInTheDocument();
   });
 
-  it('should render correct summary', () => {
+  it('should render correct standfirst', () => {
     const { getByText } = renderComponent();
 
-    const summaryText = getByText(leadArticle.summary);
-    expect(summaryText).toBeInTheDocument();
+    const standfirstText = getByText(leadArticle.standfirst);
+    expect(standfirstText).toBeInTheDocument();
   });
   it('should render correct readingTime', () => {
     const { getByText } = renderComponent();

--- a/packages/ts-newskit/src/components/slices/lead-article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-article/index.tsx
@@ -32,7 +32,7 @@ type ImageProps = {
 export interface LeadArticleProps {
   headline: string;
   flag?: string;
-  summary?: string;
+  standfirst?: string;
   tagL1?: {
     label: string;
     href: string;
@@ -59,7 +59,7 @@ export interface LeadArticleProps {
 export const LeadArticle = ({
   headline,
   flag,
-  summary,
+  standfirst,
   tagL1,
   images,
   url,
@@ -183,7 +183,7 @@ export const LeadArticle = ({
         >
           {headline}
         </CardHeadlineLink>
-        {summary && (
+        {standfirst && (
           <TextBlock
             typographyPreset={{
               xs: 'editorialParagraph020',
@@ -192,7 +192,7 @@ export const LeadArticle = ({
             marginBlockStart={textBlockMarginBlockStart}
             as="p"
           >
-            {summary}
+            {standfirst}
           </TextBlock>
         )}
         <TagAndFlag

--- a/packages/ts-newskit/src/components/slices/shared/GroupedArticle.stories.mdx
+++ b/packages/ts-newskit/src/components/slices/shared/GroupedArticle.stories.mdx
@@ -37,12 +37,12 @@ export const GroupedArticleStory = ({tagL1 , articles}) => (
   articles:[
   {
     "headline": "Short title of the card describing the main content",
-    "summary": "Short paragraph description of the article, outlining main story and focus.",
+    "standfirst": "Short paragraph description of the article, outlining main story and focus.",
     "url": "https://www.thetimes.co.uk",
   },
   {
     "headline": "Short title of the card describing the main content",
-    "summary": "Short paragraph description of the article, outlining main story and focus.",
+    "standfirst": "Short paragraph description of the article, outlining main story and focus.",
     "url": "https://www.thetimes.co.uk",
   }
 ]}}>

--- a/packages/ts-newskit/src/slices/fixtures/data.json
+++ b/packages/ts-newskit/src/slices/fixtures/data.json
@@ -6,7 +6,7 @@
       "href": ""
     },
     "headline": "Sarcacens an inclusive club? They didnt look out for me",
-    "summary": "Lyon lock Joel Kpoku tells Will Kelleher that he’s fired up to face old team — and urges more English stars to move to France",
+    "standfirst": "Lyon lock Joel Kpoku tells Will Kelleher that he’s fired up to face old team — and urges more English stars to move to France",
     "images": {
       "alt": "",
       "caption": "Caption",

--- a/packages/ts-newskit/src/slices/fixtures/lead-story.json
+++ b/packages/ts-newskit/src/slices/fixtures/lead-story.json
@@ -5,7 +5,7 @@
       "href": ""
     },
     "headline": "Sarcacens an inclusive club? They didnt look out for me",
-    "summary": "Lyon lock Joel Kpoku tells Will Kelleher that he’s fired up to face old team — and urges more English stars to move to France",
+    "standfirst": "Lyon lock Joel Kpoku tells Will Kelleher that he’s fired up to face old team — and urges more English stars to move to France",
     "images": {
       "alt": "",
       "caption": "Caption",
@@ -253,7 +253,7 @@
       "crops": []
     },
     "headline": "Short title of the card describing the main content",
-    "summary": "Short paragraph description of the article, outlining main story and focus.",
+    "standfirst": "Short paragraph description of the article, outlining main story and focus.",
     "tag": {
       "label": "Tag",
       "href": "/"
@@ -343,7 +343,7 @@
           ]
         },
         "headline": "Short title of the card describing the main content",
-        "summary": "Short paragraph description of the article, outlining main story and focus.",
+        "standfirst": "Short paragraph description of the article, outlining main story and focus.",
         "url": "#",
         "tag": {
           "label": "",
@@ -388,7 +388,7 @@
           ]
         },
         "headline": "Short title of the card describing the main content 2",
-        "summary": "Short paragraph description of the article, outlining main story and focus.",
+        "standfirst": "Short paragraph description of the article, outlining main story and focus.",
         "url": "#",
         "tag": {
           "label": "",
@@ -517,7 +517,7 @@
         ]
       },
       "headline": "Short title of the card describing the main content",
-      "summary": "Short paragraph description of the article, outlining main story and focus.",
+      "standfirst": "Short paragraph description of the article, outlining main story and focus.",
       "url": "https://www.thetimes.co.uk",
       "tag": {
         "label": "Tag",
@@ -562,7 +562,7 @@
         ]
       },
       "headline": "Short title of the card describing the main content 2",
-      "summary": "Short paragraph description of the article, outlining main story and focus.",
+      "standfirst": "Short paragraph description of the article, outlining main story and focus.",
       "url": "https://www.thetimes.co.uk",
       "tag": {
         "label": "Tag",
@@ -609,7 +609,7 @@
         ]
       },
       "headline": "Short title of the card describing the main content",
-      "summary": "Short paragraph description of the article, outlining main story and focus.",
+      "standfirst": "Short paragraph description of the article, outlining main story and focus.",
       "url": "https://www.thetimes.co.uk",
       "tag": {
         "label": "Tag",
@@ -654,7 +654,7 @@
         ]
       },
       "headline": "Short title of the card describing the main content 2",
-      "summary": "Short paragraph description of the article, outlining main story and focus.",
+      "standfirst": "Short paragraph description of the article, outlining main story and focus.",
       "url": "https://www.thetimes.co.uk",
       "tag": {
         "label": "Tag",

--- a/packages/ts-newskit/src/slices/fixtures/lead-story3.json
+++ b/packages/ts-newskit/src/slices/fixtures/lead-story3.json
@@ -209,7 +209,7 @@
         "crops": []
       },
       "headline": "Short title of the card describing the main content",
-      "summary": "Short paragraph description of the article, outlining main story and focus.",
+      "standfirst": "Short paragraph description of the article, outlining main story and focus.",
       "url": "https://www.thetimes.co.uk",
       "tag": {
         "label": "Tag",
@@ -229,7 +229,7 @@
         "crops": []
       },
       "headline": "Short title of the card describing the main content",
-      "summary": "Short paragraph description of the article, outlining main story and focus.",
+      "standfirst": "Short paragraph description of the article, outlining main story and focus.",
       "url": "https://www.thetimes.co.uk",
       "tag": {
         "label": "Tag",
@@ -249,7 +249,7 @@
         "crops": []
       },
       "headline": "Short title of the card describing the main content",
-      "summary": "Short paragraph description of the article, outlining main story and focus.",
+      "standfirst": "Short paragraph description of the article, outlining main story and focus.",
       "url": "https://www.thetimes.co.uk",
       "tag": {
         "label": "Tag",
@@ -269,7 +269,7 @@
         "crops": []
       },
       "headline": "Short title of the card describing the main content",
-      "summary": "Short paragraph description of the article, outlining main story and focus.",
+      "standfirst": "Short paragraph description of the article, outlining main story and focus.",
       "url": "https://www.thetimes.co.uk",
       "tag": {
         "label": "Tag",


### PR DESCRIPTION
### Description

Noticed that by formatting the summary in render to check for standfirst and then truncate the summary if not available, it added that summary to existing slices that shouldn't have a summary. We are able to avoid this by renaming the prop standfirst so that other slices don't pick it up. 


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.
