### PR TITLE
fix(TMRX-1408): fixed link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Any of these source files can be debugged directly.
 
 ## Link times-components to the Render project
 
-Follow these steps [here](https://github.com/newsuk/cps-content-render#locally-mount-your-custom-build-of-times-components)
+Follow these steps [here](https://github.com/newsuk/cps-content-render#integrating-with-times-components)
 
 ## Debugging the tests
 


### PR DESCRIPTION
### Description

Currently, the link under “Link times-components to the Render project“ in Times Components' README links to [here](https://github.com/newsuk/cps-content-render#locally-mount-your-custom-build-of-times-components) in cps-content-render. This link does not point to the correct heading of the page. The correct link is [this](https://github.com/newsuk/cps-content-render#integrating-with-times-components).

[JIRA-1408](https://nidigitalsolutions.jira.com/browse/TMRX-1408)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?
