### PR TITLE
chore(TMRX-000): Add initial breakpoint state to resolve empty loading stat

### DIFF
--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -766,8 +766,6 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Render Content Bucket 1 Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;
-
 exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/index.test.tsx
@@ -33,12 +33,6 @@ describe('Render Content Bucket 1 Slice', () => {
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
-
-  test('Slice matches snapshot for `null` breakpoint value', () => {
-    (useBreakpointKey as any).mockReturnValue(null);
-    const { asFragment } = renderComponent();
-    expect(asFragment()).toMatchSnapshot();
-  });
 });
 
 describe('Content Bucket 1 Articles list ', () => {

--- a/packages/ts-newskit/src/slices/content-bucket-1/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-1/index.tsx
@@ -37,8 +37,8 @@ export const ContentBucket1 = ({
   articles,
   clickHandler
 }: ContentBucket1Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
-    null
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>(
+    'xl'
   );
   const breakpointKey = useBreakpointKey();
   useEffect(
@@ -47,10 +47,6 @@ export const ContentBucket1 = ({
     },
     [breakpointKey]
   );
-
-  if (!currentBreakpoint) {
-    return null;
-  }
 
   const isMobile = ['xs', 'sm'].includes(currentBreakpoint);
   const modifiedLeadArticle = {

--- a/packages/ts-newskit/src/slices/content-bucket-1/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-1/index.tsx
@@ -37,9 +37,7 @@ export const ContentBucket1 = ({
   articles,
   clickHandler
 }: ContentBucket1Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>(
-    'xl'
-  );
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xl');
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {

--- a/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -589,5 +589,3 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
   </div>
 </DocumentFragment>
 `;
-
-exports[`Render Content Bucket 2 Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;

--- a/packages/ts-newskit/src/slices/content-bucket-2/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-2/__tests__/index.test.tsx
@@ -38,11 +38,6 @@ describe('Render Content Bucket 2 Slice', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('Slice matches snapshot for `null` breakpoint value', async () => {
-    (useBreakpointKey as any).mockReturnValue(null);
-    const { asFragment } = await renderComponent();
-    expect(asFragment()).toMatchSnapshot();
-  });
 });
 
 describe('Content Bucket 2 Articles list above `md` breakpoint', () => {

--- a/packages/ts-newskit/src/slices/content-bucket-2/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-2/__tests__/index.test.tsx
@@ -37,7 +37,6 @@ describe('Render Content Bucket 2 Slice', () => {
     const { asFragment } = await renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
-
 });
 
 describe('Content Bucket 2 Articles list above `md` breakpoint', () => {

--- a/packages/ts-newskit/src/slices/content-bucket-2/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-2/index.tsx
@@ -26,10 +26,6 @@ export const ContentBucket2 = ({
     [breakpointKey]
   );
 
-  if (!currentBreakpoint) {
-    return null;
-  }
-
   const isMob = currentBreakpoint === 'xs' || currentBreakpoint === 'sm';
 
   return (

--- a/packages/ts-newskit/src/slices/content-bucket-2/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-2/index.tsx
@@ -15,8 +15,8 @@ export const ContentBucket2 = ({
   articles,
   clickHandler
 }: ContentBucket2Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
-    null
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>(
+    'xl'
   );
   const breakpointKey = useBreakpointKey();
   useEffect(

--- a/packages/ts-newskit/src/slices/content-bucket-2/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-2/index.tsx
@@ -15,9 +15,7 @@ export const ContentBucket2 = ({
   articles,
   clickHandler
 }: ContentBucket2Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>(
-    'xl'
-  );
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xl');
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {

--- a/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -883,8 +883,6 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Render Content Bucket 3 Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;
-
 exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ts-newskit/src/slices/content-bucket-3/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-3/__tests__/index.test.tsx
@@ -28,7 +28,6 @@ describe('Render Content Bucket 3 Slice', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-
   test('Slice matches snapshot for mobile', () => {
     (useBreakpointKey as any).mockReturnValue('sm');
     const { asFragment } = renderComponent();

--- a/packages/ts-newskit/src/slices/content-bucket-3/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-3/__tests__/index.test.tsx
@@ -28,11 +28,6 @@ describe('Render Content Bucket 3 Slice', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('Slice matches snapshot for `null` breakpoint value', () => {
-    (useBreakpointKey as any).mockReturnValue(null);
-    const { asFragment } = renderComponent();
-    expect(asFragment()).toMatchSnapshot();
-  });
 
   test('Slice matches snapshot for mobile', () => {
     (useBreakpointKey as any).mockReturnValue('sm');

--- a/packages/ts-newskit/src/slices/content-bucket-3/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-3/index.tsx
@@ -39,8 +39,8 @@ export const ContentBucket3 = ({
   articles,
   clickHandler
 }: ContentBucket3Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
-    null
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>(
+    'xl'
   );
   const breakpointKey = useBreakpointKey();
   useEffect(

--- a/packages/ts-newskit/src/slices/content-bucket-3/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-3/index.tsx
@@ -39,9 +39,7 @@ export const ContentBucket3 = ({
   articles,
   clickHandler
 }: ContentBucket3Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>(
-    'xl'
-  );
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xl');
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {

--- a/packages/ts-newskit/src/slices/content-bucket-3/index.tsx
+++ b/packages/ts-newskit/src/slices/content-bucket-3/index.tsx
@@ -50,10 +50,6 @@ export const ContentBucket3 = ({
     [breakpointKey]
   );
 
-  if (!currentBreakpoint) {
-    return null;
-  }
-
   const isMobile = ['xs', 'sm'].includes(currentBreakpoint);
   const isMedium = currentBreakpoint === 'md';
   const isLarge = ['lg', 'xl'].includes(currentBreakpoint);

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -1506,8 +1506,6 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Render Lead Story 1 Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;
-
 exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKey is "md" 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/index.test.tsx
@@ -26,11 +26,6 @@ describe('Render Lead Story 1 Slice', () => {
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
-  test('Slice matches snapshot for `null` breakpoint value', () => {
-    (useBreakpointKey as any).mockReturnValue(null);
-    const { asFragment } = renderComponent();
-    expect(asFragment()).toMatchSnapshot();
-  });
   test('modifies articles correctly when breakpointKey is "md"', () => {
     (useBreakpointKey as any).mockReturnValue('md');
     const { asFragment } = renderComponent();

--- a/packages/ts-newskit/src/slices/lead-story-1/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-1/index.tsx
@@ -47,9 +47,7 @@ export const LeadStory1 = ({
   articlesWithListItems,
   clickHandler
 }: LeadStory1Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>(
-    'xl'
-  );
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xl');
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {

--- a/packages/ts-newskit/src/slices/lead-story-1/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-1/index.tsx
@@ -47,8 +47,8 @@ export const LeadStory1 = ({
   articlesWithListItems,
   clickHandler
 }: LeadStory1Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
-    null
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>(
+    'xl'
   );
   const breakpointKey = useBreakpointKey();
   useEffect(
@@ -57,10 +57,6 @@ export const LeadStory1 = ({
     },
     [breakpointKey]
   );
-
-  if (!currentBreakpoint) {
-    return null;
-  }
 
   const screenXsAndSm =
     currentBreakpoint === 'xs' || currentBreakpoint === 'sm';

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -1408,8 +1408,6 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Render Lead Story 2 Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;
-
 exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKey is "md" 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/index.test.tsx
@@ -42,9 +42,4 @@ describe('Render Lead Story 2 Slice', () => {
     const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
   });
-  test('Slice matches snapshot for `null` breakpoint value', () => {
-    (useBreakpointKey as any).mockReturnValue(null);
-    const { asFragment } = renderComponent();
-    expect(asFragment()).toMatchSnapshot();
-  });
 });

--- a/packages/ts-newskit/src/slices/lead-story-2/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-2/index.tsx
@@ -36,9 +36,7 @@ export const LeadStory2 = ({
   horizontalArticles,
   clickHandler
 }: LeadStory2Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>(
-    'xl'
-  );
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xl');
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {

--- a/packages/ts-newskit/src/slices/lead-story-2/index.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-2/index.tsx
@@ -36,8 +36,8 @@ export const LeadStory2 = ({
   horizontalArticles,
   clickHandler
 }: LeadStory2Props) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
-    null
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>(
+    'xl'
   );
   const breakpointKey = useBreakpointKey();
   useEffect(
@@ -46,10 +46,6 @@ export const LeadStory2 = ({
     },
     [breakpointKey]
   );
-
-  if (!currentBreakpoint) {
-    return null;
-  }
 
   const modifedArticles =
     currentBreakpoint === 'xl'

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Render SectionBucket Slice Slice matches snapshot for \`null\` breakpoint value 1`] = `<DocumentFragment />`;
-
 exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/index.test.tsx
@@ -47,12 +47,6 @@ const renderComponent = () =>
   );
 
 describe('Render SectionBucket Slice', () => {
-  test('Slice matches snapshot for `null` breakpoint value', () => {
-    (useBreakpointKey as any).mockReturnValue(null);
-    const { asFragment } = renderComponent();
-    expect(asFragment()).toMatchSnapshot();
-  });
-
   test('Slice matches snapshot with sm', () => {
     (useBreakpointKey as any).mockReturnValue('sm');
     const { asFragment } = renderComponent();

--- a/packages/ts-newskit/src/slices/section-bucket/index.tsx
+++ b/packages/ts-newskit/src/slices/section-bucket/index.tsx
@@ -69,8 +69,8 @@ export const SectionBucket = ({
   clickHandler,
   sliceHeaderClickHandler
 }: SectionBucketProps) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys | null>(
-    null
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>(
+    'xl'
   );
   const breakpointKey = useBreakpointKey();
   useEffect(
@@ -79,10 +79,6 @@ export const SectionBucket = ({
     },
     [breakpointKey]
   );
-
-  if (!currentBreakpoint) {
-    return null;
-  }
 
   const isMobile = currentBreakpoint === 'xs' || currentBreakpoint === 'sm';
 

--- a/packages/ts-newskit/src/slices/section-bucket/index.tsx
+++ b/packages/ts-newskit/src/slices/section-bucket/index.tsx
@@ -69,9 +69,7 @@ export const SectionBucket = ({
   clickHandler,
   sliceHeaderClickHandler
 }: SectionBucketProps) => {
-  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>(
-    'xl'
-  );
+  const [currentBreakpoint, setBreakpoint] = useState<BreakpointKeys>('xl');
   const breakpointKey = useBreakpointKey();
   useEffect(
     () => {


### PR DESCRIPTION
### Description

Initialise the components with a breakpoint value so they don't render as empty components before client side breakpoint is found. 
This doesn't entirely fix the loading issue as we use breakpointKey to manipulate data etc. But is an improvement in the meantime before we introduce our refactor. 

[TMRX-1529](https://nidigitalsolutions.jira.com/browse/TMRX-1529)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMRX-1529]: https://nidigitalsolutions.jira.com/browse/TMRX-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ