### PR TITLE
fix(TMRX-1615): secondary nav mobile spacing

### DIFF
--- a/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-nav-desktop.test.tsx.snap
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/__tests__/__snapshots__/secondary-nav-desktop.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Secondary Menu Desktop should render snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="css-dp277b"
+    class="css-1obchgy"
   >
     <div
       class="css-gre9re"

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/index.tsx
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/index.tsx
@@ -53,7 +53,7 @@ export const SecondaryNavigation = ({
   };
 
   return (
-    <SecondaryNavContainer topDesktop={stickyTopDesktop} topMobile={stickyTop}>
+    <SecondaryNavContainer topDesktop={stickyTopDesktop} topMobile={stickyTop && stickyTop - 0.5}>
       <Visible sm xs>
         <SecondaryNavMobile
           data={data}

--- a/packages/ts-newskit/src/components/navigation/secondary-menu/index.tsx
+++ b/packages/ts-newskit/src/components/navigation/secondary-menu/index.tsx
@@ -53,7 +53,10 @@ export const SecondaryNavigation = ({
   };
 
   return (
-    <SecondaryNavContainer topDesktop={stickyTopDesktop} topMobile={stickyTop && stickyTop - 0.5}>
+    <SecondaryNavContainer
+      topDesktop={stickyTopDesktop}
+      topMobile={stickyTop && stickyTop - 0.5}
+    >
       <Visible sm xs>
         <SecondaryNavMobile
           data={data}


### PR DESCRIPTION
### Description

There is space between main nav and secondary nav.

[JIRA-1615](https://nidigitalsolutions.jira.com/browse/TMRX-1615)

![image](https://github.com/newsuk/times-components/assets/142982056/a00a7038-987c-4532-a294-e4af7bb891fb)

### Checklist

- [X] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.
