### PR TITLE
fix(TMRX-1580): Add lazy loading to images that aren't lead images

### DIFF
--- a/packages/ts-newskit/src/components/slices/article/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/article/__tests__/__snapshots__/index.test.tsx.snap
@@ -7,18 +7,14 @@ exports[`Render Article List Item items should render without margin 1`] = `
   >
     <div
       class="css-1kwj960"
-      loading="lazy"
     >
       <picture
-        class="css-zp0elg"
+        class="css-l4lngz"
       >
-        <div
-          class="css-5pczz7"
-        />
         <img
           alt="This is ALT Text"
-          class="css-1qgqq71"
-          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+          class="css-ssxt4f"
+          loading="lazy"
         />
       </picture>
     </div>
@@ -85,18 +81,14 @@ exports[`Render Article List Item should render a snapshot 1`] = `
   >
     <div
       class="css-1kwj960"
-      loading="lazy"
     >
       <picture
-        class="css-zp0elg"
+        class="css-l4lngz"
       >
-        <div
-          class="css-5pczz7"
-        />
         <img
           alt="This is ALT Text"
-          class="css-1qgqq71"
-          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+          class="css-ssxt4f"
+          loading="lazy"
         />
       </picture>
     </div>

--- a/packages/ts-newskit/src/components/slices/article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/article/index.tsx
@@ -89,12 +89,12 @@ export const Article = ({
     contentType;
 
   const cardImage = {
-      media: {
-        src: imageWithCorrectRatio!.url,
-        alt: (images && images.alt) || headline,
-        loadingAspectRatio: imageWithCorrectRatio!.ratio || '3:2'
-      }
-    };
+    media: {
+      src: imageWithCorrectRatio!.url,
+      alt: (images && images.alt) || headline,
+      loadingAspectRatio: imageWithCorrectRatio!.ratio || '3:2'
+    }
+  };
 
   const marginBlockStart = imageRight || hideImage ? 'space000' : 'space040';
   const hasImage =

--- a/packages/ts-newskit/src/components/slices/article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/article/index.tsx
@@ -88,12 +88,11 @@ export const Article = ({
     label ||
     contentType;
 
-  const cardImage = !hideImage &&
-    imageWithCorrectRatio && {
+  const cardImage = {
       media: {
-        src: imageWithCorrectRatio.url,
+        src: imageWithCorrectRatio!.url,
         alt: (images && images.alt) || headline,
-        loadingAspectRatio: imageWithCorrectRatio.ratio || '3:2'
+        loadingAspectRatio: imageWithCorrectRatio!.ratio || '3:2'
       }
     };
 
@@ -153,7 +152,7 @@ export const Article = ({
         isLeadImage ? (
           <FullWidthCardMediaMob {...cardImage} />
         ) : (
-          <CardMedia {...{ ...cardImage, loading: 'lazy' }} />
+          <CardMedia media={{ ...cardImage.media, loading: 'lazy' }} />
         )
       ) : null}
       <CardContent alignContent="start">

--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -327,18 +327,14 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -398,18 +394,14 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="‘American owners pose threat to English pyramid’"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -478,18 +470,14 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
             </div>
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -558,18 +546,14 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
             </div>
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Blow for rebel clubs as court says Uefa can block Super League"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -1101,18 +1085,14 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1177,18 +1157,14 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="‘American owners pose threat to English pyramid’"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1253,18 +1229,14 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1329,18 +1301,14 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Blow for rebel clubs as court says Uefa can block Super League"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>

--- a/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -100,18 +100,14 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -251,18 +247,14 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="‘American owners pose threat to English pyramid’"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -402,18 +394,14 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -553,18 +541,14 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Blow for rebel clubs as court says Uefa can block Super League"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -728,18 +712,14 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -879,18 +859,14 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="‘American owners pose threat to English pyramid’"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1030,18 +1006,14 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1181,18 +1153,14 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Blow for rebel clubs as court says Uefa can block Super League"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>

--- a/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -444,18 +444,14 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -515,18 +511,14 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="‘American owners pose threat to English pyramid’"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -595,18 +587,14 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
             </div>
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -675,18 +663,14 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
             </div>
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Blow for rebel clubs as court says Uefa can block Super League"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/article-stack.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/article-stack.test.tsx.snap
@@ -28,18 +28,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -136,18 +132,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -244,18 +236,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -352,18 +340,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -460,18 +444,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -577,18 +557,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="American owners pose threat to English pyramid 2"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -652,18 +628,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="American owners pose threat to English pyramid 2"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -727,18 +699,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="American owners pose threat to English pyramid 2"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -878,18 +846,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 </div>
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="American owners pose threat to English pyramid 2"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -962,18 +926,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1056,18 +1016,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1150,18 +1106,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1339,18 +1291,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 </div>
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1442,18 +1390,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Blow for rebel clubs as court says Uefa can block Super League"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1539,18 +1483,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Blow for rebel clubs as court says Uefa can block Super League"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1636,18 +1576,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Blow for rebel clubs as court says Uefa can block Super League"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1831,18 +1767,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 </div>
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Blow for rebel clubs as court says Uefa can block Super League"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1937,18 +1869,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -2045,18 +1973,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -2153,18 +2077,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -2370,18 +2290,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 </div>
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -2490,18 +2406,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -2598,18 +2510,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -2706,18 +2614,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -2814,18 +2718,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -2922,18 +2822,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -3039,18 +2935,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="American owners pose threat to English pyramid 2"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -3114,18 +3006,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="American owners pose threat to English pyramid 2"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -3189,18 +3077,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="American owners pose threat to English pyramid 2"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -3340,18 +3224,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
             </div>
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="American owners pose threat to English pyramid 2"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -3424,18 +3304,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -3518,18 +3394,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -3612,18 +3484,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -3801,18 +3669,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
             </div>
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -3904,18 +3768,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Blow for rebel clubs as court says Uefa can block Super League"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -4001,18 +3861,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Blow for rebel clubs as court says Uefa can block Super League"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -4098,18 +3954,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Blow for rebel clubs as court says Uefa can block Super League"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -4293,18 +4145,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
             </div>
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Blow for rebel clubs as court says Uefa can block Super League"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -4399,18 +4247,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -4507,18 +4351,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -4615,18 +4455,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -4832,18 +4668,14 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
             </div>
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -4954,18 +4786,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="American owners pose threat to English pyramid 2"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -5029,18 +4857,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="American owners pose threat to English pyramid 2"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -5104,18 +4928,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="American owners pose threat to English pyramid 2"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -5179,18 +4999,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="American owners pose threat to English pyramid 2"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -5254,18 +5070,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="American owners pose threat to English pyramid 2"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -5342,18 +5154,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -5436,18 +5244,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -5530,18 +5334,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -5624,18 +5424,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -5718,18 +5514,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -5825,18 +5617,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="Blow for rebel clubs as court says Uefa can block Super League"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -5922,18 +5710,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="Blow for rebel clubs as court says Uefa can block Super League"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -6019,18 +5803,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="Blow for rebel clubs as court says Uefa can block Super League"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -6116,18 +5896,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="Blow for rebel clubs as court says Uefa can block Super League"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>
@@ -6213,18 +5989,14 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
         >
           <div
             class="css-1kwj960"
-            loading="lazy"
           >
             <picture
-              class="css-zp0elg"
+              class="css-l4lngz"
             >
-              <div
-                class="css-5pczz7"
-              />
               <img
                 alt="Blow for rebel clubs as court says Uefa can block Super League"
-                class="css-1qgqq71"
-                src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                class="css-ssxt4f"
+                loading="lazy"
               />
             </picture>
           </div>

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -1431,18 +1431,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -1528,18 +1524,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -1625,18 +1617,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -1877,18 +1865,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="‘American owners pose threat to English pyramid’"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -1952,18 +1936,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="‘American owners pose threat to English pyramid’"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -2027,18 +2007,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="‘American owners pose threat to English pyramid’"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -2143,18 +2119,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2251,18 +2223,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2359,18 +2327,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2467,18 +2431,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2575,18 +2535,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2692,18 +2648,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2767,18 +2719,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2842,18 +2790,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2993,18 +2937,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3077,18 +3017,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3171,18 +3107,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3265,18 +3197,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3454,18 +3382,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3557,18 +3481,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3654,18 +3574,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3751,18 +3667,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3946,18 +3858,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -4052,18 +3960,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -4160,18 +4064,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -4268,18 +4168,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -4485,18 +4381,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -4605,18 +4497,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4713,18 +4601,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4821,18 +4705,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4929,18 +4809,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5037,18 +4913,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5154,18 +5026,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5229,18 +5097,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5304,18 +5168,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5455,18 +5315,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5539,18 +5395,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5633,18 +5485,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5727,18 +5575,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5916,18 +5760,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6019,18 +5859,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6116,18 +5952,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6213,18 +6045,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6408,18 +6236,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6514,18 +6338,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6622,18 +6442,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6730,18 +6546,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6947,18 +6759,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -7076,18 +6884,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7184,18 +6988,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7292,18 +7092,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7400,18 +7196,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7508,18 +7300,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7625,18 +7413,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7700,18 +7484,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7775,18 +7555,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7926,18 +7702,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -8010,18 +7782,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -8104,18 +7872,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -8198,18 +7962,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -8387,18 +8147,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -8493,18 +8249,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8601,18 +8353,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8709,18 +8457,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8817,18 +8561,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8925,18 +8665,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9042,18 +8778,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9117,18 +8849,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9192,18 +8920,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9343,18 +9067,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9427,18 +9147,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9521,18 +9237,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9615,18 +9327,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9804,18 +9512,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9918,18 +9622,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10015,18 +9715,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10192,18 +9888,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10289,18 +9981,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10399,18 +10087,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10507,18 +10191,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10706,18 +10386,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10814,18 +10490,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10965,18 +10637,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11073,18 +10741,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11181,18 +10845,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11289,18 +10949,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11397,18 +11053,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11514,18 +11166,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11589,18 +11237,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11664,18 +11308,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11815,18 +11455,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11899,18 +11535,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11993,18 +11625,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12087,18 +11715,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12276,18 +11900,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12379,18 +11999,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12476,18 +12092,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12573,18 +12185,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12768,18 +12376,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12874,18 +12478,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12982,18 +12582,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -13090,18 +12686,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -13307,18 +12899,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -13427,18 +13015,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13535,18 +13119,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13643,18 +13223,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13751,18 +13327,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13859,18 +13431,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13976,18 +13544,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14051,18 +13615,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14126,18 +13686,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14277,18 +13833,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14361,18 +13913,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14455,18 +14003,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14549,18 +14093,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14738,18 +14278,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14841,18 +14377,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14938,18 +14470,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -15035,18 +14563,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -15230,18 +14754,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -15336,18 +14856,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -15444,18 +14960,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -15552,18 +15064,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -15769,18 +15277,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -15898,18 +15402,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16006,18 +15506,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16114,18 +15610,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16222,18 +15714,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16330,18 +15818,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16447,18 +15931,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16522,18 +16002,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16597,18 +16073,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16748,18 +16220,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16832,18 +16300,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16926,18 +16390,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -17020,18 +16480,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -17209,18 +16665,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -17315,18 +16767,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17423,18 +16871,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17531,18 +16975,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17639,18 +17079,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17747,18 +17183,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17864,18 +17296,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17939,18 +17367,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -18014,18 +17438,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -18165,18 +17585,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -18249,18 +17665,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -18343,18 +17755,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -18437,18 +17845,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -18626,18 +18030,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -18740,18 +18140,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -18837,18 +18233,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -19014,18 +18406,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -19111,18 +18499,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -19221,18 +18605,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -19329,18 +18709,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -19528,18 +18904,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -19636,18 +19008,14 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -21178,18 +20546,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -21275,18 +20639,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -21372,18 +20732,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -21624,18 +20980,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="‘American owners pose threat to English pyramid’"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -21699,18 +21051,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="‘American owners pose threat to English pyramid’"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -21774,18 +21122,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="‘American owners pose threat to English pyramid’"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -21890,18 +21234,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -21998,18 +21338,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22106,18 +21442,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22214,18 +21546,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22322,18 +21650,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22439,18 +21763,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22514,18 +21834,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22589,18 +21905,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22740,18 +22052,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22824,18 +22132,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22918,18 +22222,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23012,18 +22312,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23201,18 +22497,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23304,18 +22596,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23401,18 +22689,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23498,18 +22782,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23693,18 +22973,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23799,18 +23075,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23907,18 +23179,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24015,18 +23283,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24232,18 +23496,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24352,18 +23612,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24460,18 +23716,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24568,18 +23820,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24676,18 +23924,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24784,18 +24028,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24901,18 +24141,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24976,18 +24212,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25051,18 +24283,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25202,18 +24430,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25286,18 +24510,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25380,18 +24600,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25474,18 +24690,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25663,18 +24875,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25766,18 +24974,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25863,18 +25067,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25960,18 +25160,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26155,18 +25351,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26261,18 +25453,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26369,18 +25557,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26477,18 +25661,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26694,18 +25874,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26823,18 +25999,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -26931,18 +26103,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27039,18 +26207,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27147,18 +26311,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27255,18 +26415,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27372,18 +26528,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27447,18 +26599,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27522,18 +26670,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27673,18 +26817,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27757,18 +26897,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27851,18 +26987,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27945,18 +27077,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -28134,18 +27262,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -28240,18 +27364,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28348,18 +27468,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28456,18 +27572,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28564,18 +27676,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28672,18 +27780,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28789,18 +27893,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28864,18 +27964,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28939,18 +28035,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -29090,18 +28182,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -29174,18 +28262,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -29268,18 +28352,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -29362,18 +28442,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -29551,18 +28627,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -29665,18 +28737,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -29762,18 +28830,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -29939,18 +29003,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -30036,18 +29096,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -30146,18 +29202,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -30254,18 +29306,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -30453,18 +29501,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -30561,18 +29605,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -30712,18 +29752,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30820,18 +29856,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30928,18 +29960,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31036,18 +30064,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31144,18 +30168,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31261,18 +30281,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31336,18 +30352,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31411,18 +30423,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31562,18 +30570,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31646,18 +30650,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31740,18 +30740,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31834,18 +30830,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32023,18 +31015,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32126,18 +31114,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32223,18 +31207,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32320,18 +31300,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32515,18 +31491,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32621,18 +31593,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32729,18 +31697,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32837,18 +31801,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -33054,18 +32014,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -33174,18 +32130,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33282,18 +32234,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33390,18 +32338,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33498,18 +32442,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33606,18 +32546,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33723,18 +32659,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33798,18 +32730,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33873,18 +32801,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34024,18 +32948,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34108,18 +33028,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34202,18 +33118,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34296,18 +33208,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34485,18 +33393,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34588,18 +33492,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34685,18 +33585,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34782,18 +33678,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34977,18 +33869,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -35083,18 +33971,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -35191,18 +34075,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -35299,18 +34179,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -35516,18 +34392,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -35645,18 +34517,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35753,18 +34621,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35861,18 +34725,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35969,18 +34829,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -36077,18 +34933,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -36194,18 +35046,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -36269,18 +35117,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -36344,18 +35188,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -36495,18 +35335,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -36579,18 +35415,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -36673,18 +35505,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -36767,18 +35595,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -36956,18 +35780,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -37062,18 +35882,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37170,18 +35986,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37278,18 +36090,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37386,18 +36194,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37494,18 +36298,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37611,18 +36411,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37686,18 +36482,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37761,18 +36553,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37912,18 +36700,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37996,18 +36780,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -38090,18 +36870,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -38184,18 +36960,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -38373,18 +37145,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -38487,18 +37255,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -38584,18 +37348,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -38761,18 +37521,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -38858,18 +37614,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -38968,18 +37720,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -39076,18 +37824,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -39275,18 +38019,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -39383,18 +38123,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -40925,18 +39661,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -41022,18 +39754,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -41119,18 +39847,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -41371,18 +40095,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="‘American owners pose threat to English pyramid’"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -41446,18 +40166,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="‘American owners pose threat to English pyramid’"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -41521,18 +40237,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="‘American owners pose threat to English pyramid’"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -41637,18 +40349,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -41745,18 +40453,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -41853,18 +40557,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -41961,18 +40661,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42069,18 +40765,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42186,18 +40878,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42261,18 +40949,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42336,18 +41020,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42487,18 +41167,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42571,18 +41247,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42665,18 +41337,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42759,18 +41427,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42948,18 +41612,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43051,18 +41711,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43148,18 +41804,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43245,18 +41897,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43440,18 +42088,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43546,18 +42190,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43654,18 +42294,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43762,18 +42398,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43979,18 +42611,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -44099,18 +42727,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44207,18 +42831,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44315,18 +42935,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44423,18 +43039,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44531,18 +43143,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44648,18 +43256,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44723,18 +43327,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44798,18 +43398,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44949,18 +43545,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -45033,18 +43625,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -45127,18 +43715,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -45221,18 +43805,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -45410,18 +43990,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -45513,18 +44089,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -45610,18 +44182,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -45707,18 +44275,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -45902,18 +44466,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -46008,18 +44568,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -46116,18 +44672,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -46224,18 +44776,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -46441,18 +44989,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -46570,18 +45114,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46678,18 +45218,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46786,18 +45322,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46894,18 +45426,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47002,18 +45530,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47119,18 +45643,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47194,18 +45714,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47269,18 +45785,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47420,18 +45932,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47504,18 +46012,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47598,18 +46102,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47692,18 +46192,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47881,18 +46377,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47987,18 +46479,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48095,18 +46583,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48203,18 +46687,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48311,18 +46791,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48419,18 +46895,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48536,18 +47008,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48611,18 +47079,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48686,18 +47150,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48837,18 +47297,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48921,18 +47377,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49015,18 +47467,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49109,18 +47557,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49298,18 +47742,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49412,18 +47852,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -49509,18 +47945,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -49686,18 +48118,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -49783,18 +48211,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -49893,18 +48317,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -50001,18 +48421,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -50200,18 +48616,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -50308,18 +48720,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -50459,18 +48867,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50567,18 +48971,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50675,18 +49075,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50783,18 +49179,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50891,18 +49283,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51008,18 +49396,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51083,18 +49467,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51158,18 +49538,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51309,18 +49685,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51393,18 +49765,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51487,18 +49855,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51581,18 +49945,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51770,18 +50130,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51873,18 +50229,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51970,18 +50322,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -52067,18 +50415,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -52262,18 +50606,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -52368,18 +50708,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -52476,18 +50812,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -52584,18 +50916,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -52801,18 +51129,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -52921,18 +51245,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53029,18 +51349,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53137,18 +51453,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53245,18 +51557,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53353,18 +51661,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53470,18 +51774,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53545,18 +51845,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53620,18 +51916,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53771,18 +52063,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53855,18 +52143,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53949,18 +52233,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -54043,18 +52323,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -54232,18 +52508,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -54335,18 +52607,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -54432,18 +52700,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -54529,18 +52793,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -54724,18 +52984,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -54830,18 +53086,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -54938,18 +53190,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -55046,18 +53294,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -55263,18 +53507,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -55392,18 +53632,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55500,18 +53736,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55608,18 +53840,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55716,18 +53944,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55824,18 +54048,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55941,18 +54161,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56016,18 +54232,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56091,18 +54303,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56242,18 +54450,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56326,18 +54530,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56420,18 +54620,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56514,18 +54710,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56703,18 +54895,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56809,18 +54997,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -56917,18 +55101,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -57025,18 +55205,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -57133,18 +55309,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -57241,18 +55413,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -57358,18 +55526,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -57433,18 +55597,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -57508,18 +55668,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -57659,18 +55815,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -57743,18 +55895,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -57837,18 +55985,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -57931,18 +56075,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -58120,18 +56260,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -58234,18 +56370,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -58331,18 +56463,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -58508,18 +56636,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -58605,18 +56729,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -58715,18 +56835,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -58823,18 +56939,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -59022,18 +57134,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -59130,18 +57238,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -60672,18 +58776,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -60769,18 +58869,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -60866,18 +58962,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -61118,18 +59210,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="‘American owners pose threat to English pyramid’"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -61193,18 +59281,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="‘American owners pose threat to English pyramid’"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -61268,18 +59352,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 >
                   <div
                     class="css-1kwj960"
-                    loading="lazy"
                   >
                     <picture
-                      class="css-zp0elg"
+                      class="css-l4lngz"
                     >
-                      <div
-                        class="css-5pczz7"
-                      />
                       <img
                         alt="‘American owners pose threat to English pyramid’"
-                        class="css-1qgqq71"
-                        src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                        class="css-ssxt4f"
+                        loading="lazy"
                       />
                     </picture>
                   </div>
@@ -61384,18 +59464,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61492,18 +59568,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61600,18 +59672,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61708,18 +59776,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61816,18 +59880,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61933,18 +59993,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62008,18 +60064,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62083,18 +60135,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62234,18 +60282,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62318,18 +60362,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62412,18 +60452,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62506,18 +60542,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62695,18 +60727,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62798,18 +60826,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62895,18 +60919,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62992,18 +61012,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -63187,18 +61203,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -63293,18 +61305,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -63401,18 +61409,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -63509,18 +61513,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -63726,18 +61726,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -63846,18 +61842,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -63954,18 +61946,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64062,18 +62050,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64170,18 +62154,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64278,18 +62258,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64395,18 +62371,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64470,18 +62442,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64545,18 +62513,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64696,18 +62660,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64780,18 +62740,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64874,18 +62830,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64968,18 +62920,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -65157,18 +63105,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -65260,18 +63204,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -65357,18 +63297,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -65454,18 +63390,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -65649,18 +63581,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -65755,18 +63683,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -65863,18 +63787,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -65971,18 +63891,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -66188,18 +64104,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -66317,18 +64229,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66425,18 +64333,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66533,18 +64437,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66641,18 +64541,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66749,18 +64645,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66866,18 +64758,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66941,18 +64829,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -67016,18 +64900,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -67167,18 +65047,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -67251,18 +65127,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -67345,18 +65217,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -67439,18 +65307,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -67628,18 +65492,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -67734,18 +65594,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67842,18 +65698,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67950,18 +65802,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68058,18 +65906,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68166,18 +66010,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68283,18 +66123,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68358,18 +66194,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68433,18 +66265,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68584,18 +66412,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68668,18 +66492,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68762,18 +66582,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68856,18 +66672,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -69045,18 +66857,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -69159,18 +66967,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -69256,18 +67060,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -69433,18 +67233,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -69530,18 +67326,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -69640,18 +67432,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -69748,18 +67536,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -69947,18 +67731,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -70055,18 +67835,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -70206,18 +67982,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70314,18 +68086,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70422,18 +68190,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70530,18 +68294,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70638,18 +68398,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70755,18 +68511,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70830,18 +68582,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70905,18 +68653,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -71056,18 +68800,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -71140,18 +68880,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -71234,18 +68970,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -71328,18 +69060,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -71517,18 +69245,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -71620,18 +69344,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -71717,18 +69437,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -71814,18 +69530,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -72009,18 +69721,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -72115,18 +69823,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -72223,18 +69927,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -72331,18 +70031,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -72548,18 +70244,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -72668,18 +70360,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -72776,18 +70464,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -72884,18 +70568,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -72992,18 +70672,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73100,18 +70776,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73217,18 +70889,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73292,18 +70960,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73367,18 +71031,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73518,18 +71178,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73602,18 +71258,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73696,18 +71348,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73790,18 +71438,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73979,18 +71623,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -74082,18 +71722,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -74179,18 +71815,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -74276,18 +71908,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -74471,18 +72099,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -74577,18 +72201,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -74685,18 +72305,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -74793,18 +72409,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -75010,18 +72622,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -75139,18 +72747,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75247,18 +72851,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75355,18 +72955,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75463,18 +73059,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75571,18 +73163,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75688,18 +73276,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75763,18 +73347,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75838,18 +73418,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75989,18 +73565,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -76073,18 +73645,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -76167,18 +73735,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -76261,18 +73825,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -76450,18 +74010,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -76556,18 +74112,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76664,18 +74216,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76772,18 +74320,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76880,18 +74424,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76988,18 +74528,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77105,18 +74641,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77180,18 +74712,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77255,18 +74783,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77406,18 +74930,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77490,18 +75010,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77584,18 +75100,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77678,18 +75190,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77867,18 +75375,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77981,18 +75485,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -78078,18 +75578,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -78255,18 +75751,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -78352,18 +75844,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -78462,18 +75950,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -78570,18 +76054,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -78769,18 +76249,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -78877,18 +76353,14 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -1805,18 +1805,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -1913,18 +1909,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2021,18 +2013,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2129,18 +2117,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2237,18 +2221,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2354,18 +2334,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2429,18 +2405,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2504,18 +2476,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2655,18 +2623,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2739,18 +2703,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2833,18 +2793,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2927,18 +2883,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3116,18 +3068,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3219,18 +3167,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3316,18 +3260,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3413,18 +3353,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3608,18 +3544,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3714,18 +3646,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3822,18 +3750,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3930,18 +3854,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -4147,18 +4067,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -4267,18 +4183,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4375,18 +4287,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4483,18 +4391,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4591,18 +4495,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4699,18 +4599,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4816,18 +4712,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4891,18 +4783,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4966,18 +4854,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5117,18 +5001,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5201,18 +5081,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5295,18 +5171,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5389,18 +5261,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5578,18 +5446,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5681,18 +5545,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5778,18 +5638,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5875,18 +5731,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6070,18 +5922,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6176,18 +6024,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6284,18 +6128,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6392,18 +6232,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6609,18 +6445,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -6738,18 +6570,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -6846,18 +6674,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -6954,18 +6778,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7062,18 +6882,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7170,18 +6986,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7287,18 +7099,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7362,18 +7170,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7437,18 +7241,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7588,18 +7388,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7672,18 +7468,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7766,18 +7558,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7860,18 +7648,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -8049,18 +7833,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -8155,18 +7935,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8263,18 +8039,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8371,18 +8143,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8479,18 +8247,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8587,18 +8351,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8704,18 +8464,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8779,18 +8535,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8854,18 +8606,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9005,18 +8753,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9089,18 +8833,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9183,18 +8923,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9277,18 +9013,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9466,18 +9198,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -9580,18 +9308,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -9677,18 +9401,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -9854,18 +9574,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -9951,18 +9667,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10061,18 +9773,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10169,18 +9877,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10368,18 +10072,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10476,18 +10176,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -10627,18 +10323,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -10735,18 +10427,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -10843,18 +10531,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -10951,18 +10635,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11059,18 +10739,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11176,18 +10852,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11251,18 +10923,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11326,18 +10994,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11477,18 +11141,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11561,18 +11221,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11655,18 +11311,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11749,18 +11401,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11938,18 +11586,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12041,18 +11685,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12138,18 +11778,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12235,18 +11871,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12430,18 +12062,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12536,18 +12164,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12644,18 +12268,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12752,18 +12372,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12969,18 +12585,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -13089,18 +12701,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13197,18 +12805,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13305,18 +12909,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13413,18 +13013,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13521,18 +13117,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13638,18 +13230,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13713,18 +13301,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13788,18 +13372,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13939,18 +13519,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14023,18 +13599,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14117,18 +13689,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14211,18 +13779,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14400,18 +13964,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14503,18 +14063,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14600,18 +14156,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14697,18 +14249,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14892,18 +14440,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14998,18 +14542,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -15106,18 +14646,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -15214,18 +14750,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -15431,18 +14963,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -15560,18 +15088,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -15668,18 +15192,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -15776,18 +15296,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -15884,18 +15400,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -15992,18 +15504,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16109,18 +15617,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16184,18 +15688,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16259,18 +15759,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16410,18 +15906,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16494,18 +15986,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16588,18 +16076,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16682,18 +16166,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16871,18 +16351,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -16977,18 +16453,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17085,18 +16557,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17193,18 +16661,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17301,18 +16765,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17409,18 +16869,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17526,18 +16982,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17601,18 +17053,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17676,18 +17124,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17827,18 +17271,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17911,18 +17351,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -18005,18 +17441,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -18099,18 +17531,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -18288,18 +17716,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -18402,18 +17826,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -18499,18 +17919,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -18676,18 +18092,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -18773,18 +18185,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -18883,18 +18291,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -18991,18 +18395,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -19190,18 +18590,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -19298,18 +18694,14 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -21214,18 +20606,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -21322,18 +20710,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -21430,18 +20814,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -21538,18 +20918,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -21646,18 +21022,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -21763,18 +21135,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -21838,18 +21206,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -21913,18 +21277,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22064,18 +21424,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22148,18 +21504,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22242,18 +21594,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22336,18 +21684,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22525,18 +21869,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22628,18 +21968,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22725,18 +22061,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -22822,18 +22154,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23017,18 +22345,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23123,18 +22447,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23231,18 +22551,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23339,18 +22655,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23556,18 +22868,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -23676,18 +22984,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -23784,18 +23088,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -23892,18 +23192,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24000,18 +23296,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24108,18 +23400,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24225,18 +23513,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24300,18 +23584,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24375,18 +23655,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24526,18 +23802,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24610,18 +23882,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24704,18 +23972,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24798,18 +24062,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -24987,18 +24247,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25090,18 +24346,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25187,18 +24439,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25284,18 +24532,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25479,18 +24723,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25585,18 +24825,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25693,18 +24929,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25801,18 +25033,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26018,18 +25246,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26147,18 +25371,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -26255,18 +25475,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -26363,18 +25579,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -26471,18 +25683,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -26579,18 +25787,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -26696,18 +25900,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -26771,18 +25971,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -26846,18 +26042,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -26997,18 +26189,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27081,18 +26269,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27175,18 +26359,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27269,18 +26449,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27458,18 +26634,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27564,18 +26736,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -27672,18 +26840,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -27780,18 +26944,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -27888,18 +27048,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -27996,18 +27152,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28113,18 +27265,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28188,18 +27336,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28263,18 +27407,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28414,18 +27554,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28498,18 +27634,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28592,18 +27724,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28686,18 +27814,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28875,18 +27999,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -28989,18 +28109,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -29086,18 +28202,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -29263,18 +28375,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -29360,18 +28468,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -29470,18 +28574,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -29578,18 +28678,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -29777,18 +28873,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -29885,18 +28977,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -30036,18 +29124,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30144,18 +29228,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30252,18 +29332,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30360,18 +29436,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30468,18 +29540,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30585,18 +29653,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30660,18 +29724,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30735,18 +29795,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30886,18 +29942,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30970,18 +30022,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31064,18 +30112,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31158,18 +30202,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31347,18 +30387,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31450,18 +30486,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31547,18 +30579,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31644,18 +30672,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31839,18 +30863,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -31945,18 +30965,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32053,18 +31069,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32161,18 +31173,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32378,18 +31386,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32498,18 +31502,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -32606,18 +31606,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -32714,18 +31710,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -32822,18 +31814,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -32930,18 +31918,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33047,18 +32031,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33122,18 +32102,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33197,18 +32173,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33348,18 +32320,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33432,18 +32400,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33526,18 +32490,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33620,18 +32580,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33809,18 +32765,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -33912,18 +32864,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34009,18 +32957,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34106,18 +33050,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34301,18 +33241,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34407,18 +33343,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34515,18 +33447,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34623,18 +33551,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34840,18 +33764,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34969,18 +33889,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35077,18 +33993,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35185,18 +34097,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35293,18 +34201,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35401,18 +34305,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35518,18 +34418,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35593,18 +34489,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35668,18 +34560,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35819,18 +34707,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35903,18 +34787,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -35997,18 +34877,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -36091,18 +34967,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -36280,18 +35152,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -36386,18 +35254,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -36494,18 +35358,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -36602,18 +35462,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -36710,18 +35566,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -36818,18 +35670,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -36935,18 +35783,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37010,18 +35854,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37085,18 +35925,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37236,18 +36072,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37320,18 +36152,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37414,18 +36242,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37508,18 +36332,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37697,18 +36517,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -37811,18 +36627,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -37908,18 +36720,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -38085,18 +36893,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -38182,18 +36986,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -38292,18 +37092,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -38400,18 +37196,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -38599,18 +37391,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -38707,18 +37495,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -40623,18 +39407,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -40731,18 +39511,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -40839,18 +39615,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -40947,18 +39719,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -41055,18 +39823,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -41172,18 +39936,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -41247,18 +40007,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -41322,18 +40078,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -41473,18 +40225,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -41557,18 +40305,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -41651,18 +40395,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -41745,18 +40485,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -41934,18 +40670,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42037,18 +40769,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42134,18 +40862,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42231,18 +40955,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42426,18 +41146,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42532,18 +41248,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42640,18 +41352,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42748,18 +41456,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42965,18 +41669,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43085,18 +41785,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -43193,18 +41889,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -43301,18 +41993,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -43409,18 +42097,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -43517,18 +42201,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -43634,18 +42314,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -43709,18 +42385,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -43784,18 +42456,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -43935,18 +42603,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44019,18 +42683,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44113,18 +42773,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44207,18 +42863,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44396,18 +43048,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44499,18 +43147,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44596,18 +43240,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44693,18 +43333,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44888,18 +43524,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44994,18 +43626,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -45102,18 +43730,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -45210,18 +43834,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -45427,18 +44047,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -45556,18 +44172,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -45664,18 +44276,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -45772,18 +44380,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -45880,18 +44484,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -45988,18 +44588,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46105,18 +44701,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46180,18 +44772,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46255,18 +44843,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46406,18 +44990,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46490,18 +45070,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46584,18 +45160,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46678,18 +45250,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46867,18 +45435,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46973,18 +45537,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -47081,18 +45641,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -47189,18 +45745,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -47297,18 +45849,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -47405,18 +45953,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -47522,18 +46066,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -47597,18 +46137,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -47672,18 +46208,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -47823,18 +46355,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -47907,18 +46435,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48001,18 +46525,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48095,18 +46615,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48284,18 +46800,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48398,18 +46910,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -48495,18 +47003,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -48672,18 +47176,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -48769,18 +47269,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -48879,18 +47375,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -48987,18 +47479,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -49186,18 +47674,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -49294,18 +47778,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -49445,18 +47925,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -49553,18 +48029,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -49661,18 +48133,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -49769,18 +48237,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -49877,18 +48341,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -49994,18 +48454,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50069,18 +48525,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50144,18 +48596,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50295,18 +48743,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50379,18 +48823,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50473,18 +48913,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50567,18 +49003,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50756,18 +49188,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50859,18 +49287,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50956,18 +49380,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51053,18 +49473,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51248,18 +49664,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51354,18 +49766,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51462,18 +49870,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51570,18 +49974,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51787,18 +50187,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51907,18 +50303,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52015,18 +50407,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52123,18 +50511,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52231,18 +50615,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52339,18 +50719,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52456,18 +50832,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52531,18 +50903,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52606,18 +50974,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52757,18 +51121,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52841,18 +51201,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52935,18 +51291,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53029,18 +51381,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53218,18 +51566,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53321,18 +51665,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53418,18 +51758,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53515,18 +51851,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53710,18 +52042,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53816,18 +52144,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53924,18 +52248,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -54032,18 +52352,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -54249,18 +52565,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -54378,18 +52690,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -54486,18 +52794,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -54594,18 +52898,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -54702,18 +53002,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -54810,18 +53106,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -54927,18 +53219,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55002,18 +53290,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55077,18 +53361,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55228,18 +53508,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55312,18 +53588,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55406,18 +53678,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55500,18 +53768,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55689,18 +53953,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55795,18 +54055,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -55903,18 +54159,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -56011,18 +54263,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -56119,18 +54367,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -56227,18 +54471,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -56344,18 +54584,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -56419,18 +54655,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -56494,18 +54726,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -56645,18 +54873,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -56729,18 +54953,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -56823,18 +55043,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -56917,18 +55133,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -57106,18 +55318,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -57220,18 +55428,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -57317,18 +55521,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -57494,18 +55694,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -57591,18 +55787,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -57701,18 +55893,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -57809,18 +55997,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -58008,18 +56192,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -58116,18 +56296,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -60032,18 +58208,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60140,18 +58312,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60248,18 +58416,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60356,18 +58520,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60464,18 +58624,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60581,18 +58737,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60656,18 +58808,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60731,18 +58879,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60882,18 +59026,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60966,18 +59106,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61060,18 +59196,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61154,18 +59286,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61343,18 +59471,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61446,18 +59570,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61543,18 +59663,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61640,18 +59756,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61835,18 +59947,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61941,18 +60049,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62049,18 +60153,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62157,18 +60257,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62374,18 +60470,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -62494,18 +60586,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62602,18 +60690,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62710,18 +60794,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62818,18 +60898,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62926,18 +61002,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -63043,18 +61115,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -63118,18 +61186,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -63193,18 +61257,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -63344,18 +61404,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -63428,18 +61484,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -63522,18 +61574,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -63616,18 +61664,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -63805,18 +61849,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -63908,18 +61948,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64005,18 +62041,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64102,18 +62134,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64297,18 +62325,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64403,18 +62427,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64511,18 +62531,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64619,18 +62635,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64836,18 +62848,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -64965,18 +62973,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65073,18 +63077,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65181,18 +63181,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65289,18 +63285,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65397,18 +63389,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65514,18 +63502,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65589,18 +63573,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65664,18 +63644,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65815,18 +63791,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65899,18 +63871,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65993,18 +63961,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66087,18 +64051,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66276,18 +64236,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66382,18 +64338,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -66490,18 +64442,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -66598,18 +64546,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -66706,18 +64650,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -66814,18 +64754,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -66931,18 +64867,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67006,18 +64938,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67081,18 +65009,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67232,18 +65156,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67316,18 +65236,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67410,18 +65326,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67504,18 +65416,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67693,18 +65601,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67807,18 +65711,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -67904,18 +65804,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -68081,18 +65977,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -68178,18 +66070,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -68288,18 +66176,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -68396,18 +66280,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -68595,18 +66475,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -68703,18 +66579,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -68854,18 +66726,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -68962,18 +66830,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69070,18 +66934,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69178,18 +67038,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69286,18 +67142,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69403,18 +67255,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69478,18 +67326,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69553,18 +67397,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69704,18 +67544,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69788,18 +67624,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69882,18 +67714,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69976,18 +67804,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70165,18 +67989,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70268,18 +68088,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70365,18 +68181,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70462,18 +68274,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70657,18 +68465,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70763,18 +68567,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70871,18 +68671,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70979,18 +68775,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -71196,18 +68988,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -71316,18 +69104,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71424,18 +69208,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71532,18 +69312,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71640,18 +69416,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71748,18 +69520,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71865,18 +69633,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71940,18 +69704,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -72015,18 +69775,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -72166,18 +69922,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -72250,18 +70002,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -72344,18 +70092,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -72438,18 +70182,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -72627,18 +70367,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -72730,18 +70466,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -72827,18 +70559,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -72924,18 +70652,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73119,18 +70843,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73225,18 +70945,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73333,18 +71049,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73441,18 +71153,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73658,18 +71366,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -73787,18 +71491,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -73895,18 +71595,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74003,18 +71699,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74111,18 +71803,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74219,18 +71907,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74336,18 +72020,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74411,18 +72091,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74486,18 +72162,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74637,18 +72309,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid 2"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74721,18 +72389,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74815,18 +72479,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74909,18 +72569,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75098,18 +72754,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75204,18 +72856,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -75312,18 +72960,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -75420,18 +73064,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -75528,18 +73168,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -75636,18 +73272,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -75753,18 +73385,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -75828,18 +73456,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -75903,18 +73527,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76054,18 +73674,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid 2"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76138,18 +73754,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76232,18 +73844,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76326,18 +73934,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76515,18 +74119,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76629,18 +74229,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -76726,18 +74322,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -76903,18 +74495,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -77000,18 +74588,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -77110,18 +74694,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -77218,18 +74798,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -77417,18 +74993,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -77525,18 +75097,14 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>

--- a/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -841,18 +841,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -945,18 +941,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -1049,18 +1041,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -1153,18 +1141,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -1257,18 +1241,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -1370,18 +1350,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -1445,18 +1421,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -1520,18 +1492,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -1671,18 +1639,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -1755,18 +1719,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -1849,18 +1809,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -1943,18 +1899,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2132,18 +2084,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2235,18 +2183,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2332,18 +2276,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2429,18 +2369,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2624,18 +2560,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2730,18 +2662,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2838,18 +2766,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -2946,18 +2870,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3163,18 +3083,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -3283,18 +3199,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -3387,18 +3299,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -3491,18 +3399,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -3595,18 +3499,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -3699,18 +3599,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -3812,18 +3708,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -3887,18 +3779,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -3962,18 +3850,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4113,18 +3997,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4197,18 +4077,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4291,18 +4167,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4385,18 +4257,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4574,18 +4442,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4677,18 +4541,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4774,18 +4634,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -4871,18 +4727,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5066,18 +4918,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5172,18 +5020,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5280,18 +5124,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5388,18 +5228,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5605,18 +5441,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -5734,18 +5566,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -5838,18 +5666,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -5942,18 +5766,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -6046,18 +5866,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -6150,18 +5966,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -6263,18 +6075,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -6338,18 +6146,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -6413,18 +6217,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -6564,18 +6364,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -6648,18 +6444,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -6742,18 +6534,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -6836,18 +6624,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7025,18 +6809,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -7131,18 +6911,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -7235,18 +7011,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -7339,18 +7111,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -7443,18 +7211,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -7547,18 +7311,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -7660,18 +7420,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -7735,18 +7491,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -7810,18 +7562,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -7961,18 +7709,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8045,18 +7789,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8139,18 +7879,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8233,18 +7969,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8422,18 +8154,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -8536,18 +8264,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -8633,18 +8357,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -8810,18 +8530,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -8907,18 +8623,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -9017,18 +8729,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -9125,18 +8833,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -9324,18 +9028,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -9432,18 +9132,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -9583,18 +9279,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -9687,18 +9379,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -9791,18 +9479,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -9982,18 +9666,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -10095,18 +9775,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -10170,18 +9846,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -10245,18 +9917,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -10396,18 +10064,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -10480,18 +10144,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -10574,18 +10234,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -10668,18 +10324,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -10857,18 +10509,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -10960,18 +10608,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11057,18 +10701,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11154,18 +10794,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11349,18 +10985,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11455,18 +11087,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11563,18 +11191,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11671,18 +11295,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -11888,18 +11508,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -12008,18 +11624,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -12112,18 +11724,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -12216,18 +11824,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -12407,18 +12011,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -12520,18 +12120,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -12595,18 +12191,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -12670,18 +12262,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -12821,18 +12409,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -12905,18 +12489,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -12999,18 +12579,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13093,18 +12669,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13282,18 +12854,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13385,18 +12953,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13482,18 +13046,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13579,18 +13139,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13774,18 +13330,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13880,18 +13432,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -13988,18 +13536,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14096,18 +13640,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14313,18 +13853,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -14442,18 +13978,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -14546,18 +14078,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -14650,18 +14178,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -14841,18 +14365,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -14954,18 +14474,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -15029,18 +14545,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -15104,18 +14616,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -15255,18 +14763,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -15339,18 +14843,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -15433,18 +14933,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -15527,18 +15023,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -15716,18 +15208,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -15822,18 +15310,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -15926,18 +15410,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -16030,18 +15510,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -16221,18 +15697,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -16334,18 +15806,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -16409,18 +15877,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -16484,18 +15948,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -16635,18 +16095,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -16719,18 +16175,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -16813,18 +16265,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -16907,18 +16355,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17096,18 +16540,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -17210,18 +16650,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -17307,18 +16743,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -17484,18 +16916,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -17581,18 +17009,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -17691,18 +17115,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -17799,18 +17219,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -17998,18 +17414,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -18106,18 +17518,14 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -19058,18 +18466,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -19162,18 +18566,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -19266,18 +18666,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -19370,18 +18766,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -19474,18 +18866,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -19587,18 +18975,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -19662,18 +19046,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -19737,18 +19117,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -19888,18 +19264,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -19972,18 +19344,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -20066,18 +19434,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -20160,18 +19524,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -20349,18 +19709,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -20452,18 +19808,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -20549,18 +19901,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -20646,18 +19994,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -20841,18 +20185,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -20947,18 +20287,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -21055,18 +20391,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -21163,18 +20495,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -21380,18 +20708,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -21500,18 +20824,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -21604,18 +20924,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -21708,18 +21024,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -21812,18 +21124,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -21916,18 +21224,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -22029,18 +21333,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -22104,18 +21404,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -22179,18 +21475,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -22330,18 +21622,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -22414,18 +21702,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -22508,18 +21792,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -22602,18 +21882,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -22791,18 +22067,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -22894,18 +22166,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -22991,18 +22259,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -23088,18 +22352,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -23283,18 +22543,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -23389,18 +22645,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -23497,18 +22749,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -23605,18 +22853,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -23822,18 +23066,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -23951,18 +23191,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24055,18 +23291,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24159,18 +23391,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24263,18 +23491,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24367,18 +23591,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24480,18 +23700,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24555,18 +23771,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24630,18 +23842,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24781,18 +23989,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24865,18 +24069,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -24959,18 +24159,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -25053,18 +24249,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -25242,18 +24434,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -25348,18 +24536,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25452,18 +24636,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25556,18 +24736,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25660,18 +24836,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25764,18 +24936,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25877,18 +25045,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -25952,18 +25116,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26027,18 +25187,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26178,18 +25334,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26262,18 +25414,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26356,18 +25504,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26450,18 +25594,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26639,18 +25779,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -26753,18 +25889,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -26850,18 +25982,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -27027,18 +26155,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -27124,18 +26248,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -27234,18 +26354,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -27342,18 +26458,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -27541,18 +26653,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -27649,18 +26757,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -27800,18 +26904,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -27904,18 +27004,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -28008,18 +27104,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -28199,18 +27291,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -28312,18 +27400,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -28387,18 +27471,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -28462,18 +27542,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -28613,18 +27689,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -28697,18 +27769,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -28791,18 +27859,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -28885,18 +27949,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -29074,18 +28134,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -29177,18 +28233,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -29274,18 +28326,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -29371,18 +28419,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -29566,18 +28610,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -29672,18 +28712,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -29780,18 +28816,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -29888,18 +28920,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30105,18 +29133,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -30225,18 +29249,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -30329,18 +29349,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -30433,18 +29449,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -30624,18 +29636,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -30737,18 +29745,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -30812,18 +29816,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -30887,18 +29887,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -31038,18 +30034,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -31122,18 +30114,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -31216,18 +30204,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -31310,18 +30294,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -31499,18 +30479,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -31602,18 +30578,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -31699,18 +30671,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -31796,18 +30764,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -31991,18 +30955,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -32097,18 +31057,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -32205,18 +31161,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -32313,18 +31265,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -32530,18 +31478,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -32659,18 +31603,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32763,18 +31703,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -32867,18 +31803,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -33058,18 +31990,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -33171,18 +32099,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -33246,18 +32170,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -33321,18 +32241,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -33472,18 +32388,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -33556,18 +32468,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -33650,18 +32558,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -33744,18 +32648,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -33933,18 +32833,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -34039,18 +32935,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34143,18 +33035,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34247,18 +33135,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34438,18 +33322,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34551,18 +33431,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34626,18 +33502,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34701,18 +33573,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34852,18 +33720,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -34936,18 +33800,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -35030,18 +33890,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -35124,18 +33980,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -35313,18 +34165,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -35427,18 +34275,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -35524,18 +34368,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -35701,18 +34541,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -35798,18 +34634,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -35908,18 +34740,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -36016,18 +34844,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -36215,18 +35039,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -36323,18 +35143,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -37275,18 +36091,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -37379,18 +36191,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -37483,18 +36291,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -37587,18 +36391,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -37691,18 +36491,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -37804,18 +36600,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -37879,18 +36671,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -37954,18 +36742,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -38105,18 +36889,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -38189,18 +36969,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -38283,18 +37059,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -38377,18 +37149,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -38566,18 +37334,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -38669,18 +37433,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -38766,18 +37526,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -38863,18 +37619,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -39058,18 +37810,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -39164,18 +37912,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -39272,18 +38016,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -39380,18 +38120,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -39597,18 +38333,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -39717,18 +38449,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -39821,18 +38549,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -39925,18 +38649,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -40029,18 +38749,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -40133,18 +38849,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -40246,18 +38958,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -40321,18 +39029,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -40396,18 +39100,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -40547,18 +39247,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -40631,18 +39327,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -40725,18 +39417,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -40819,18 +39507,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -41008,18 +39692,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -41111,18 +39791,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -41208,18 +39884,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -41305,18 +39977,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -41500,18 +40168,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -41606,18 +40270,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -41714,18 +40374,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -41822,18 +40478,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -42039,18 +40691,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -42168,18 +40816,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42272,18 +40916,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42376,18 +41016,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42480,18 +41116,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42584,18 +41216,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42697,18 +41325,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42772,18 +41396,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42847,18 +41467,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -42998,18 +41614,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43082,18 +41694,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43176,18 +41784,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43270,18 +41874,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43459,18 +42059,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -43565,18 +42161,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -43669,18 +42261,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -43773,18 +42361,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -43877,18 +42461,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -43981,18 +42561,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44094,18 +42670,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44169,18 +42741,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44244,18 +42812,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44395,18 +42959,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44479,18 +43039,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44573,18 +43129,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44667,18 +43219,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44856,18 +43404,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -44970,18 +43514,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -45067,18 +43607,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -45244,18 +43780,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -45341,18 +43873,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -45451,18 +43979,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -45559,18 +44083,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -45758,18 +44278,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -45866,18 +44382,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -46017,18 +44529,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46121,18 +44629,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46225,18 +44729,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46416,18 +44916,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46529,18 +45025,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46604,18 +45096,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46679,18 +45167,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46830,18 +45314,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -46914,18 +45394,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47008,18 +45484,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47102,18 +45574,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47291,18 +45759,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47394,18 +45858,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47491,18 +45951,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47588,18 +46044,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47783,18 +46235,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47889,18 +46337,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -47997,18 +46441,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -48105,18 +46545,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -48322,18 +46758,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -48442,18 +46874,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48546,18 +46974,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48650,18 +47074,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48841,18 +47261,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -48954,18 +47370,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49029,18 +47441,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49104,18 +47512,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49255,18 +47659,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49339,18 +47739,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49433,18 +47829,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49527,18 +47919,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49716,18 +48104,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49819,18 +48203,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -49916,18 +48296,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -50013,18 +48389,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -50208,18 +48580,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -50314,18 +48682,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -50422,18 +48786,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -50530,18 +48890,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -50747,18 +49103,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -50876,18 +49228,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -50980,18 +49328,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51084,18 +49428,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51275,18 +49615,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51388,18 +49724,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51463,18 +49795,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51538,18 +49866,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51689,18 +50013,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51773,18 +50093,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51867,18 +50183,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -51961,18 +50273,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -52150,18 +50458,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -52256,18 +50560,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52360,18 +50660,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52464,18 +50760,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52655,18 +50947,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52768,18 +51056,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52843,18 +51127,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -52918,18 +51198,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53069,18 +51345,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53153,18 +51425,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53247,18 +51515,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53341,18 +51605,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53530,18 +51790,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -53644,18 +51900,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -53741,18 +51993,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -53918,18 +52166,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -54015,18 +52259,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -54125,18 +52365,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -54233,18 +52469,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -54432,18 +52664,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -54540,18 +52768,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -55492,18 +53716,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55596,18 +53816,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55700,18 +53916,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55804,18 +54016,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -55908,18 +54116,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56021,18 +54225,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56096,18 +54296,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56171,18 +54367,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56322,18 +54514,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56406,18 +54594,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56500,18 +54684,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56594,18 +54774,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56783,18 +54959,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56886,18 +55058,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -56983,18 +55151,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -57080,18 +55244,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -57275,18 +55435,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -57381,18 +55537,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -57489,18 +55641,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -57597,18 +55745,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -57814,18 +55958,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -57934,18 +56074,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -58038,18 +56174,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -58142,18 +56274,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -58246,18 +56374,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -58350,18 +56474,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -58463,18 +56583,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -58538,18 +56654,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -58613,18 +56725,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -58764,18 +56872,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -58848,18 +56952,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -58942,18 +57042,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -59036,18 +57132,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -59225,18 +57317,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -59328,18 +57416,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -59425,18 +57509,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -59522,18 +57602,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -59717,18 +57793,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -59823,18 +57895,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -59931,18 +57999,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -60039,18 +58103,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -60256,18 +58316,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -60385,18 +58441,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60489,18 +58541,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60593,18 +58641,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60697,18 +58741,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60801,18 +58841,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60914,18 +58950,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -60989,18 +59021,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61064,18 +59092,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61215,18 +59239,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61299,18 +59319,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61393,18 +59409,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61487,18 +59499,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61676,18 +59684,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -61782,18 +59786,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -61886,18 +59886,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -61990,18 +59986,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62094,18 +60086,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62198,18 +60186,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62311,18 +60295,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62386,18 +60366,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62461,18 +60437,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62612,18 +60584,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62696,18 +60664,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62790,18 +60754,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -62884,18 +60844,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -63073,18 +61029,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -63187,18 +61139,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -63284,18 +61232,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -63461,18 +61405,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -63558,18 +61498,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -63668,18 +61604,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -63776,18 +61708,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -63975,18 +61903,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -64083,18 +62007,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -64234,18 +62154,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -64338,18 +62254,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -64442,18 +62354,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -64633,18 +62541,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -64746,18 +62650,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -64821,18 +62721,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -64896,18 +62792,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65047,18 +62939,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65131,18 +63019,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65225,18 +63109,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65319,18 +63199,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65508,18 +63384,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65611,18 +63483,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65708,18 +63576,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -65805,18 +63669,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66000,18 +63860,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66106,18 +63962,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66214,18 +64066,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66322,18 +64170,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66539,18 +64383,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -66659,18 +64499,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -66763,18 +64599,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -66867,18 +64699,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67058,18 +64886,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67171,18 +64995,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67246,18 +65066,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67321,18 +65137,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67472,18 +65284,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67556,18 +65364,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67650,18 +65454,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67744,18 +65544,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -67933,18 +65729,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68036,18 +65828,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68133,18 +65921,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68230,18 +66014,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68425,18 +66205,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68531,18 +66307,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68639,18 +66411,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68747,18 +66515,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -68964,18 +66728,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -69093,18 +66853,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69197,18 +66953,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69301,18 +67053,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69492,18 +67240,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69605,18 +67349,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69680,18 +67420,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69755,18 +67491,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69906,18 +67638,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -69990,18 +67718,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70084,18 +67808,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70178,18 +67898,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70367,18 +68083,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -70473,18 +68185,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -70577,18 +68285,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -70681,18 +68385,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -70872,18 +68572,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -70985,18 +68681,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71060,18 +68752,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71135,18 +68823,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71286,18 +68970,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71370,18 +69050,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71464,18 +69140,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71558,18 +69230,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71747,18 +69415,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -71861,18 +69525,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -71958,18 +69618,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -72135,18 +69791,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -72232,18 +69884,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -72342,18 +69990,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -72450,18 +70094,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -72649,18 +70289,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -72757,18 +70393,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -73709,18 +71341,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -73813,18 +71441,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -73917,18 +71541,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74021,18 +71641,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74125,18 +71741,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74238,18 +71850,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74313,18 +71921,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74388,18 +71992,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74539,18 +72139,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74623,18 +72219,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74717,18 +72309,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -74811,18 +72399,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75000,18 +72584,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75103,18 +72683,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75200,18 +72776,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75297,18 +72869,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75492,18 +73060,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75598,18 +73162,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75706,18 +73266,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -75814,18 +73370,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -76031,18 +73583,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -76151,18 +73699,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76255,18 +73799,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76359,18 +73899,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76463,18 +73999,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76567,18 +74099,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76680,18 +74208,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76755,18 +74279,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76830,18 +74350,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -76981,18 +74497,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77065,18 +74577,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77159,18 +74667,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77253,18 +74757,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77442,18 +74942,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77545,18 +75041,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77642,18 +75134,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77739,18 +75227,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -77934,18 +75418,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -78040,18 +75520,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -78148,18 +75624,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -78256,18 +75728,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -78473,18 +75941,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -78602,18 +76066,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -78706,18 +76166,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -78810,18 +76266,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -78914,18 +76366,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -79018,18 +76466,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -79131,18 +76575,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -79206,18 +76646,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -79281,18 +76717,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -79432,18 +76864,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -79516,18 +76944,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -79610,18 +77034,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -79704,18 +77124,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -79893,18 +77309,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -79999,18 +77411,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -80103,18 +77511,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -80207,18 +77611,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -80311,18 +77711,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -80415,18 +77811,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -80528,18 +77920,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -80603,18 +77991,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -80678,18 +78062,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -80829,18 +78209,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -80913,18 +78289,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -81007,18 +78379,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -81101,18 +78469,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -81290,18 +78654,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -81404,18 +78764,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -81501,18 +78857,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -81678,18 +79030,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -81775,18 +79123,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -81885,18 +79229,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -81993,18 +79333,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -82192,18 +79528,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -82300,18 +79632,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -82451,18 +79779,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -82555,18 +79879,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -82659,18 +79979,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -82850,18 +80166,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -82963,18 +80275,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -83038,18 +80346,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -83113,18 +80417,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -83264,18 +80564,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -83348,18 +80644,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -83442,18 +80734,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -83536,18 +80824,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -83725,18 +81009,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -83828,18 +81108,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -83925,18 +81201,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -84022,18 +81294,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -84217,18 +81485,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -84323,18 +81587,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -84431,18 +81691,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -84539,18 +81795,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -84756,18 +82008,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                              class="css-1qgqq71"
-                              src="/assets/small_04.jpg"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -84876,18 +82124,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -84980,18 +82224,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -85084,18 +82324,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -85275,18 +82511,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -85388,18 +82620,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -85463,18 +82691,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -85538,18 +82762,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -85689,18 +82909,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -85773,18 +82989,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -85867,18 +83079,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -85961,18 +83169,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -86150,18 +83354,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -86253,18 +83453,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -86350,18 +83546,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -86447,18 +83639,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -86642,18 +83830,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -86748,18 +83932,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -86856,18 +84036,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -86964,18 +84140,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -87181,18 +84353,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                          class="css-1qgqq71"
-                          src="/assets/small_04.jpg"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -87310,18 +84478,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -87414,18 +84578,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -87518,18 +84678,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -87709,18 +84865,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -87822,18 +84974,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -87897,18 +85045,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -87972,18 +85116,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -88123,18 +85263,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="American owners pose threat to English pyramid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -88207,18 +85343,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -88301,18 +85433,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -88395,18 +85523,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       >
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -88584,18 +85708,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         </div>
                         <div
                           class="css-1kwj960"
-                          loading="lazy"
                         >
                           <picture
-                            class="css-zp0elg"
+                            class="css-l4lngz"
                           >
-                            <div
-                              class="css-5pczz7"
-                            />
                             <img
                               alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                              class="css-1qgqq71"
-                              src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                              class="css-ssxt4f"
+                              loading="lazy"
                             />
                           </picture>
                         </div>
@@ -88690,18 +85810,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -88794,18 +85910,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -88898,18 +86010,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -89089,18 +86197,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -89202,18 +86306,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -89277,18 +86377,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -89352,18 +86448,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -89503,18 +86595,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="American owners pose threat to English pyramid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -89587,18 +86675,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -89681,18 +86765,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -89775,18 +86855,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   >
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -89964,18 +87040,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     </div>
                     <div
                       class="css-1kwj960"
-                      loading="lazy"
                     >
                       <picture
-                        class="css-zp0elg"
+                        class="css-l4lngz"
                       >
-                        <div
-                          class="css-5pczz7"
-                        />
                         <img
                           alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
-                          class="css-1qgqq71"
-                          src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                          class="css-ssxt4f"
+                          loading="lazy"
                         />
                       </picture>
                     </div>
@@ -90078,18 +87150,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -90175,18 +87243,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -90352,18 +87416,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -90449,18 +87509,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
-                            class="css-1qgqq71"
-                            src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -90559,18 +87615,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -90667,18 +87719,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -90866,18 +87914,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>
@@ -90974,18 +88018,14 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     >
                       <div
                         class="css-1kwj960"
-                        loading="lazy"
                       >
                         <picture
-                          class="css-zp0elg"
+                          class="css-l4lngz"
                         >
-                          <div
-                            class="css-5pczz7"
-                          />
                           <img
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
-                            class="css-1qgqq71"
-                            src="/assets/small_04.jpg"
+                            class="css-ssxt4f"
+                            loading="lazy"
                           />
                         </picture>
                       </div>

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
@@ -76,18 +76,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Short title of the card describing the main content 9"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -340,18 +336,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Short title of the card describing the main content 12"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -604,18 +596,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Short title of the card describing the main content 15"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -868,18 +856,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Short title of the card describing the main content 18"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -1146,18 +1130,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             >
               <div
                 class="css-1kwj960"
-                loading="lazy"
               >
                 <picture
-                  class="css-zp0elg"
+                  class="css-l4lngz"
                 >
-                  <div
-                    class="css-5pczz7"
-                  />
                   <img
                     alt="Short title of the card describing the main content 9"
-                    class="css-1qgqq71"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                    class="css-ssxt4f"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -1410,18 +1390,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             >
               <div
                 class="css-1kwj960"
-                loading="lazy"
               >
                 <picture
-                  class="css-zp0elg"
+                  class="css-l4lngz"
                 >
-                  <div
-                    class="css-5pczz7"
-                  />
                   <img
                     alt="Short title of the card describing the main content 12"
-                    class="css-1qgqq71"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                    class="css-ssxt4f"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -1674,18 +1650,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             >
               <div
                 class="css-1kwj960"
-                loading="lazy"
               >
                 <picture
-                  class="css-zp0elg"
+                  class="css-l4lngz"
                 >
-                  <div
-                    class="css-5pczz7"
-                  />
                   <img
                     alt="Short title of the card describing the main content 15"
-                    class="css-1qgqq71"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                    class="css-ssxt4f"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -1938,18 +1910,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             >
               <div
                 class="css-1kwj960"
-                loading="lazy"
               >
                 <picture
-                  class="css-zp0elg"
+                  class="css-l4lngz"
                 >
-                  <div
-                    class="css-5pczz7"
-                  />
                   <img
                     alt="Short title of the card describing the main content 18"
-                    class="css-1qgqq71"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                    class="css-ssxt4f"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -2228,18 +2196,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Short title of the card describing the main content 9"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -2492,18 +2456,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Short title of the card describing the main content 12"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -2756,18 +2716,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Short title of the card describing the main content 15"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -3020,18 +2976,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
               >
                 <div
                   class="css-1kwj960"
-                  loading="lazy"
                 >
                   <picture
-                    class="css-zp0elg"
+                    class="css-l4lngz"
                   >
-                    <div
-                      class="css-5pczz7"
-                    />
                     <img
                       alt="Short title of the card describing the main content 18"
-                      class="css-1qgqq71"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                      class="css-ssxt4f"
+                      loading="lazy"
                     />
                   </picture>
                 </div>
@@ -3298,18 +3250,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
             >
               <div
                 class="css-1kwj960"
-                loading="lazy"
               >
                 <picture
-                  class="css-zp0elg"
+                  class="css-l4lngz"
                 >
-                  <div
-                    class="css-5pczz7"
-                  />
                   <img
                     alt="Short title of the card describing the main content 9"
-                    class="css-1qgqq71"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                    class="css-ssxt4f"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -3562,18 +3510,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
             >
               <div
                 class="css-1kwj960"
-                loading="lazy"
               >
                 <picture
-                  class="css-zp0elg"
+                  class="css-l4lngz"
                 >
-                  <div
-                    class="css-5pczz7"
-                  />
                   <img
                     alt="Short title of the card describing the main content 12"
-                    class="css-1qgqq71"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                    class="css-ssxt4f"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -3826,18 +3770,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
             >
               <div
                 class="css-1kwj960"
-                loading="lazy"
               >
                 <picture
-                  class="css-zp0elg"
+                  class="css-l4lngz"
                 >
-                  <div
-                    class="css-5pczz7"
-                  />
                   <img
                     alt="Short title of the card describing the main content 15"
-                    class="css-1qgqq71"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                    class="css-ssxt4f"
+                    loading="lazy"
                   />
                 </picture>
               </div>
@@ -4090,18 +4030,14 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
             >
               <div
                 class="css-1kwj960"
-                loading="lazy"
               >
                 <picture
-                  class="css-zp0elg"
+                  class="css-l4lngz"
                 >
-                  <div
-                    class="css-5pczz7"
-                  />
                   <img
                     alt="Short title of the card describing the main content 18"
-                    class="css-1qgqq71"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                    class="css-ssxt4f"
+                    loading="lazy"
                   />
                 </picture>
               </div>

--- a/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -33,18 +33,14 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Short title of the card describing the main content"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -128,18 +124,14 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Short title of the card describing the main content 2"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -237,18 +229,14 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Short title of the card describing the main content 3"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -332,18 +320,14 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Short title of the card describing the main content 4"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -834,18 +818,14 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Short title of the card describing the main content"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -929,18 +909,14 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Short title of the card describing the main content 2"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -1038,18 +1014,14 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Short title of the card describing the main content 3"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>
@@ -1133,18 +1105,14 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
           >
             <div
               class="css-1kwj960"
-              loading="lazy"
             >
               <picture
-                class="css-zp0elg"
+                class="css-l4lngz"
               >
-                <div
-                  class="css-5pczz7"
-                />
                 <img
                   alt="Short title of the card describing the main content 4"
-                  class="css-1qgqq71"
-                  src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173"
+                  class="css-ssxt4f"
+                  loading="lazy"
                 />
               </picture>
             </div>


### PR DESCRIPTION
### Description

Add lazy loading to images that aren't lead images

[TMRX-1580](https://nidigitalsolutions.jira.com/browse/TMRX-1580)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?



[TMRX-1580]: https://nidigitalsolutions.jira.com/browse/TMRX-1580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ