### PR TITLE
fix(TMRX-000): Remove quotes around styles

### DIFF
--- a/packages/ts-newskit/src/components/slices/lead-article/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/lead-article/__tests__/__snapshots__/index.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Render Component one should render a snapshot 1`] = `
       class="css-1vuk75f"
     >
       <div
-        class="lcpItem css-1rkt0l2"
+        class="lcpItem css-4t8ylq"
       >
         <picture
           class="css-zp0elg"

--- a/packages/ts-newskit/src/components/slices/shared-styles/index.ts
+++ b/packages/ts-newskit/src/components/slices/shared-styles/index.ts
@@ -59,16 +59,14 @@ export const FullWidthCardMediaMob = styled(CardMedia)<{
   className?: string;
 }>`
   height: ${({ className }) => (className ? 0 : '100%')};
-  overflow: "hidden";
-  position: "relative";
-  width: "100%";
+  overflow: hidden;
+  position: relative;
   padding-bottom: ${({ ratio }) => (ratio ? `${100 / getRatio(ratio)}%;` : 0)};
-img: {
+  img: {
     opacity: 1,
     zIndex: 2,
-    width: "100%",
-    position: "absolute",
-    display: "block"
+    position: absolute,
+    display: block
   }
   ${getMediaQueryFromTheme('xs', 'md')} {
     ${getSpacingCssFromTheme(setFullWidthMargin, 'space045')};

--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
             class="css-1vuk75f"
           >
             <div
-              class="lcpItem css-1rkt0l2"
+              class="lcpItem css-4t8ylq"
             >
               <picture
                 class="css-zp0elg"
@@ -783,7 +783,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
             class="css-j6pksw"
           >
             <div
-              class="lcpItem css-1rkt0l2"
+              class="lcpItem css-4t8ylq"
             >
               <picture
                 class="css-zp0elg"

--- a/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                 class="css-1nw1nne"
               >
                 <div
-                  class="css-1sg6411"
+                  class="css-75ozqf"
                 >
                   <picture
                     class="css-zp0elg"
@@ -637,7 +637,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                 class="css-1nw1nne"
               >
                 <div
-                  class="css-1sg6411"
+                  class="css-75ozqf"
                 >
                   <picture
                     class="css-zp0elg"

--- a/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
               class="css-1nw1nne"
             >
               <div
-                class="css-1sg6411"
+                class="css-75ozqf"
               >
                 <picture
                   class="css-zp0elg"
@@ -161,7 +161,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
               class="css-1nw1nne"
             >
               <div
-                class="css-1sg6411"
+                class="css-75ozqf"
               >
                 <picture
                   class="css-zp0elg"
@@ -903,7 +903,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
               class="css-1nw1nne"
             >
               <div
-                class="css-1sg6411"
+                class="css-75ozqf"
               >
                 <picture
                   class="css-zp0elg"
@@ -1043,7 +1043,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                 />
               </div>
               <div
-                class="css-1sg6411"
+                class="css-75ozqf"
               >
                 <picture
                   class="css-zp0elg"

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1rkt0l2"
+                class="lcpItem css-4t8ylq"
               >
                 <picture
                   class="css-zp0elg"
@@ -198,7 +198,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1rkt0l2"
+                class="lcpItem css-4t8ylq"
               >
                 <picture
                   class="css-zp0elg"
@@ -1088,7 +1088,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 class="css-j6pksw"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -19136,7 +19136,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1rkt0l2"
+                class="lcpItem css-4t8ylq"
               >
                 <picture
                   class="css-zp0elg"
@@ -19313,7 +19313,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1rkt0l2"
+                class="lcpItem css-4t8ylq"
               >
                 <picture
                   class="css-zp0elg"
@@ -20203,7 +20203,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="css-j6pksw"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -38251,7 +38251,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1rkt0l2"
+                class="lcpItem css-4t8ylq"
               >
                 <picture
                   class="css-zp0elg"
@@ -38428,7 +38428,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1rkt0l2"
+                class="lcpItem css-4t8ylq"
               >
                 <picture
                   class="css-zp0elg"
@@ -39318,7 +39318,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="css-j6pksw"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -57366,7 +57366,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1rkt0l2"
+                class="lcpItem css-4t8ylq"
               >
                 <picture
                   class="css-zp0elg"
@@ -57543,7 +57543,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1rkt0l2"
+                class="lcpItem css-4t8ylq"
               >
                 <picture
                   class="css-zp0elg"
@@ -58433,7 +58433,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="css-j6pksw"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/article-stacks.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/article-stacks.test.tsx.snap
@@ -262,7 +262,7 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1rkt0l2"
+                class="lcpItem css-4t8ylq"
               >
                 <picture
                   class="css-zp0elg"
@@ -399,7 +399,7 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1rkt0l2"
+                class="lcpItem css-4t8ylq"
               >
                 <picture
                   class="css-zp0elg"
@@ -772,7 +772,7 @@ exports[`Render ArticleStack renders with passed width 1`] = `
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1rkt0l2"
+                class="lcpItem css-4t8ylq"
               >
                 <picture
                   class="css-zp0elg"
@@ -909,7 +909,7 @@ exports[`Render ArticleStack renders with passed width 1`] = `
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1rkt0l2"
+                class="lcpItem css-4t8ylq"
               >
                 <picture
                   class="css-zp0elg"

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                 class="css-j6pksw"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -172,7 +172,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                 class="css-j6pksw"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -311,7 +311,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                 class="css-1vuk75f"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -450,7 +450,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                 class="css-1vuk75f"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -589,7 +589,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                 class="css-1vuk75f"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -1003,7 +1003,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -1140,7 +1140,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -1512,7 +1512,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -1649,7 +1649,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -18834,7 +18834,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-j6pksw"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -18973,7 +18973,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-j6pksw"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -19112,7 +19112,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-1vuk75f"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -19251,7 +19251,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-1vuk75f"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -19390,7 +19390,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-1vuk75f"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -19804,7 +19804,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -19941,7 +19941,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -20313,7 +20313,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -20450,7 +20450,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -37635,7 +37635,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-j6pksw"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -37774,7 +37774,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-j6pksw"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -37913,7 +37913,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-1vuk75f"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -38052,7 +38052,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-1vuk75f"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -38191,7 +38191,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-1vuk75f"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -38605,7 +38605,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -38742,7 +38742,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -39114,7 +39114,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -39251,7 +39251,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -56436,7 +56436,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-j6pksw"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -56575,7 +56575,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-j6pksw"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -56714,7 +56714,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-1vuk75f"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -56853,7 +56853,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-1vuk75f"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -56992,7 +56992,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-1vuk75f"
               >
                 <div
-                  class="lcpItem css-1rkt0l2"
+                  class="lcpItem css-4t8ylq"
                 >
                   <picture
                     class="css-zp0elg"
@@ -57406,7 +57406,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -57543,7 +57543,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -57915,7 +57915,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"
@@ -58052,7 +58052,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-j6pksw"
                       >
                         <div
-                          class="lcpItem css-1rkt0l2"
+                          class="lcpItem css-4t8ylq"
                         >
                           <picture
                             class="css-zp0elg"

--- a/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   class="css-j6pksw"
                 >
                   <div
-                    class="lcpItem css-1rkt0l2"
+                    class="lcpItem css-4t8ylq"
                   >
                     <picture
                       class="css-zp0elg"
@@ -676,7 +676,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1bfp96q"
+                class="lcpItem css-wltz6l"
               >
                 <picture
                   class="css-y00bg8"
@@ -17652,7 +17652,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-j6pksw"
                 >
                   <div
-                    class="lcpItem css-1rkt0l2"
+                    class="lcpItem css-4t8ylq"
                   >
                     <picture
                       class="css-zp0elg"
@@ -18301,7 +18301,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1bfp96q"
+                class="lcpItem css-wltz6l"
               >
                 <picture
                   class="css-y00bg8"
@@ -35277,7 +35277,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-j6pksw"
                 >
                   <div
-                    class="lcpItem css-1rkt0l2"
+                    class="lcpItem css-4t8ylq"
                   >
                     <picture
                       class="css-zp0elg"
@@ -35926,7 +35926,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1bfp96q"
+                class="lcpItem css-wltz6l"
               >
                 <picture
                   class="css-y00bg8"
@@ -52902,7 +52902,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-j6pksw"
                 >
                   <div
-                    class="lcpItem css-1rkt0l2"
+                    class="lcpItem css-4t8ylq"
                   >
                     <picture
                       class="css-zp0elg"
@@ -53551,7 +53551,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1bfp96q"
+                class="lcpItem css-wltz6l"
               >
                 <picture
                   class="css-y00bg8"
@@ -70527,7 +70527,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-j6pksw"
                 >
                   <div
-                    class="lcpItem css-1rkt0l2"
+                    class="lcpItem css-4t8ylq"
                   >
                     <picture
                       class="css-zp0elg"
@@ -71176,7 +71176,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
               class="css-j6pksw"
             >
               <div
-                class="lcpItem css-1bfp96q"
+                class="lcpItem css-wltz6l"
               >
                 <picture
                   class="css-y00bg8"

--- a/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -1600,7 +1600,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
             class="css-1nw1nne"
           >
             <div
-              class="css-1sg6411"
+              class="css-75ozqf"
             >
               <picture
                 class="css-zp0elg"
@@ -2001,7 +2001,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
             class="css-1nw1nne"
           >
             <div
-              class="css-1sg6411"
+              class="css-75ozqf"
             >
               <picture
                 class="css-zp0elg"
@@ -2411,7 +2411,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
             class="css-1nw1nne"
           >
             <div
-              class="css-1sg6411"
+              class="css-75ozqf"
             >
               <picture
                 class="css-zp0elg"
@@ -2812,7 +2812,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
             class="css-1nw1nne"
           >
             <div
-              class="css-1sg6411"
+              class="css-75ozqf"
             >
               <picture
                 class="css-zp0elg"


### PR DESCRIPTION
### Description

Some of the styles weren't being applied because they were wrapped in quotes. Oops. This was causing the image to overlap the caption. 


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
#### Before
![Screenshot 2023-10-17 at 11 41 58](https://github.com/newsuk/times-components/assets/44647540/3b737e95-f53a-47dc-adcd-bb5812e01a7d)
#### After
![Screenshot 2023-10-17 at 11 43 07](https://github.com/newsuk/times-components/assets/44647540/77a0791d-bd3e-4a90-8e73-a3020b56804d)



