### PR TITLE
feat(TMG-914): Update welcome banner design

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Any of these source files can be debugged directly.
 
 Follow these steps [here](https://github.com/newsuk/cps-content-render#integrating-with-times-components)
 
+## See your changes in Render with rnw.js files
+
+Besides linking the Times Components and Render repos together, you can view changes made to Times Components in Render through the rnw.js files.
+
+1. In Times Components, after you have made your changes, run `yarn bundle` in the package in which you were working. If you were working in the `ts-components` package you will need to run `yarn build` first and then `yarn bundle`.
+2. Running the command creates an rnw.js file in the root of the folder. Check the file to see if your changes have come through.
+3. Copy the contents of the rnw.js file and paste it into the related file in Render's `node_modules`. For example, if you bundled the rnw.js file in the `article-skeleton` package in Times Components, you would paste the contents into `node_modules/@times-components/article-skeleton/rnw.js`.
+4. Run render and you should see your changes.
+
 ## Debugging the tests
 
 Tests are currently using [jest](https://jestjs.io/) to run so if you want to debug any test follow these steps:

--- a/packages/ts-components/src/components/welcome-banner/WelcomeBanner.tsx
+++ b/packages/ts-components/src/components/welcome-banner/WelcomeBanner.tsx
@@ -15,7 +15,10 @@ export const WelcomeBanner: React.FC = () => {
   return isEnabled ? (
     <WelcomeBannerContainer>
       <Title data-testId="title">
-       Welcome to <br className="mobile"/>The Times <br className="larger-breakpoints"/> and <br className="mobile"/>The Sunday Times
+        Welcome to <br className="mobile" />
+        The Times <br className="larger-breakpoints" /> and{' '}
+        <br className="mobile" />
+        The Sunday Times
       </Title>
       <Text data-testId="text">We hope you enjoy your free content</Text>
     </WelcomeBannerContainer>

--- a/packages/ts-components/src/components/welcome-banner/WelcomeBanner.tsx
+++ b/packages/ts-components/src/components/welcome-banner/WelcomeBanner.tsx
@@ -15,7 +15,7 @@ export const WelcomeBanner: React.FC = () => {
   return isEnabled ? (
     <WelcomeBannerContainer>
       <Title data-testId="title">
-        Welcome to The Times and The Sunday Times
+       Welcome to <br className="mobile"/>The Times <br className="larger-breakpoints"/> and <br className="mobile"/>The Sunday Times
       </Title>
       <Text data-testId="text">We hope you enjoy your free content</Text>
     </WelcomeBannerContainer>

--- a/packages/ts-components/src/components/welcome-banner/styles.ts
+++ b/packages/ts-components/src/components/welcome-banner/styles.ts
@@ -8,13 +8,13 @@ export const WelcomeBannerContainer = styled.div`
   width: 100%;
   margin-bottom: 28px;
   padding: 16px 34px;
-  border: 1px solid ${colours.functional.primary};
+  background-color: ${colours.functional.bannerBackground};
 `;
 
 export const Title = styled.div`
   color: ${colours.functional.greyText};
   font-family: ${fonts.headline};
-  font-size: 28px;
+  font-size: 40px;
   line-height: 31px;
   text-align: center;
 `;

--- a/packages/ts-components/src/components/welcome-banner/styles.ts
+++ b/packages/ts-components/src/components/welcome-banner/styles.ts
@@ -6,7 +6,7 @@ export const WelcomeBannerContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   width: 100%;
-  margin-bottom: 28px;
+  margin-bottom: 16px;
   padding: 16px 34px;
   background-color: ${colours.functional.bannerBackground};
 `;

--- a/packages/ts-components/src/components/welcome-banner/styles.ts
+++ b/packages/ts-components/src/components/welcome-banner/styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { colours, fonts } from '@times-components/ts-styleguide';
+import { colours, fonts, breakpoints } from '@times-components/ts-styleguide';
 
 export const WelcomeBannerContainer = styled.div`
   display: flex;
@@ -7,7 +7,7 @@ export const WelcomeBannerContainer = styled.div`
   justify-content: center;
   width: 100%;
   margin-bottom: 16px;
-  padding: 16px 34px;
+  padding: 18px 16px;
   background-color: ${colours.functional.bannerBackground};
 `;
 
@@ -15,8 +15,23 @@ export const Title = styled.div`
   color: ${colours.functional.greyText};
   font-family: ${fonts.headline};
   font-size: 40px;
-  line-height: 31px;
-  text-align: center;
+  line-height: 45px;
+  text-align: left;
+  br.mobile {
+    display: inline;
+  }
+  br.larger-breakpoints {
+    display: none;
+  }
+  @media (min-width: ${breakpoints.medium}px) {
+    text-align: center;
+    br.mobile {
+      display: none;
+    }
+    br.larger-breakpoints {
+      display: inline;
+    }
+  }
 `;
 
 export const Text = styled.div`
@@ -24,6 +39,9 @@ export const Text = styled.div`
   color: ${colours.functional.primary};
   font-family: ${fonts.supporting};
   font-size: 18px;
-  text-align: center;
   line-height: 27px;
+  text-align: left;
+  @media (min-width: ${breakpoints.medium}px) {
+    text-align: center;
+  }
 `;

--- a/packages/ts-styleguide/src/styleguide/colours/functional.tsx
+++ b/packages/ts-styleguide/src/styleguide/colours/functional.tsx
@@ -6,6 +6,7 @@ export const functionalColours = {
   articleFlagUpdated: '#3C81BE',
   backgroundPrimary: '#F9F9F9',
   backgroundSecondary: '#EDEDED',
+  bannerBackground: '#BEDEED',
   black: '#000000',
   border: '#F0F0F0',
   brandColour: '#1D1D1B',


### PR DESCRIPTION
### Description

This PR updates the design of the Welcome banner to make the title font bigger, make the background blue and change the alignment and line breaks at different breakpoints.

[TMG-914](https://nidigitalsolutions.jira.com/browse/TMG-914)


### Checklist

- [x] Have you done any manual testing?
- [x] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Old welcome banner:
<img width="1217" alt="image" src="https://github.com/newsuk/times-components/assets/50234696/7f33277e-58ca-40ad-a6f1-fd7eebd46ae2">

Updated mobile design:
![image](https://github.com/newsuk/times-components/assets/50234696/a088b54e-e86d-48e4-bcd5-b0ab1cd9f749)

Updated design at larger breakpoints:
![image](https://github.com/newsuk/times-components/assets/50234696/d3b7d0ad-cc52-4232-a08a-4a13c5fd19d3)



[TMG-914]: https://nidigitalsolutions.jira.com/browse/TMG-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ