### PR TITLE
feat(TMRX-1634): change to today section rail title

### DIFF
--- a/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
@@ -6,7 +6,9 @@ exports[`1. a single related article 1`] = `
     <h3
       aria-level="3"
       role="heading"
-    />
+    >
+      Read more
+    </h3>
   </div>
   <div>
     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
@@ -6,9 +6,7 @@ exports[`1. a single related article 1`] = `
     <h3
       aria-level="3"
       role="heading"
-    >
-      Read more
-    </h3>
+    />
   </div>
   <div>
     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
@@ -7,7 +7,7 @@ exports[`1. a single related article 1`] = `
       aria-level="3"
       role="heading"
     >
-      Related articles
+      Read more
     </h3>
   </div>
   <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
@@ -6,7 +6,9 @@ exports[`1. two related articles 1`] = `
     <h3
       aria-level="3"
       role="heading"
-    />
+    >
+      Read more
+    </h3>
   </div>
   <div>
     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
@@ -7,7 +7,7 @@ exports[`1. two related articles 1`] = `
       aria-level="3"
       role="heading"
     >
-      Related articles
+      Read more
     </h3>
   </div>
   <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
@@ -6,9 +6,7 @@ exports[`1. two related articles 1`] = `
     <h3
       aria-level="3"
       role="heading"
-    >
-      Read more
-    </h3>
+    />
   </div>
   <div>
     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
@@ -6,9 +6,7 @@ exports[`1. three related articles 1`] = `
     <h3
       aria-level="3"
       role="heading"
-    >
-      Read more
-    </h3>
+    />
   </div>
   <div>
     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
@@ -7,7 +7,7 @@ exports[`1. three related articles 1`] = `
       aria-level="3"
       role="heading"
     >
-      Related articles
+      Read more
     </h3>
   </div>
   <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
@@ -6,7 +6,9 @@ exports[`1. three related articles 1`] = `
     <h3
       aria-level="3"
       role="heading"
-    />
+    >
+      Read more
+    </h3>
   </div>
   <div>
     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
@@ -6,9 +6,7 @@ exports[`1. has video 1`] = `
     <h3
       aria-level="3"
       role="heading"
-    >
-      Read more
-    </h3>
+    />
   </div>
   <div>
     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
@@ -6,7 +6,9 @@ exports[`1. has video 1`] = `
     <h3
       aria-level="3"
       role="heading"
-    />
+    >
+      Read more
+    </h3>
   </div>
   <div>
     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
@@ -7,7 +7,7 @@ exports[`1. has video 1`] = `
       aria-level="3"
       role="heading"
     >
-      Related articles
+      Read more
     </h3>
   </div>
   <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
@@ -7,7 +7,7 @@ exports[`1. no short headline 1`] = `
       aria-level="3"
       role="heading"
     >
-      Related articles
+      Read more
     </h3>
   </div>
   <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
@@ -6,7 +6,9 @@ exports[`1. no short headline 1`] = `
     <h3
       aria-level="3"
       role="heading"
-    />
+    >
+      Read more
+    </h3>
   </div>
   <div>
     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
@@ -6,9 +6,7 @@ exports[`1. no short headline 1`] = `
     <h3
       aria-level="3"
       role="heading"
-    >
-      Read more
-    </h3>
+    />
   </div>
   <div>
     <div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -340,9 +340,7 @@ exports[`default styles 1`] = `
   >
     <h3
       className="c1"
-    >
-      Read more
-    </h3>
+    />
   </div>
   <div
     className="c2"

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -341,7 +341,7 @@ exports[`default styles 1`] = `
     <h3
       className="c1"
     >
-      Related articles
+      Read more
     </h3>
   </div>
   <div

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -340,7 +340,9 @@ exports[`default styles 1`] = `
   >
     <h3
       className="c1"
-    />
+    >
+      Read more
+    </h3>
   </div>
   <div
     className="c2"

--- a/packages/related-articles/src/related-articles-heading.js
+++ b/packages/related-articles/src/related-articles-heading.js
@@ -1,7 +1,6 @@
 import React from "react";
 import styled from "styled-components";
 import { TcView, checkStylesForUnits } from "@times-components/utils";
-
 import styles from "./styles";
 
 export const HeadingForRelatedArticles = styled.h3`

--- a/packages/related-articles/src/related-articles-heading.js
+++ b/packages/related-articles/src/related-articles-heading.js
@@ -1,7 +1,6 @@
 import React from "react";
 import styled from "styled-components";
 import { TcView, checkStylesForUnits } from "@times-components/utils";
-import PropTypes from "prop-types";
 
 import styles from "./styles";
 
@@ -25,17 +24,10 @@ const RelatedArticlesHeading = () => (
       aria-level="3"
       styles={checkStylesForUnits(styles.title)}
     >
-      Read more
     </HeadingForRelatedArticles>
   </TcView>
 );
 
-RelatedArticlesHeading.propTypes = {
-  heading: PropTypes.string
-};
 
-RelatedArticlesHeading.defaultProps = {
-  heading: "Related articles"
-};
 
 export default RelatedArticlesHeading;

--- a/packages/related-articles/src/related-articles-heading.js
+++ b/packages/related-articles/src/related-articles-heading.js
@@ -24,6 +24,7 @@ const RelatedArticlesHeading = () => (
       aria-level="3"
       styles={checkStylesForUnits(styles.title)}
     >
+      Read more
     </HeadingForRelatedArticles>
   </TcView>
 );

--- a/packages/related-articles/src/related-articles-heading.js
+++ b/packages/related-articles/src/related-articles-heading.js
@@ -18,14 +18,14 @@ export const HeadingForRelatedArticles = styled.h3`
   ${props => props.styles && props.styles};
 `;
 
-const RelatedArticlesHeading = ({ heading }) => (
+const RelatedArticlesHeading = () => (
   <TcView style={styles.titleContainer}>
     <HeadingForRelatedArticles
       role="heading"
       aria-level="3"
       styles={checkStylesForUnits(styles.title)}
     >
-      {heading}
+      Read more
     </HeadingForRelatedArticles>
   </TcView>
 );

--- a/packages/related-articles/src/related-articles.js
+++ b/packages/related-articles/src/related-articles.js
@@ -13,7 +13,7 @@ class RelatedArticles extends Component {
   }
 
   render() {
-    const { isVisible, onPress, slice, heading } = this.props;
+    const { isVisible, onPress, slice } = this.props;
     if (!slice) return null;
     const { items, sliceName } = slice;
     if (
@@ -59,7 +59,7 @@ class RelatedArticles extends Component {
 
     return (
       <TcView>
-        <RelatedArticlesHeading heading={heading} />
+        <RelatedArticlesHeading />
         <StandardSlice
           itemCount={items.length}
           renderItems={config =>


### PR DESCRIPTION
### Description

When I visit an article and scroll towards the end of the article
I want to be presented with recommended articles
So that I can discover content of interest to me (and continue reading)
Acceptance Criteria


The today’s section rail is titled: Read more (need final decision on heading from @Tim Arbabzadah ) - :white_check_mark:  Agreed 2/11

This is presented across all articles (from all sections)

Given I’m a web user
And I visit an article page
When I scroll to the end of an article
And I’m presented with the today’s section rail
Then the title of the rail reads: Read more

Reason for change

To avoid a recurring issue whereby the title is presented as Today’s unknown section
[JIRA-1634](https://nidigitalsolutions.jira.com/browse/TMRX-1634)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
<img width="1290" alt="Screenshot 2023-11-06 at 09 57 53" src="https://github.com/newsuk/times-components/assets/116718171/772a664c-14ea-4b41-80c4-0156a4afc184">

