### PR TITLE
fix(TMRX-1617): only render slice header as link if href is provided

### DIFF
--- a/packages/ts-newskit/src/components/slices/slice-header/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/slice-header/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Render Header should render a snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="css-4ikyhe"
+    class="css-1z0zvv5"
   >
     <a
       class="css-1pyvojw"

--- a/packages/ts-newskit/src/components/slices/slice-header/index.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/index.tsx
@@ -17,6 +17,25 @@ export interface SliceHeaderProps {
   sliceHeaderClickHandler: (title: string) => void;
 }
 
+const SliceHeaderLinkWrapper = ({
+  href,
+  onClick,
+  children
+}: {
+  onClick: () => void;
+  href?: string;
+  children: React.ReactNode;
+}) => {
+  if (href) {
+    return (
+      <SliceHeaderLink href={href} onClick={onClick}>
+        {children}
+      </SliceHeaderLink>
+    );
+  }
+  return <>{children}</>;
+};
+
 export const SliceHeader = ({
   title,
   href,
@@ -36,7 +55,7 @@ export const SliceHeader = ({
         md: 'sliceHeaderPresetDesktop'
       }}
     >
-      <SliceHeaderLink
+      <SliceHeaderLinkWrapper
         href={href}
         onClick={() => sliceHeaderClickHandler(title)}
       >
@@ -71,7 +90,7 @@ export const SliceHeader = ({
             </IconButton>
           )}
         </SliceHeaderContainer>
-      </SliceHeaderLink>
+      </SliceHeaderLinkWrapper>
     </SliceHeaderWrapper>
   );
 };

--- a/packages/ts-newskit/src/components/slices/slice-header/styles.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/styles.tsx
@@ -1,7 +1,7 @@
 import { Block, Stack, getColorCssFromTheme, styled } from 'newskit';
 
 export const SliceHeaderWrapper = styled(Block)`
-  &:hover {
+  & a:hover {
     cursor: pointer;
 
     h3 {
@@ -13,7 +13,7 @@ export const SliceHeaderWrapper = styled(Block)`
     }
   }
 
-  &:active {
+  & a:active {
     h3 {
       ${getColorCssFromTheme('color', 'interactiveLink030')};
     }

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-4ikyhe"
+                class="css-1z0zvv5"
               >
                 <a
                   class="css-1pyvojw"
@@ -317,7 +317,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-4ikyhe"
+                class="css-1z0zvv5"
               >
                 <a
                   class="css-1pyvojw"
@@ -610,7 +610,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-4ikyhe"
+                class="css-1z0zvv5"
               >
                 <a
                   class="css-1pyvojw"
@@ -903,7 +903,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-4ikyhe"
+                class="css-1z0zvv5"
               >
                 <a
                   class="css-1pyvojw"
@@ -1210,7 +1210,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-4ikyhe"
+              class="css-1z0zvv5"
             >
               <a
                 class="css-1pyvojw"
@@ -1503,7 +1503,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-4ikyhe"
+              class="css-1z0zvv5"
             >
               <a
                 class="css-1pyvojw"
@@ -1796,7 +1796,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-4ikyhe"
+              class="css-1z0zvv5"
             >
               <a
                 class="css-1pyvojw"
@@ -2089,7 +2089,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-4ikyhe"
+              class="css-1z0zvv5"
             >
               <a
                 class="css-1pyvojw"
@@ -2408,7 +2408,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-4ikyhe"
+                class="css-1z0zvv5"
               >
                 <a
                   class="css-1pyvojw"
@@ -2701,7 +2701,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-4ikyhe"
+                class="css-1z0zvv5"
               >
                 <a
                   class="css-1pyvojw"
@@ -2994,7 +2994,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-4ikyhe"
+                class="css-1z0zvv5"
               >
                 <a
                   class="css-1pyvojw"
@@ -3287,7 +3287,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-4ikyhe"
+                class="css-1z0zvv5"
               >
                 <a
                   class="css-1pyvojw"
@@ -3594,7 +3594,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-4ikyhe"
+              class="css-1z0zvv5"
             >
               <a
                 class="css-1pyvojw"
@@ -3887,7 +3887,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-4ikyhe"
+              class="css-1z0zvv5"
             >
               <a
                 class="css-1pyvojw"
@@ -4180,7 +4180,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-4ikyhe"
+              class="css-1z0zvv5"
             >
               <a
                 class="css-1pyvojw"
@@ -4473,7 +4473,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-4ikyhe"
+              class="css-1z0zvv5"
             >
               <a
                 class="css-1pyvojw"


### PR DESCRIPTION
### Description

The slice header has a hover state and the cursor changes when you hover over it as default. It needs to only do this if there is a link on the block title. See - https://www.thetimes.co.uk/sport/all-sport

Acceptance Criteria
- Slice header behaves as clickable if there is a link
- Slice header behaves as text if no link.

[JIRA-1617](https://nidigitalsolutions.jira.com/browse/TMRX-1617)


### Checklist

- [X] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
<img width="730" alt="Screenshot 2023-10-27 at 09 51 33" src="https://github.com/newsuk/times-components/assets/142982056/a1d317c9-c51e-4eaf-8b1a-7151feeb7f8c">

