### PR TITLE
fix(TMRX-1312): Add object name to SliceHeader for tracking

### DIFF
--- a/packages/ts-newskit/src/components/slices/slice-header/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/__tests__/index.test.tsx
@@ -39,6 +39,7 @@ describe('Render Header', () => {
     fireEvent.click(getByRole('link'));
     expect(analyticsStream).toHaveBeenCalledWith({
       action: 'Clicked',
+      object: 'SliceHeader',
       attrs: {
         article_parent_name: 'Rugby Union',
         eventTime: '2021-05-03T00:00:00.000Z',

--- a/packages/ts-newskit/src/components/slices/slice-header/index.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/index.tsx
@@ -37,7 +37,11 @@ export const SliceHeader = ({
     fireAnalyticsEvent && fireAnalyticsEvent(clickEvent());
   };
   return (
-    <TrackingContextProvider>
+    <TrackingContextProvider
+      context={{
+        object: 'SliceHeader'
+      }}
+    >
       {({ fireAnalyticsEvent }) => (
         <Block stylePreset="sliceHeaderPreset">
           <Stack


### PR DESCRIPTION
### Description

We need to pass the object name to the tracking event to map with the allow list. 

[TMRX-1312](https://nidigitalsolutions.jira.com/browse/TMRX-1312)

### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMRX-1312]: https://nidigitalsolutions.jira.com/browse/TMRX-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ