### PR TITLE
fix(TMRX-0000): add min height to slice header

### DIFF
--- a/packages/ts-newskit/src/components/slices/shared-styles/index.ts
+++ b/packages/ts-newskit/src/components/slices/shared-styles/index.ts
@@ -9,7 +9,8 @@ import {
   getMediaQueryFromTheme,
   LinkInline,
   Hidden,
-  TextBlock
+  TextBlock,
+  Stack
 } from 'newskit';
 import TheTimesLight from '@newskit-themes/the-times/TheTimes-light.json';
 
@@ -89,4 +90,8 @@ export const Wrapper = styled.div`
   display: flex;
   align-items: center;
   ${getSpacingCssFromTheme('gap', 'space010')};
+`;
+
+export const StyledStack = styled(Stack)`
+  min-height: 72px;
 `;

--- a/packages/ts-newskit/src/components/slices/slice-header/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/slice-header/__tests__/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Render Header should render a snapshot 1`] = `
     class="css-lihpnt"
   >
     <div
-      class="css-128qn49"
+      class="css-1tcvqka"
     >
       <div
         class="css-86cix"

--- a/packages/ts-newskit/src/components/slices/slice-header/index.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { NewsKitChevronRightIcon } from '../../../assets';
-import { Block, FlagSize, IconButton, Stack, TitleBar } from 'newskit';
+import { Block, FlagSize, IconButton, TitleBar } from 'newskit';
 import {
   TrackingContextProvider,
   TrackingContext
 } from '../../../utils/TrackingContextProvider';
+import { StyledStack } from '../shared-styles';
 
 export interface SliceHeaderProps {
   title: string;
@@ -44,7 +45,7 @@ export const SliceHeader = ({
     >
       {({ fireAnalyticsEvent }) => (
         <Block stylePreset="sliceHeaderPreset">
-          <Stack
+          <StyledStack
             flow="horizontal-center"
             stackDistribution="space-between"
             paddingBlock={padding}
@@ -75,7 +76,7 @@ export const SliceHeader = ({
                 <NewsKitChevronRightIcon />
               </IconButton>
             )}
-          </Stack>
+          </StyledStack>
         </Block>
       )}
     </TrackingContextProvider>

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             class="css-lihpnt"
           >
             <div
-              class="css-66z36v"
+              class="css-kdlajr"
             >
               <div
                 class="css-86cix"
@@ -284,7 +284,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             class="css-lihpnt"
           >
             <div
-              class="css-66z36v"
+              class="css-kdlajr"
             >
               <div
                 class="css-86cix"
@@ -547,7 +547,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             class="css-lihpnt"
           >
             <div
-              class="css-66z36v"
+              class="css-kdlajr"
             >
               <div
                 class="css-86cix"
@@ -810,7 +810,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             class="css-lihpnt"
           >
             <div
-              class="css-66z36v"
+              class="css-kdlajr"
             >
               <div
                 class="css-86cix"
@@ -1088,7 +1088,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
           class="css-lihpnt"
         >
           <div
-            class="css-66z36v"
+            class="css-kdlajr"
           >
             <div
               class="css-86cix"
@@ -1351,7 +1351,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
           class="css-lihpnt"
         >
           <div
-            class="css-66z36v"
+            class="css-kdlajr"
           >
             <div
               class="css-86cix"
@@ -1614,7 +1614,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
           class="css-lihpnt"
         >
           <div
-            class="css-66z36v"
+            class="css-kdlajr"
           >
             <div
               class="css-86cix"
@@ -1877,7 +1877,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
           class="css-lihpnt"
         >
           <div
-            class="css-66z36v"
+            class="css-kdlajr"
           >
             <div
               class="css-86cix"


### PR DESCRIPTION
### Description

When there's no icon in the slice header, the header height shrinks. So, I addressed this by adding a minimum height to fix the issue.
[JIRA-0000](https://nidigitalsolutions.jira.com/browse/JIRA-0000)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?

### Screenshots (if appropriate):

before 
<img width="1318" alt="Screenshot 2023-08-30 at 19 35 58" src="https://github.com/newsuk/times-components/assets/116718171/a6e16c5c-1dbe-43d8-9996-4545a27e52e4">

after
<img width="1051" alt="Screenshot 2023-08-30 at 19 46 07" src="https://github.com/newsuk/times-components/assets/116718171/4798196c-7fd3-4293-b715-36c7c6e8e23a">

