### PR TITLE
fix(TM-000): Add specific Lerna version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
       steps:
         - run:
             name: 'Install Lerna'
-            command: yarn global add lerna
+            command: yarn global add lerna@7.4.2
             working_directory: ~/project/
 
 jobs:


### PR DESCRIPTION
### Description

Lerna [version 8](https://github.com/lerna/lerna/releases) expects Node 18+

This PR keeps Lerna below version 8 so we do not have to update Node (yet!).

### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
