### PR TITLE
feat(TMPZ-167-168): Winning/Losing Screen UI

### DIFF
--- a/packages/ts-newskit/package.json
+++ b/packages/ts-newskit/package.json
@@ -53,7 +53,6 @@
     "@emotion/react": "11.11.0",
     "@emotion/styled": "11.11.0",
     "@newskit-themes/the-times": "0.2.0",
-    "@emotion-icons/material": "3.14.0",
     "isomorphic-unfetch": "3.1.0",
     "lodash.merge": "4.6.2",
     "newskit": "7.2.0",

--- a/packages/ts-newskit/package.json
+++ b/packages/ts-newskit/package.json
@@ -53,6 +53,7 @@
     "@emotion/react": "11.11.0",
     "@emotion/styled": "11.11.0",
     "@newskit-themes/the-times": "0.2.0",
+    "@emotion-icons/material": "3.14.0",
     "isomorphic-unfetch": "3.1.0",
     "lodash.merge": "4.6.2",
     "newskit": "7.2.0",

--- a/packages/ts-newskit/src/assets/CrossIcon.tsx
+++ b/packages/ts-newskit/src/assets/CrossIcon.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+const CrossIcon = (props: any) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <mask
+      id="mask0_2039_16982"
+      style={{ maskType: 'alpha' }}
+      maskUnits="userSpaceOnUse"
+      x="0"
+      y="0"
+      width="24"
+      height="24"
+    >
+      <path
+        d="M19.7071 7.11711L20.4142 6.41L19.7071 5.70289L18.2971 4.29289L17.59 3.58579L16.8829 4.29289L12 9.17579L7.11711 4.29289L6.41 3.58579L5.70289 4.29289L4.29289 5.70289L3.58579 6.41L4.29289 7.11711L9.17579 12L4.29289 16.8829L3.58579 17.59L4.29289 18.2971L5.70289 19.7071L6.41 20.4142L7.11711 19.7071L12 14.8242L16.8829 19.7071L17.59 20.4142L18.2971 19.7071L19.7071 18.2971L20.4142 17.59L19.7071 16.8829L14.8242 12L19.7071 7.11711Z"
+        stroke="#BF0000"
+        strokeWidth="2"
+        fill="none"
+      />
+    </mask>
+    <g mask="url(#mask0_2039_16982)">
+      <rect width="24" height="24" fill="#BF0000" />
+    </g>
+  </svg>
+);
+
+export default CrossIcon;

--- a/packages/ts-newskit/src/assets/DoneIcon.tsx
+++ b/packages/ts-newskit/src/assets/DoneIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const DoneIcon = (props: any) => (
+  <svg
+    {...props}
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M19.77 5.03l1.4 1.4L8.43 19.17l-5.6-5.6 1.4-1.4 4.2 4.2L19.77 5.03m0-2.83L8.43 13.54l-4.2-4.2L0 13.57 8.43 22 24 6.43 19.77 2.2z"
+      stroke="#006C6F"
+      strokeWidth="1"
+    />
+  </svg>
+);
+
+export default DoneIcon;

--- a/packages/ts-newskit/src/assets/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/assets/__tests__/__snapshots__/index.test.tsx.snap
@@ -320,6 +320,26 @@ exports[`Icons Component: NewsKitCrosswordsIcon NewsKitCrosswordsIcon renders wi
 </DocumentFragment>
 `;
 
+exports[`Icons Component: NewsKitDoneIcon NewsKitDoneIcon renders with default props 1`] = `
+<DocumentFragment>
+  <svg
+    aria-hidden="true"
+    class="css-ny3roy"
+    focusable="false"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M19.77 5.03l1.4 1.4L8.43 19.17l-5.6-5.6 1.4-1.4 4.2 4.2L19.77 5.03m0-2.83L8.43 13.54l-4.2-4.2L0 13.57 8.43 22 24 6.43 19.77 2.2z"
+      stroke="#006C6F"
+      stroke-width="1"
+    />
+  </svg>
+</DocumentFragment>
+`;
+
 exports[`Icons Component: NewsKitFilledArrowIcon NewsKitFilledArrowIcon renders with default props 1`] = `
 <DocumentFragment>
   <svg

--- a/packages/ts-newskit/src/assets/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/assets/__tests__/__snapshots__/index.test.tsx.snap
@@ -196,6 +196,44 @@ exports[`Icons Component: NewsKitCloseIcon NewsKitCloseIcon renders with default
 </DocumentFragment>
 `;
 
+exports[`Icons Component: NewsKitCrossIcon NewsKitCrossIcon renders with default props 1`] = `
+<DocumentFragment>
+  <svg
+    class="css-ny3roy"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <mask
+      height="24"
+      id="mask0_2039_16982"
+      maskUnits="userSpaceOnUse"
+      style="mask-type: alpha;"
+      width="24"
+      x="0"
+      y="0"
+    >
+      <path
+        d="M19.7071 7.11711L20.4142 6.41L19.7071 5.70289L18.2971 4.29289L17.59 3.58579L16.8829 4.29289L12 9.17579L7.11711 4.29289L6.41 3.58579L5.70289 4.29289L4.29289 5.70289L3.58579 6.41L4.29289 7.11711L9.17579 12L4.29289 16.8829L3.58579 17.59L4.29289 18.2971L5.70289 19.7071L6.41 20.4142L7.11711 19.7071L12 14.8242L16.8829 19.7071L17.59 20.4142L18.2971 19.7071L19.7071 18.2971L20.4142 17.59L19.7071 16.8829L14.8242 12L19.7071 7.11711Z"
+        fill="none"
+        stroke="#BF0000"
+        stroke-width="2"
+      />
+    </mask>
+    <g
+      mask="url(#mask0_2039_16982)"
+    >
+      <rect
+        fill="#BF0000"
+        height="24"
+        width="24"
+      />
+    </g>
+  </svg>
+</DocumentFragment>
+`;
+
 exports[`Icons Component: NewsKitCrosswordsIcon NewsKitCrosswordsIcon renders with default props 1`] = `
 <DocumentFragment>
   <svg

--- a/packages/ts-newskit/src/assets/index.tsx
+++ b/packages/ts-newskit/src/assets/index.tsx
@@ -29,6 +29,7 @@ import WordPuzzlesIcon from './WordPuzzles';
 import NumbersAndLogicIcon from './NumbersAndLogic';
 import QuizzesAndTeasersIcon from './QuizzesAndTeasers';
 import BoardAndCardGamesIcon from './BoardAndCardGames';
+import CrossIcon from './CrossIcon';
 
 const RoundedCloseIcon = styled(RoundedPlusIcon)`
   transform: rotate(45deg);
@@ -181,4 +182,9 @@ export const NewsKitQuizzesAndTeasersIcon = customToNewsKitIcon(
 export const NewsKitBoardAndCardGamesIcon = customToNewsKitIcon(
   'NewsKitBoardAndCardGamesIcon',
   props => <BoardAndCardGamesIcon {...props} />
+);
+
+export const NewsKitCrossIcon = customToNewsKitIcon(
+  'NewsKitCrossIcon',
+  props => <CrossIcon {...props} />
 );

--- a/packages/ts-newskit/src/assets/index.tsx
+++ b/packages/ts-newskit/src/assets/index.tsx
@@ -30,6 +30,7 @@ import NumbersAndLogicIcon from './NumbersAndLogic';
 import QuizzesAndTeasersIcon from './QuizzesAndTeasers';
 import BoardAndCardGamesIcon from './BoardAndCardGames';
 import CrossIcon from './CrossIcon';
+import DoneIcon from './DoneIcon';
 
 const RoundedCloseIcon = styled(RoundedPlusIcon)`
   transform: rotate(45deg);
@@ -188,3 +189,7 @@ export const NewsKitCrossIcon = customToNewsKitIcon(
   'NewsKitCrossIcon',
   props => <CrossIcon {...props} />
 );
+
+export const NewsKitDoneIcon = customToNewsKitIcon('NewsKitDoneIcon', props => (
+  <DoneIcon {...props} />
+));

--- a/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/__tests__/__snapshots__/index.test.tsx.snap
@@ -10,18 +10,17 @@ exports[`FinalScreen Component should render snapshot for FinalScreen Component 
     >
       <svg
         aria-hidden="true"
-        class="css-17wgohv-EmotionIconBase ex0cdmw0"
-        fill="currentColor"
+        class="css-ny3roy"
         focusable="false"
+        height="24"
         viewBox="0 0 24 24"
+        width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M0 0h24v24H0V0z"
-          fill="none"
-        />
-        <path
           d="M19.77 5.03l1.4 1.4L8.43 19.17l-5.6-5.6 1.4-1.4 4.2 4.2L19.77 5.03m0-2.83L8.43 13.54l-4.2-4.2L0 13.57 8.43 22 24 6.43 19.77 2.2z"
+          stroke="#006C6F"
+          stroke-width="1"
         />
       </svg>
     </div>

--- a/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FinalScreen Component should render snapshot for FinalScreen Component 1`] = `
+<DocumentFragment>
+  <div
+    class="css-13byt3y"
+  >
+    <div
+      class="css-14n2dha"
+    >
+      <svg
+        aria-hidden="true"
+        class="css-17wgohv-EmotionIconBase ex0cdmw0"
+        fill="currentColor"
+        focusable="false"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 0h24v24H0V0z"
+          fill="none"
+        />
+        <path
+          d="M19.77 5.03l1.4 1.4L8.43 19.17l-5.6-5.6 1.4-1.4 4.2 4.2L19.77 5.03m0-2.83L8.43 13.54l-4.2-4.2L0 13.57 8.43 22 24 6.43 19.77 2.2z"
+        />
+      </svg>
+    </div>
+    <h3
+      class="css-17o21eh"
+    >
+      Cape Verde
+    </h3>
+    <p
+      class="css-16gaswt"
+    />
+    <div>
+      Well done, you’re a genius!
+    </div>
+    You did it with 2 hints.
+    <p />
+  </div>
+</DocumentFragment>
+`;

--- a/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/__tests__/index.test.tsx
@@ -43,5 +43,4 @@ describe('FinalScreen Component', () => {
     );
     expect(getByText("You didn't get it this time.")).toBeInTheDocument();
   });
-
 });

--- a/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/__tests__/index.test.tsx
@@ -44,10 +44,4 @@ describe('FinalScreen Component', () => {
     expect(getByText("You didn't get it this time.")).toBeInTheDocument();
   });
 
-  it('should display "Well done, you\'re a genius!" for "Win" status', () => {
-    const { getByText } = render(
-      <FinalScreen message={message} hints={hints} ans={ans} status={status} />
-    );
-    expect(getByText(message)).toBeInTheDocument();
-  });
 });

--- a/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/__tests__/index.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render } from '../../../../../utils/test-utils';
+import '@testing-library/jest-dom';
+import { FinalScreen } from '../index';
+
+const message = 'Well done, you’re a genius!';
+const hints = 2;
+const ans = 'Cape Verde';
+const status = 'Win';
+
+describe('FinalScreen Component', () => {
+  it('should render snapshot for FinalScreen Component', () => {
+    const { asFragment } = render(
+      <FinalScreen message={message} hints={hints} ans={ans} status={status} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should display the provided message', () => {
+    const { getByText } = render(
+      <FinalScreen message={message} hints={hints} ans={ans} status={status} />
+    );
+    expect(getByText(message)).toBeInTheDocument();
+  });
+
+  it('should display the provided answer', () => {
+    const { getByText } = render(
+      <FinalScreen message={message} hints={hints} ans={ans} status={status} />
+    );
+    expect(getByText(ans)).toBeInTheDocument();
+  });
+
+  it('should display the provided hints', () => {
+    const { getByText } = render(
+      <FinalScreen message={message} hints={hints} ans={ans} status={status} />
+    );
+    expect(getByText(`You did it with ${hints} hints.`)).toBeInTheDocument();
+  });
+
+  it('should display "You didn\'t get it this time." for "Loose" status', () => {
+    const { getByText } = render(
+      <FinalScreen message={message} hints={hints} ans={ans} status="Loose" />
+    );
+    expect(getByText("You didn't get it this time.")).toBeInTheDocument();
+  });
+
+  it('should display "Well done, you\'re a genius!" for "Win" status', () => {
+    const { getByText } = render(
+      <FinalScreen message={message} hints={hints} ans={ans} status={status} />
+    );
+    expect(getByText(message)).toBeInTheDocument();
+  });
+});

--- a/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/__tests__/index.test.tsx
@@ -37,9 +37,9 @@ describe('FinalScreen Component', () => {
     expect(getByText(`You did it with ${hints} hints.`)).toBeInTheDocument();
   });
 
-  it('should display "You didn\'t get it this time." for "Loose" status', () => {
+  it('should display "You didn\'t get it this time." for "Lose" status', () => {
     const { getByText } = render(
-      <FinalScreen message={message} hints={hints} ans={ans} status="Loose" />
+      <FinalScreen message={message} hints={hints} ans={ans} status="Lose" />
     );
     expect(getByText("You didn't get it this time.")).toBeInTheDocument();
   });

--- a/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/finalScreen.stories.mdx
+++ b/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/finalScreen.stories.mdx
@@ -40,7 +40,7 @@ export const FinalScreenStory = ({ message, hints, ans, status }) => (
     status: "Win"
 }}
 argTypes={{
-    status: { control: "select", options: ["Win", "Loose"] }
+    status: { control: "select", options: ["Win", "Lose"] }
 }}>
   {FinalScreenStory.bind({})}
 </Story>

--- a/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/finalScreen.stories.mdx
+++ b/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/finalScreen.stories.mdx
@@ -1,0 +1,46 @@
+import { Meta, Story, Props } from '@storybook/addon-docs'
+import { TCThemeProvider } from '../../../../utils/index';
+import { FinalScreen } from './index';
+
+<Meta
+  title="Newskit Components/Puzzles/FinalScreen"
+  component={FinalScreen}
+/>
+
+# Feedback component
+The `FinalScreen` component displays the winning/loosing screen for daily quiz.
+
+
+## Props
+<Props of={FinalScreen} />
+
+## Code Example
+`<FinalScreen 
+       message: "Well done, you’re a genius!"
+       hints: 2
+       ans: "Cape verde"
+       status: "Win"
+ />`
+
+An example of the `data` structure can be found in the 'Controls' section on the 'Canvas' tab, where you can customise the data being fed to the FinalScreen component.
+
+## View Component
+Please click the 'Canvas' tab for a better viewing experience, where you can update the props and review at the different breakpoints by clicking the preview icon and selecting from our list of pre-defined breakpoints (XS, SM, MD, LG and XL).
+
+export const FinalScreenStory = ({ message, hints, ans, status }) => (
+  <TCThemeProvider>
+    <FinalScreen {...{ message, hints, ans, status }}/>
+  </TCThemeProvider>
+);
+
+<Story name="FinalScreen" args={{
+    message: "Well done, you’re a <strong>genius</strong>!",
+    hints: 2,
+    ans: "Cape Verde",
+    status: "Win"
+}}
+argTypes={{
+    status: { control: "select", options: ["Win", "Loose"] }
+}}>
+  {FinalScreenStory.bind({})}
+</Story>

--- a/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/index.tsx
+++ b/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/index.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { Block, toNewsKitIcon } from 'newskit';
+import { Block } from 'newskit';
 import { StyledTextBlock, StyledBlock } from './styles';
-import { DoneOutline } from '@emotion-icons/material/DoneOutline';
-import { NewsKitCrossIcon } from '../../../../assets';
-const IconDoneOutline = toNewsKitIcon(DoneOutline);
+import { NewsKitCrossIcon, NewsKitDoneIcon } from '../../../../assets';
 
 export interface FinalScreenProps {
   message: string;
@@ -24,13 +22,7 @@ export const FinalScreen = ({
   return (
     <Block>
       <StyledBlock>
-        {status === 'Win' ? (
-          <IconDoneOutline
-            overrides={{ stylePreset: 'inkPositive', size: 'iconSize020' }}
-          />
-        ) : (
-          <NewsKitCrossIcon />
-        )}
+        {status === 'Win' ? <NewsKitDoneIcon /> : <NewsKitCrossIcon />}
       </StyledBlock>
       <StyledTextBlock
         as="h3"

--- a/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/index.tsx
+++ b/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/index.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Block, toNewsKitIcon } from 'newskit';
+import { StyledTextBlock, StyledBlock } from './styles';
+import { DoneOutline } from '@emotion-icons/material/DoneOutline';
+import { NewsKitCrossIcon } from '../../../../assets';
+const IconDoneOutline = toNewsKitIcon(DoneOutline);
+
+export interface FinalScreenProps {
+  message: string;
+  hints: number;
+  ans: string;
+  status: 'Win' | 'Loose' | string;
+}
+
+export const FinalScreen = ({
+  message,
+  hints,
+  ans,
+  status
+}: FinalScreenProps) => {
+  const insertBoldTag = (text: string) => {
+    return { __html: text };
+  };
+  return (
+    <Block>
+      <StyledBlock>
+        {status === 'Win' ? (
+          <IconDoneOutline
+            overrides={{ stylePreset: 'inkPositive', size: 'iconSize020' }}
+          />
+        ) : (
+          <NewsKitCrossIcon />
+        )}
+      </StyledBlock>
+      <StyledTextBlock
+        as="h3"
+        typographyPreset="utilitySubheading050"
+        stylePreset={status === 'Win' ? 'inkPositive' : 'inkNotice'}
+        marginBlockStart="space030"
+        marginBlockEnd="space050"
+      >
+        {ans}
+      </StyledTextBlock>
+      {status === 'Loose' ? (
+        <StyledTextBlock
+          as="p"
+          typographyPreset="utilityBody020"
+          stylePreset="inkContrast"
+        >
+          You didn't get it this time.
+        </StyledTextBlock>
+      ) : (
+        <StyledTextBlock
+          as="p"
+          typographyPreset="utilityBody020"
+          stylePreset="inkContrast"
+        >
+          <div dangerouslySetInnerHTML={insertBoldTag(message)} />
+          You did it with {hints} hints.
+        </StyledTextBlock>
+      )}
+    </Block>
+  );
+};

--- a/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/index.tsx
+++ b/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/index.tsx
@@ -9,7 +9,7 @@ export interface FinalScreenProps {
   message: string;
   hints: number;
   ans: string;
-  status: 'Win' | 'Loose' | string;
+  status: 'Win' | 'Lose' | string;
 }
 
 export const FinalScreen = ({
@@ -41,7 +41,7 @@ export const FinalScreen = ({
       >
         {ans}
       </StyledTextBlock>
-      {status === 'Loose' ? (
+      {status === 'Lose' ? (
         <StyledTextBlock
           as="p"
           typographyPreset="utilityBody020"

--- a/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/styles.ts
+++ b/packages/ts-newskit/src/components/puzzles/daily-quiz/final-screen/styles.ts
@@ -1,0 +1,9 @@
+import { styled, TextBlock, Block } from 'newskit';
+
+export const StyledTextBlock = styled(TextBlock)`
+  text-align: center;
+`;
+
+export const StyledBlock = styled(Block)`
+  text-align: center;
+`;


### PR DESCRIPTION
### Description

- Created a component for the Winning/Losing screen for the daily quiz page, by passing the status
- Added unit tests for the above component

### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
<img width="1169" alt="Screenshot 2023-09-28 at 6 40 44 PM" src="https://github.com/newsuk/times-components/assets/105289286/0b7994be-4c97-4aba-ad09-bd966c44c9ea">
<img width="1200" alt="Screenshot 2023-09-28 at 6 40 53 PM" src="https://github.com/newsuk/times-components/assets/105289286/b703d8cd-4b88-47a8-a40d-590b424ab515">



