### PR TITLE
feat(TMRX-1312): Remove slice header tracking temporarily

### DIFF
--- a/packages/ts-newskit/src/components/slices/slice-header/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/__tests__/index.test.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, fireEvent } from '../../../../utils/test-utils';
+import { render } from '../../../../utils/test-utils';
 import { SliceHeader } from '../index';
-import { TrackingContextProvider } from '../../../../utils/TrackingContextProvider';
-import mockDate from 'mockdate';
 
 describe('Render Header', () => {
   it('should render a snapshot', () => {
@@ -27,27 +25,6 @@ describe('Render Header', () => {
     );
     const text = getByText('Rugby Union');
     expect(text).toHaveStyle('color: #01000d');
-  });
-  it('should trigger tracking', () => {
-    mockDate.set(1620000000000);
-    const analyticsStream = jest.fn();
-    const { getByRole } = render(
-      <TrackingContextProvider analyticsStream={analyticsStream}>
-        <SliceHeader title="Rugby Union" href="https://www.thetimes.co.uk/" />
-      </TrackingContextProvider>
-    );
-    fireEvent.click(getByRole('link'));
-    expect(analyticsStream).toHaveBeenCalledWith({
-      action: 'Clicked',
-      object: 'SliceHeader',
-      attrs: {
-        article_parent_name: 'Rugby Union',
-        eventTime: '2021-05-03T00:00:00.000Z',
-        event_navigation_action: 'navigation',
-        event_navigation_browsing_method: 'click',
-        event_navigation_name: 'title block link'
-      }
-    });
   });
   it('does not render the icon button if no href is supplied', () => {
     const { queryByRole } = render(<SliceHeader title="Rugby Union" />);

--- a/packages/ts-newskit/src/components/slices/slice-header/index.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/index.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { NewsKitChevronRightIcon } from '../../../assets';
 import { Block, FlagSize, IconButton, Stack, TitleBar } from 'newskit';
-import {
-  TrackingContextProvider,
-  TrackingContext
-} from '../../../utils/TrackingContextProvider';
 
 export interface SliceHeaderProps {
   title: string;
@@ -22,27 +18,7 @@ export const SliceHeader = ({
   iconArrowSize = 'iconSize020',
   iconSize = 'medium',
   padding = 'space030'
-}: SliceHeaderProps) => {
-  const clickEvent = () => ({
-    action: 'Clicked',
-    attrs: {
-      event_navigation_action: 'navigation',
-      event_navigation_name: 'title block link',
-      event_navigation_browsing_method: 'click',
-      article_parent_name: title
-    }
-  });
-
-  const handleClick = (fireAnalyticsEvent: (evt: TrackingContext) => void) => {
-    fireAnalyticsEvent && fireAnalyticsEvent(clickEvent());
-  };
-  return (
-    <TrackingContextProvider
-      context={{
-        object: 'SliceHeader'
-      }}
-    >
-      {({ fireAnalyticsEvent }) => (
+}: SliceHeaderProps) => (
         <Block stylePreset="sliceHeaderPreset">
           <Stack
             flow="horizontal-center"
@@ -70,14 +46,10 @@ export const SliceHeader = ({
                 }}
                 role="link"
                 href={href}
-                onClick={() => handleClick(fireAnalyticsEvent)}
               >
                 <NewsKitChevronRightIcon />
               </IconButton>
             )}
           </Stack>
         </Block>
-      )}
-    </TrackingContextProvider>
   );
-};

--- a/packages/ts-newskit/src/components/slices/slice-header/index.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/index.tsx
@@ -19,37 +19,37 @@ export const SliceHeader = ({
   iconSize = 'medium',
   padding = 'space030'
 }: SliceHeaderProps) => (
-        <Block stylePreset="sliceHeaderPreset">
-          <Stack
-            flow="horizontal-center"
-            stackDistribution="space-between"
-            paddingBlock={padding}
-          >
-            <TitleBar
-              overrides={{
-                heading: {
-                  typographyPreset: titleTypographyPreset,
-                  stylePreset: 'inkBrand010'
-                },
-                paddingInline: 'space000',
-                paddingBlock: 'space000'
-              }}
-            >
-              {title}
-            </TitleBar>
-            {href && (
-              <IconButton
-                size={iconSize}
-                overrides={{
-                  stylePreset: 'sliceIconPreset',
-                  iconSize: iconArrowSize
-                }}
-                role="link"
-                href={href}
-              >
-                <NewsKitChevronRightIcon />
-              </IconButton>
-            )}
-          </Stack>
-        </Block>
-  );
+  <Block stylePreset="sliceHeaderPreset">
+    <Stack
+      flow="horizontal-center"
+      stackDistribution="space-between"
+      paddingBlock={padding}
+    >
+      <TitleBar
+        overrides={{
+          heading: {
+            typographyPreset: titleTypographyPreset,
+            stylePreset: 'inkBrand010'
+          },
+          paddingInline: 'space000',
+          paddingBlock: 'space000'
+        }}
+      >
+        {title}
+      </TitleBar>
+      {href && (
+        <IconButton
+          size={iconSize}
+          overrides={{
+            stylePreset: 'sliceIconPreset',
+            iconSize: iconArrowSize
+          }}
+          role="link"
+          href={href}
+        >
+          <NewsKitChevronRightIcon />
+        </IconButton>
+      )}
+    </Stack>
+  </Block>
+);


### PR DESCRIPTION
### Description

We currently use the SliceHeader component as the new UI for the block title component. This has it's own tracking set up in render so we don't need to include this for now. In future if we use the SliceHeader as originally intended as part of certain slices we can re-include this tracking. 

### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.
