### PR TITLE
Fix/TMRX-1467 mobile web l 2 dropdown page should not scroll if l 2 is expanded

### DIFF
--- a/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-nav-mobile.test.tsx.snap
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-nav-mobile.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Secondary Menu should render snapshot 1`] = `
         </li>
       </div>
       <div
-        class="css-1jmdk2t"
+        class="css-kf0duk"
       >
         <div
           class="css-74ql93"

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/index.tsx
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/index.tsx
@@ -12,6 +12,7 @@ interface SecondaryNavigationProps {
   stickyTopDesktop?: number;
   onClick?: (isExpanded: boolean) => void;
   defaultSelectedIndex?: number;
+  hightMobile?: string;
 }
 
 export const SecondaryNavigation = ({
@@ -20,7 +21,8 @@ export const SecondaryNavigation = ({
   stickyTopDesktop,
   stickyTop,
   onClick,
-  defaultSelectedIndex = -1
+  defaultSelectedIndex = -1,
+  hightMobile = 'auto'
 }: SecondaryNavigationProps) => {
   const selectedItem =
     defaultSelectedIndex >= 0
@@ -51,7 +53,12 @@ export const SecondaryNavigation = ({
   return (
     <SecondaryNavContainer topDesktop={stickyTopDesktop} topMobile={stickyTop}>
       <Visible sm xs>
-        <SecondaryNavMobile data={data} options={options} onClick={onClick} />
+        <SecondaryNavMobile
+          data={data}
+          options={options}
+          onClick={onClick}
+          height={hightMobile}
+        />
       </Visible>
       <Visible md lg xl>
         <SecondaryNavDesktop data={data} options={options} />

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/index.tsx
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/index.tsx
@@ -12,7 +12,7 @@ interface SecondaryNavigationProps {
   stickyTopDesktop?: number;
   onClick?: (isExpanded: boolean) => void;
   defaultSelectedIndex?: number;
-  hightMobile?: string;
+  heightMobile?: string;
 }
 
 export const SecondaryNavigation = ({
@@ -22,7 +22,7 @@ export const SecondaryNavigation = ({
   stickyTop,
   onClick,
   defaultSelectedIndex = -1,
-  hightMobile = 'auto'
+  heightMobile = 'auto'
 }: SecondaryNavigationProps) => {
   const selectedItem =
     defaultSelectedIndex >= 0
@@ -57,7 +57,7 @@ export const SecondaryNavigation = ({
           data={data}
           options={options}
           onClick={onClick}
-          height={hightMobile}
+          height={heightMobile}
         />
       </Visible>
       <Visible md lg xl>

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/mobile/index.tsx
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/mobile/index.tsx
@@ -9,11 +9,12 @@ export const SecondaryNavMobile: React.FC<{
   options: SecondaryMenuOptions;
   data: SecondaryMenuItem[];
   onClick?: (isExpanded: boolean) => void;
-}> = ({ options, data, onClick }) => {
+  height?: string
+}> = ({ options, data, onClick, height = 'auto' }) => {
   const { isExpanded, isSelected } = options;
   const subMenuTitle = isExpanded ? 'Close' : 'See all';
   const navRef = useRef<HTMLDivElement>(null);
-  const [height, setHeight] = useState<string>('auto');
+  const [navHeight, setNavHeight] = useState<string>(height);
 
   useEffect(
     () => {
@@ -21,12 +22,12 @@ export const SecondaryNavMobile: React.FC<{
         if (
           window.innerHeight <= navRef.current.getBoundingClientRect().bottom
         ) {
-          setHeight(
+          setNavHeight(
             `${window.innerHeight -
               navRef.current.getBoundingClientRect().top}px`
           );
         } else {
-          setHeight('100vh');
+          setNavHeight('100vh');
         }
       }
     },
@@ -48,7 +49,7 @@ export const SecondaryNavMobile: React.FC<{
         onClick={onClick}
       />
       {isExpanded ? (
-        <NavItemsMobileContainer $height={height} ref={navRef}>
+        <NavItemsMobileContainer $height={navHeight} ref={navRef}>
           <NavItems data={data} options={options} />
         </NavItemsMobileContainer>
       ) : null}

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/mobile/index.tsx
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/mobile/index.tsx
@@ -27,7 +27,7 @@ export const SecondaryNavMobile: React.FC<{
               navRef.current.getBoundingClientRect().top}px`
           );
         } else {
-          setNavHeight('100vh');
+          setNavHeight(height);
         }
       }
     },

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/mobile/index.tsx
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/mobile/index.tsx
@@ -9,7 +9,7 @@ export const SecondaryNavMobile: React.FC<{
   options: SecondaryMenuOptions;
   data: SecondaryMenuItem[];
   onClick?: (isExpanded: boolean) => void;
-  height?: string
+  height?: string;
 }> = ({ options, data, onClick, height = 'auto' }) => {
   const { isExpanded, isSelected } = options;
   const subMenuTitle = isExpanded ? 'Close' : 'See all';

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/secondary-navigation.stories.mdx
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/secondary-navigation.stories.mdx
@@ -25,13 +25,13 @@ An example of the `data` structure can be found in the 'Controls' section on the
 ## View Component
 Please click the 'Canvas' tab for a better viewing experience, where you can review at the different breakpoints by clicking the preview icon and selecting from our list of pre-defined breakpoints (XS, SM, MD, LG and XL).
 
-export const SecondaryNavStory = ({data, pageSlug, stickyTopDesktop, stickyTop, defaultSelectedIndex }) => (
+export const SecondaryNavStory = ({data, pageSlug, stickyTopDesktop, stickyTop, defaultSelectedIndex, heightMobile }) => (
   <TCThemeProvider>
   <div style={{ "minHeight": "200vh" }}>
     <div style={{ "backgroundColor": "white", "minHeight": "340px", "textAlign": "center" }}>
       <h1>Top Content</h1>
     </div>
-    <SecondaryNavigation data={mainMenuItems} pageSlug={pageSlug} stickyTopDesktop={stickyTopDesktop} stickyTop={stickyTop} defaultSelectedIndex={defaultSelectedIndex}/>
+    <SecondaryNavigation data={mainMenuItems} pageSlug={pageSlug} stickyTopDesktop={stickyTopDesktop} stickyTop={stickyTop} defaultSelectedIndex={defaultSelectedIndex} heightMobile={heightMobile} />
     <div style={{ "backgroundColor": "cyan", "textAlign": "center" }}>
       <h1>Bottom Content</h1>
     </div>


### PR DESCRIPTION
### Description

A small fix for a default state of height.
Used to be default set to 'auto' and this makes the first time expand not being full page.
A corresponding render repo PR should pass '100vh' to it. See the recording below.
 
[TMRX-1467](https://nidigitalsolutions.jira.com/browse/TMRX-1467)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):


https://github.com/newsuk/times-components/assets/139121277/5bf60665-5fd2-40d1-8cea-cc54bb6ae006




[TMRX-1467]: https://nidigitalsolutions.jira.com/browse/TMRX-1467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ