### PR TITLE
fix(TMRX-1634): change today's rail title

### DIFF
--- a/packages/ts-components/src/components/recommended-articles/RecommendedFetch.tsx
+++ b/packages/ts-components/src/components/recommended-articles/RecommendedFetch.tsx
@@ -24,6 +24,7 @@ export const RecommendedFetch: React.FC<{
   useEffect(() => {
     try {
       const acsCookie = window.nuk.getCookieValue('acs_tnl');
+
       const envName = window.__TIMES_CONFIG__.environmentName;
 
       if (acsCookie && isValidEnvironment(envName)) {

--- a/packages/ts-components/src/components/recommended-articles/RecommendedFetch.tsx
+++ b/packages/ts-components/src/components/recommended-articles/RecommendedFetch.tsx
@@ -14,13 +14,6 @@ import { RecommendedArticles } from './RecommendedArticles';
 const isValidEnvironment = (name: string) =>
   ['local-prod', 'pr', 'uat', 'staging', 'prod'].includes(name);
 
-export const getSectionText = (section: string): string => {
-  if (['scotland', 'ireland', 'times2'].includes(section)) {
-    return section.charAt(0).toUpperCase() + section.slice(1);
-  }
-  return section;
-};
-
 export const RecommendedFetch: React.FC<{
   articleId: string;
   articleHeadline: string;
@@ -42,7 +35,7 @@ export const RecommendedFetch: React.FC<{
     }
   }, []);
 
-  const heading = `Today\u{2019}s ${getSectionText(articleSection)}`;
+  const heading = 'Read more';
 
   return isClientSide ? (
     <FetchProvider

--- a/packages/ts-components/src/components/recommended-articles/__tests__/RecommendedFetch.test.tsx
+++ b/packages/ts-components/src/components/recommended-articles/__tests__/RecommendedFetch.test.tsx
@@ -38,7 +38,7 @@ describe('<RecommendedFetch>', () => {
 
     expect(getByText('FetchProvider'));
     expect(getByText('RecommendedArticles'));
-    expect(getByText('Today’s news'));
+    expect(getByText('Read more'));
 
     expect(asFragment()).toMatchSnapshot();
   });
@@ -52,7 +52,7 @@ describe('<RecommendedFetch>', () => {
       />
     );
 
-    expect(getByText('Today’s Scotland'));
+    expect(getByText('Read more'));
   });
 
   it('should render an uppercase section name for Ireland', () => {
@@ -64,6 +64,6 @@ describe('<RecommendedFetch>', () => {
       />
     );
 
-    expect(getByText('Today’s Ireland'));
+    expect(getByText('Read more'));
   });
 });

--- a/packages/ts-components/src/components/recommended-articles/__tests__/__snapshots__/RecommendedFetch.test.tsx.snap
+++ b/packages/ts-components/src/components/recommended-articles/__tests__/__snapshots__/RecommendedFetch.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<RecommendedFetch> should render headers in lowercase correctly 1`] = `
         RecommendedArticles
       </div>
       <div>
-        Today’s news
+        Read more
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Description

When I visit an article and scroll towards the end of the article
I want to be presented with recommended articles
So that I can discover content of interest to me (and continue reading)
Acceptance Criteria


The today’s section rail is titled: Read more (need final decision on heading from @Tim Arbabzadah ) - :white_check_mark:  Agreed 2/11

This is presented across all articles (from all sections)

Description

Given I’m a web user
And I visit an article page
When I scroll to the end of an article
And I’m presented with the today’s section rail
Then the title of the rail reads: Read more

Reason for change

To avoid a recurring issue whereby the title is presented as Today’s unknown section
[JIRA-1634](https://nidigitalsolutions.jira.com/browse/TMRX-1634)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?
