### PR TITLE
fix(TMRX-1477): add min-height to slice header

### DIFF
--- a/packages/ts-newskit/src/components/slices/slice-header/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/slice-header/__tests__/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Render Header should render a snapshot 1`] = `
     class="css-lihpnt"
   >
     <div
-      class="css-128qn49"
+      class="css-1tcvqka"
     >
       <div
         class="css-86cix"

--- a/packages/ts-newskit/src/components/slices/slice-header/index.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { NewsKitChevronRightIcon } from '../../../assets';
-import { Block, FlagSize, IconButton, Stack, TitleBar } from 'newskit';
+import { Block, FlagSize, IconButton, TitleBar } from 'newskit';
 import {
   TrackingContextProvider,
   TrackingContext
 } from '../../../utils/TrackingContextProvider';
+import { SliceHeaderContainer } from './styles';
 
 export interface SliceHeaderProps {
   title: string;
@@ -44,7 +45,7 @@ export const SliceHeader = ({
     >
       {({ fireAnalyticsEvent }) => (
         <Block stylePreset="sliceHeaderPreset">
-          <Stack
+          <SliceHeaderContainer
             flow="horizontal-center"
             stackDistribution="space-between"
             paddingBlock={padding}
@@ -75,7 +76,7 @@ export const SliceHeader = ({
                 <NewsKitChevronRightIcon />
               </IconButton>
             )}
-          </Stack>
+          </SliceHeaderContainer>
         </Block>
       )}
     </TrackingContextProvider>

--- a/packages/ts-newskit/src/components/slices/slice-header/styles.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/styles.tsx
@@ -1,0 +1,5 @@
+import { Stack, styled } from "newskit";
+
+export const SliceHeaderContainer = styled(Stack)`
+  min-height: 72px;
+`

--- a/packages/ts-newskit/src/components/slices/slice-header/styles.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/styles.tsx
@@ -1,5 +1,5 @@
-import { Stack, styled } from "newskit";
+import { Stack, styled } from 'newskit';
 
 export const SliceHeaderContainer = styled(Stack)`
   min-height: 72px;
-`
+`;

--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-1klr24i"
@@ -771,7 +771,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for \`null\` break
 exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-1klr24i"

--- a/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoint 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-zry7cx"
@@ -316,7 +316,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
 exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoint 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-zry7cx"

--- a/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-1klr24i"
@@ -888,7 +888,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for \`null\` break
 exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-1klr24i"

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-1polam9"
@@ -1511,7 +1511,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot for \`null\` breakpoin
 exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKey is "md" 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-1polam9"
@@ -2764,7 +2764,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
 exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKey is "sm" 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-1polam9"
@@ -4277,7 +4277,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
 exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKey is "xs" 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-1polam9"

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-1waal5p"
@@ -1413,7 +1413,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot for \`null\` breakpoin
 exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKey is "md" 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-1waal5p"
@@ -2568,7 +2568,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
 exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKey is "sm" 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-1waal5p"
@@ -3950,7 +3950,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
 exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKey is "xs" 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-1waal5p"

--- a/packages/ts-newskit/src/slices/lead-story-2/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-2/index.tsx
@@ -1,7 +1,6 @@
 import {
   Block,
   Divider,
-  Stack,
   useBreakpointKey,
   Visible,
   BreakpointKeys
@@ -15,7 +14,11 @@ import { ArticleProps } from '../../components/slices/article';
 import { LeadStoryDivider, StackItem, BlockItem } from '../shared-styles';
 import { ArticleStack } from './article-stacks';
 import { FullWidthBlock } from '../../components/slices/shared-styles';
-import { ArticleStackLeadStory, ComposedArticleStack } from '../shared';
+import {
+  ArticleStackLeadStory,
+  ComposedArticleStack,
+  CustomStackLayout
+} from '../shared';
 import { ClickHandlerType } from '../types';
 
 export interface LeadStory2Props {
@@ -73,15 +76,7 @@ export const LeadStory2 = ({
   };
 
   return (
-    <Stack
-      flow="horizontal-top"
-      stackDistribution="center"
-      wrap="wrap"
-      marginInline={{
-        xs: 'space045',
-        md: 'space000'
-      }}
-    >
+    <CustomStackLayout>
       <StackItem
         $width={{
           xs: '100%',
@@ -153,6 +148,6 @@ export const LeadStory2 = ({
           clickHandler={clickHandler}
         />
       )}
-    </Stack>
+    </CustomStackLayout>
   );
 };

--- a/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-9tpu5q"
@@ -1325,7 +1325,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot for \`null\` breakpoin
 exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKey is "md" 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-9tpu5q"
@@ -2392,7 +2392,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
 exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKey is "sm" 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-9tpu5q"
@@ -3730,7 +3730,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
 exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKey is "xs" 1`] = `
 <DocumentFragment>
   <div
-    class="css-1sr0a1l"
+    class="css-1b7p4pb"
   >
     <div
       class="css-9tpu5q"

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             class="css-lihpnt"
           >
             <div
-              class="css-66z36v"
+              class="css-kdlajr"
             >
               <div
                 class="css-86cix"
@@ -286,7 +286,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             class="css-lihpnt"
           >
             <div
-              class="css-66z36v"
+              class="css-kdlajr"
             >
               <div
                 class="css-86cix"
@@ -549,7 +549,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             class="css-lihpnt"
           >
             <div
-              class="css-66z36v"
+              class="css-kdlajr"
             >
               <div
                 class="css-86cix"
@@ -812,7 +812,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             class="css-lihpnt"
           >
             <div
-              class="css-66z36v"
+              class="css-kdlajr"
             >
               <div
                 class="css-86cix"
@@ -1090,7 +1090,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
           class="css-lihpnt"
         >
           <div
-            class="css-66z36v"
+            class="css-kdlajr"
           >
             <div
               class="css-86cix"
@@ -1353,7 +1353,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
           class="css-lihpnt"
         >
           <div
-            class="css-66z36v"
+            class="css-kdlajr"
           >
             <div
               class="css-86cix"
@@ -1616,7 +1616,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
           class="css-lihpnt"
         >
           <div
-            class="css-66z36v"
+            class="css-kdlajr"
           >
             <div
               class="css-86cix"
@@ -1879,7 +1879,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
           class="css-lihpnt"
         >
           <div
-            class="css-66z36v"
+            class="css-kdlajr"
           >
             <div
               class="css-86cix"

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot for \`null\` breakpoi
 exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
 <DocumentFragment>
   <div
-    class="css-1r18k3i"
+    class="css-1q37olt"
   >
     <div
       class="css-6uqogc"
@@ -1076,7 +1076,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
 exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
 <DocumentFragment>
   <div
-    class="css-1frprgo"
+    class="css-1233jpw"
   >
     <div
       class="css-gmqme8"

--- a/packages/ts-newskit/src/slices/section-bucket/index.tsx
+++ b/packages/ts-newskit/src/slices/section-bucket/index.tsx
@@ -86,7 +86,7 @@ export const SectionBucket = ({
 
   return isMobile ? (
     <Scroll
-      overrides={{ overlays: { stylePreset: 'transparentBackground' } }}
+      overrides={{ overlays: { stylePreset: 'transparentBackground' }, marginBlock: 'space040' }}
       tabIndex={undefined}
     >
       {ArticleStackBlocks}
@@ -99,6 +99,7 @@ export const SectionBucket = ({
         lg: '976px',
         xl: '1276px'
       }}
+      marginBlock="space040"
     >
       {ArticleStackBlocks}
     </BlockItem>

--- a/packages/ts-newskit/src/slices/section-bucket/index.tsx
+++ b/packages/ts-newskit/src/slices/section-bucket/index.tsx
@@ -86,7 +86,10 @@ export const SectionBucket = ({
 
   return isMobile ? (
     <Scroll
-      overrides={{ overlays: { stylePreset: 'transparentBackground' }, marginBlock: 'space040' }}
+      overrides={{
+        overlays: { stylePreset: 'transparentBackground' },
+        marginBlock: 'space040'
+      }}
       tabIndex={undefined}
     >
       {ArticleStackBlocks}

--- a/packages/ts-newskit/src/slices/shared/layouts.tsx
+++ b/packages/ts-newskit/src/slices/shared/layouts.tsx
@@ -11,7 +11,7 @@ export const CustomStackLayout: React.FC = ({ children }) => {
         xs: 'space045',
         md: 'space000'
       }}
-      marginBlock='space040'
+      marginBlock="space040"
     >
       {children}
     </Stack>

--- a/packages/ts-newskit/src/slices/shared/layouts.tsx
+++ b/packages/ts-newskit/src/slices/shared/layouts.tsx
@@ -11,6 +11,7 @@ export const CustomStackLayout: React.FC = ({ children }) => {
         xs: 'space045',
         md: 'space000'
       }}
+      marginBlock='space040'
     >
       {children}
     </Stack>

--- a/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
     class="css-1frprgo"
   >
     <div
-      class="css-1sr0a1l"
+      class="css-1b7p4pb"
     >
       <div
         class="css-13tedu1"
@@ -431,7 +431,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="css-1sr0a1l"
+      class="css-1b7p4pb"
     >
       <div
         class="css-13tedu1"
@@ -803,7 +803,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
     class="css-1frprgo"
   >
     <div
-      class="css-1sr0a1l"
+      class="css-1b7p4pb"
     >
       <div
         class="css-13tedu1"
@@ -1228,7 +1228,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
       </div>
     </div>
     <div
-      class="css-1sr0a1l"
+      class="css-1b7p4pb"
     >
       <div
         class="css-13tedu1"
@@ -1598,7 +1598,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
     class="css-1frprgo"
   >
     <div
-      class="css-1sr0a1l"
+      class="css-1b7p4pb"
     >
       <div
         class="css-13tedu1"
@@ -1999,7 +1999,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
       </div>
     </div>
     <div
-      class="css-1sr0a1l"
+      class="css-1b7p4pb"
     >
       <div
         class="css-13tedu1"
@@ -2409,7 +2409,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
     class="css-1frprgo"
   >
     <div
-      class="css-1sr0a1l"
+      class="css-1b7p4pb"
     >
       <div
         class="css-13tedu1"
@@ -2810,7 +2810,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
       </div>
     </div>
     <div
-      class="css-1sr0a1l"
+      class="css-1b7p4pb"
     >
       <div
         class="css-13tedu1"


### PR DESCRIPTION
### Description

Add `min-height` style to Slice Header, to maintain minimum height when icon for link is not included.

Also, added spacing to slices through `CustomStackLayout`

[TMRX-1477](https://nidigitalsolutions.jira.com/browse/TMRX-1477)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMRX-1477]: https://nidigitalsolutions.jira.com/browse/TMRX-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ