### PR TITLE
feat(TMRX-1406): add logic to await breakpoint value before loading s…

### DIFF
--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -766,6 +766,8 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Render Content Bucket 1 Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;
+
 exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/index.test.tsx
@@ -33,6 +33,12 @@ describe('Render Content Bucket 1 Slice', () => {
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test('Slice matches snapshot for `null` breakpoint value', () => {
+    (useBreakpointKey as any).mockReturnValue(null);
+    const { asFragment } = renderComponent();
+    expect(asFragment()).toMatchSnapshot();
+  });
 });
 
 describe('Content Bucket 1 Articles list ', () => {

--- a/packages/ts-newskit/src/slices/content-bucket-1/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-1/index.tsx
@@ -37,7 +37,7 @@ export const ContentBucket1 = ({
   articles,
   clickHandler
 }: ContentBucket1Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xs');
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -45,8 +45,12 @@ export const ContentBucket1 = ({
     },
     [breakpointKey]
   );
-  const isMobile = ['xs', 'sm'].includes(currentBreakpoint);
+  
+  if(!currentBreakpoint) {
+    return null;
+  }
 
+  const isMobile = ['xs', 'sm'].includes(currentBreakpoint);
   const modifiedLeadArticle = {
     ...leadArticle,
     imageTop: isMobile,

--- a/packages/ts-newskit/src/slices/content-bucket-1/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-1/index.tsx
@@ -37,7 +37,9 @@ export const ContentBucket1 = ({
   articles,
   clickHandler
 }: ContentBucket1Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
+    null
+  );
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -45,8 +47,8 @@ export const ContentBucket1 = ({
     },
     [breakpointKey]
   );
-  
-  if(!currentBreakpoint) {
+
+  if (!currentBreakpoint) {
     return null;
   }
 

--- a/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -589,3 +589,5 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
   </div>
 </DocumentFragment>
 `;
+
+exports[`Render Content Bucket 2 Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;

--- a/packages/ts-newskit/src/slices/content-bucket-2/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-2/__tests__/index.test.tsx
@@ -37,6 +37,12 @@ describe('Render Content Bucket 2 Slice', () => {
     const { asFragment } = await renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test('Slice matches snapshot for `null` breakpoint value', async () => {
+    (useBreakpointKey as any).mockReturnValue(null);
+    const { asFragment } = await renderComponent();
+    expect(asFragment()).toMatchSnapshot();
+  });
 });
 
 describe('Content Bucket 2 Articles list above `md` breakpoint', () => {

--- a/packages/ts-newskit/src/slices/content-bucket-2/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-2/index.tsx
@@ -15,7 +15,7 @@ export const ContentBucket2 = ({
   articles,
   clickHandler
 }: ContentBucket2Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xs');
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -23,6 +23,11 @@ export const ContentBucket2 = ({
     },
     [breakpointKey]
   );
+
+  if(!currentBreakpoint) {
+    return null;
+  }
+
   const isMob = currentBreakpoint === 'xs' || currentBreakpoint === 'sm';
 
   return (

--- a/packages/ts-newskit/src/slices/content-bucket-2/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-2/index.tsx
@@ -15,7 +15,9 @@ export const ContentBucket2 = ({
   articles,
   clickHandler
 }: ContentBucket2Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
+    null
+  );
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -24,7 +26,7 @@ export const ContentBucket2 = ({
     [breakpointKey]
   );
 
-  if(!currentBreakpoint) {
+  if (!currentBreakpoint) {
     return null;
   }
 

--- a/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -883,6 +883,8 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Render Content Bucket 3 Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;
+
 exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ts-newskit/src/slices/content-bucket-3/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-3/__tests__/index.test.tsx
@@ -28,6 +28,12 @@ describe('Render Content Bucket 3 Slice', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  test('Slice matches snapshot for `null` breakpoint value', () => {
+    (useBreakpointKey as any).mockReturnValue(null);
+    const { asFragment } = renderComponent();
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   test('Slice matches snapshot for mobile', () => {
     (useBreakpointKey as any).mockReturnValue('sm');
     const { asFragment } = renderComponent();

--- a/packages/ts-newskit/src/slices/content-bucket-3/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-3/index.tsx
@@ -24,7 +24,7 @@ import { CustomStackLayout } from '../shared';
 import { FullWidthHidden } from '../../components/slices/shared-styles';
 import { ClickHandlerType } from '../types';
 
-export interface ContentBucket1Props {
+export interface ContentBucket3Props {
   leadArticleLeft: LeadArticleProps;
   leadArticleRight: LeadArticleProps;
   comments: CommentCardProps[];
@@ -38,8 +38,8 @@ export const ContentBucket3 = ({
   comments,
   articles,
   clickHandler
-}: ContentBucket1Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xs');
+}: ContentBucket3Props) => {
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -47,6 +47,11 @@ export const ContentBucket3 = ({
     },
     [breakpointKey]
   );
+
+  if(!currentBreakpoint) {
+    return null;
+  }
+
   const isMobile = ['xs', 'sm'].includes(currentBreakpoint);
   const isMedium = currentBreakpoint === 'md';
   const isLarge = ['lg', 'xl'].includes(currentBreakpoint);

--- a/packages/ts-newskit/src/slices/content-bucket-3/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-3/index.tsx
@@ -39,7 +39,9 @@ export const ContentBucket3 = ({
   articles,
   clickHandler
 }: ContentBucket3Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
+    null
+  );
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -48,7 +50,7 @@ export const ContentBucket3 = ({
     [breakpointKey]
   );
 
-  if(!currentBreakpoint) {
+  if (!currentBreakpoint) {
     return null;
   }
 

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -1506,6 +1506,8 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Render Lead Story 1 Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;
+
 exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKey is "md" 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/index.test.tsx
@@ -46,6 +46,4 @@ describe('Render Lead Story 1 Slice', () => {
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
-
-
 });

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/index.test.tsx
@@ -26,6 +26,11 @@ describe('Render Lead Story 1 Slice', () => {
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
+  test('Slice matches snapshot for `null` breakpoint value', () => {
+    (useBreakpointKey as any).mockReturnValue(null);
+    const { asFragment } = renderComponent();
+    expect(asFragment()).toMatchSnapshot();
+  });
   test('modifies articles correctly when breakpointKey is "md"', () => {
     (useBreakpointKey as any).mockReturnValue('md');
     const { asFragment } = renderComponent();
@@ -36,10 +41,11 @@ describe('Render Lead Story 1 Slice', () => {
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
-
   test('modifies articles correctly when breakpointKey is "sm"', () => {
     (useBreakpointKey as any).mockReturnValue('sm');
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
+
+
 });

--- a/packages/ts-newskit/src/slices/lead-story-1/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-1/index.tsx
@@ -48,7 +48,9 @@ export const LeadStory1 = ({
   articlesWithListItems,
   clickHandler
 }: LeadStory1Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
+    null
+  );
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -57,7 +59,7 @@ export const LeadStory1 = ({
     [breakpointKey]
   );
 
-  if(!currentBreakpoint) {
+  if (!currentBreakpoint) {
     return null;
   }
 

--- a/packages/ts-newskit/src/slices/lead-story-1/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-1/index.tsx
@@ -48,7 +48,7 @@ export const LeadStory1 = ({
   articlesWithListItems,
   clickHandler
 }: LeadStory1Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xs');
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -56,6 +56,11 @@ export const LeadStory1 = ({
     },
     [breakpointKey]
   );
+
+  if(!currentBreakpoint) {
+    return null;
+  }
+
   const screenXsAndSm =
     currentBreakpoint === 'xs' || currentBreakpoint === 'sm';
   const modifiedArticles =

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -1408,6 +1408,8 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Render Lead Story 2 Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;
+
 exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKey is "md" 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/index.test.tsx
@@ -42,4 +42,9 @@ describe('Render Lead Story 2 Slice', () => {
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
+  test('Slice matches snapshot for `null` breakpoint value', () => {
+    (useBreakpointKey as any).mockReturnValue(null);
+    const { asFragment } = renderComponent();
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/packages/ts-newskit/src/slices/lead-story-2/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-2/index.tsx
@@ -33,7 +33,7 @@ export const LeadStory2 = ({
   horizontalArticles,
   clickHandler
 }: LeadStory2Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xs');
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -41,6 +41,10 @@ export const LeadStory2 = ({
     },
     [breakpointKey]
   );
+
+  if(!currentBreakpoint) {
+    return null;
+  }
 
   const modifedArticles =
     currentBreakpoint === 'xl'

--- a/packages/ts-newskit/src/slices/lead-story-2/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-2/index.tsx
@@ -33,7 +33,9 @@ export const LeadStory2 = ({
   horizontalArticles,
   clickHandler
 }: LeadStory2Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
+    null
+  );
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -42,7 +44,7 @@ export const LeadStory2 = ({
     [breakpointKey]
   );
 
-  if(!currentBreakpoint) {
+  if (!currentBreakpoint) {
     return null;
   }
 

--- a/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -1320,6 +1320,8 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Render Lead Story 3 Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;
+
 exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKey is "md" 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ts-newskit/src/slices/lead-story-3/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-3/__tests__/index.test.tsx
@@ -42,4 +42,9 @@ describe('Render Lead Story 3 Slice', () => {
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
+  test('Slice matches snapshot for `null` breakpoint value', () => {
+    (useBreakpointKey as any).mockReturnValue(null);
+    const { asFragment } = renderComponent();
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/packages/ts-newskit/src/slices/lead-story-3/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-3/index.tsx
@@ -32,7 +32,7 @@ export const LeadStory3 = ({
   leadArticles,
   clickHandler
 }: LeadStory3Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xs');
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -40,6 +40,10 @@ export const LeadStory3 = ({
     },
     [breakpointKey]
   );
+
+  if(!currentBreakpoint) {
+    return null;
+  }
 
   const modifedArticles =
     currentBreakpoint === 'xl'

--- a/packages/ts-newskit/src/slices/lead-story-3/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-3/index.tsx
@@ -32,7 +32,9 @@ export const LeadStory3 = ({
   leadArticles,
   clickHandler
 }: LeadStory3Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
+    null
+  );
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -41,7 +43,7 @@ export const LeadStory3 = ({
     [breakpointKey]
   );
 
-  if(!currentBreakpoint) {
+  if (!currentBreakpoint) {
     return null;
   }
 

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render SectionBucket Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;
+
 exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/index.test.tsx
@@ -32,6 +32,12 @@ const renderComponent = () =>
   );
 
 describe('Render SectionBucket Slice', () => {
+  test('Slice matches snapshot for `null` breakpoint value', () => {
+    (useBreakpointKey as any).mockReturnValue(null);
+    const { asFragment } = renderComponent();
+    expect(asFragment()).toMatchSnapshot();
+  });
+  
   test('Slice matches snapshot with sm', () => {
     (useBreakpointKey as any).mockReturnValue('sm');
     const { asFragment } = renderComponent();

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/index.test.tsx
@@ -37,7 +37,7 @@ describe('Render SectionBucket Slice', () => {
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
-  
+
   test('Slice matches snapshot with sm', () => {
     (useBreakpointKey as any).mockReturnValue('sm');
     const { asFragment } = renderComponent();

--- a/packages/ts-newskit/src/slices/section-bucket/index.tsx
+++ b/packages/ts-newskit/src/slices/section-bucket/index.tsx
@@ -52,7 +52,7 @@ export const SectionBucket = ({
   articleStackFour,
   clickHandler
 }: SectionBucketProps) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xs');
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -60,6 +60,11 @@ export const SectionBucket = ({
     },
     [breakpointKey]
   );
+
+  if(!currentBreakpoint) {
+    return null;
+  }
+
   const isMobile = currentBreakpoint === 'xs' || currentBreakpoint === 'sm';
 
   const articleStacksArray = [

--- a/packages/ts-newskit/src/slices/section-bucket/index.tsx
+++ b/packages/ts-newskit/src/slices/section-bucket/index.tsx
@@ -52,7 +52,9 @@ export const SectionBucket = ({
   articleStackFour,
   clickHandler
 }: SectionBucketProps) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
+    null
+  );
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -61,7 +63,7 @@ export const SectionBucket = ({
     [breakpointKey]
   );
 
-  if(!currentBreakpoint) {
+  if (!currentBreakpoint) {
     return null;
   }
 

--- a/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -795,6 +795,8 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;
+
 exports[`Render StackModule 1 Slice modifies articles correctly when breakpointKey is "md" 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ts-newskit/src/slices/stacked-module-1/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/stacked-module-1/__tests__/index.test.tsx
@@ -42,4 +42,9 @@ describe('Render StackModule 1 Slice', () => {
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
+  test('Slice matches snapshot for `null` breakpoint value', () => {
+    (useBreakpointKey as any).mockReturnValue(null);
+    const { asFragment } = renderComponent();
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/packages/ts-newskit/src/slices/stacked-module-1/index.tsx
+++ b/packages/ts-newskit/src/slices/stacked-module-1/index.tsx
@@ -86,7 +86,9 @@ const articleStack = ({
 );
 
 export const StackModule1 = ({ articles, clickHandler }: StackModule1Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
+    null
+  );
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -95,7 +97,7 @@ export const StackModule1 = ({ articles, clickHandler }: StackModule1Props) => {
     [breakpointKey]
   );
 
-  if(!currentBreakpoint) {
+  if (!currentBreakpoint) {
     return null;
   }
 

--- a/packages/ts-newskit/src/slices/stacked-module-1/index.tsx
+++ b/packages/ts-newskit/src/slices/stacked-module-1/index.tsx
@@ -86,7 +86,7 @@ const articleStack = ({
 );
 
 export const StackModule1 = ({ articles, clickHandler }: StackModule1Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xs');
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(null);
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {
@@ -94,6 +94,11 @@ export const StackModule1 = ({ articles, clickHandler }: StackModule1Props) => {
     },
     [breakpointKey]
   );
+
+  if(!currentBreakpoint) {
+    return null;
+  }
+
   const isMob = currentBreakpoint === 'xs' || currentBreakpoint === 'sm';
   const articlesTop = articles.slice(0, 4);
   const articlesBottom = articles.slice(4);


### PR DESCRIPTION
### Description

Addition of logic to await breakpoint value before loading slices. This prevents the layout of the slice shifting before we're able to retrieve the correct breakpoint value on the client side.

[TMRX-1406](https://nidigitalsolutions.jira.com/browse/TMRX-1406)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMRX-1406]: https://nidigitalsolutions.jira.com/browse/TMRX-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ