### PR TITLE
fix(TMRX-000): Add component to slice header tracking

### DIFF
--- a/packages/ts-newskit/src/components/slices/slice-header/index.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/index.tsx
@@ -39,6 +39,7 @@ export const SliceHeader = ({
   return (
     <TrackingContextProvider
       context={{
+        component: 'SliceHeader',
         object: 'SliceHeader'
       }}
     >


### PR DESCRIPTION
### Description

The tracking team have implemented the config that will hopefully allow us to pass tracking from times-components onto channel pages. 
Need to pass both Component and Object fields to the tracking context provider. 


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.
