### PR TITLE
feat(TMRX-1386): Fixed inconsistent padding between elements in L2 Nav

### DIFF
--- a/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/create-menu.test.tsx.snap
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/create-menu.test.tsx.snap
@@ -15,11 +15,11 @@ exports[`Create Menu should render snapshot 1`] = `
         class="css-ov1ktg"
       >
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="page"
-            class="css-8wrz8o"
+            class="css-np1loc"
             data-testid="buttonLink"
             href="/home"
           >
@@ -31,11 +31,11 @@ exports[`Create Menu should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/news"
           >
@@ -47,11 +47,11 @@ exports[`Create Menu should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/comment"
           >
@@ -63,11 +63,11 @@ exports[`Create Menu should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/life-and-style"
           >
@@ -79,11 +79,11 @@ exports[`Create Menu should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/arts-and-books"
           >
@@ -95,11 +95,11 @@ exports[`Create Menu should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/sport"
           >
@@ -111,11 +111,11 @@ exports[`Create Menu should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/business-and-money"
           >
@@ -128,7 +128,7 @@ exports[`Create Menu should render snapshot 1`] = `
         </li>
       </div>
       <li
-        class="nk-menu-item css-1i0pcg0"
+        class="nk-menu-item css-1i1v9fb"
       >
         <button
           aria-expanded="false"

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/create-menu.test.tsx.snap
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/create-menu.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Create Menu should render snapshot 1`] = `
         class="css-ov1ktg"
       >
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="page"
@@ -31,7 +31,7 @@ exports[`Create Menu should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -47,7 +47,7 @@ exports[`Create Menu should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -63,7 +63,7 @@ exports[`Create Menu should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -79,7 +79,7 @@ exports[`Create Menu should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -95,7 +95,7 @@ exports[`Create Menu should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -111,7 +111,7 @@ exports[`Create Menu should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -128,7 +128,7 @@ exports[`Create Menu should render snapshot 1`] = `
         </li>
       </div>
       <li
-        class="nk-menu-item css-1e8z97h"
+        class="nk-menu-item css-1i0pcg0"
       >
         <button
           aria-expanded="false"

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/navitems.test.tsx.snap
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/navitems.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Navitems Desktop should render snapshot 1`] = `
   >
     <a
       aria-current="false"
-      class="css-1c56mmi"
+      class="css-ilh6is"
       data-testid="buttonLink"
       href="/home"
     >
@@ -23,7 +23,7 @@ exports[`Navitems Desktop should render snapshot 1`] = `
   >
     <a
       aria-current="false"
-      class="css-1c56mmi"
+      class="css-ilh6is"
       data-testid="buttonLink"
       href="/news"
     >
@@ -39,7 +39,7 @@ exports[`Navitems Desktop should render snapshot 1`] = `
   >
     <a
       aria-current="false"
-      class="css-1c56mmi"
+      class="css-ilh6is"
       data-testid="buttonLink"
       href="/comment"
     >

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-desktop.test.tsx.snap
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-desktop.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
         class="css-ov1ktg"
       >
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="page"
@@ -31,7 +31,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -47,7 +47,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -63,7 +63,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -79,7 +79,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -95,7 +95,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -111,7 +111,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -127,7 +127,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"
@@ -143,7 +143,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1e8z97h"
+          class="nk-menu-item css-1i0pcg0"
         >
           <a
             aria-current="false"

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-desktop.test.tsx.snap
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-desktop.test.tsx.snap
@@ -15,11 +15,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
         class="css-ov1ktg"
       >
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="page"
-            class="css-8wrz8o"
+            class="css-np1loc"
             data-testid="buttonLink"
             href="/home"
           >
@@ -31,11 +31,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/news"
           >
@@ -47,11 +47,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/comment"
           >
@@ -63,11 +63,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/life-and-style"
           >
@@ -79,11 +79,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/arts-and-books"
           >
@@ -95,11 +95,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/sport"
           >
@@ -111,11 +111,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/business-and-money"
           >
@@ -127,11 +127,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/puzzles"
           >
@@ -143,11 +143,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
           </a>
         </li>
         <li
-          class="nk-menu-item css-1i0pcg0"
+          class="nk-menu-item css-1i1v9fb"
         >
           <a
             aria-current="false"
-            class="css-3c5d0n"
+            class="css-ltup8m"
             data-testid="buttonLink"
             href="/magazines"
           >

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-nav-desktop.test.tsx.snap
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-nav-desktop.test.tsx.snap
@@ -80,11 +80,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
             class="css-ov1ktg"
           >
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="page"
-                class="css-8wrz8o"
+                class="css-np1loc"
                 data-testid="buttonLink"
                 href="/home"
               >
@@ -96,11 +96,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/news"
               >
@@ -112,11 +112,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/comment"
               >
@@ -128,11 +128,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/life-and-style"
               >
@@ -144,11 +144,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/arts-and-books"
               >
@@ -160,11 +160,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/sport"
               >
@@ -176,11 +176,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/business-and-money"
               >
@@ -192,11 +192,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/puzzles"
               >
@@ -208,11 +208,11 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/magazines"
               >

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-nav-desktop.test.tsx.snap
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-nav-desktop.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
             class="css-ov1ktg"
           >
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="page"
@@ -96,7 +96,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -112,7 +112,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -128,7 +128,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -144,7 +144,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -160,7 +160,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -176,7 +176,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -192,7 +192,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -208,7 +208,7 @@ exports[`Secondary Menu Desktop should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-nav-mobile.test.tsx.snap
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-nav-mobile.test.tsx.snap
@@ -80,11 +80,11 @@ exports[`Secondary Menu should render snapshot 1`] = `
             class="css-ov1ktg"
           >
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="page"
-                class="css-8wrz8o"
+                class="css-np1loc"
                 data-testid="buttonLink"
                 href="/home"
               >
@@ -96,11 +96,11 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/news"
               >
@@ -112,11 +112,11 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/comment"
               >
@@ -128,11 +128,11 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/life-and-style"
               >
@@ -144,11 +144,11 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/arts-and-books"
               >
@@ -160,11 +160,11 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/sport"
               >
@@ -176,11 +176,11 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/business-and-money"
               >
@@ -192,11 +192,11 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/puzzles"
               >
@@ -208,11 +208,11 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1i0pcg0"
+              class="nk-menu-item css-1i1v9fb"
             >
               <a
                 aria-current="false"
-                class="css-3c5d0n"
+                class="css-ltup8m"
                 data-testid="buttonLink"
                 href="/magazines"
               >

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-nav-mobile.test.tsx.snap
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-nav-mobile.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`Secondary Menu should render snapshot 1`] = `
             class="css-ov1ktg"
           >
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="page"
@@ -96,7 +96,7 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -112,7 +112,7 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -128,7 +128,7 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -144,7 +144,7 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -160,7 +160,7 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -176,7 +176,7 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -192,7 +192,7 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"
@@ -208,7 +208,7 @@ exports[`Secondary Menu should render snapshot 1`] = `
               </a>
             </li>
             <li
-              class="nk-menu-item css-1e8z97h"
+              class="nk-menu-item css-1i0pcg0"
             >
               <a
                 aria-current="false"

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/desktop/create-menu.tsx
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/desktop/create-menu.tsx
@@ -71,7 +71,7 @@ export const CreateMenu: React.FC<{
       hasMoreItems={moreMenuItemsLength > 0 ? true : false}
       aria-label="Secondary Navigation"
       overrides={{
-        spaceInline: 'space040'
+        spaceInline: 'space000'
       }}
       ref={contanierRef}
     >

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/desktop/create-menu.tsx
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/desktop/create-menu.tsx
@@ -71,7 +71,7 @@ export const CreateMenu: React.FC<{
       hasMoreItems={moreMenuItemsLength > 0 ? true : false}
       aria-label="Secondary Navigation"
       overrides={{
-        spaceInline: 'space030'
+        spaceInline: 'space040'
       }}
       ref={contanierRef}
     >

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/desktop/navItems.tsx
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/desktop/navItems.tsx
@@ -14,8 +14,8 @@ export const NavItems: React.FC<{
       {data.slice(0, hasMenuItem).map(({ title, slug, url }) => (
         <StyledMenuItemsDesktop
           overrides={{
-            paddingInlineStart: '6px',
-            paddingInlineEnd: '6px',
+            paddingInlineStart: '16px',
+            paddingInlineEnd: '16px',
             stylePreset: 'menuItemDesktop',
             typographyPreset: 'newPreset040'
           }}

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/desktop/navItems.tsx
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/desktop/navItems.tsx
@@ -14,8 +14,7 @@ export const NavItems: React.FC<{
       {data.slice(0, hasMenuItem).map(({ title, slug, url }) => (
         <StyledMenuItemsDesktop
           overrides={{
-            paddingInlineStart: '16px',
-            paddingInlineEnd: '16px',
+            paddingInline: 'space040',
             stylePreset: 'menuItemDesktop',
             typographyPreset: 'newPreset040'
           }}


### PR DESCRIPTION
### Description

Padding on secondary nav should match the padding in place for top level nav as this is correct

Increase right margin on Menu item from 12px to 16px

[TMRX-1386](https://nidigitalsolutions.jira.com/browse/TMRX-1386)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots :

<img width="924" alt="Screenshot 2023-08-15 at 10 29 27" src="https://github.com/newsuk/times-components/assets/139121129/abf1efd9-9ecb-4940-b1d0-d7274e659aba">


[TMRX-1386]: https://nidigitalsolutions.jira.com/browse/TMRX-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ