### PR TITLE
feat(TMRX-1444): Update image on mobile web for Lead 1 and Lead 3

### DIFF
--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -44,7 +44,7 @@
     "react-test-renderer": "16.9.0"
   },
   "dependencies": {
-    "@times-components/utils": "6.16.9",
+    "@times-components/utils": "6.16.10",
     "css": "^2.2.1",
     "enzyme-to-json": "3.3.5",
     "hyphenate-style-name": "1.0.2",

--- a/packages/ts-newskit/package.json
+++ b/packages/ts-newskit/package.json
@@ -27,6 +27,7 @@
     "fix:prettier": "prettier \"src/**/*.{ts,tsx}\" \"__tests__/**/*.tsx\" --write",
     "fix:tslint": "tslint --fix --project .",
     "lint": "tslint --project . && prettier \"src/**/*.{ts,tsx}\" --list-different",
+    "prepublishOnly": "yarn transpile && yarn bundle",
     "test:unit": "TZ=UTC jest --coverage",
     "test:unit:updatesnapshot": "TZ=UTC yarn test:unit -u",
     "watch:build": "run-s clean && run-p build:* \"build:module -- -w\"",

--- a/packages/ts-newskit/src/slices/fixtures/lead-story.json
+++ b/packages/ts-newskit/src/slices/fixtures/lead-story.json
@@ -262,7 +262,32 @@
       "alt": "",
       "credits": "Gareth Fuller/Press Association",
       "caption": "Sarcacens an inclusive club? They didnt look out for me",
-      "crops": []
+      "crops": [
+        {
+          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173",
+          "ratio": "3:2"
+        },
+        {
+          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=2497%2C1405%2C1041%2C169",
+          "ratio": "16:9"
+        },
+        {
+          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=2563%2C2563%2C828%2C173",
+          "ratio": "1:1"
+        },
+        {
+          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=1708%2C2563%2C1256%2C173",
+          "ratio": "2:3"
+        },
+        {
+          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=2050%2C2563%2C1085%2C173",
+          "ratio": "4:5"
+        },
+        {
+          "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3203%2C2563%2C508%2C173",
+          "ratio": "5:4"
+        }
+      ]
     },
     "headline": "Short title of the card describing the main content",
     "id": "191234568",

--- a/packages/ts-newskit/src/slices/fixtures/lead-story3.json
+++ b/packages/ts-newskit/src/slices/fixtures/lead-story3.json
@@ -218,7 +218,7 @@
         "caption": "Sarcacens an inclusive club? They didnt look out for me",
         "crops": [
           {
-            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7c246bf4-fa83-11ed-9be0-622d8a105167.jpg?crop=1200%2C1500%2C0%2C0&resize=747",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173",
             "ratio": "3:2"
           },
           {

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -1961,6 +1961,36 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
         class="css-6wqjuf"
       >
         <div
+          class="css-1l8qede"
+        >
+          <div
+            class="css-uxw9nr"
+          >
+            <picture
+              class="css-zp0elg"
+            >
+              <div
+                class="css-5pczz7"
+              />
+              <img
+                alt="Short title of the card describing the main content"
+                class="css-1qgqq71"
+                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+              />
+            </picture>
+          </div>
+          <p
+            class="css-9pk24b"
+          >
+            Sarcacens an inclusive club? They didnt look out for me
+            <span
+              class="css-16qlzb7"
+            >
+              Gareth Fuller/Press Association
+            </span>
+          </p>
+        </div>
+        <div
           class="css-gpke1l"
         >
           <div
@@ -2993,6 +3023,36 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
       <div
         class="css-6wqjuf"
       >
+        <div
+          class="css-1l8qede"
+        >
+          <div
+            class="css-uxw9nr"
+          >
+            <picture
+              class="css-zp0elg"
+            >
+              <div
+                class="css-5pczz7"
+              />
+              <img
+                alt="Short title of the card describing the main content"
+                class="css-1qgqq71"
+                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+              />
+            </picture>
+          </div>
+          <p
+            class="css-9pk24b"
+          >
+            Sarcacens an inclusive club? They didnt look out for me
+            <span
+              class="css-16qlzb7"
+            >
+              Gareth Fuller/Press Association
+            </span>
+          </p>
+        </div>
         <div
           class="css-gpke1l"
         >

--- a/packages/ts-newskit/src/slices/lead-story-1/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-1/index.tsx
@@ -81,7 +81,8 @@ export const LeadStory1 = ({
           ? 'editorialHeadline050'
           : 'editorialHeadline060',
     showTagL1: false,
-    hideImage: true
+    hideImage: !screenXsAndSm,
+    imageTop: true
   };
 
   const modifiedLeadArticle = {

--- a/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -1759,6 +1759,36 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
             class="css-6wqjuf"
           >
             <div
+              class="css-1l8qede"
+            >
+              <div
+                class="css-uxw9nr"
+              >
+                <picture
+                  class="css-zp0elg"
+                >
+                  <div
+                    class="css-5pczz7"
+                  />
+                  <img
+                    alt="Short title of the card describing the main content"
+                    class="css-1qgqq71"
+                    src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  />
+                </picture>
+              </div>
+              <p
+                class="css-9pk24b"
+              >
+                Sarcacens an inclusive club? They didnt look out for me
+                <span
+                  class="css-16qlzb7"
+                >
+                  Gareth Fuller/Press Association
+                </span>
+              </p>
+            </div>
+            <div
               class="css-gpke1l"
             >
               <a
@@ -2698,6 +2728,36 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
           <div
             class="css-6wqjuf"
           >
+            <div
+              class="css-1l8qede"
+            >
+              <div
+                class="css-uxw9nr"
+              >
+                <picture
+                  class="css-zp0elg"
+                >
+                  <div
+                    class="css-5pczz7"
+                  />
+                  <img
+                    alt="Short title of the card describing the main content"
+                    class="css-1qgqq71"
+                    src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  />
+                </picture>
+              </div>
+              <p
+                class="css-9pk24b"
+              >
+                Sarcacens an inclusive club? They didnt look out for me
+                <span
+                  class="css-16qlzb7"
+                >
+                  Gareth Fuller/Press Association
+                </span>
+              </p>
+            </div>
             <div
               class="css-gpke1l"
             >

--- a/packages/ts-newskit/src/slices/lead-story-3/article-stack.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-3/article-stack.tsx
@@ -32,7 +32,6 @@ export const ArticleStack = ({
                   hideImage: !screenXsAndSm,
                   imageTop: true,
                   textBlockMarginBlockStart: 'space050',
-                  loadingAspectRatio: '3:2',
                   headlineTypographyPreset:
                     breakpointKey === 'xs'
                       ? 'editorialHeadline040'

--- a/packages/ts-newskit/src/slices/lead-story-3/article-stack.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-3/article-stack.tsx
@@ -12,27 +12,27 @@ export interface ArticlesProps {
   leadArticles: LeadArticleProps[];
   breakpointKey: BreakpointKeys;
   clickHandler: ClickHandlerType;
+  screenXsAndSm: boolean;
 }
 
 export const ArticleStack = ({
   leadArticles,
   breakpointKey,
-  clickHandler
+  clickHandler,
+  screenXsAndSm
 }: ArticlesProps) => {
-  const modifiedArticles = leadArticles.map(leadArticle => ({
-    ...leadArticle,
-    hideImage: true
-  }));
-
   return (
     <BlockNoTopMargin>
-      {modifiedArticles &&
-        modifiedArticles.map((modifiedArticle, index) => {
+      {leadArticles &&
+        leadArticles.map((modifiedArticle, index) => {
           const articlesWithModifiedTypography =
             index === 0
               ? {
                   ...modifiedArticle,
+                  hideImage: !screenXsAndSm,
+                  imageTop: true,
                   textBlockMarginBlockStart: 'space050',
+                  loadingAspectRatio: '3:2',
                   headlineTypographyPreset:
                     breakpointKey === 'xs'
                       ? 'editorialHeadline040'
@@ -42,7 +42,8 @@ export const ArticleStack = ({
                 }
               : {
                   ...modifiedArticle,
-                  headlineTypographyPreset: 'editorialHeadline020'
+                  headlineTypographyPreset: 'editorialHeadline020',
+                  hideImage: true
                 };
           return (
             <>

--- a/packages/ts-newskit/src/slices/lead-story-3/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-3/index.tsx
@@ -78,6 +78,7 @@ export const LeadStory3 = ({
           leadArticles={modifedLeadArticles}
           breakpointKey={currentBreakpoint}
           clickHandler={clickHandler}
+          screenXsAndSm={screenXsAndSm}
         />
       </StackItem>
       <StackItem

--- a/yarn.lock
+++ b/yarn.lock
@@ -5504,45 +5504,6 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
 
-"@times-components/link@3.12.8":
-  version "3.12.8"
-  resolved "https://registry.yarnpkg.com/@times-components/link/-/link-3.12.8.tgz#86f7181cecb08304744fc66474fab8c591f097b3"
-  integrity sha512-7aT9nbLPVaXcpNbQleux2edIr/GrBjd1PqiEFQhpgDI77TkLbHfJ/rjkCbWALToadoTaYVe8Zhfc3jeUAcPdKA==
-  dependencies:
-    "@times-components/ts-styleguide" "1.44.1"
-    "@times-components/utils" "6.16.9"
-    prop-types "15.7.2"
-    react "16.9.0"
-    react-dom "16.9.0"
-    styled-components "4.3.2"
-
-"@times-components/ts-styleguide@1.44.1":
-  version "1.44.1"
-  resolved "https://registry.yarnpkg.com/@times-components/ts-styleguide/-/ts-styleguide-1.44.1.tgz#30277ce81273a6c41d0939a779aa4368703afbbe"
-  integrity sha512-UoNXIVcJro1SAxnX3n0xa7h8PaVSbWwk1HWpzfVP96MaPyyuJbpsFNR5LWvfdbzegh9GHFJeHY9r07Bpa1Bs6w==
-  dependencies:
-    "@times-components/link" "3.12.8"
-    "@times-components/utils" "6.16.9"
-    react "16.9.0"
-    styled-components "4.3.2"
-
-"@times-components/utils@6.16.9":
-  version "6.16.9"
-  resolved "https://registry.yarnpkg.com/@times-components/utils/-/utils-6.16.9.tgz#98a02d4d6f084811e6a648a0ef195db0856c407a"
-  integrity sha512-i4gnGgTfpFcXeFuxRMLgPJwIt/li1R7AQSf7b4AYxUbY2rAQPCfx3b/Fsf1WfZz7HMFwUEoSVtk9/ixdFCiuVg==
-  dependencies:
-    "@times-components/schema" "0.7.4"
-    "@times-components/ts-styleguide" "1.44.1"
-    apollo-cache-inmemory "1.5.1"
-    apollo-client "2.5.1"
-    apollo-link "1.2.4"
-    apollo-link-http "1.5.14"
-    apollo-link-persisted-queries "0.2.2"
-    lodash.omitby "4.6.0"
-    prop-types "15.7.2"
-    styled-components "4.3.2"
-    unfetch "^3.0.0"
-
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5504,6 +5504,45 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
 
+"@times-components/link@3.12.8":
+  version "3.12.8"
+  resolved "https://registry.yarnpkg.com/@times-components/link/-/link-3.12.8.tgz#86f7181cecb08304744fc66474fab8c591f097b3"
+  integrity sha512-7aT9nbLPVaXcpNbQleux2edIr/GrBjd1PqiEFQhpgDI77TkLbHfJ/rjkCbWALToadoTaYVe8Zhfc3jeUAcPdKA==
+  dependencies:
+    "@times-components/ts-styleguide" "1.44.1"
+    "@times-components/utils" "6.16.9"
+    prop-types "15.7.2"
+    react "16.9.0"
+    react-dom "16.9.0"
+    styled-components "4.3.2"
+
+"@times-components/ts-styleguide@1.44.1":
+  version "1.44.1"
+  resolved "https://registry.yarnpkg.com/@times-components/ts-styleguide/-/ts-styleguide-1.44.1.tgz#30277ce81273a6c41d0939a779aa4368703afbbe"
+  integrity sha512-UoNXIVcJro1SAxnX3n0xa7h8PaVSbWwk1HWpzfVP96MaPyyuJbpsFNR5LWvfdbzegh9GHFJeHY9r07Bpa1Bs6w==
+  dependencies:
+    "@times-components/link" "3.12.8"
+    "@times-components/utils" "6.16.9"
+    react "16.9.0"
+    styled-components "4.3.2"
+
+"@times-components/utils@6.16.9":
+  version "6.16.9"
+  resolved "https://registry.yarnpkg.com/@times-components/utils/-/utils-6.16.9.tgz#98a02d4d6f084811e6a648a0ef195db0856c407a"
+  integrity sha512-i4gnGgTfpFcXeFuxRMLgPJwIt/li1R7AQSf7b4AYxUbY2rAQPCfx3b/Fsf1WfZz7HMFwUEoSVtk9/ixdFCiuVg==
+  dependencies:
+    "@times-components/schema" "0.7.4"
+    "@times-components/ts-styleguide" "1.44.1"
+    apollo-cache-inmemory "1.5.1"
+    apollo-client "2.5.1"
+    apollo-link "1.2.4"
+    apollo-link-http "1.5.14"
+    apollo-link-persisted-queries "0.2.2"
+    lodash.omitby "4.6.0"
+    prop-types "15.7.2"
+    styled-components "4.3.2"
+    unfetch "^3.0.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
### Description

Himesh has requested that we show the image in mobile web for the first article in the lead 1 & 3 2 ices. 

Designs here: 

Lead 1 https://www.figma.com/file/C1K0ePqSX0irobX6lAMq7h/Sport-section?type=design&node-id=274%3A129455&mode=design&t=o5auQUx6vwJntLTS-1 - Connect your Figma account

Lead 3 https://www.figma.com/file/C1K0ePqSX0irobX6lAMq7h/Sport-section?type=design&node-id=274%3A178284&mode=design&t=o5auQUx6vwJntLTS-1 - Connect your Figma account 
[JIRA-1234](https://nidigitalsolutions.jira.com/browse/JIRA-1234)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
Lead 1
<img width="738" alt="Screenshot 2023-08-10 at 15 25 20" src="https://github.com/newsuk/times-components/assets/116718171/3dacf3b1-db46-43ae-b355-ae10cf7c4594">
Lead 3
<img width="713" alt="Screenshot 2023-08-10 at 15 25 58" src="https://github.com/newsuk/times-components/assets/116718171/170f2094-84e1-402e-9fec-f19d12cce963">
