### PR TITLE
fix(TMRX-000): Add new video Icon SVG

### DIFF
--- a/packages/ts-newskit/src/assets/VideoIcon.tsx
+++ b/packages/ts-newskit/src/assets/VideoIcon.tsx
@@ -1,36 +1,18 @@
-import React, { SVGProps } from 'react';
-
-const VideoIcon = (props: SVGProps<SVGSVGElement>) => (
+import * as React from "react"
+const VideoIcon: React.FC = (props: any) => (
   <svg
-    width="18"
-    height="20"
-    viewBox="0 0 22 24"
-    fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    xmlnsXlink="http://www.w3.org/1999/xlink"
+    width={24}
+    height={24}
+    fill="none"
     {...props}
   >
-    <rect width="22" height="24" fill="url(#pattern0)" />
-    <defs>
-      <pattern
-        id="pattern0"
-        patternContentUnits="objectBoundingBox"
-        width="1"
-        height="1"
-      >
-        <use
-          xlinkHref="#image0_3031_245372"
-          transform="matrix(0.0454545 0 0 0.0416667 -0.0909091 0)"
-        />
-      </pattern>
-      <image
-        id="image0_3031_245372"
-        width="24"
-        height="24"
-        xlinkHref="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAA90lEQVR4nN2UPQrCQBCFPwJJZeElvI5GkZSexc6ot/AXbD2Incaf9LaihZUrC5NGk+wmEYQ8eE0yM2+Znwd1hwcEwAqIgIcwkm+BxJRCD4gBZeAF6BYp7AATi8Lqg2PJNWJaorgShjZtURXpZxX3pJ9VBeKswQeGxF0BkX6awNqQ5AAD4GohsEgTOBmSEjSAIfDMidV38oW7pUCCFrDJiNW1fiKwzYi9pQkcLQWasu95LTqkCSx/OOTZX9bUBc4VDkyZDg1xxSrFX0AbA8o4qRKOsIAj1lv05aGtXSfwLWeiHaBDSbiyEdpb9G7rY9TcA3P5p2NqjDd1yyIEG3kosgAAAABJRU5ErkJggg=="
-      />
-    </defs>
+    <path
+      fill="#01000D"
+      fillRule="evenodd"
+      d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Zm4-10-6-3.75v7.5L16 12Z"
+      clipRule="evenodd"
+    />
   </svg>
-);
-
+)
 export default VideoIcon;

--- a/packages/ts-newskit/src/assets/VideoIcon.tsx
+++ b/packages/ts-newskit/src/assets/VideoIcon.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import * as React from 'react';
 const VideoIcon: React.FC = (props: any) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -14,5 +14,5 @@ const VideoIcon: React.FC = (props: any) => (
       clipRule="evenodd"
     />
   </svg>
-)
+);
 export default VideoIcon;

--- a/packages/ts-newskit/src/assets/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/assets/__tests__/__snapshots__/index.test.tsx.snap
@@ -1487,36 +1487,16 @@ exports[`Icons Component: NewsKitVideoButtonIcon NewsKitVideoButtonIcon renders 
   <svg
     class="css-ny3roy"
     fill="none"
-    height="20"
-    viewBox="0 0 22 24"
-    width="18"
+    height="24"
+    width="24"
     xmlns="http://www.w3.org/2000/svg"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
   >
-    <rect
-      fill="url(#pattern0)"
-      height="24"
-      width="22"
+    <path
+      clip-rule="evenodd"
+      d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Zm4-10-6-3.75v7.5L16 12Z"
+      fill="#01000D"
+      fill-rule="evenodd"
     />
-    <defs>
-      <pattern
-        height="1"
-        id="pattern0"
-        patternContentUnits="objectBoundingBox"
-        width="1"
-      >
-        <use
-          transform="matrix(0.0454545 0 0 0.0416667 -0.0909091 0)"
-          xlink:href="#image0_3031_245372"
-        />
-      </pattern>
-      <image
-        height="24"
-        id="image0_3031_245372"
-        width="24"
-        xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAA90lEQVR4nN2UPQrCQBCFPwJJZeElvI5GkZSexc6ot/AXbD2Incaf9LaihZUrC5NGk+wmEYQ8eE0yM2+Znwd1hwcEwAqIgIcwkm+BxJRCD4gBZeAF6BYp7AATi8Lqg2PJNWJaorgShjZtURXpZxX3pJ9VBeKswQeGxF0BkX6awNqQ5AAD4GohsEgTOBmSEjSAIfDMidV38oW7pUCCFrDJiNW1fiKwzYi9pQkcLQWasu95LTqkCSx/OOTZX9bUBc4VDkyZDg1xxSrFX0AbA8o4qRKOsIAj1lv05aGtXSfwLWeiHaBDSbiyEdpb9G7rY9TcA3P5p2NqjDd1yyIEG3kosgAAAABJRU5ErkJggg=="
-      />
-    </defs>
   </svg>
 </DocumentFragment>
 `;

--- a/packages/ts-newskit/src/components/slices/shared/articleTileInfo.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/articleTileInfo.tsx
@@ -96,7 +96,11 @@ export const ArticleTileInfo = ({
           )}
           {hasVideo && (
             <TileWrapper>
-              <CustomTextBlock text="VIDEO" stylePreset="inkContrast" icon={<VideoIcon/>}/>
+              <CustomTextBlock
+                text="VIDEO"
+                stylePreset="inkContrast"
+                icon={<VideoIcon />}
+              />
             </TileWrapper>
           )}
           {label && (

--- a/packages/ts-newskit/src/components/slices/shared/articleTileInfo.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/articleTileInfo.tsx
@@ -4,6 +4,7 @@ import { ContainerInline, StyledBlock } from '../shared-styles';
 import { LiveTag } from './live-tag';
 import { CustomTextBlock } from './customTextBlock';
 import { getActiveArticleFlags } from '../../../utils/getActiveArticleFlag';
+import { NewsKitVideoButtonIcon as VideoIcon } from '../../../assets';
 
 export type expirableFlagsProps = {
   type: string;
@@ -95,7 +96,7 @@ export const ArticleTileInfo = ({
           )}
           {hasVideo && (
             <TileWrapper>
-              <CustomTextBlock text="VIDEO" stylePreset="inkContrast" />
+              <CustomTextBlock text="VIDEO" stylePreset="inkContrast" icon={<VideoIcon/>}/>
             </TileWrapper>
           )}
           {label && (

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -277,6 +277,20 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     <div
                       class="css-gb5m6n"
                     >
+                      <svg
+                        class="css-ny3roy"
+                        fill="none"
+                        height="24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Zm4-10-6-3.75v7.5L16 12Z"
+                          fill="#01000D"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
                       VIDEO
                     </div>
                   </span>
@@ -9000,6 +9014,20 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                     <div
                       class="css-gb5m6n"
                     >
+                      <svg
+                        class="css-ny3roy"
+                        fill="none"
+                        height="24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Zm4-10-6-3.75v7.5L16 12Z"
+                          fill="#01000D"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
                       VIDEO
                     </div>
                   </span>
@@ -17723,6 +17751,20 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     <div
                       class="css-gb5m6n"
                     >
+                      <svg
+                        class="css-ny3roy"
+                        fill="none"
+                        height="24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Zm4-10-6-3.75v7.5L16 12Z"
+                          fill="#01000D"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
                       VIDEO
                     </div>
                   </span>
@@ -26446,6 +26488,20 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     <div
                       class="css-gb5m6n"
                     >
+                      <svg
+                        class="css-ny3roy"
+                        fill="none"
+                        height="24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Zm4-10-6-3.75v7.5L16 12Z"
+                          fill="#01000D"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
                       VIDEO
                     </div>
                   </span>
@@ -35169,6 +35225,20 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     <div
                       class="css-gb5m6n"
                     >
+                      <svg
+                        class="css-ny3roy"
+                        fill="none"
+                        height="24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Zm4-10-6-3.75v7.5L16 12Z"
+                          fill="#01000D"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
                       VIDEO
                     </div>
                   </span>


### PR DESCRIPTION
### Description

Design sent us a new SVG for the video Icon so have included that again.

### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
<img width="776" alt="Screenshot 2023-10-27 at 12 44 43" src="https://github.com/newsuk/times-components/assets/44647540/50865f51-6abf-4c83-972a-45f486e0f35d">

