### PR TITLE
feat(TMPZ-249): update puzzle sidebar

### DIFF
--- a/packages/ts-newskit/src/components/puzzles/article-sidebar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/article-sidebar/__tests__/__snapshots__/index.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`ArticleSidebar should render ArticleSidebar component 1`] = `
         class="css-13byt3y"
       >
         <div
-          class="css-1icspiw"
+          class="css-61bc40"
         >
           <a
             class="css-xm00pa"
@@ -30,38 +30,28 @@ exports[`ArticleSidebar should render ArticleSidebar component 1`] = `
             >
               Puzzles for you
             </h3>
-            <svg
-              class="css-176gl8i"
-              fill="none"
-              height="24"
-              overrides="[object Object]"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              class="css-1alxo68"
+              data-testid="button"
+              type="button"
             >
-              <g
-                clip-path="url(#clip0_154_17)"
+              <svg
+                aria-hidden="true"
+                class="css-3rbz36"
+                fill="currentcolor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12C0 18.6274 5.37258 24 12 24C18.6274 24 24 18.6274 24 12Z"
-                  fill="#EEEEEE"
+                  d="M0 0h24v24H0z"
+                  fill="none"
                 />
                 <path
-                  d="M14.667 12L10.667 8L9.72699 8.94L12.7803 12L9.72699 15.06L10.667 16L14.667 12Z"
+                  d="m12 8-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"
+                  fill="currentcolor"
                 />
-              </g>
-              <defs>
-                <clippath
-                  id="clip0_154_17"
-                >
-                  <rect
-                    fill="white"
-                    height="24"
-                    width="24"
-                  />
-                </clippath>
-              </defs>
-            </svg>
+              </svg>
+            </button>
           </div>
         </div>
         <p

--- a/packages/ts-newskit/src/components/puzzles/article-sidebar/index.tsx
+++ b/packages/ts-newskit/src/components/puzzles/article-sidebar/index.tsx
@@ -7,10 +7,12 @@ import {
   CardContent,
   CardLink,
   Divider,
-  Stack
+  Stack,
+  IconButton
 } from 'newskit';
-import { NewsKitChevronRightCircleIcon } from '../../../assets';
+import { NewsKitChevronRightIcon } from '../../../assets';
 import { Puzzle } from './types';
+import { StyledCardComposable } from './styles';
 
 export interface ArticleSideBarProps {
   sectionTitle: string;
@@ -27,7 +29,7 @@ export const ArticleSidebar: FC<ArticleSideBarProps> = ({
     <Block stylePreset="sidebarCard" paddingBlockStart="space030">
       <Block>
         <Block>
-          <CardComposable
+          <StyledCardComposable
             overrides={{
               marginBlockEnd: 'space030',
               stylePreset: 'cardTitleIcon'
@@ -39,15 +41,17 @@ export const ArticleSidebar: FC<ArticleSideBarProps> = ({
                 {sectionTitle}
               </TextBlock>
 
-              <NewsKitChevronRightCircleIcon
+              <IconButton
                 overrides={{
-                  size: 'iconSize020',
-                  paddingInline: 'space000',
-                  paddingBlock: 'space000'
+                  stylePreset: 'iconPreset',
+                  width: 'sizing050',
+                  height: 'sizing050'
                 }}
-              />
+              >
+                <NewsKitChevronRightIcon />
+              </IconButton>
             </Stack>
-          </CardComposable>
+          </StyledCardComposable>
 
           <TextBlock
             as="p"

--- a/packages/ts-newskit/src/components/puzzles/article-sidebar/styles.ts
+++ b/packages/ts-newskit/src/components/puzzles/article-sidebar/styles.ts
@@ -1,0 +1,9 @@
+import { CardComposable, getColorCssFromTheme, styled } from 'newskit';
+
+export const StyledCardComposable = styled(CardComposable)`
+  &:hover {
+    button {
+      ${getColorCssFromTheme('backgroundColor', 'interface040')};
+    }
+  }
+`;

--- a/packages/ts-newskit/src/theme/puzzles-web-light/style-presets.ts
+++ b/packages/ts-newskit/src/theme/puzzles-web-light/style-presets.ts
@@ -190,12 +190,18 @@ stylePresets.transparentCard = {
 
 stylePresets.cardTitleIcon = {
   base: {
-    color: '{{colors.inkBrand010}}',
-    iconColor: '{{colors.inkBrand010}}'
+    color: '{{colors.inkBrand010}}'
   },
 
   hover: {
-    color: '{{colors.interactiveLink020}}',
-    iconColor: '{{colors.interactiveLink020}}'
+    color: '{{colors.interactiveLink020}}'
+  }
+};
+
+stylePresets.iconPreset = {
+  base: {
+    backgroundColor: '{{colors.interactiveSecondary020}}',
+    color: '{{colors.inkBrand010}}',
+    borderRadius: '{{borders.borderRadiusCircle}}'
   }
 };


### PR DESCRIPTION
### Description

Fixed below feedback on the article sidebar.
"Please darken the circle on hover, but the chevron should stay orange."

[TMPZ-249](https://nidigitalsolutions.jira.com/jira/software/c/projects/TMPZ/boards/1656?selectedIssue=TMPZ-249)


### Checklist

- [X] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):



[TMPZ-249]: https://nidigitalsolutions.jira.com/browse/TMPZ-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ