### PR TITLE
feat(TMRX-1300): create article byline block

### DIFF
--- a/packages/article-skeleton/src/article-body/article-body.js
+++ b/packages/article-skeleton/src/article-body/article-body.js
@@ -423,6 +423,8 @@ const renderers = ({
               // time={attributes.time}
               breaking={attributes.breaking}
               headline={attributes.headline}
+              authorSlug={attributes.slug}
+              description={attributes.description}
             />
           </div>
         );

--- a/packages/ts-components/src/components/article-header/ArticleBylineBlock.stories.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleBylineBlock.stories.tsx
@@ -24,7 +24,7 @@ storiesOf('Typescript Component/Article Header', module).add(
     const props = getAttributes();
     return (
       <ArticleBylineBlock
-        data={{
+        authorData={{
           slug: 'oliver-wright',
           name: props.name,
           jobTitle: props.jobTitle,

--- a/packages/ts-components/src/components/article-header/ArticleBylineBlock.stories.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleBylineBlock.stories.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { text } from '@storybook/addon-knobs';
+import { ArticleBylineBlock } from './ArticleBylineBlock';
+
+const getAttributes = () => {
+  const id = 'Options';
+
+  const name = text('Name', 'Oliver Wright', id);
+  const jobTitle = text('Job Title', 'Policy Editor', id);
+  const image = text(
+    'Image',
+    'https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F043bbdb4-f8df-4856-92a4-132cc1524cb9.jpg?crop=668%2C668%2C0%2C0&resize=200',
+    id
+  );
+  const description = text('Description', 'Analysis', id);
+
+  return { name, jobTitle, image, description };
+};
+
+storiesOf('Typescript Component/Article Header', module).add(
+  'Article Byline Block',
+  () => {
+    const props = getAttributes();
+    return (
+      <ArticleBylineBlock
+        data={{
+          slug: 'oliver-wright',
+          name: props.name,
+          jobTitle: props.jobTitle,
+          image: props.image
+        }}
+        description={props.description}
+      />
+    );
+  }
+);

--- a/packages/ts-components/src/components/article-header/ArticleBylineBlock.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleBylineBlock.tsx
@@ -12,10 +12,10 @@ import {
 } from './styles';
 
 export const ArticleBylineBlock: React.FC<{
-  data?: ArticleByline | null;
+  data?: ArticleByline;
   description?: string;
 }> = ({ data, description }) => {
-  if (!(data && data.name && data.image) && !description) {
+  if (!((data && data.name) || (data && data.image)) && !description) {
     return null;
   }
 

--- a/packages/ts-components/src/components/article-header/ArticleBylineBlock.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleBylineBlock.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { ArticleByline } from '../../types/related-article-slice';
+import {
+  BylineBlockContainer,
+  BylineBlockImgContainer,
+  BylineBlockImg,
+  BylineBlockContent,
+  BylineBlockAuthorContent,
+  BylineBlockAuthorName,
+  BylineBlockAuthorJobTitle,
+  BylineBlockAuthorDescription
+} from './styles';
+
+export const ArticleBylineBlock: React.FC<{
+  data?: ArticleByline | null;
+  description?: string;
+}> = ({ data, description }) => {
+  if (!(data && data.name && data.image) && !description) {
+    return null;
+  }
+
+  return (
+    <BylineBlockContainer>
+      {data &&
+        data.image && (
+          <BylineBlockImgContainer>
+            <BylineBlockImg src={data.image} alt={data.name} />
+          </BylineBlockImgContainer>
+        )}
+      <BylineBlockContent>
+        <BylineBlockAuthorContent>
+          {data &&
+            data.name && (
+              <BylineBlockAuthorName>{data.name}</BylineBlockAuthorName>
+            )}
+          {data &&
+            data.jobTitle && (
+              <BylineBlockAuthorJobTitle>
+                {data.jobTitle}
+              </BylineBlockAuthorJobTitle>
+            )}
+        </BylineBlockAuthorContent>
+        {description && (
+          <BylineBlockAuthorDescription>
+            {description}
+          </BylineBlockAuthorDescription>
+        )}
+      </BylineBlockContent>
+    </BylineBlockContainer>
+  );
+};

--- a/packages/ts-components/src/components/article-header/ArticleBylineBlock.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleBylineBlock.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ArticleByline } from '../../types/related-article-slice';
+import { ArticleBylineAuthorData } from '../../types/related-article-slice';
 import {
   BylineBlockContainer,
   BylineBlockImgContainer,
@@ -8,42 +8,43 @@ import {
   BylineBlockAuthorContent,
   BylineBlockAuthorName,
   BylineBlockAuthorJobTitle,
-  BylineBlockAuthorDescription
+  BylineBlockDescription
 } from './styles';
 
 export const ArticleBylineBlock: React.FC<{
-  data?: ArticleByline;
+  authorData?: ArticleBylineAuthorData;
   description?: string;
-}> = ({ data, description }) => {
-  if (!((data && data.name) || (data && data.image)) && !description) {
+}> = ({ authorData, description }) => {
+  if (
+    !((authorData && authorData.name) || (authorData && authorData.image)) &&
+    !description
+  ) {
     return null;
   }
 
   return (
     <BylineBlockContainer>
-      {data &&
-        data.image && (
+      {authorData &&
+        authorData.image && (
           <BylineBlockImgContainer>
-            <BylineBlockImg src={data.image} alt={data.name} />
+            <BylineBlockImg src={authorData.image} alt={authorData.name} />
           </BylineBlockImgContainer>
         )}
       <BylineBlockContent>
         <BylineBlockAuthorContent>
-          {data &&
-            data.name && (
-              <BylineBlockAuthorName>{data.name}</BylineBlockAuthorName>
+          {authorData &&
+            authorData.name && (
+              <BylineBlockAuthorName>{authorData.name}</BylineBlockAuthorName>
             )}
-          {data &&
-            data.jobTitle && (
+          {authorData &&
+            authorData.jobTitle && (
               <BylineBlockAuthorJobTitle>
-                {data.jobTitle}
+                {authorData.jobTitle}
               </BylineBlockAuthorJobTitle>
             )}
         </BylineBlockAuthorContent>
         {description && (
-          <BylineBlockAuthorDescription>
-            {description}
-          </BylineBlockAuthorDescription>
+          <BylineBlockDescription>{description}</BylineBlockDescription>
         )}
       </BylineBlockContent>
     </BylineBlockContainer>

--- a/packages/ts-components/src/components/article-header/ArticleHeader.stories.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleHeader.stories.tsx
@@ -25,11 +25,8 @@ const getAttributes = () => {
 
   const headline = text('Headline', 'This is the headline', id);
 
+  const authorSlug = text('Author Slug', 'oliver-wright', id);
   const description = text('Description', 'Analysis', id);
-
-  const authorSlugOptions = ['Oliver Wright', 'Milan Haria', 'Ibrahim Kurhan'];
-  const defaultValue = authorSlugOptions[0];
-  const authorSlug = select('Author Slug', authorSlugOptions, defaultValue, id);
 
   return { updated, breaking, headline, authorSlug, description };
 };

--- a/packages/ts-components/src/components/article-header/ArticleHeader.stories.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleHeader.stories.tsx
@@ -25,7 +25,13 @@ const getAttributes = () => {
 
   const headline = text('Headline', 'This is the headline', id);
 
-  return { updated, breaking, headline };
+  const description = text('Description', 'Analysis', id);
+
+  const authorSlugOptions = ['Oliver Wright', 'Milan Haria', 'Ibrahim Kurhan'];
+  const defaultValue = authorSlugOptions[0];
+  const authorSlug = select('Author Slug', authorSlugOptions, defaultValue, id);
+
+  return { updated, breaking, headline, authorSlug, description };
 };
 
 storiesOf('Typescript Component/Article Header', module)
@@ -39,6 +45,8 @@ storiesOf('Typescript Component/Article Header', module)
           // time={props.time}
           breaking={props.breaking}
           headline={encodeURIComponent(props.headline)}
+          authorSlug={props.authorSlug}
+          description={props.description}
         />
       </ArticleHarness>
     );
@@ -52,6 +60,8 @@ storiesOf('Typescript Component/Article Header', module)
           // date={props.date}
           // time={props.time}
           breaking={props.breaking}
+          authorSlug={props.authorSlug}
+          description={props.description}
         />
       </ArticleHarness>
     );

--- a/packages/ts-components/src/components/article-header/ArticleHeader.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleHeader.tsx
@@ -41,7 +41,7 @@ const ArticleHeader: React.FC<{
   description?: string;
 }> = ({ updated, breaking, headline, authorSlug, description }) => {
   const [timezone, setTimezone] = useState<string>('');
-  const [bylineData, setBylineData] = useState<ArticleByline | null>(null);
+  const [bylineData, setBylineData] = useState<ArticleByline>();
 
   const currentDateTime = new Date();
   const updatedDate = new Date(updated);

--- a/packages/ts-components/src/components/article-header/ArticleHeader.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleHeader.tsx
@@ -59,16 +59,18 @@ const ArticleHeader: React.FC<{
 
   useEffect(
     () => {
-      if (authorSlug) {
-        // TODO: fetch the data
-        setBylineData({
-          slug: authorSlug,
-          name: 'Oliver Wright',
-          jobTitle: 'Policy Editor',
-          image:
-            'https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F043bbdb4-f8df-4856-92a4-132cc1524cb9.jpg?crop=668%2C668%2C0%2C0&resize=200'
-        });
-      }
+      const fetchData = async () => {
+        try {
+          const response = await fetch(`/api/author-profile/${authorSlug}`);
+          const authorDetails = await response.json();
+          setBylineData(authorDetails);
+        } catch (err) {
+          // tslint:disable-next-line:no-console
+          console.log(err);
+        }
+      };
+
+      fetchData();
     },
     [authorSlug]
   );

--- a/packages/ts-components/src/components/article-header/ArticleHeader.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleHeader.tsx
@@ -21,6 +21,8 @@ import {
   UpdatesContainer,
   FlagContainer
 } from './styles';
+import { ArticleByline } from '../../types/related-article-slice';
+import { ArticleBylineBlock } from './ArticleBylineBlock';
 
 const anchorString = (updateTxt = '', headlineTxt = '') => {
   const onlyNumbersReg = /\D+/g;
@@ -35,8 +37,11 @@ const ArticleHeader: React.FC<{
   updated: string;
   breaking?: string;
   headline?: string;
-}> = ({ updated, breaking, headline }) => {
+  authorSlug?: string;
+  description?: string;
+}> = ({ updated, breaking, headline, authorSlug, description }) => {
   const [timezone, setTimezone] = useState<string>('');
+  const [bylineData, setBylineData] = useState<ArticleByline | null>(null);
 
   const currentDateTime = new Date();
   const updatedDate = new Date(updated);
@@ -51,6 +56,22 @@ const ArticleHeader: React.FC<{
       setTimezone(format(parsedDate, 'zzz', { timeZone }));
     }
   });
+
+  useEffect(
+    () => {
+      if (authorSlug) {
+        // TODO: fetch the data
+        setBylineData({
+          slug: authorSlug,
+          name: 'Oliver Wright',
+          jobTitle: 'Policy Editor',
+          image:
+            'https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F043bbdb4-f8df-4856-92a4-132cc1524cb9.jpg?crop=668%2C668%2C0%2C0&resize=200'
+        });
+      }
+    },
+    [authorSlug]
+  );
 
   const timeSincePublishing =
     formatDistanceStrict(updatedDate, currentDateTime, {
@@ -102,6 +123,7 @@ const ArticleHeader: React.FC<{
       </UpdatesContainer>
 
       {headline && <Headline>{safeDecodeURIComponent(headline)}</Headline>}
+      <ArticleBylineBlock data={bylineData} description={description} />
     </Container>
   );
 };

--- a/packages/ts-components/src/components/article-header/ArticleHeader.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleHeader.tsx
@@ -21,7 +21,7 @@ import {
   UpdatesContainer,
   FlagContainer
 } from './styles';
-import { ArticleByline } from '../../types/related-article-slice';
+import { ArticleBylineAuthorData } from '../../types/related-article-slice';
 import { ArticleBylineBlock } from './ArticleBylineBlock';
 
 const anchorString = (updateTxt = '', headlineTxt = '') => {
@@ -41,7 +41,7 @@ const ArticleHeader: React.FC<{
   description?: string;
 }> = ({ updated, breaking, headline, authorSlug, description }) => {
   const [timezone, setTimezone] = useState<string>('');
-  const [bylineData, setBylineData] = useState<ArticleByline>();
+  const [authorData, setAuthorData] = useState<ArticleBylineAuthorData>();
 
   const currentDateTime = new Date();
   const updatedDate = new Date(updated);
@@ -63,7 +63,7 @@ const ArticleHeader: React.FC<{
         try {
           const response = await fetch(`/api/author-profile/${authorSlug}`);
           const authorDetails = await response.json();
-          setBylineData(authorDetails);
+          setAuthorData(authorDetails);
         } catch (err) {
           // tslint:disable-next-line:no-console
           console.log(err);
@@ -125,7 +125,7 @@ const ArticleHeader: React.FC<{
       </UpdatesContainer>
 
       {headline && <Headline>{safeDecodeURIComponent(headline)}</Headline>}
-      <ArticleBylineBlock data={bylineData} description={description} />
+      <ArticleBylineBlock authorData={authorData} description={description} />
     </Container>
   );
 };

--- a/packages/ts-components/src/components/article-header/__tests__/ArticleBylineBlock.test.tsx
+++ b/packages/ts-components/src/components/article-header/__tests__/ArticleBylineBlock.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import {ArticleBylineBlock} from '../ArticleBylineBlock';
+
+  describe('Article byline block', () => {
+
+    const data = {
+      slug: 'oliver-wright',
+      name: "Oliver Wright",
+      jobTitle: "Privacy Editor",
+      image: 'https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F043bbdb4-f8df-4856-92a4-132cc1524cb9.jpg?crop=668%2C668%2C0%2C0&resize=200'
+    }
+    const description = 'Analysis';
+
+    it('Displays description', () => {
+
+      const { getByText } = render(
+        <ArticleBylineBlock data={undefined} description={description} />
+      );
+
+      expect(getByText(description)).toBeVisible();
+    });
+
+    it('Does not display the byline block component when no details exist', () => {
+
+      const { queryByText } = render(
+        <ArticleBylineBlock />
+      );
+
+      expect(queryByText(data.name)).not.toBeInTheDocument();
+      expect(queryByText(description)).not.toBeInTheDocument();
+    });
+
+    it('Displays author details and description', () => {
+
+      const { getByText, getByRole } = render(
+        <ArticleBylineBlock
+          data={data}
+          description={description}
+        />
+      );
+      expect(getByText(data.name)).toBeVisible();
+      expect(getByText(data.jobTitle)).toBeVisible();
+      const bylineImg = getByRole('img');
+      expect(bylineImg).toHaveAttribute(
+        'src',
+        'https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F043bbdb4-f8df-4856-92a4-132cc1524cb9.jpg?crop=668%2C668%2C0%2C0&resize=200'
+      );
+    });
+});

--- a/packages/ts-components/src/components/article-header/__tests__/ArticleBylineBlock.test.tsx
+++ b/packages/ts-components/src/components/article-header/__tests__/ArticleBylineBlock.test.tsx
@@ -16,7 +16,7 @@ describe('Article byline block', () => {
 
   it('Displays description', () => {
     const { getByText } = render(
-      <ArticleBylineBlock data={undefined} description={description} />
+      <ArticleBylineBlock authorData={undefined} description={description} />
     );
 
     expect(getByText(description)).toBeVisible();
@@ -31,7 +31,7 @@ describe('Article byline block', () => {
 
   it('Displays author details and description', () => {
     const { getByText, getByRole } = render(
-      <ArticleBylineBlock data={data} description={description} />
+      <ArticleBylineBlock authorData={data} description={description} />
     );
     expect(getByText(data.name)).toBeVisible();
     expect(getByText(data.jobTitle)).toBeVisible();

--- a/packages/ts-components/src/components/article-header/__tests__/ArticleBylineBlock.test.tsx
+++ b/packages/ts-components/src/components/article-header/__tests__/ArticleBylineBlock.test.tsx
@@ -2,51 +2,43 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import {ArticleBylineBlock} from '../ArticleBylineBlock';
+import { ArticleBylineBlock } from '../ArticleBylineBlock';
 
-  describe('Article byline block', () => {
+describe('Article byline block', () => {
+  const data = {
+    slug: 'oliver-wright',
+    name: 'Oliver Wright',
+    jobTitle: 'Privacy Editor',
+    image:
+      'https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F043bbdb4-f8df-4856-92a4-132cc1524cb9.jpg?crop=668%2C668%2C0%2C0&resize=200'
+  };
+  const description = 'Analysis';
 
-    const data = {
-      slug: 'oliver-wright',
-      name: "Oliver Wright",
-      jobTitle: "Privacy Editor",
-      image: 'https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F043bbdb4-f8df-4856-92a4-132cc1524cb9.jpg?crop=668%2C668%2C0%2C0&resize=200'
-    }
-    const description = 'Analysis';
+  it('Displays description', () => {
+    const { getByText } = render(
+      <ArticleBylineBlock data={undefined} description={description} />
+    );
 
-    it('Displays description', () => {
+    expect(getByText(description)).toBeVisible();
+  });
 
-      const { getByText } = render(
-        <ArticleBylineBlock data={undefined} description={description} />
-      );
+  it('Does not display the byline block component when no details exist', () => {
+    const { queryByText } = render(<ArticleBylineBlock />);
 
-      expect(getByText(description)).toBeVisible();
-    });
+    expect(queryByText(data.name)).not.toBeInTheDocument();
+    expect(queryByText(description)).not.toBeInTheDocument();
+  });
 
-    it('Does not display the byline block component when no details exist', () => {
-
-      const { queryByText } = render(
-        <ArticleBylineBlock />
-      );
-
-      expect(queryByText(data.name)).not.toBeInTheDocument();
-      expect(queryByText(description)).not.toBeInTheDocument();
-    });
-
-    it('Displays author details and description', () => {
-
-      const { getByText, getByRole } = render(
-        <ArticleBylineBlock
-          data={data}
-          description={description}
-        />
-      );
-      expect(getByText(data.name)).toBeVisible();
-      expect(getByText(data.jobTitle)).toBeVisible();
-      const bylineImg = getByRole('img');
-      expect(bylineImg).toHaveAttribute(
-        'src',
-        'https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F043bbdb4-f8df-4856-92a4-132cc1524cb9.jpg?crop=668%2C668%2C0%2C0&resize=200'
-      );
-    });
+  it('Displays author details and description', () => {
+    const { getByText, getByRole } = render(
+      <ArticleBylineBlock data={data} description={description} />
+    );
+    expect(getByText(data.name)).toBeVisible();
+    expect(getByText(data.jobTitle)).toBeVisible();
+    const bylineImg = getByRole('img');
+    expect(bylineImg).toHaveAttribute(
+      'src',
+      'https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F043bbdb4-f8df-4856-92a4-132cc1524cb9.jpg?crop=668%2C668%2C0%2C0&resize=200'
+    );
+  });
 });

--- a/packages/ts-components/src/components/article-header/__tests__/ArticleHeader.test.tsx
+++ b/packages/ts-components/src/components/article-header/__tests__/ArticleHeader.test.tsx
@@ -144,4 +144,39 @@ describe('ArticleHeader', () => {
       expect(getByText('December 31')).toBeVisible();
     });
   });
+
+  describe('Byline block', () => {
+    afterEach(() => MockDate.reset());
+
+    const updated = '2021-12-31T22:30:00+00:00';
+    const description = 'Analysis';
+
+    it('Displays description', () => {
+      MockDate.set('2022-01-01T02:30:00+00:00');
+
+      const { getByText } = render(
+        <ArticleHeader updated={updated} description={description} />
+      );
+
+      expect(getByText('Analysis')).toBeVisible();
+    });
+
+    it('Displays author details', () => {
+      MockDate.set('2022-01-01T02:30:00+00:00');
+
+      const { getByText, getByRole } = render(
+        <ArticleHeader
+          updated={updated}
+          authorSlug="oliver-wright"
+          description={description}
+        />
+      );
+      expect(getByText('Oliver Wright')).toBeVisible();
+      const bylineImg = getByRole('img');
+      expect(bylineImg).toHaveAttribute(
+        'src',
+        'https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F043bbdb4-f8df-4856-92a4-132cc1524cb9.jpg?crop=668%2C668%2C0%2C0&resize=200'
+      );
+    });
+  });
 });

--- a/packages/ts-components/src/components/article-header/__tests__/ArticleHeader.test.tsx
+++ b/packages/ts-components/src/components/article-header/__tests__/ArticleHeader.test.tsx
@@ -161,7 +161,17 @@ describe('ArticleHeader', () => {
       expect(getByText('Analysis')).toBeVisible();
     });
 
-    it('Displays author details', () => {
+    it('Does not display the byline block component when no details exist', () => {
+      MockDate.set('2022-01-01T02:30:00+00:00');
+
+      const { queryByText } = render(
+        <ArticleHeader updated={updated} description={description} />
+      );
+
+      expect(queryByText('Oliver Wright')).not.toBeInTheDocument();
+    });
+
+    it.skip('Displays author details', () => {
       MockDate.set('2022-01-01T02:30:00+00:00');
 
       const { getByText, getByRole } = render(

--- a/packages/ts-components/src/components/article-header/__tests__/ArticleHeader.test.tsx
+++ b/packages/ts-components/src/components/article-header/__tests__/ArticleHeader.test.tsx
@@ -144,49 +144,4 @@ describe('ArticleHeader', () => {
       expect(getByText('December 31')).toBeVisible();
     });
   });
-
-  describe('Byline block', () => {
-    afterEach(() => MockDate.reset());
-
-    const updated = '2021-12-31T22:30:00+00:00';
-    const description = 'Analysis';
-
-    it('Displays description', () => {
-      MockDate.set('2022-01-01T02:30:00+00:00');
-
-      const { getByText } = render(
-        <ArticleHeader updated={updated} description={description} />
-      );
-
-      expect(getByText('Analysis')).toBeVisible();
-    });
-
-    it('Does not display the byline block component when no details exist', () => {
-      MockDate.set('2022-01-01T02:30:00+00:00');
-
-      const { queryByText } = render(
-        <ArticleHeader updated={updated} description={description} />
-      );
-
-      expect(queryByText('Oliver Wright')).not.toBeInTheDocument();
-    });
-
-    it.skip('Displays author details', () => {
-      MockDate.set('2022-01-01T02:30:00+00:00');
-
-      const { getByText, getByRole } = render(
-        <ArticleHeader
-          updated={updated}
-          authorSlug="oliver-wright"
-          description={description}
-        />
-      );
-      expect(getByText('Oliver Wright')).toBeVisible();
-      const bylineImg = getByRole('img');
-      expect(bylineImg).toHaveAttribute(
-        'src',
-        'https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F043bbdb4-f8df-4856-92a4-132cc1524cb9.jpg?crop=668%2C668%2C0%2C0&resize=200'
-      );
-    });
-  });
 });

--- a/packages/ts-components/src/components/article-header/styles.ts
+++ b/packages/ts-components/src/components/article-header/styles.ts
@@ -86,3 +86,55 @@ export const Headline = styled.h2`
 export const FlagContainer = styled.div`
   margin-right: 8px;
 `;
+
+export const BylineBlockContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: 24px;
+  font-family: Roboto;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 16px;
+`;
+
+export const BylineBlockImgContainer = styled.div`
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  overflow: hidden;
+  margin-right: 10px;
+`;
+
+export const BylineBlockImg = styled.img`
+  height: 100%;
+  width: 100%;
+`;
+
+export const BylineBlockContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const BylineBlockAuthorContent = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 2px;
+`;
+
+export const BylineBlockAuthorName = styled.p`
+  color: #069;
+  margin-right: 5px;
+  margin-block: 0;
+`;
+
+export const BylineBlockAuthorJobTitle = styled.p`
+  color: #696969;
+  margin-block: 0;
+`;
+
+export const BylineBlockAuthorDescription = styled.p`
+  color: #696969;
+  font-weight: 500;
+  margin-block: 0;
+`;

--- a/packages/ts-components/src/components/article-header/styles.ts
+++ b/packages/ts-components/src/components/article-header/styles.ts
@@ -133,7 +133,7 @@ export const BylineBlockAuthorJobTitle = styled.p`
   margin-block: 0;
 `;
 
-export const BylineBlockAuthorDescription = styled.p`
+export const BylineBlockDescription = styled.p`
   color: #696969;
   font-weight: 500;
   margin-block: 0;

--- a/packages/ts-components/src/types/related-article-slice.ts
+++ b/packages/ts-components/src/types/related-article-slice.ts
@@ -18,7 +18,7 @@ type Byline = {
 
 type Bylines = Array<{ byline: Byline[]; image?: any }>;
 
-export type ArticleByline = {
+export type ArticleBylineAuthorData = {
   slug: string;
   name?: string;
   jobTitle?: string;

--- a/packages/ts-components/src/types/related-article-slice.ts
+++ b/packages/ts-components/src/types/related-article-slice.ts
@@ -18,6 +18,13 @@ type Byline = {
 
 type Bylines = Array<{ byline: Byline[]; image?: any }>;
 
+export type ArticleByline = {
+  slug: string;
+  name?: string;
+  jobTitle?: string;
+  image?: string;
+};
+
 type Summary = {
   name: string;
   attributes?: { [attribute: string]: string };


### PR DESCRIPTION
### Description

Context

An update to the current live file separating block with the rule and fine and date to include a byline name and pic.

Purpose

We need this as the current way of using datawrapper byline pics get very heavy from a page load point of view so we are hoping this way would be much lighter

Requirements

It’d be great if this was really easy to update - so if we had some analysis from William Hague for example (!), we could quickly add his byline embed.

It would be great if the second line had enough space for us to be able to include a sentence of description with the author byline, thus helping google discover authors who are experts in their fields. 

Technical implementation: 
You can expect two new fields in the parameters data for the live dividers. One will be the slug name of the author, and another will be an update type.

With the slug name of the author this will be used to query the additional author information (name, image and jobTitle) 

For this query as it is within times-components we may need to use a similar approach to the one we have for live update button where you create a new route in cps-content-render /api which you pass the slug of the author to fetch this data. 

For the update type you should be able to just take the value and render that on the UI component. 

N.B. both fields should be OPTIONAL 

Designs

Figma: [Breaking & Live News Prototype](https://www.figma.com/file/9W57iKCgqQstLzTOxI1AAr/Breaking-%26-Live-News-Prototype?type=design&node-id=0-1&t=2lrHQgXHrGJx8r1h-0) 

https://docs.google.com/document/d/1J-axkSya1ytBrtrhKYqiBveIHo_VgeWdT2REJD49I4Q/edit

Stakeholders

Anthony Cappaert (Design Editor)
Andrew Keys (Acting Creative Director)
Barney Henderson (Assistant Editor)
Tim Arbabzadah (Chief Sub Editor)


[JIRA-1300](https://nidigitalsolutions.jira.com/browse/TMRX-1300)


### Checklist

- [X] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
<img width="1081" alt="Screenshot 2023-09-11 at 12 19 47" src="https://github.com/newsuk/times-components/assets/142982056/bb2526da-4eb3-4b33-8993-b17ec519cde5">
