### PR TITLE
Render IconButton conditionally in SliceHeader

### DIFF
--- a/packages/ts-newskit/src/components/slices/slice-header/SliceHeader.stories.mdx
+++ b/packages/ts-newskit/src/components/slices/slice-header/SliceHeader.stories.mdx
@@ -39,6 +39,6 @@ export const HeaderStory = ({ title , href}) => (
   </NewsKitProvider>
 );
 
-<Story name="SliceHeader" args={{ title: 'Rugby Union', href : undefined }}>
+<Story name="SliceHeader" args={{ title: 'Rugby Union', href : '/' }}>
   {HeaderStory.bind({})}
 </Story>

--- a/packages/ts-newskit/src/components/slices/slice-header/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/__tests__/index.test.tsx
@@ -49,4 +49,10 @@ describe('Render Header', () => {
       }
     });
   });
+  it('does not render the icon button if no href is supplied', () => {
+    const { queryByRole } = render(
+      <SliceHeader title="Rugby Union" />
+    );
+    expect(queryByRole('link')).toBeFalsy()
+  })
 });

--- a/packages/ts-newskit/src/components/slices/slice-header/index.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/index.tsx
@@ -8,7 +8,7 @@ import {
 
 export interface SliceHeaderProps {
   title: string;
-  href: string;
+  href?: string;
   titleTypographyPreset?: string;
   iconArrowSize?: string;
   iconSize?: FlagSize;
@@ -61,18 +61,20 @@ export const SliceHeader = ({
             >
               {title}
             </TitleBar>
-            <IconButton
-              size={iconSize}
-              overrides={{
-                stylePreset: 'sliceIconPreset',
-                iconSize: iconArrowSize
-              }}
-              role="link"
-              href={href}
-              onClick={() => handleClick(fireAnalyticsEvent)}
-            >
-              <NewsKitChevronRightIcon />
-            </IconButton>
+              {href && (
+                <IconButton
+                size={iconSize}
+                overrides={{
+                  stylePreset: 'sliceIconPreset',
+                  iconSize: iconArrowSize
+                }}
+                role="link"
+                href={href}
+                onClick={() => handleClick(fireAnalyticsEvent)}
+                >
+                <NewsKitChevronRightIcon />
+                </IconButton>
+              )}
           </Stack>
         </Block>
       )}


### PR DESCRIPTION
### Description

Links on Block titles from channel builder are an optional field, so render the icon button only if href is available


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.
