### PR TITLE
fix(TMRX-1594): Remove video icon for now as the iamge doesnt work in render

### DIFF
--- a/packages/ts-newskit/src/components/slices/shared/articleTileInfo.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/articleTileInfo.tsx
@@ -95,7 +95,7 @@ export const ArticleTileInfo = ({
           )}
           {hasVideo && (
             <TileWrapper>
-              <CustomTextBlock text="VIDEO" stylePreset='inkContrast' />
+              <CustomTextBlock text="VIDEO" stylePreset="inkContrast" />
             </TileWrapper>
           )}
           {label && (

--- a/packages/ts-newskit/src/components/slices/shared/articleTileInfo.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/articleTileInfo.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Divider } from 'newskit';
 import { ContainerInline, StyledBlock } from '../shared-styles';
 import { LiveTag } from './live-tag';
-import { NewsKitVideoButtonIcon } from '../../../assets/index';
 import { CustomTextBlock } from './customTextBlock';
 import { getActiveArticleFlags } from '../../../utils/getActiveArticleFlag';
 
@@ -96,7 +95,7 @@ export const ArticleTileInfo = ({
           )}
           {hasVideo && (
             <TileWrapper>
-              <CustomTextBlock text="VIDEO" icon={<NewsKitVideoButtonIcon />} />
+              <CustomTextBlock text="VIDEO" stylePreset='inkContrast' />
             </TileWrapper>
           )}
           {label && (

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -277,40 +277,6 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     <div
                       class="css-gb5m6n"
                     >
-                      <svg
-                        class="css-ny3roy"
-                        fill="none"
-                        height="20"
-                        viewBox="0 0 22 24"
-                        width="18"
-                        xmlns="http://www.w3.org/2000/svg"
-                        xmlns:xlink="http://www.w3.org/1999/xlink"
-                      >
-                        <rect
-                          fill="url(#pattern0)"
-                          height="24"
-                          width="22"
-                        />
-                        <defs>
-                          <pattern
-                            height="1"
-                            id="pattern0"
-                            patternContentUnits="objectBoundingBox"
-                            width="1"
-                          >
-                            <use
-                              transform="matrix(0.0454545 0 0 0.0416667 -0.0909091 0)"
-                              xlink:href="#image0_3031_245372"
-                            />
-                          </pattern>
-                          <image
-                            height="24"
-                            id="image0_3031_245372"
-                            width="24"
-                            xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAA90lEQVR4nN2UPQrCQBCFPwJJZeElvI5GkZSexc6ot/AXbD2Incaf9LaihZUrC5NGk+wmEYQ8eE0yM2+Znwd1hwcEwAqIgIcwkm+BxJRCD4gBZeAF6BYp7AATi8Lqg2PJNWJaorgShjZtURXpZxX3pJ9VBeKswQeGxF0BkX6awNqQ5AAD4GohsEgTOBmSEjSAIfDMidV38oW7pUCCFrDJiNW1fiKwzYi9pQkcLQWasu95LTqkCSx/OOTZX9bUBc4VDkyZDg1xxSrFX0AbA8o4qRKOsIAj1lv05aGtXSfwLWeiHaBDSbiyEdpb9G7rY9TcA3P5p2NqjDd1yyIEG3kosgAAAABJRU5ErkJggg=="
-                          />
-                        </defs>
-                      </svg>
                       VIDEO
                     </div>
                   </span>
@@ -9034,40 +9000,6 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                     <div
                       class="css-gb5m6n"
                     >
-                      <svg
-                        class="css-ny3roy"
-                        fill="none"
-                        height="20"
-                        viewBox="0 0 22 24"
-                        width="18"
-                        xmlns="http://www.w3.org/2000/svg"
-                        xmlns:xlink="http://www.w3.org/1999/xlink"
-                      >
-                        <rect
-                          fill="url(#pattern0)"
-                          height="24"
-                          width="22"
-                        />
-                        <defs>
-                          <pattern
-                            height="1"
-                            id="pattern0"
-                            patternContentUnits="objectBoundingBox"
-                            width="1"
-                          >
-                            <use
-                              transform="matrix(0.0454545 0 0 0.0416667 -0.0909091 0)"
-                              xlink:href="#image0_3031_245372"
-                            />
-                          </pattern>
-                          <image
-                            height="24"
-                            id="image0_3031_245372"
-                            width="24"
-                            xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAA90lEQVR4nN2UPQrCQBCFPwJJZeElvI5GkZSexc6ot/AXbD2Incaf9LaihZUrC5NGk+wmEYQ8eE0yM2+Znwd1hwcEwAqIgIcwkm+BxJRCD4gBZeAF6BYp7AATi8Lqg2PJNWJaorgShjZtURXpZxX3pJ9VBeKswQeGxF0BkX6awNqQ5AAD4GohsEgTOBmSEjSAIfDMidV38oW7pUCCFrDJiNW1fiKwzYi9pQkcLQWasu95LTqkCSx/OOTZX9bUBc4VDkyZDg1xxSrFX0AbA8o4qRKOsIAj1lv05aGtXSfwLWeiHaBDSbiyEdpb9G7rY9TcA3P5p2NqjDd1yyIEG3kosgAAAABJRU5ErkJggg=="
-                          />
-                        </defs>
-                      </svg>
                       VIDEO
                     </div>
                   </span>
@@ -17791,40 +17723,6 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     <div
                       class="css-gb5m6n"
                     >
-                      <svg
-                        class="css-ny3roy"
-                        fill="none"
-                        height="20"
-                        viewBox="0 0 22 24"
-                        width="18"
-                        xmlns="http://www.w3.org/2000/svg"
-                        xmlns:xlink="http://www.w3.org/1999/xlink"
-                      >
-                        <rect
-                          fill="url(#pattern0)"
-                          height="24"
-                          width="22"
-                        />
-                        <defs>
-                          <pattern
-                            height="1"
-                            id="pattern0"
-                            patternContentUnits="objectBoundingBox"
-                            width="1"
-                          >
-                            <use
-                              transform="matrix(0.0454545 0 0 0.0416667 -0.0909091 0)"
-                              xlink:href="#image0_3031_245372"
-                            />
-                          </pattern>
-                          <image
-                            height="24"
-                            id="image0_3031_245372"
-                            width="24"
-                            xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAA90lEQVR4nN2UPQrCQBCFPwJJZeElvI5GkZSexc6ot/AXbD2Incaf9LaihZUrC5NGk+wmEYQ8eE0yM2+Znwd1hwcEwAqIgIcwkm+BxJRCD4gBZeAF6BYp7AATi8Lqg2PJNWJaorgShjZtURXpZxX3pJ9VBeKswQeGxF0BkX6awNqQ5AAD4GohsEgTOBmSEjSAIfDMidV38oW7pUCCFrDJiNW1fiKwzYi9pQkcLQWasu95LTqkCSx/OOTZX9bUBc4VDkyZDg1xxSrFX0AbA8o4qRKOsIAj1lv05aGtXSfwLWeiHaBDSbiyEdpb9G7rY9TcA3P5p2NqjDd1yyIEG3kosgAAAABJRU5ErkJggg=="
-                          />
-                        </defs>
-                      </svg>
                       VIDEO
                     </div>
                   </span>
@@ -26548,40 +26446,6 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     <div
                       class="css-gb5m6n"
                     >
-                      <svg
-                        class="css-ny3roy"
-                        fill="none"
-                        height="20"
-                        viewBox="0 0 22 24"
-                        width="18"
-                        xmlns="http://www.w3.org/2000/svg"
-                        xmlns:xlink="http://www.w3.org/1999/xlink"
-                      >
-                        <rect
-                          fill="url(#pattern0)"
-                          height="24"
-                          width="22"
-                        />
-                        <defs>
-                          <pattern
-                            height="1"
-                            id="pattern0"
-                            patternContentUnits="objectBoundingBox"
-                            width="1"
-                          >
-                            <use
-                              transform="matrix(0.0454545 0 0 0.0416667 -0.0909091 0)"
-                              xlink:href="#image0_3031_245372"
-                            />
-                          </pattern>
-                          <image
-                            height="24"
-                            id="image0_3031_245372"
-                            width="24"
-                            xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAA90lEQVR4nN2UPQrCQBCFPwJJZeElvI5GkZSexc6ot/AXbD2Incaf9LaihZUrC5NGk+wmEYQ8eE0yM2+Znwd1hwcEwAqIgIcwkm+BxJRCD4gBZeAF6BYp7AATi8Lqg2PJNWJaorgShjZtURXpZxX3pJ9VBeKswQeGxF0BkX6awNqQ5AAD4GohsEgTOBmSEjSAIfDMidV38oW7pUCCFrDJiNW1fiKwzYi9pQkcLQWasu95LTqkCSx/OOTZX9bUBc4VDkyZDg1xxSrFX0AbA8o4qRKOsIAj1lv05aGtXSfwLWeiHaBDSbiyEdpb9G7rY9TcA3P5p2NqjDd1yyIEG3kosgAAAABJRU5ErkJggg=="
-                          />
-                        </defs>
-                      </svg>
                       VIDEO
                     </div>
                   </span>
@@ -35305,40 +35169,6 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     <div
                       class="css-gb5m6n"
                     >
-                      <svg
-                        class="css-ny3roy"
-                        fill="none"
-                        height="20"
-                        viewBox="0 0 22 24"
-                        width="18"
-                        xmlns="http://www.w3.org/2000/svg"
-                        xmlns:xlink="http://www.w3.org/1999/xlink"
-                      >
-                        <rect
-                          fill="url(#pattern0)"
-                          height="24"
-                          width="22"
-                        />
-                        <defs>
-                          <pattern
-                            height="1"
-                            id="pattern0"
-                            patternContentUnits="objectBoundingBox"
-                            width="1"
-                          >
-                            <use
-                              transform="matrix(0.0454545 0 0 0.0416667 -0.0909091 0)"
-                              xlink:href="#image0_3031_245372"
-                            />
-                          </pattern>
-                          <image
-                            height="24"
-                            id="image0_3031_245372"
-                            width="24"
-                            xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAA90lEQVR4nN2UPQrCQBCFPwJJZeElvI5GkZSexc6ot/AXbD2Incaf9LaihZUrC5NGk+wmEYQ8eE0yM2+Znwd1hwcEwAqIgIcwkm+BxJRCD4gBZeAF6BYp7AATi8Lqg2PJNWJaorgShjZtURXpZxX3pJ9VBeKswQeGxF0BkX6awNqQ5AAD4GohsEgTOBmSEjSAIfDMidV38oW7pUCCFrDJiNW1fiKwzYi9pQkcLQWasu95LTqkCSx/OOTZX9bUBc4VDkyZDg1xxSrFX0AbA8o4qRKOsIAj1lv05aGtXSfwLWeiHaBDSbiyEdpb9G7rY9TcA3P5p2NqjDd1yyIEG3kosgAAAABJRU5ErkJggg=="
-                          />
-                        </defs>
-                      </svg>
                       VIDEO
                     </div>
                   </span>


### PR DESCRIPTION
### Description

The video icon isn't working in render because it points to an image which we don't have. For now I have removed the icon, and will ask design to provide a full SVG for the icon. 
Small change to styling as in the design the video label does not have a brand colour applied to it. 
[Design](https://www.figma.com/file/zYjnqWXVY0cFFaJgcSqM5M/Section-Slices?type=design&node-id=3019-241814&mode=design&t=E27GNkj82g43QA9Y-0)

### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
-- Current behaviour in staging
![Screenshot 2023-10-26 at 10 53 06](https://github.com/newsuk/times-components/assets/44647540/95852a5f-7ec5-491a-a5dd-88796c3e8a82)
-- Now in storybook
<img width="472" alt="Screenshot 2023-10-26 at 10 51 57" src="https://github.com/newsuk/times-components/assets/44647540/00977758-e9ed-4725-9ca9-b7f475939dfe">

