### PR TITLE
fix(TMRX-1577): Dont call fetch if authorSlug is undefined

### DIFF
--- a/packages/ts-components/src/components/article-header/ArticleHeader.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleHeader.tsx
@@ -41,7 +41,10 @@ const ArticleHeader: React.FC<{
   description?: string;
 }> = ({ updated, breaking, headline, authorSlug, description }) => {
   const [timezone, setTimezone] = useState<string>('');
-  const [authorData, setAuthorData] = useState<ArticleBylineAuthorData | null>();
+  const [
+    authorData,
+    setAuthorData
+  ] = useState<ArticleBylineAuthorData | null>();
 
   const currentDateTime = new Date();
   const updatedDate = new Date(updated);
@@ -60,7 +63,7 @@ const ArticleHeader: React.FC<{
   useEffect(
     () => {
       if (authorSlug === undefined) {
-        setAuthorData(null)
+        setAuthorData(null);
         return;
       }
       const fetchData = async () => {
@@ -129,7 +132,9 @@ const ArticleHeader: React.FC<{
       </UpdatesContainer>
 
       {headline && <Headline>{safeDecodeURIComponent(headline)}</Headline>}
-      {authorData && (<ArticleBylineBlock authorData={authorData} description={description} />)}
+      {authorData && (
+        <ArticleBylineBlock authorData={authorData} description={description} />
+      )}
     </Container>
   );
 };

--- a/packages/ts-components/src/components/article-header/ArticleHeader.tsx
+++ b/packages/ts-components/src/components/article-header/ArticleHeader.tsx
@@ -41,7 +41,7 @@ const ArticleHeader: React.FC<{
   description?: string;
 }> = ({ updated, breaking, headline, authorSlug, description }) => {
   const [timezone, setTimezone] = useState<string>('');
-  const [authorData, setAuthorData] = useState<ArticleBylineAuthorData>();
+  const [authorData, setAuthorData] = useState<ArticleBylineAuthorData | null>();
 
   const currentDateTime = new Date();
   const updatedDate = new Date(updated);
@@ -59,6 +59,10 @@ const ArticleHeader: React.FC<{
 
   useEffect(
     () => {
+      if (authorSlug === undefined) {
+        setAuthorData(null)
+        return;
+      }
       const fetchData = async () => {
         try {
           const response = await fetch(`/api/author-profile/${authorSlug}`);
@@ -125,7 +129,7 @@ const ArticleHeader: React.FC<{
       </UpdatesContainer>
 
       {headline && <Headline>{safeDecodeURIComponent(headline)}</Headline>}
-      <ArticleBylineBlock authorData={authorData} description={description} />
+      {authorData && (<ArticleBylineBlock authorData={authorData} description={description} />)}
     </Container>
   );
 };


### PR DESCRIPTION
### Description

We are calling the fetch to /api/author-profile even if we don't have an author. This adds a check so that we don't call the route with undefined

[TMRX-1577](https://nidigitalsolutions.jira.com/browse/TMRX-1577)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
#### Before
![Screenshot 2023-10-12 at 15 41 31](https://github.com/newsuk/times-components/assets/44647540/9bfdea1a-a330-48d9-9f80-4852364b3557)


#### After
![Screenshot 2023-10-12 at 16 41 07](https://github.com/newsuk/times-components/assets/44647540/f0d6dc95-b7b7-40f9-be9b-6bf110e28d08)


[TMRX-1577]: https://nidigitalsolutions.jira.com/browse/TMRX-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ