### PR TITLE
fix(TMRX-1578): revert article tile info line break changes

### DIFF
--- a/packages/ts-newskit/src/components/slices/lead-article/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/lead-article/__tests__/__snapshots__/index.test.tsx.snap
@@ -66,9 +66,13 @@ exports[`Render Component one should render a snapshot 1`] = `
           />
         </div>
         <span
-          class="css-1kanhs9"
+          class="css-1basb1c"
         >
-          INTERVIEW
+          <div
+            class="css-gb5m6n"
+          >
+            INTERVIEW
+          </div>
         </span>
         <div
           class="css-p44zak"
@@ -80,9 +84,13 @@ exports[`Render Component one should render a snapshot 1`] = `
           />
         </div>
         <span
-          class="css-1kanhs9"
+          class="css-1basb1c"
         >
-          MARTIN SAMUEL
+          <div
+            class="css-gb5m6n"
+          >
+            MARTIN SAMUEL
+          </div>
         </span>
         <div
           class="css-p44zak"

--- a/packages/ts-newskit/src/components/slices/shared-styles/index.ts
+++ b/packages/ts-newskit/src/components/slices/shared-styles/index.ts
@@ -129,10 +129,8 @@ export const StyledBlock = styled(Block)`
   ${getSpacingCssFromTheme('row-gap', 'space020')};
 `;
 
-export const VideoIconContainer = styled.span`
-  vertical-align: baseline;
-  line-height: 24px;
-  :last-child > div {
-    display: none;
-  }
+export const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  ${getSpacingCssFromTheme('gap', 'space010')};
 `;

--- a/packages/ts-newskit/src/components/slices/shared/articleTileInfo.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/articleTileInfo.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { Divider } from 'newskit';
-import {
-  ContainerInline,
-  StyledBlock,
-  VideoIconContainer
-} from '../shared-styles';
+import { ContainerInline, StyledBlock } from '../shared-styles';
 import { LiveTag } from './live-tag';
 import { CustomTextBlock } from './customTextBlock';
 import { getActiveArticleFlags } from '../../../utils/getActiveArticleFlag';
@@ -92,17 +88,11 @@ export const ArticleTileInfo = ({
           )}
           {hasVideo && (
             <TileWrapper>
-              <VideoIconContainer>
-                <CustomTextBlock
-                  text="VIDEO"
-                  stylePreset="inkContrast"
-                  icon={
-                    <VideoIcon
-                      style={{ verticalAlign: 'top', marginRight: '4px' }}
-                    />
-                  }
-                />
-              </VideoIconContainer>
+              <CustomTextBlock
+                text="VIDEO"
+                stylePreset="inkContrast"
+                icon={<VideoIcon />}
+              />
             </TileWrapper>
           )}
           {label && (

--- a/packages/ts-newskit/src/components/slices/shared/customTextBlock.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/customTextBlock.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
-import { InlineTextBlock } from '../shared-styles';
+import { TextBlock } from 'newskit';
+import { Wrapper } from '../shared-styles';
 
 export const CustomTextBlock = ({
   text,
@@ -11,13 +12,15 @@ export const CustomTextBlock = ({
   icon?: ReactNode;
 }) => {
   return (
-    <InlineTextBlock
+    <TextBlock
       typographyPreset="utilityLabel005"
       stylePreset={stylePreset ? stylePreset : 'inkBrand010'}
       as="span"
     >
-      {icon}
-      {text}
-    </InlineTextBlock>
+      <Wrapper>
+        {icon}
+        {text}
+      </Wrapper>
+    </TextBlock>
   );
 };

--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -76,9 +76,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -90,9 +94,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -240,9 +248,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -254,9 +266,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -572,9 +588,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -586,9 +606,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -660,9 +684,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -674,9 +702,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -748,9 +780,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -762,9 +798,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -836,9 +876,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -850,9 +894,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -929,9 +977,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -943,9 +995,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1017,9 +1073,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1031,9 +1091,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1105,9 +1169,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1119,9 +1187,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1193,9 +1265,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1207,9 +1283,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1509,9 +1589,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1523,9 +1607,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1673,9 +1761,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1687,9 +1779,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -2005,9 +2101,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2019,9 +2119,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2093,9 +2197,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2107,9 +2215,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2181,9 +2293,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2195,9 +2311,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2269,9 +2389,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2283,9 +2407,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2362,9 +2490,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2376,9 +2508,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2450,9 +2586,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2464,9 +2604,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2538,9 +2682,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2552,9 +2700,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2626,9 +2778,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2640,9 +2796,13 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"

--- a/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -49,9 +49,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -63,9 +67,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -125,9 +133,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -139,9 +151,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -203,9 +219,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -217,9 +237,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -279,9 +303,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -293,9 +321,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -357,9 +389,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -371,9 +407,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -433,9 +473,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -447,9 +491,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -511,9 +559,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -525,9 +577,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -587,9 +643,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -601,9 +661,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -690,9 +754,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -704,9 +772,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -766,9 +838,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -780,9 +856,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -844,9 +924,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -858,9 +942,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -920,9 +1008,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -934,9 +1026,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -998,9 +1094,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1012,9 +1112,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1074,9 +1178,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1088,9 +1196,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1152,9 +1264,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1166,9 +1282,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1228,9 +1348,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1242,9 +1366,13 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"

--- a/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -72,9 +72,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -86,9 +90,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      MARTIN SAMUEL
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        MARTIN SAMUEL
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -216,9 +224,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -230,9 +242,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      MARTIN SAMUEL
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        MARTIN SAMUEL
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -506,9 +522,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -520,9 +540,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -577,9 +601,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -591,9 +619,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -648,9 +680,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -662,9 +698,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -719,9 +759,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -733,9 +777,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -801,9 +849,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -815,9 +867,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -889,9 +945,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -903,9 +963,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -977,9 +1041,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -991,9 +1059,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1065,9 +1137,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1079,9 +1155,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1377,9 +1457,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1391,9 +1475,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      MARTIN SAMUEL
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        MARTIN SAMUEL
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1521,9 +1609,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1535,9 +1627,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      MARTIN SAMUEL
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        MARTIN SAMUEL
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1811,9 +1907,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1825,9 +1925,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1882,9 +1986,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1896,9 +2004,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1953,9 +2065,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1967,9 +2083,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2024,9 +2144,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2038,9 +2162,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2106,9 +2234,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2120,9 +2252,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2194,9 +2330,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2208,9 +2348,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2282,9 +2426,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2296,9 +2444,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2370,9 +2522,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2384,9 +2540,13 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/article-stack.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/article-stack.test.tsx.snap
@@ -50,9 +50,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -64,9 +68,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -159,9 +167,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -173,9 +185,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -287,9 +303,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -301,9 +321,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -373,9 +397,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -387,9 +415,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -468,9 +500,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -482,9 +518,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -573,9 +613,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -587,9 +631,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -687,9 +735,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -701,9 +753,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -795,9 +851,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      UPDATED
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        UPDATED
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -809,9 +869,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -912,9 +976,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -926,9 +994,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1031,9 +1103,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1045,9 +1121,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1152,9 +1232,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1166,9 +1250,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1261,9 +1349,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1275,9 +1367,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1389,9 +1485,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1403,9 +1503,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1475,9 +1579,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1489,9 +1597,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1570,9 +1682,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1584,9 +1700,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1675,9 +1795,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1689,9 +1813,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1789,9 +1917,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1803,9 +1935,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1897,9 +2033,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1911,9 +2051,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2014,9 +2158,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  BREAKING
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    BREAKING
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2028,9 +2176,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2133,9 +2285,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  BREAKING
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    BREAKING
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2147,9 +2303,13 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2253,9 +2413,13 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
             class="article-info css-1wte5n0"
           >
             <span
-              class="css-ciimpt"
+              class="css-6tvr2h"
             >
-              UPDATED
+              <div
+                class="css-gb5m6n"
+              >
+                UPDATED
+              </div>
             </span>
             <div
               class="css-p44zak"
@@ -2267,9 +2431,13 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
               />
             </div>
             <span
-              class="css-1kanhs9"
+              class="css-1basb1c"
             >
-              PROFILE
+              <div
+                class="css-gb5m6n"
+              >
+                PROFILE
+              </div>
             </span>
             <div
               class="css-p44zak"
@@ -2338,9 +2506,13 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
             class="article-info css-1wte5n0"
           >
             <span
-              class="css-ciimpt"
+              class="css-6tvr2h"
             >
-              EXCLUSIVE
+              <div
+                class="css-gb5m6n"
+              >
+                EXCLUSIVE
+              </div>
             </span>
             <div
               class="css-p44zak"
@@ -2352,9 +2524,13 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
               />
             </div>
             <span
-              class="css-1kanhs9"
+              class="css-1basb1c"
             >
-              REVIEW
+              <div
+                class="css-gb5m6n"
+              >
+                REVIEW
+              </div>
             </span>
             <div
               class="css-p44zak"
@@ -2442,9 +2618,13 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
             class="article-info css-1wte5n0"
           >
             <span
-              class="css-ciimpt"
+              class="css-6tvr2h"
             >
-              UPDATED
+              <div
+                class="css-gb5m6n"
+              >
+                UPDATED
+              </div>
             </span>
             <div
               class="css-p44zak"
@@ -2456,9 +2636,13 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
               />
             </div>
             <span
-              class="css-1kanhs9"
+              class="css-1basb1c"
             >
-              Q&A
+              <div
+                class="css-gb5m6n"
+              >
+                Q&A
+              </div>
             </span>
             <div
               class="css-p44zak"

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -189,9 +189,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  BREAKING
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    BREAKING
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -203,9 +207,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -260,9 +268,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -274,16 +286,15 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-127sukd"
+                    class="css-1basb1c"
                   >
-                    <span
-                      class="css-1kanhs9"
+                    <div
+                      class="css-gb5m6n"
                     >
                       <svg
                         class="css-ny3roy"
                         fill="none"
                         height="24"
-                        style="vertical-align: top; margin-right: 4px;"
                         width="24"
                         xmlns="http://www.w3.org/2000/svg"
                       >
@@ -295,7 +306,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         />
                       </svg>
                       VIDEO
-                    </span>
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -356,9 +367,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -370,9 +385,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -503,9 +522,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -517,9 +540,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -641,9 +668,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        NEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          NEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -655,9 +686,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -748,9 +783,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -762,9 +801,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -829,9 +872,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        NEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          NEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -843,9 +890,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -933,9 +984,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -947,9 +1002,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -1050,9 +1109,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1064,9 +1127,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1159,9 +1226,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1173,9 +1244,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1287,9 +1362,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1301,9 +1380,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1373,9 +1456,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1387,9 +1474,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1468,9 +1559,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1482,9 +1577,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1573,9 +1672,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1587,9 +1690,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1687,9 +1794,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1701,9 +1812,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1795,9 +1910,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1809,9 +1928,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1912,9 +2035,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1926,9 +2053,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2031,9 +2162,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2045,9 +2180,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2152,9 +2291,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2166,9 +2309,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2261,9 +2408,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2275,9 +2426,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2389,9 +2544,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2403,9 +2562,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2475,9 +2638,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2489,9 +2656,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2570,9 +2741,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2584,9 +2759,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2675,9 +2854,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2689,9 +2872,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2789,9 +2976,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2803,9 +2994,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2897,9 +3092,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2911,9 +3110,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3014,9 +3217,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3028,9 +3235,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3133,9 +3344,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3147,9 +3362,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3263,9 +3482,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3277,9 +3500,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3372,9 +3599,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3386,9 +3617,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3500,9 +3735,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3514,9 +3753,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3586,9 +3829,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3600,9 +3847,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3681,9 +3932,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3695,9 +3950,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3786,9 +4045,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3800,9 +4063,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3893,9 +4160,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3907,9 +4178,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4002,9 +4277,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4016,9 +4295,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4130,9 +4413,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4144,9 +4431,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4216,9 +4507,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4230,9 +4525,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4311,9 +4610,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4325,9 +4628,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4416,9 +4723,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4430,9 +4741,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4528,9 +4843,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4542,9 +4861,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4635,9 +4958,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4649,9 +4976,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4786,9 +5117,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4800,9 +5135,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4895,9 +5234,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4909,9 +5252,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5023,9 +5370,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5037,9 +5388,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5109,9 +5464,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5123,9 +5482,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5204,9 +5567,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5218,9 +5585,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5309,9 +5680,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5323,9 +5698,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5423,9 +5802,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5437,9 +5820,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5531,9 +5918,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5545,9 +5936,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5648,9 +6043,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5662,9 +6061,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5767,9 +6170,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5781,9 +6188,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5888,9 +6299,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5902,9 +6317,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5997,9 +6416,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6011,9 +6434,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6125,9 +6552,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6139,9 +6570,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6211,9 +6646,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6225,9 +6664,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6306,9 +6749,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6320,9 +6767,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6411,9 +6862,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6425,9 +6880,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6525,9 +6984,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6539,9 +7002,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6633,9 +7100,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6647,9 +7118,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6750,9 +7225,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6764,9 +7243,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6869,9 +7352,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6883,9 +7370,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6999,9 +7490,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7013,9 +7508,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7108,9 +7607,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7122,9 +7625,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7236,9 +7743,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7250,9 +7761,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7322,9 +7837,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7336,9 +7855,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7417,9 +7940,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7431,9 +7958,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7522,9 +8053,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7536,9 +8071,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7629,9 +8168,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7643,9 +8186,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7738,9 +8285,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7752,9 +8303,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7866,9 +8421,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7880,9 +8439,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7952,9 +8515,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7966,9 +8533,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8047,9 +8618,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8061,9 +8636,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8152,9 +8731,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8166,9 +8749,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8264,9 +8851,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8278,9 +8869,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8371,9 +8966,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8385,9 +8984,13 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8649,9 +9252,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  BREAKING
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    BREAKING
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -8663,9 +9270,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -8720,9 +9331,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -8734,16 +9349,15 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                     />
                   </div>
                   <span
-                    class="css-127sukd"
+                    class="css-1basb1c"
                   >
-                    <span
-                      class="css-1kanhs9"
+                    <div
+                      class="css-gb5m6n"
                     >
                       <svg
                         class="css-ny3roy"
                         fill="none"
                         height="24"
-                        style="vertical-align: top; margin-right: 4px;"
                         width="24"
                         xmlns="http://www.w3.org/2000/svg"
                       >
@@ -8755,7 +9369,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         />
                       </svg>
                       VIDEO
-                    </span>
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -8816,9 +9430,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -8830,9 +9448,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -8963,9 +9585,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -8977,9 +9603,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -9101,9 +9731,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        NEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          NEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -9115,9 +9749,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -9208,9 +9846,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -9222,9 +9864,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -9289,9 +9935,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        NEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          NEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -9303,9 +9953,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -9393,9 +10047,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -9407,9 +10065,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -9510,9 +10172,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9524,9 +10190,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9619,9 +10289,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9633,9 +10307,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9747,9 +10425,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9761,9 +10443,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9833,9 +10519,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9847,9 +10537,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9928,9 +10622,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9942,9 +10640,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10033,9 +10735,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10047,9 +10753,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10147,9 +10857,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10161,9 +10875,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10255,9 +10973,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10269,9 +10991,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10372,9 +11098,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10386,9 +11116,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10491,9 +11225,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10505,9 +11243,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10612,9 +11354,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10626,9 +11372,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10721,9 +11471,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10735,9 +11489,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10849,9 +11607,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10863,9 +11625,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10935,9 +11701,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10949,9 +11719,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11030,9 +11804,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11044,9 +11822,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11135,9 +11917,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11149,9 +11935,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11249,9 +12039,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11263,9 +12057,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11357,9 +12155,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11371,9 +12173,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11474,9 +12280,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11488,9 +12298,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11593,9 +12407,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11607,9 +12425,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11723,9 +12545,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11737,9 +12563,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11832,9 +12662,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11846,9 +12680,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11960,9 +12798,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11974,9 +12816,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12046,9 +12892,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12060,9 +12910,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12141,9 +12995,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12155,9 +13013,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12246,9 +13108,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12260,9 +13126,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12353,9 +13223,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12367,9 +13241,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12462,9 +13340,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12476,9 +13358,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12590,9 +13476,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12604,9 +13494,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12676,9 +13570,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12690,9 +13588,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12771,9 +13673,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12785,9 +13691,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12876,9 +13786,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12890,9 +13804,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12988,9 +13906,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13002,9 +13924,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13095,9 +14021,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13109,9 +14039,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13246,9 +14180,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13260,9 +14198,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13355,9 +14297,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13369,9 +14315,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13483,9 +14433,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13497,9 +14451,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13569,9 +14527,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13583,9 +14545,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13664,9 +14630,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13678,9 +14648,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13769,9 +14743,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13783,9 +14761,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13883,9 +14865,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13897,9 +14883,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13991,9 +14981,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -14005,9 +14999,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -14108,9 +15106,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -14122,9 +15124,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -14227,9 +15233,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -14241,9 +15251,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -14348,9 +15362,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14362,9 +15380,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14457,9 +15479,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14471,9 +15497,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14585,9 +15615,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14599,9 +15633,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14671,9 +15709,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14685,9 +15727,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14766,9 +15812,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14780,9 +15830,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14871,9 +15925,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14885,9 +15943,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14985,9 +16047,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14999,9 +16065,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15093,9 +16163,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15107,9 +16181,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15210,9 +16288,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15224,9 +16306,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15329,9 +16415,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15343,9 +16433,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15459,9 +16553,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15473,9 +16571,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15568,9 +16670,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15582,9 +16688,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15696,9 +16806,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15710,9 +16824,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15782,9 +16900,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15796,9 +16918,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15877,9 +17003,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15891,9 +17021,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15982,9 +17116,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15996,9 +17134,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -16089,9 +17231,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16103,9 +17249,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16198,9 +17348,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16212,9 +17366,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16326,9 +17484,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16340,9 +17502,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16412,9 +17578,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16426,9 +17596,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16507,9 +17681,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16521,9 +17699,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16612,9 +17794,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16626,9 +17812,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16724,9 +17914,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16738,9 +17932,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16831,9 +18029,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16845,9 +18047,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -17109,9 +18315,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  BREAKING
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    BREAKING
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -17123,9 +18333,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -17180,9 +18394,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -17194,16 +18412,15 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-127sukd"
+                    class="css-1basb1c"
                   >
-                    <span
-                      class="css-1kanhs9"
+                    <div
+                      class="css-gb5m6n"
                     >
                       <svg
                         class="css-ny3roy"
                         fill="none"
                         height="24"
-                        style="vertical-align: top; margin-right: 4px;"
                         width="24"
                         xmlns="http://www.w3.org/2000/svg"
                       >
@@ -17215,7 +18432,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </svg>
                       VIDEO
-                    </span>
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -17276,9 +18493,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -17290,9 +18511,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -17423,9 +18648,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -17437,9 +18666,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -17561,9 +18794,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        NEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          NEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -17575,9 +18812,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -17668,9 +18909,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -17682,9 +18927,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -17749,9 +18998,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        NEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          NEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -17763,9 +19016,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -17853,9 +19110,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -17867,9 +19128,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -17970,9 +19235,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17984,9 +19253,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18079,9 +19352,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18093,9 +19370,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18207,9 +19488,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18221,9 +19506,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18293,9 +19582,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18307,9 +19600,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18388,9 +19685,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18402,9 +19703,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18493,9 +19798,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18507,9 +19816,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18607,9 +19920,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18621,9 +19938,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18715,9 +20036,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18729,9 +20054,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18832,9 +20161,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18846,9 +20179,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18951,9 +20288,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18965,9 +20306,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -19072,9 +20417,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19086,9 +20435,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19181,9 +20534,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19195,9 +20552,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19309,9 +20670,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19323,9 +20688,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19395,9 +20764,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19409,9 +20782,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19490,9 +20867,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19504,9 +20885,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19595,9 +20980,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19609,9 +20998,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19709,9 +21102,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19723,9 +21120,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19817,9 +21218,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19831,9 +21236,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19934,9 +21343,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19948,9 +21361,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20053,9 +21470,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20067,9 +21488,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20183,9 +21608,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20197,9 +21626,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20292,9 +21725,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20306,9 +21743,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20420,9 +21861,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20434,9 +21879,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20506,9 +21955,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20520,9 +21973,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20601,9 +22058,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20615,9 +22076,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20706,9 +22171,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20720,9 +22189,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20813,9 +22286,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20827,9 +22304,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20922,9 +22403,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20936,9 +22421,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21050,9 +22539,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21064,9 +22557,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21136,9 +22633,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21150,9 +22651,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21231,9 +22736,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21245,9 +22754,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21336,9 +22849,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21350,9 +22867,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21448,9 +22969,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21462,9 +22987,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21555,9 +23084,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21569,9 +23102,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21706,9 +23243,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21720,9 +23261,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21815,9 +23360,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21829,9 +23378,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21943,9 +23496,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21957,9 +23514,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22029,9 +23590,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22043,9 +23608,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22124,9 +23693,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22138,9 +23711,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22229,9 +23806,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22243,9 +23824,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22343,9 +23928,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22357,9 +23946,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22451,9 +24044,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22465,9 +24062,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22568,9 +24169,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22582,9 +24187,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22687,9 +24296,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22701,9 +24314,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22808,9 +24425,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22822,9 +24443,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22917,9 +24542,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22931,9 +24560,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23045,9 +24678,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23059,9 +24696,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23131,9 +24772,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23145,9 +24790,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23226,9 +24875,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23240,9 +24893,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23331,9 +24988,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23345,9 +25006,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23445,9 +25110,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23459,9 +25128,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23553,9 +25226,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23567,9 +25244,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23670,9 +25351,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23684,9 +25369,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23789,9 +25478,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23803,9 +25496,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23919,9 +25616,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23933,9 +25634,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24028,9 +25733,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24042,9 +25751,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24156,9 +25869,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24170,9 +25887,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24242,9 +25963,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24256,9 +25981,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24337,9 +26066,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24351,9 +26084,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24442,9 +26179,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24456,9 +26197,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24549,9 +26294,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24563,9 +26312,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24658,9 +26411,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24672,9 +26429,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24786,9 +26547,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24800,9 +26565,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24872,9 +26641,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24886,9 +26659,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24967,9 +26744,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24981,9 +26762,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25072,9 +26857,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25086,9 +26875,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25184,9 +26977,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25198,9 +26995,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25291,9 +27092,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25305,9 +27110,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25569,9 +27378,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  BREAKING
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    BREAKING
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -25583,9 +27396,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -25640,9 +27457,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -25654,16 +27475,15 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-127sukd"
+                    class="css-1basb1c"
                   >
-                    <span
-                      class="css-1kanhs9"
+                    <div
+                      class="css-gb5m6n"
                     >
                       <svg
                         class="css-ny3roy"
                         fill="none"
                         height="24"
-                        style="vertical-align: top; margin-right: 4px;"
                         width="24"
                         xmlns="http://www.w3.org/2000/svg"
                       >
@@ -25675,7 +27495,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </svg>
                       VIDEO
-                    </span>
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -25736,9 +27556,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -25750,9 +27574,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -25883,9 +27711,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -25897,9 +27729,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -26021,9 +27857,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        NEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          NEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -26035,9 +27875,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -26128,9 +27972,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -26142,9 +27990,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -26209,9 +28061,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        NEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          NEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -26223,9 +28079,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -26313,9 +28173,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -26327,9 +28191,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -26430,9 +28298,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26444,9 +28316,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26539,9 +28415,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26553,9 +28433,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26667,9 +28551,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26681,9 +28569,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26753,9 +28645,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26767,9 +28663,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26848,9 +28748,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26862,9 +28766,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26953,9 +28861,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26967,9 +28879,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27067,9 +28983,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27081,9 +29001,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27175,9 +29099,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27189,9 +29117,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27292,9 +29224,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27306,9 +29242,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27411,9 +29351,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27425,9 +29369,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27532,9 +29480,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27546,9 +29498,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27641,9 +29597,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27655,9 +29615,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27769,9 +29733,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27783,9 +29751,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27855,9 +29827,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27869,9 +29845,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27950,9 +29930,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27964,9 +29948,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28055,9 +30043,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28069,9 +30061,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28169,9 +30165,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28183,9 +30183,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28277,9 +30281,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28291,9 +30299,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28394,9 +30406,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28408,9 +30424,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28513,9 +30533,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28527,9 +30551,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28643,9 +30671,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28657,9 +30689,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28752,9 +30788,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28766,9 +30806,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28880,9 +30924,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28894,9 +30942,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28966,9 +31018,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28980,9 +31036,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29061,9 +31121,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29075,9 +31139,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29166,9 +31234,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29180,9 +31252,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29273,9 +31349,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29287,9 +31367,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29382,9 +31466,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29396,9 +31484,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29510,9 +31602,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29524,9 +31620,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29596,9 +31696,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29610,9 +31714,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29691,9 +31799,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29705,9 +31817,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29796,9 +31912,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29810,9 +31930,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29908,9 +32032,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29922,9 +32050,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -30015,9 +32147,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -30029,9 +32165,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -30166,9 +32306,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30180,9 +32324,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30275,9 +32423,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30289,9 +32441,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30403,9 +32559,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30417,9 +32577,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30489,9 +32653,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30503,9 +32671,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30584,9 +32756,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30598,9 +32774,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30689,9 +32869,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30703,9 +32887,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30803,9 +32991,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30817,9 +33009,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30911,9 +33107,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30925,9 +33125,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -31028,9 +33232,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -31042,9 +33250,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -31147,9 +33359,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -31161,9 +33377,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -31268,9 +33488,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31282,9 +33506,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31377,9 +33605,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31391,9 +33623,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31505,9 +33741,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31519,9 +33759,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31591,9 +33835,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31605,9 +33853,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31686,9 +33938,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31700,9 +33956,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31791,9 +34051,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31805,9 +34069,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31905,9 +34173,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31919,9 +34191,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32013,9 +34289,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32027,9 +34307,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32130,9 +34414,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32144,9 +34432,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32249,9 +34541,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32263,9 +34559,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32379,9 +34679,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32393,9 +34697,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32488,9 +34796,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32502,9 +34814,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32616,9 +34932,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32630,9 +34950,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32702,9 +35026,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32716,9 +35044,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32797,9 +35129,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32811,9 +35147,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32902,9 +35242,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32916,9 +35260,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -33009,9 +35357,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33023,9 +35375,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33118,9 +35474,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33132,9 +35492,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33246,9 +35610,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33260,9 +35628,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33332,9 +35704,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33346,9 +35722,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33427,9 +35807,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33441,9 +35825,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33532,9 +35920,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33546,9 +35938,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33644,9 +36040,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33658,9 +36058,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33751,9 +36155,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33765,9 +36173,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -34029,9 +36441,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  BREAKING
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    BREAKING
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -34043,9 +36459,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -34100,9 +36520,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -34114,16 +36538,15 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-127sukd"
+                    class="css-1basb1c"
                   >
-                    <span
-                      class="css-1kanhs9"
+                    <div
+                      class="css-gb5m6n"
                     >
                       <svg
                         class="css-ny3roy"
                         fill="none"
                         height="24"
-                        style="vertical-align: top; margin-right: 4px;"
                         width="24"
                         xmlns="http://www.w3.org/2000/svg"
                       >
@@ -34135,7 +36558,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </svg>
                       VIDEO
-                    </span>
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -34196,9 +36619,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -34210,9 +36637,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -34343,9 +36774,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -34357,9 +36792,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -34481,9 +36920,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        NEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          NEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -34495,9 +36938,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -34588,9 +37035,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -34602,9 +37053,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -34669,9 +37124,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        NEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          NEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -34683,9 +37142,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -34773,9 +37236,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -34787,9 +37254,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -34890,9 +37361,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34904,9 +37379,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34999,9 +37478,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35013,9 +37496,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35127,9 +37614,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35141,9 +37632,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35213,9 +37708,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35227,9 +37726,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35308,9 +37811,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35322,9 +37829,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35413,9 +37924,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35427,9 +37942,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35527,9 +38046,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35541,9 +38064,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35635,9 +38162,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35649,9 +38180,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35752,9 +38287,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35766,9 +38305,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35871,9 +38414,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35885,9 +38432,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35992,9 +38543,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36006,9 +38561,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36101,9 +38660,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36115,9 +38678,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36229,9 +38796,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36243,9 +38814,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36315,9 +38890,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36329,9 +38908,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36410,9 +38993,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36424,9 +39011,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36515,9 +39106,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36529,9 +39124,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36629,9 +39228,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36643,9 +39246,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36737,9 +39344,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36751,9 +39362,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36854,9 +39469,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36868,9 +39487,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36973,9 +39596,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36987,9 +39614,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37103,9 +39734,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37117,9 +39752,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37212,9 +39851,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37226,9 +39869,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37340,9 +39987,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37354,9 +40005,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37426,9 +40081,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37440,9 +40099,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37521,9 +40184,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37535,9 +40202,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37626,9 +40297,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37640,9 +40315,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37733,9 +40412,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37747,9 +40430,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37842,9 +40529,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37856,9 +40547,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37970,9 +40665,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37984,9 +40683,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -38056,9 +40759,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -38070,9 +40777,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -38151,9 +40862,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -38165,9 +40880,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -38256,9 +40975,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -38270,9 +40993,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -38368,9 +41095,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -38382,9 +41113,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -38475,9 +41210,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -38489,9 +41228,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -38626,9 +41369,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38640,9 +41387,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38735,9 +41486,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38749,9 +41504,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38863,9 +41622,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38877,9 +41640,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38949,9 +41716,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38963,9 +41734,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39044,9 +41819,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39058,9 +41837,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39149,9 +41932,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39163,9 +41950,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39263,9 +42054,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39277,9 +42072,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39371,9 +42170,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39385,9 +42188,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39488,9 +42295,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39502,9 +42313,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39607,9 +42422,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39621,9 +42440,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39728,9 +42551,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39742,9 +42569,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39837,9 +42668,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39851,9 +42686,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39965,9 +42804,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39979,9 +42822,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40051,9 +42898,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40065,9 +42916,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40146,9 +43001,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40160,9 +43019,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40251,9 +43114,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40265,9 +43132,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40365,9 +43236,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40379,9 +43254,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40473,9 +43352,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40487,9 +43370,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40590,9 +43477,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40604,9 +43495,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40709,9 +43604,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40723,9 +43622,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40839,9 +43742,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40853,9 +43760,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40948,9 +43859,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40962,9 +43877,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -41076,9 +43995,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -41090,9 +44013,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -41162,9 +44089,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -41176,9 +44107,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -41257,9 +44192,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -41271,9 +44210,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -41362,9 +44305,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -41376,9 +44323,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -41469,9 +44420,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41483,9 +44438,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41578,9 +44537,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41592,9 +44555,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41706,9 +44673,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41720,9 +44691,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41792,9 +44767,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41806,9 +44785,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41887,9 +44870,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41901,9 +44888,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41992,9 +44983,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -42006,9 +45001,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -42104,9 +45103,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -42118,9 +45121,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -42211,9 +45218,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -42225,9 +45236,13 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/article-stacks.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/article-stacks.test.tsx.snap
@@ -31,9 +31,13 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    NEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      NEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -45,9 +49,13 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    PROFILE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      PROFILE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -149,9 +157,13 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -163,9 +175,13 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -310,9 +326,13 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  NEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    NEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -324,9 +344,13 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -462,9 +486,13 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -476,9 +504,13 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  INTERVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    INTERVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -591,9 +623,13 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    NEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      NEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -605,9 +641,13 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    PROFILE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      PROFILE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -709,9 +749,13 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -723,9 +767,13 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -870,9 +918,13 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  NEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    NEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -884,9 +936,13 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1022,9 +1078,13 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1036,9 +1096,13 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  INTERVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    INTERVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -81,9 +81,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -95,9 +99,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -244,9 +252,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -258,9 +270,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -370,9 +386,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           class="article-info css-1wte5n0"
                         >
                           <span
-                            class="css-ciimpt"
+                            class="css-6tvr2h"
                           >
-                            NEW
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              NEW
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -384,9 +404,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             />
                           </div>
                           <span
-                            class="css-1kanhs9"
+                            class="css-1basb1c"
                           >
-                            PROFILE
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              PROFILE
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -488,9 +512,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           class="article-info css-1wte5n0"
                         >
                           <span
-                            class="css-ciimpt"
+                            class="css-6tvr2h"
                           >
-                            EXCLUSIVE
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              EXCLUSIVE
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -502,9 +530,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             />
                           </div>
                           <span
-                            class="css-1kanhs9"
+                            class="css-1basb1c"
                           >
-                            REVIEW
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              REVIEW
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -649,9 +681,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          NEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            NEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -663,9 +699,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -801,9 +841,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -815,9 +859,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -965,9 +1013,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -979,9 +1031,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1074,9 +1130,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1088,9 +1148,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1202,9 +1266,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1216,9 +1284,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1288,9 +1360,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1302,9 +1378,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1383,9 +1463,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1397,9 +1481,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1488,9 +1576,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1502,9 +1594,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1602,9 +1698,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1616,9 +1716,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1710,9 +1814,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1724,9 +1832,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1827,9 +1939,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1841,9 +1957,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1946,9 +2066,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1960,9 +2084,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2067,9 +2195,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2081,9 +2213,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2176,9 +2312,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2190,9 +2330,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2304,9 +2448,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2318,9 +2466,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2390,9 +2542,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2404,9 +2560,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2485,9 +2645,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2499,9 +2663,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2590,9 +2758,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2604,9 +2776,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2704,9 +2880,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2718,9 +2898,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2812,9 +2996,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2826,9 +3014,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2929,9 +3121,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2943,9 +3139,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3048,9 +3248,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3062,9 +3266,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3178,9 +3386,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3192,9 +3404,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3287,9 +3503,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3301,9 +3521,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3415,9 +3639,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3429,9 +3657,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3501,9 +3733,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3515,9 +3751,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3596,9 +3836,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3610,9 +3854,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3701,9 +3949,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3715,9 +3967,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3808,9 +4064,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3822,9 +4082,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3917,9 +4181,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3931,9 +4199,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4045,9 +4317,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4059,9 +4335,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4131,9 +4411,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4145,9 +4429,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4226,9 +4514,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4240,9 +4532,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4331,9 +4627,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4345,9 +4645,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4443,9 +4747,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4457,9 +4765,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4550,9 +4862,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4564,9 +4880,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4701,9 +5021,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4715,9 +5039,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4810,9 +5138,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4824,9 +5156,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4938,9 +5274,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4952,9 +5292,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5024,9 +5368,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5038,9 +5386,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5119,9 +5471,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5133,9 +5489,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5224,9 +5584,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5238,9 +5602,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5338,9 +5706,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5352,9 +5724,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5446,9 +5822,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5460,9 +5840,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5563,9 +5947,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5577,9 +5965,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5682,9 +6074,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5696,9 +6092,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5803,9 +6203,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5817,9 +6221,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5912,9 +6320,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5926,9 +6338,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6040,9 +6456,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6054,9 +6474,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6126,9 +6550,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6140,9 +6568,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6221,9 +6653,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6235,9 +6671,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6326,9 +6766,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6340,9 +6784,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6440,9 +6888,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6454,9 +6906,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6548,9 +7004,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6562,9 +7022,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6665,9 +7129,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6679,9 +7147,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6784,9 +7256,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6798,9 +7274,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6914,9 +7394,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -6928,9 +7412,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7023,9 +7511,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7037,9 +7529,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7151,9 +7647,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7165,9 +7665,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7237,9 +7741,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7251,9 +7759,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7332,9 +7844,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7346,9 +7862,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7437,9 +7957,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7451,9 +7975,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7544,9 +8072,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7558,9 +8090,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7653,9 +8189,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7667,9 +8207,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7781,9 +8325,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7795,9 +8343,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7867,9 +8419,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7881,9 +8437,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7962,9 +8522,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7976,9 +8540,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8067,9 +8635,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8081,9 +8653,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8179,9 +8755,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8193,9 +8773,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8286,9 +8870,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8300,9 +8888,13 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8456,9 +9048,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -8470,9 +9066,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -8619,9 +9219,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -8633,9 +9237,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -8745,9 +9353,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           class="article-info css-1wte5n0"
                         >
                           <span
-                            class="css-ciimpt"
+                            class="css-6tvr2h"
                           >
-                            NEW
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              NEW
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -8759,9 +9371,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             />
                           </div>
                           <span
-                            class="css-1kanhs9"
+                            class="css-1basb1c"
                           >
-                            PROFILE
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              PROFILE
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -8863,9 +9479,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           class="article-info css-1wte5n0"
                         >
                           <span
-                            class="css-ciimpt"
+                            class="css-6tvr2h"
                           >
-                            EXCLUSIVE
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              EXCLUSIVE
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -8877,9 +9497,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             />
                           </div>
                           <span
-                            class="css-1kanhs9"
+                            class="css-1basb1c"
                           >
-                            REVIEW
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              REVIEW
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -9024,9 +9648,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          NEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            NEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9038,9 +9666,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9176,9 +9808,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9190,9 +9826,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9340,9 +9980,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9354,9 +9998,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9449,9 +10097,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9463,9 +10115,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9577,9 +10233,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9591,9 +10251,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9663,9 +10327,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9677,9 +10345,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9758,9 +10430,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9772,9 +10448,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9863,9 +10543,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9877,9 +10561,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9977,9 +10665,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9991,9 +10683,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10085,9 +10781,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10099,9 +10799,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10202,9 +10906,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10216,9 +10924,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10321,9 +11033,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10335,9 +11051,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10442,9 +11162,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10456,9 +11180,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10551,9 +11279,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10565,9 +11297,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10679,9 +11415,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10693,9 +11433,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10765,9 +11509,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10779,9 +11527,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10860,9 +11612,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10874,9 +11630,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10965,9 +11725,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10979,9 +11743,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11079,9 +11847,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11093,9 +11865,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11187,9 +11963,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11201,9 +11981,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11304,9 +12088,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11318,9 +12106,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11423,9 +12215,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11437,9 +12233,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11553,9 +12353,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11567,9 +12371,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11662,9 +12470,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11676,9 +12488,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11790,9 +12606,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11804,9 +12624,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11876,9 +12700,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11890,9 +12718,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11971,9 +12803,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11985,9 +12821,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12076,9 +12916,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12090,9 +12934,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12183,9 +13031,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12197,9 +13049,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12292,9 +13148,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12306,9 +13166,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12420,9 +13284,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12434,9 +13302,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12506,9 +13378,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12520,9 +13396,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12601,9 +13481,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12615,9 +13499,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12706,9 +13594,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12720,9 +13612,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12818,9 +13714,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12832,9 +13732,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12925,9 +13829,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12939,9 +13847,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13076,9 +13988,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13090,9 +14006,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13185,9 +14105,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13199,9 +14123,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13313,9 +14241,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13327,9 +14259,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13399,9 +14335,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13413,9 +14353,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13494,9 +14438,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13508,9 +14456,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13599,9 +14551,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13613,9 +14569,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13713,9 +14673,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13727,9 +14691,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13821,9 +14789,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13835,9 +14807,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13938,9 +14914,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13952,9 +14932,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -14057,9 +15041,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -14071,9 +15059,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -14178,9 +15170,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14192,9 +15188,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14287,9 +15287,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14301,9 +15305,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14415,9 +15423,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14429,9 +15441,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14501,9 +15517,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14515,9 +15535,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14596,9 +15620,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14610,9 +15638,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14701,9 +15733,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14715,9 +15751,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14815,9 +15855,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14829,9 +15873,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14923,9 +15971,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14937,9 +15989,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15040,9 +16096,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15054,9 +16114,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15159,9 +16223,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15173,9 +16241,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15289,9 +16361,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15303,9 +16379,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15398,9 +16478,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15412,9 +16496,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15526,9 +16614,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15540,9 +16632,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15612,9 +16708,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15626,9 +16726,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15707,9 +16811,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15721,9 +16829,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15812,9 +16924,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15826,9 +16942,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15919,9 +17039,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15933,9 +17057,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16028,9 +17156,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16042,9 +17174,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16156,9 +17292,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16170,9 +17310,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16242,9 +17386,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16256,9 +17404,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16337,9 +17489,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16351,9 +17507,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16442,9 +17602,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16456,9 +17620,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16554,9 +17722,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16568,9 +17740,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16661,9 +17837,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16675,9 +17855,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16831,9 +18015,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -16845,9 +18033,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -16994,9 +18186,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -17008,9 +18204,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -17120,9 +18320,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           class="article-info css-1wte5n0"
                         >
                           <span
-                            class="css-ciimpt"
+                            class="css-6tvr2h"
                           >
-                            NEW
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              NEW
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -17134,9 +18338,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             />
                           </div>
                           <span
-                            class="css-1kanhs9"
+                            class="css-1basb1c"
                           >
-                            PROFILE
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              PROFILE
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -17238,9 +18446,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           class="article-info css-1wte5n0"
                         >
                           <span
-                            class="css-ciimpt"
+                            class="css-6tvr2h"
                           >
-                            EXCLUSIVE
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              EXCLUSIVE
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -17252,9 +18464,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             />
                           </div>
                           <span
-                            class="css-1kanhs9"
+                            class="css-1basb1c"
                           >
-                            REVIEW
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              REVIEW
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -17399,9 +18615,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          NEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            NEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -17413,9 +18633,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -17551,9 +18775,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -17565,9 +18793,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -17715,9 +18947,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17729,9 +18965,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17824,9 +19064,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17838,9 +19082,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17952,9 +19200,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17966,9 +19218,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18038,9 +19294,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18052,9 +19312,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18133,9 +19397,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18147,9 +19415,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18238,9 +19510,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18252,9 +19528,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18352,9 +19632,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18366,9 +19650,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18460,9 +19748,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18474,9 +19766,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18577,9 +19873,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18591,9 +19891,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18696,9 +20000,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18710,9 +20018,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18817,9 +20129,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18831,9 +20147,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18926,9 +20246,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18940,9 +20264,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19054,9 +20382,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19068,9 +20400,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19140,9 +20476,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19154,9 +20494,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19235,9 +20579,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19249,9 +20597,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19340,9 +20692,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19354,9 +20710,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19454,9 +20814,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19468,9 +20832,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19562,9 +20930,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19576,9 +20948,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19679,9 +21055,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19693,9 +21073,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19798,9 +21182,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19812,9 +21200,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19928,9 +21320,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -19942,9 +21338,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20037,9 +21437,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20051,9 +21455,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20165,9 +21573,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20179,9 +21591,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20251,9 +21667,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20265,9 +21685,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20346,9 +21770,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20360,9 +21788,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20451,9 +21883,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20465,9 +21901,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20558,9 +21998,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20572,9 +22016,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20667,9 +22115,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20681,9 +22133,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20795,9 +22251,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20809,9 +22269,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20881,9 +22345,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20895,9 +22363,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20976,9 +22448,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20990,9 +22466,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21081,9 +22561,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21095,9 +22579,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21193,9 +22681,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21207,9 +22699,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21300,9 +22796,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21314,9 +22814,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21451,9 +22955,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21465,9 +22973,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21560,9 +23072,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21574,9 +23090,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21688,9 +23208,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21702,9 +23226,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21774,9 +23302,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21788,9 +23320,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21869,9 +23405,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21883,9 +23423,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21974,9 +23518,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21988,9 +23536,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22088,9 +23640,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22102,9 +23658,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22196,9 +23756,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22210,9 +23774,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22313,9 +23881,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22327,9 +23899,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22432,9 +24008,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22446,9 +24026,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22553,9 +24137,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22567,9 +24155,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22662,9 +24254,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22676,9 +24272,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22790,9 +24390,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22804,9 +24408,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22876,9 +24484,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22890,9 +24502,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22971,9 +24587,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22985,9 +24605,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23076,9 +24700,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23090,9 +24718,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23190,9 +24822,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23204,9 +24840,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23298,9 +24938,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23312,9 +24956,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23415,9 +25063,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23429,9 +25081,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23534,9 +25190,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23548,9 +25208,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23664,9 +25328,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23678,9 +25346,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23773,9 +25445,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23787,9 +25463,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23901,9 +25581,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23915,9 +25599,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23987,9 +25675,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24001,9 +25693,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24082,9 +25778,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24096,9 +25796,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24187,9 +25891,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24201,9 +25909,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24294,9 +26006,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24308,9 +26024,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24403,9 +26123,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24417,9 +26141,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24531,9 +26259,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24545,9 +26277,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24617,9 +26353,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24631,9 +26371,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24712,9 +26456,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24726,9 +26474,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24817,9 +26569,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24831,9 +26587,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24929,9 +26689,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24943,9 +26707,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25036,9 +26804,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25050,9 +26822,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25206,9 +26982,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -25220,9 +27000,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -25369,9 +27153,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -25383,9 +27171,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    MARTIN SAMUEL
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      MARTIN SAMUEL
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -25495,9 +27287,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           class="article-info css-1wte5n0"
                         >
                           <span
-                            class="css-ciimpt"
+                            class="css-6tvr2h"
                           >
-                            NEW
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              NEW
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -25509,9 +27305,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             />
                           </div>
                           <span
-                            class="css-1kanhs9"
+                            class="css-1basb1c"
                           >
-                            PROFILE
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              PROFILE
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -25613,9 +27413,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           class="article-info css-1wte5n0"
                         >
                           <span
-                            class="css-ciimpt"
+                            class="css-6tvr2h"
                           >
-                            EXCLUSIVE
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              EXCLUSIVE
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -25627,9 +27431,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             />
                           </div>
                           <span
-                            class="css-1kanhs9"
+                            class="css-1basb1c"
                           >
-                            REVIEW
+                            <div
+                              class="css-gb5m6n"
+                            >
+                              REVIEW
+                            </div>
                           </span>
                           <div
                             class="css-p44zak"
@@ -25774,9 +27582,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          NEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            NEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25788,9 +27600,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25926,9 +27742,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25940,9 +27760,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -26090,9 +27914,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26104,9 +27932,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26199,9 +28031,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26213,9 +28049,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26327,9 +28167,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26341,9 +28185,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26413,9 +28261,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26427,9 +28279,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26508,9 +28364,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26522,9 +28382,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26613,9 +28477,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26627,9 +28495,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26727,9 +28599,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26741,9 +28617,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26835,9 +28715,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26849,9 +28733,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26952,9 +28840,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26966,9 +28858,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27071,9 +28967,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27085,9 +28985,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27192,9 +29096,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27206,9 +29114,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27301,9 +29213,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27315,9 +29231,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27429,9 +29349,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27443,9 +29367,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27515,9 +29443,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27529,9 +29461,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27610,9 +29546,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27624,9 +29564,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27715,9 +29659,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27729,9 +29677,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27829,9 +29781,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27843,9 +29799,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27937,9 +29897,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27951,9 +29915,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28054,9 +30022,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28068,9 +30040,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28173,9 +30149,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28187,9 +30167,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28303,9 +30287,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28317,9 +30305,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28412,9 +30404,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28426,9 +30422,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28540,9 +30540,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28554,9 +30558,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28626,9 +30634,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28640,9 +30652,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28721,9 +30737,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28735,9 +30755,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28826,9 +30850,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28840,9 +30868,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28933,9 +30965,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28947,9 +30983,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29042,9 +31082,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29056,9 +31100,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29170,9 +31218,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29184,9 +31236,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29256,9 +31312,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29270,9 +31330,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29351,9 +31415,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29365,9 +31433,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29456,9 +31528,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29470,9 +31546,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29568,9 +31648,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29582,9 +31666,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29675,9 +31763,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29689,9 +31781,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29826,9 +31922,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29840,9 +31940,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29935,9 +32039,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29949,9 +32057,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30063,9 +32175,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30077,9 +32193,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30149,9 +32269,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30163,9 +32287,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30244,9 +32372,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30258,9 +32390,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30349,9 +32485,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30363,9 +32503,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30463,9 +32607,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30477,9 +32625,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30571,9 +32723,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30585,9 +32741,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30688,9 +32848,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30702,9 +32866,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30807,9 +32975,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30821,9 +32993,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30928,9 +33104,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -30942,9 +33122,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31037,9 +33221,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31051,9 +33239,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31165,9 +33357,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31179,9 +33375,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31251,9 +33451,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31265,9 +33469,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31346,9 +33554,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31360,9 +33572,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31451,9 +33667,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31465,9 +33685,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31565,9 +33789,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31579,9 +33807,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31673,9 +33905,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31687,9 +33923,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31790,9 +34030,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31804,9 +34048,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31909,9 +34157,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31923,9 +34175,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32039,9 +34295,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32053,9 +34313,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32148,9 +34412,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32162,9 +34430,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32276,9 +34548,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32290,9 +34566,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32362,9 +34642,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              UPDATED
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                UPDATED
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32376,9 +34660,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32457,9 +34745,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32471,9 +34763,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32562,9 +34858,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32576,9 +34876,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32669,9 +34973,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32683,9 +34991,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32778,9 +35090,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32792,9 +35108,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32906,9 +35226,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32920,9 +35244,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32992,9 +35320,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33006,9 +35338,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33087,9 +35423,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33101,9 +35441,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33192,9 +35536,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33206,9 +35554,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33304,9 +35656,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          UPDATED
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            UPDATED
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33318,9 +35674,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33411,9 +35771,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33425,9 +35789,13 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"

--- a/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -65,9 +65,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -79,9 +83,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -170,9 +178,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -184,9 +196,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -288,9 +304,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -302,9 +322,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -393,9 +417,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -407,9 +435,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -511,9 +543,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -525,9 +561,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -616,9 +656,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -630,9 +674,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -766,9 +814,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -780,9 +832,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -935,9 +991,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1044,9 +1104,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1158,9 +1222,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1172,9 +1240,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1244,9 +1316,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1258,9 +1334,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1339,9 +1419,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1353,9 +1437,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1444,9 +1532,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1458,9 +1550,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1558,9 +1654,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1572,9 +1672,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1666,9 +1770,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1680,9 +1788,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1783,9 +1895,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1797,9 +1913,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1902,9 +2022,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -1916,9 +2040,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2037,9 +2165,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2146,9 +2278,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2260,9 +2396,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2274,9 +2414,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2346,9 +2490,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2360,9 +2508,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2441,9 +2593,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2455,9 +2611,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2546,9 +2706,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2560,9 +2724,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2660,9 +2828,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2674,9 +2846,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2768,9 +2944,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2782,9 +2962,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2885,9 +3069,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -2899,9 +3087,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3004,9 +3196,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3018,9 +3214,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3148,9 +3348,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3257,9 +3461,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3371,9 +3579,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3385,9 +3597,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3457,9 +3673,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3471,9 +3691,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3552,9 +3776,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3566,9 +3794,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3657,9 +3889,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3671,9 +3907,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3778,9 +4018,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3887,9 +4131,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4001,9 +4249,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4015,9 +4267,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4087,9 +4343,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4101,9 +4361,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4182,9 +4446,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4196,9 +4464,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4287,9 +4559,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4301,9 +4577,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4399,9 +4679,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4413,9 +4697,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4506,9 +4794,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4520,9 +4812,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4671,9 +4967,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4780,9 +5080,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4894,9 +5198,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4908,9 +5216,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4980,9 +5292,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -4994,9 +5310,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5075,9 +5395,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5089,9 +5413,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5180,9 +5508,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5194,9 +5526,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5294,9 +5630,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5308,9 +5648,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5402,9 +5746,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5416,9 +5764,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5519,9 +5871,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5533,9 +5889,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5638,9 +5998,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5652,9 +6016,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -5773,9 +6141,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5882,9 +6254,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5996,9 +6372,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6010,9 +6390,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6082,9 +6466,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6096,9 +6484,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6177,9 +6569,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6191,9 +6587,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6282,9 +6682,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6296,9 +6700,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6396,9 +6804,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6410,9 +6822,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6504,9 +6920,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6518,9 +6938,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6621,9 +7045,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6635,9 +7063,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6740,9 +7172,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6754,9 +7190,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -6884,9 +7324,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -6993,9 +7437,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7107,9 +7555,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7121,9 +7573,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7193,9 +7649,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7207,9 +7667,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7288,9 +7752,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7302,9 +7770,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7393,9 +7865,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7407,9 +7883,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7514,9 +7994,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7623,9 +8107,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7737,9 +8225,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7751,9 +8243,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7823,9 +8319,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7837,9 +8337,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7918,9 +8422,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -7932,9 +8440,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8023,9 +8535,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8037,9 +8553,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8135,9 +8655,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8149,9 +8673,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8242,9 +8770,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8256,9 +8788,13 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8396,9 +8932,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -8410,9 +8950,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -8501,9 +9045,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -8515,9 +9063,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -8619,9 +9171,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -8633,9 +9189,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -8724,9 +9284,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -8738,9 +9302,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -8842,9 +9410,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -8856,9 +9428,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -8947,9 +9523,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -8961,9 +9541,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -9097,9 +9681,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -9111,9 +9699,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -9266,9 +9858,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9375,9 +9971,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9489,9 +10089,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9503,9 +10107,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9575,9 +10183,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9589,9 +10201,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9670,9 +10286,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9684,9 +10304,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9775,9 +10399,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9789,9 +10417,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9889,9 +10521,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9903,9 +10539,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -9997,9 +10637,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10011,9 +10655,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10114,9 +10762,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10128,9 +10780,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10233,9 +10889,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10247,9 +10907,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -10368,9 +11032,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10477,9 +11145,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10591,9 +11263,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10605,9 +11281,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10677,9 +11357,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10691,9 +11375,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10772,9 +11460,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10786,9 +11478,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10877,9 +11573,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10891,9 +11591,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10991,9 +11695,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11005,9 +11713,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11099,9 +11811,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11113,9 +11829,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11216,9 +11936,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11230,9 +11954,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11335,9 +12063,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11349,9 +12081,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -11479,9 +12215,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11588,9 +12328,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11702,9 +12446,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11716,9 +12464,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11788,9 +12540,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11802,9 +12558,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11883,9 +12643,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11897,9 +12661,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -11988,9 +12756,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12002,9 +12774,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12109,9 +12885,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12218,9 +12998,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12332,9 +13116,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12346,9 +13134,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12418,9 +13210,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12432,9 +13228,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12513,9 +13313,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12527,9 +13331,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12618,9 +13426,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12632,9 +13444,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12730,9 +13546,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12744,9 +13564,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12837,9 +13661,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -12851,9 +13679,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13002,9 +13834,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13111,9 +13947,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13225,9 +14065,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13239,9 +14083,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13311,9 +14159,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13325,9 +14177,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13406,9 +14262,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13420,9 +14280,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13511,9 +14375,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13525,9 +14393,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13625,9 +14497,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13639,9 +14515,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13733,9 +14613,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13747,9 +14631,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13850,9 +14738,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13864,9 +14756,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13969,9 +14865,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13983,9 +14883,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -14104,9 +15008,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14213,9 +15121,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14327,9 +15239,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14341,9 +15257,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14413,9 +15333,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14427,9 +15351,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14508,9 +15436,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14522,9 +15454,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14613,9 +15549,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14627,9 +15567,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14727,9 +15671,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14741,9 +15689,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14835,9 +15787,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14849,9 +15805,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14952,9 +15912,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14966,9 +15930,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15071,9 +16039,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15085,9 +16057,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15215,9 +16191,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15324,9 +16304,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15438,9 +16422,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15452,9 +16440,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15524,9 +16516,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15538,9 +16534,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15619,9 +16619,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15633,9 +16637,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15724,9 +16732,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15738,9 +16750,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -15845,9 +16861,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15954,9 +16974,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16068,9 +17092,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16082,9 +17110,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16154,9 +17186,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16168,9 +17204,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16249,9 +17289,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16263,9 +17307,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16354,9 +17402,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16368,9 +17420,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16466,9 +17522,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16480,9 +17540,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16573,9 +17637,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16587,9 +17655,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -16727,9 +17799,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -16741,9 +17817,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -16832,9 +17912,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -16846,9 +17930,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -16950,9 +18038,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -16964,9 +18056,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -17055,9 +18151,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -17069,9 +18169,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -17173,9 +18277,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -17187,9 +18295,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -17278,9 +18390,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -17292,9 +18408,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -17428,9 +18548,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -17442,9 +18566,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -17597,9 +18725,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17706,9 +18838,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17820,9 +18956,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17834,9 +18974,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17906,9 +19050,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17920,9 +19068,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18001,9 +19153,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18015,9 +19171,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18106,9 +19266,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18120,9 +19284,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18220,9 +19388,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18234,9 +19406,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18328,9 +19504,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18342,9 +19522,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18445,9 +19629,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18459,9 +19647,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18564,9 +19756,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18578,9 +19774,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18699,9 +19899,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18808,9 +20012,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18922,9 +20130,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18936,9 +20148,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19008,9 +20224,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19022,9 +20242,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19103,9 +20327,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19117,9 +20345,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19208,9 +20440,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19222,9 +20458,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19322,9 +20562,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19336,9 +20580,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19430,9 +20678,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19444,9 +20696,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19547,9 +20803,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19561,9 +20821,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19666,9 +20930,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19680,9 +20948,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19810,9 +21082,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -19919,9 +21195,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20033,9 +21313,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20047,9 +21331,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20119,9 +21407,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20133,9 +21425,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20214,9 +21510,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20228,9 +21528,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20319,9 +21623,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20333,9 +21641,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -20440,9 +21752,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20549,9 +21865,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20663,9 +21983,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20677,9 +22001,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20749,9 +22077,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20763,9 +22095,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20844,9 +22180,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20858,9 +22198,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20949,9 +22293,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20963,9 +22311,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21061,9 +22413,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21075,9 +22431,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21168,9 +22528,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21182,9 +22546,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -21333,9 +22701,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21442,9 +22814,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21556,9 +22932,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21570,9 +22950,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21642,9 +23026,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21656,9 +23044,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21737,9 +23129,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21751,9 +23147,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21842,9 +23242,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21856,9 +23260,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21956,9 +23364,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21970,9 +23382,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22064,9 +23480,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22078,9 +23498,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22181,9 +23605,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22195,9 +23623,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22300,9 +23732,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22314,9 +23750,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22435,9 +23875,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22544,9 +23988,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22658,9 +24106,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22672,9 +24124,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22744,9 +24200,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22758,9 +24218,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22839,9 +24303,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22853,9 +24321,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22944,9 +24416,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22958,9 +24434,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23058,9 +24538,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23072,9 +24556,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23166,9 +24654,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23180,9 +24672,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23283,9 +24779,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23297,9 +24797,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23402,9 +24906,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23416,9 +24924,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23546,9 +25058,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23655,9 +25171,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23769,9 +25289,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23783,9 +25307,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23855,9 +25383,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23869,9 +25401,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23950,9 +25486,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -23964,9 +25504,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24055,9 +25599,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24069,9 +25617,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -24176,9 +25728,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24285,9 +25841,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24399,9 +25959,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24413,9 +25977,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24485,9 +26053,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24499,9 +26071,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24580,9 +26156,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24594,9 +26174,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24685,9 +26269,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24699,9 +26287,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24797,9 +26389,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24811,9 +26407,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24904,9 +26504,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24918,9 +26522,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -25058,9 +26666,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -25072,9 +26684,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -25163,9 +26779,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -25177,9 +26797,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -25281,9 +26905,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -25295,9 +26923,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -25386,9 +27018,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -25400,9 +27036,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -25504,9 +27144,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -25518,9 +27162,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -25609,9 +27257,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -25623,9 +27275,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -25759,9 +27415,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -25773,9 +27433,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -25928,9 +27592,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26037,9 +27705,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26151,9 +27823,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26165,9 +27841,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26237,9 +27917,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26251,9 +27935,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26332,9 +28020,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26346,9 +28038,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26437,9 +28133,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26451,9 +28151,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26551,9 +28255,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26565,9 +28273,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26659,9 +28371,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26673,9 +28389,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26776,9 +28496,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26790,9 +28514,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26895,9 +28623,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -26909,9 +28641,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -27030,9 +28766,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27139,9 +28879,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27253,9 +28997,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27267,9 +29015,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27339,9 +29091,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27353,9 +29109,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27434,9 +29194,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27448,9 +29212,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27539,9 +29307,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27553,9 +29325,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27653,9 +29429,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27667,9 +29447,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27761,9 +29545,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27775,9 +29563,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27878,9 +29670,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27892,9 +29688,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -27997,9 +29797,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28011,9 +29815,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28141,9 +29949,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28250,9 +30062,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28364,9 +30180,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28378,9 +30198,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28450,9 +30274,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28464,9 +30292,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28545,9 +30377,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28559,9 +30395,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28650,9 +30490,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28664,9 +30508,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -28771,9 +30619,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28880,9 +30732,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -28994,9 +30850,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29008,9 +30868,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29080,9 +30944,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29094,9 +30962,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29175,9 +31047,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29189,9 +31065,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29280,9 +31160,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29294,9 +31178,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29392,9 +31280,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29406,9 +31298,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29499,9 +31395,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29513,9 +31413,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -29664,9 +31568,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29773,9 +31681,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29887,9 +31799,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29901,9 +31817,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29973,9 +31893,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -29987,9 +31911,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30068,9 +31996,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30082,9 +32014,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30173,9 +32109,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30187,9 +32127,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30287,9 +32231,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30301,9 +32249,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30395,9 +32347,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30409,9 +32365,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30512,9 +32472,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30526,9 +32490,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30631,9 +32599,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30645,9 +32617,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -30766,9 +32742,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -30875,9 +32855,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -30989,9 +32973,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31003,9 +32991,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31075,9 +33067,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31089,9 +33085,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31170,9 +33170,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31184,9 +33188,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31275,9 +33283,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31289,9 +33301,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31389,9 +33405,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31403,9 +33423,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31497,9 +33521,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31511,9 +33539,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31614,9 +33646,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31628,9 +33664,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31733,9 +33773,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31747,9 +33791,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -31877,9 +33925,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -31986,9 +34038,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32100,9 +34156,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32114,9 +34174,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32186,9 +34250,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32200,9 +34268,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32281,9 +34353,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32295,9 +34371,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32386,9 +34466,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32400,9 +34484,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -32507,9 +34595,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32616,9 +34708,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32730,9 +34826,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32744,9 +34844,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32816,9 +34920,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32830,9 +34938,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32911,9 +35023,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -32925,9 +35041,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33016,9 +35136,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33030,9 +35154,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33128,9 +35256,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33142,9 +35274,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33235,9 +35371,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33249,9 +35389,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -33389,9 +35533,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -33403,9 +35551,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -33494,9 +35646,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -33508,9 +35664,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -33612,9 +35772,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -33626,9 +35790,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -33717,9 +35885,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -33731,9 +35903,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -33835,9 +36011,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -33849,9 +36029,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -33940,9 +36124,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -33954,9 +36142,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      PROFILE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        PROFILE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -34090,9 +36282,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -34104,9 +36300,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -34259,9 +36459,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34368,9 +36572,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34482,9 +36690,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34496,9 +36708,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34568,9 +36784,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34582,9 +36802,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34663,9 +36887,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34677,9 +36905,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34768,9 +37000,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34782,9 +37018,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34882,9 +37122,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34896,9 +37140,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -34990,9 +37238,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35004,9 +37256,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35107,9 +37363,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35121,9 +37381,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35226,9 +37490,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35240,9 +37508,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -35361,9 +37633,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -35470,9 +37746,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -35584,9 +37864,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -35598,9 +37882,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -35670,9 +37958,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -35684,9 +37976,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -35765,9 +38061,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -35779,9 +38079,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -35870,9 +38174,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -35884,9 +38192,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -35984,9 +38296,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -35998,9 +38314,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36092,9 +38412,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36106,9 +38430,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36209,9 +38537,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36223,9 +38555,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36328,9 +38664,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36342,9 +38682,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -36472,9 +38816,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -36581,9 +38929,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -36695,9 +39047,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -36709,9 +39065,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -36781,9 +39141,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -36795,9 +39159,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -36876,9 +39244,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -36890,9 +39262,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -36981,9 +39357,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -36995,9 +39375,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -37102,9 +39486,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37211,9 +39599,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37325,9 +39717,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37339,9 +39735,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37411,9 +39811,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37425,9 +39829,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37506,9 +39914,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37520,9 +39932,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37611,9 +40027,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37625,9 +40045,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37723,9 +40147,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37737,9 +40165,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37830,9 +40262,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37844,9 +40280,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -37995,9 +40435,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38104,9 +40548,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38218,9 +40666,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38232,9 +40684,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38304,9 +40760,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38318,9 +40778,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38399,9 +40863,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38413,9 +40881,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38504,9 +40976,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38518,9 +40994,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38618,9 +41098,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38632,9 +41116,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38726,9 +41214,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38740,9 +41232,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38843,9 +41339,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38857,9 +41357,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38962,9 +41466,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -38976,9 +41484,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -39097,9 +41609,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39206,9 +41722,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39320,9 +41840,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39334,9 +41858,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39406,9 +41934,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39420,9 +41952,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39501,9 +42037,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39515,9 +42055,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39606,9 +42150,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39620,9 +42168,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39720,9 +42272,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39734,9 +42290,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39828,9 +42388,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39842,9 +42406,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39945,9 +42513,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -39959,9 +42531,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40064,9 +42640,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40078,9 +42658,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40208,9 +42792,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40317,9 +42905,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              PROFILE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                PROFILE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40431,9 +43023,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40445,9 +43041,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40517,9 +43117,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40531,9 +43135,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              REVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                REVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40612,9 +43220,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40626,9 +43238,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40717,9 +43333,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40731,9 +43351,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              INTERVIEW
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                INTERVIEW
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -40838,9 +43462,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -40947,9 +43575,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41061,9 +43693,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41075,9 +43711,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41147,9 +43787,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41161,9 +43805,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41242,9 +43890,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41256,9 +43908,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41347,9 +44003,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41361,9 +44021,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41459,9 +44123,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41473,9 +44141,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41566,9 +44238,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -41580,9 +44256,13 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"

--- a/packages/ts-newskit/src/slices/lead-story-4/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-4/__tests__/__snapshots__/index.test.tsx.snap
@@ -62,9 +62,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -76,9 +80,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    PROFILE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      PROFILE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -214,9 +222,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -315,9 +327,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -329,9 +345,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -420,9 +440,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -511,9 +535,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -525,9 +553,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -593,9 +625,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -607,9 +643,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -694,9 +734,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -708,9 +752,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -810,9 +858,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -824,9 +876,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -920,9 +976,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -934,9 +994,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1030,9 +1094,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1044,9 +1112,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1140,9 +1212,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1154,9 +1230,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1255,9 +1335,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1269,9 +1353,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1352,9 +1440,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1366,9 +1458,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1452,9 +1548,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1466,9 +1566,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1581,9 +1685,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1595,9 +1703,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1706,9 +1818,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1720,9 +1836,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1831,9 +1951,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1845,9 +1969,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1972,9 +2100,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1986,9 +2118,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    PROFILE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      PROFILE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -2130,9 +2266,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -2241,9 +2381,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -2255,9 +2399,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -2333,9 +2481,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        BREAKING
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          BREAKING
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -2347,9 +2499,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        INTERVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          INTERVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -2457,9 +2613,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2471,9 +2631,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2555,9 +2719,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2569,9 +2737,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2672,9 +2844,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2686,9 +2862,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2791,9 +2971,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2805,9 +2989,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2919,9 +3107,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -2933,9 +3125,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3038,9 +3234,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3052,9 +3252,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3166,9 +3370,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3180,9 +3388,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3285,9 +3497,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3299,9 +3515,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3413,9 +3633,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3427,9 +3651,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3532,9 +3760,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3546,9 +3778,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -3653,9 +3889,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3667,9 +3907,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3751,9 +3995,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3765,9 +4013,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3868,9 +4120,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3882,9 +4138,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -3987,9 +4247,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4001,9 +4265,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4115,9 +4383,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4129,9 +4401,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4234,9 +4510,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4248,9 +4528,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4362,9 +4646,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4376,9 +4664,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4481,9 +4773,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4495,9 +4791,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4609,9 +4909,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4623,9 +4927,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4728,9 +5036,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4742,9 +5054,13 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -4879,9 +5195,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -4893,9 +5213,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    PROFILE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      PROFILE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -5031,9 +5355,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5132,9 +5460,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5146,9 +5478,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5237,9 +5573,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5328,9 +5668,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5342,9 +5686,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5410,9 +5758,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5424,9 +5776,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5511,9 +5867,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5525,9 +5885,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -5627,9 +5991,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -5641,9 +6009,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -5737,9 +6109,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -5751,9 +6127,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -5847,9 +6227,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -5861,9 +6245,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -5957,9 +6345,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -5971,9 +6363,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -6072,9 +6468,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -6086,9 +6486,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -6169,9 +6573,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -6183,9 +6591,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -6269,9 +6681,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -6283,9 +6699,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -6398,9 +6818,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -6412,9 +6836,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -6523,9 +6951,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -6537,9 +6969,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -6648,9 +7084,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -6662,9 +7102,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -6789,9 +7233,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -6803,9 +7251,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    PROFILE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      PROFILE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -6947,9 +7399,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -7058,9 +7514,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -7072,9 +7532,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -7150,9 +7614,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        BREAKING
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          BREAKING
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -7164,9 +7632,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        INTERVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          INTERVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -7274,9 +7746,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7288,9 +7764,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7372,9 +7852,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7386,9 +7870,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7489,9 +7977,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7503,9 +7995,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7608,9 +8104,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7622,9 +8122,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7736,9 +8240,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7750,9 +8258,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7855,9 +8367,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7869,9 +8385,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7983,9 +8503,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -7997,9 +8521,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -8102,9 +8630,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -8116,9 +8648,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -8230,9 +8766,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -8244,9 +8784,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -8349,9 +8893,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -8363,9 +8911,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -8470,9 +9022,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8484,9 +9040,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8568,9 +9128,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8582,9 +9146,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8685,9 +9253,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8699,9 +9271,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8804,9 +9380,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8818,9 +9398,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8932,9 +9516,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -8946,9 +9534,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9051,9 +9643,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9065,9 +9661,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9179,9 +9779,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9193,9 +9797,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9298,9 +9906,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9312,9 +9924,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9426,9 +10042,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9440,9 +10060,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9545,9 +10169,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9559,9 +10187,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9696,9 +10328,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -9710,9 +10346,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    PROFILE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      PROFILE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -9848,9 +10488,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9949,9 +10593,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -9963,9 +10611,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10054,9 +10706,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10145,9 +10801,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10159,9 +10819,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10227,9 +10891,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10241,9 +10909,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10328,9 +11000,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10342,9 +11018,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -10444,9 +11124,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -10458,9 +11142,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -10554,9 +11242,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -10568,9 +11260,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -10664,9 +11360,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -10678,9 +11378,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -10774,9 +11478,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -10788,9 +11496,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -10889,9 +11601,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -10903,9 +11619,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -10986,9 +11706,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -11000,9 +11724,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -11086,9 +11814,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -11100,9 +11832,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -11215,9 +11951,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -11229,9 +11969,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -11340,9 +12084,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -11354,9 +12102,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -11465,9 +12217,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -11479,9 +12235,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -11606,9 +12366,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -11620,9 +12384,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    PROFILE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      PROFILE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -11764,9 +12532,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -11875,9 +12647,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -11889,9 +12665,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -11967,9 +12747,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        BREAKING
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          BREAKING
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -11981,9 +12765,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        INTERVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          INTERVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -12091,9 +12879,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12105,9 +12897,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12189,9 +12985,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12203,9 +13003,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12306,9 +13110,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12320,9 +13128,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12425,9 +13237,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12439,9 +13255,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12553,9 +13373,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12567,9 +13391,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12672,9 +13500,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12686,9 +13518,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12800,9 +13636,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12814,9 +13654,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12919,9 +13763,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -12933,9 +13781,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13047,9 +13899,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13061,9 +13917,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13166,9 +14026,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13180,9 +14044,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -13287,9 +14155,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13301,9 +14173,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13385,9 +14261,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13399,9 +14279,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13502,9 +14386,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13516,9 +14404,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13621,9 +14513,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13635,9 +14531,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13749,9 +14649,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13763,9 +14667,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13868,9 +14776,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13882,9 +14794,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -13996,9 +14912,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14010,9 +14930,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14115,9 +15039,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14129,9 +15057,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14243,9 +15175,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14257,9 +15193,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14362,9 +15302,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14376,9 +15320,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14513,9 +15461,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -14527,9 +15479,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    PROFILE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      PROFILE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -14665,9 +15621,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14766,9 +15726,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14780,9 +15744,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14871,9 +15839,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14962,9 +15934,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -14976,9 +15952,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15044,9 +16024,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15058,9 +16042,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15145,9 +16133,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15159,9 +16151,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -15261,9 +16257,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15275,9 +16275,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15371,9 +16375,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15385,9 +16393,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15481,9 +16493,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15495,9 +16511,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15591,9 +16611,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15605,9 +16629,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15706,9 +16734,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15720,9 +16752,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15803,9 +16839,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15817,9 +16857,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15903,9 +16947,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -15917,9 +16965,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -16032,9 +17084,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -16046,9 +17102,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -16157,9 +17217,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -16171,9 +17235,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -16282,9 +17350,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -16296,9 +17368,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -16423,9 +17499,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -16437,9 +17517,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    PROFILE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      PROFILE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -16581,9 +17665,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -16692,9 +17780,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -16706,9 +17798,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -16784,9 +17880,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        BREAKING
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          BREAKING
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -16798,9 +17898,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        INTERVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          INTERVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -16908,9 +18012,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -16922,9 +18030,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17006,9 +18118,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17020,9 +18136,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17123,9 +18243,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17137,9 +18261,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17242,9 +18370,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17256,9 +18388,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17370,9 +18506,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17384,9 +18524,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17489,9 +18633,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17503,9 +18651,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17617,9 +18769,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17631,9 +18787,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17736,9 +18896,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17750,9 +18914,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17864,9 +19032,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17878,9 +19050,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17983,9 +19159,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -17997,9 +19177,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -18104,9 +19288,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18118,9 +19306,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18202,9 +19394,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18216,9 +19412,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18319,9 +19519,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18333,9 +19537,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18438,9 +19646,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18452,9 +19664,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18566,9 +19782,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18580,9 +19800,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18685,9 +19909,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18699,9 +19927,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18813,9 +20045,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18827,9 +20063,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18932,9 +20172,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -18946,9 +20190,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19060,9 +20308,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19074,9 +20326,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19179,9 +20435,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19193,9 +20453,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19330,9 +20594,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -19344,9 +20612,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    PROFILE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      PROFILE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -19482,9 +20754,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19583,9 +20859,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19597,9 +20877,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19688,9 +20972,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          PROFILE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            PROFILE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19779,9 +21067,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19793,9 +21085,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          REVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            REVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19861,9 +21157,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19875,9 +21175,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          INTERVIEW
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            INTERVIEW
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19962,9 +21266,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -19976,9 +21284,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -20078,9 +21390,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20092,9 +21408,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20188,9 +21508,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20202,9 +21526,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20298,9 +21626,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20312,9 +21644,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20408,9 +21744,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20422,9 +21762,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20523,9 +21867,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20537,9 +21885,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20620,9 +21972,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20634,9 +21990,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20720,9 +22080,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20734,9 +22098,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -20849,9 +22217,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -20863,9 +22235,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -20974,9 +22350,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -20988,9 +22368,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -21099,9 +22483,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -21113,9 +22501,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -21240,9 +22632,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -21254,9 +22650,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    PROFILE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      PROFILE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -21398,9 +22798,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        PROFILE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          PROFILE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -21509,9 +22913,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        EXCLUSIVE
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          EXCLUSIVE
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -21523,9 +22931,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        REVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          REVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -21601,9 +23013,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="article-info css-1wte5n0"
                     >
                       <span
-                        class="css-ciimpt"
+                        class="css-6tvr2h"
                       >
-                        BREAKING
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          BREAKING
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -21615,9 +23031,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         />
                       </div>
                       <span
-                        class="css-1kanhs9"
+                        class="css-1basb1c"
                       >
-                        INTERVIEW
+                        <div
+                          class="css-gb5m6n"
+                        >
+                          INTERVIEW
+                        </div>
                       </span>
                       <div
                         class="css-p44zak"
@@ -21725,9 +23145,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21739,9 +23163,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21823,9 +23251,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              EXCLUSIVE
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                EXCLUSIVE
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21837,9 +23269,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21940,9 +23376,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -21954,9 +23394,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22059,9 +23503,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22073,9 +23521,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22187,9 +23639,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22201,9 +23657,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22306,9 +23766,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22320,9 +23784,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22434,9 +23902,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22448,9 +23920,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22553,9 +24029,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22567,9 +24047,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22681,9 +24165,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22695,9 +24183,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22800,9 +24292,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             class="article-info css-1wte5n0"
                           >
                             <span
-                              class="css-ciimpt"
+                              class="css-6tvr2h"
                             >
-                              BREAKING
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                BREAKING
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22814,9 +24310,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                               />
                             </div>
                             <span
-                              class="css-1kanhs9"
+                              class="css-1basb1c"
                             >
-                              Q&A
+                              <div
+                                class="css-gb5m6n"
+                              >
+                                Q&A
+                              </div>
                             </span>
                             <div
                               class="css-p44zak"
@@ -22921,9 +24421,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -22935,9 +24439,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23019,9 +24527,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          EXCLUSIVE
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            EXCLUSIVE
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23033,9 +24545,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23136,9 +24652,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23150,9 +24670,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23255,9 +24779,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23269,9 +24797,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23383,9 +24915,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23397,9 +24933,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23502,9 +25042,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23516,9 +25060,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23630,9 +25178,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23644,9 +25196,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23749,9 +25305,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23763,9 +25323,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23877,9 +25441,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23891,9 +25459,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -23996,9 +25568,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         class="article-info css-1wte5n0"
                       >
                         <span
-                          class="css-ciimpt"
+                          class="css-6tvr2h"
                         >
-                          BREAKING
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            BREAKING
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"
@@ -24010,9 +25586,13 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           />
                         </div>
                         <span
-                          class="css-1kanhs9"
+                          class="css-1basb1c"
                         >
-                          Q&A
+                          <div
+                            class="css-gb5m6n"
+                          >
+                            Q&A
+                          </div>
                         </span>
                         <div
                           class="css-p44zak"

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
@@ -103,9 +103,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -117,9 +121,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -171,9 +179,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -185,9 +197,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -239,9 +255,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -253,9 +273,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -377,9 +401,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -391,9 +419,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -445,9 +477,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -459,9 +495,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -513,9 +553,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -527,9 +571,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -651,9 +699,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -665,9 +717,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -719,9 +775,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -733,9 +793,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -787,9 +851,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -801,9 +869,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -925,9 +997,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -939,9 +1015,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -993,9 +1073,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1007,9 +1091,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1061,9 +1149,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1075,9 +1167,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -1213,9 +1309,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1227,9 +1327,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1281,9 +1385,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1295,9 +1403,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1349,9 +1461,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    NEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      NEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1363,9 +1479,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1487,9 +1607,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1501,9 +1625,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1555,9 +1683,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1569,9 +1701,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1623,9 +1759,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    NEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      NEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1637,9 +1777,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1761,9 +1905,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1775,9 +1923,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1829,9 +1981,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1843,9 +1999,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1897,9 +2057,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -1911,9 +2075,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -2035,9 +2203,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -2049,9 +2221,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -2103,9 +2279,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    NEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      NEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -2117,9 +2297,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -2171,9 +2355,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -2185,9 +2373,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -2335,9 +2527,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2349,9 +2545,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      Q&A
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        Q&A
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2403,9 +2603,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2417,9 +2621,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2471,9 +2679,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2485,9 +2697,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2609,9 +2825,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2623,9 +2843,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2677,9 +2901,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2691,9 +2919,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2745,9 +2977,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2759,9 +2995,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2883,9 +3123,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2897,9 +3141,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2951,9 +3199,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -2965,9 +3217,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -3019,9 +3275,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      EXCLUSIVE
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        EXCLUSIVE
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -3033,9 +3293,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -3157,9 +3421,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -3171,9 +3439,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -3225,9 +3497,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      NEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        NEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -3239,9 +3515,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      REVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        REVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -3293,9 +3573,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="article-info css-1wte5n0"
                   >
                     <span
-                      class="css-ciimpt"
+                      class="css-6tvr2h"
                     >
-                      BREAKING
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        BREAKING
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -3307,9 +3591,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       />
                     </div>
                     <span
-                      class="css-1kanhs9"
+                      class="css-1basb1c"
                     >
-                      INTERVIEW
+                      <div
+                        class="css-gb5m6n"
+                      >
+                        INTERVIEW
+                      </div>
                     </span>
                     <div
                       class="css-p44zak"
@@ -3445,9 +3733,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -3459,9 +3751,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    Q&A
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      Q&A
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -3513,9 +3809,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -3527,9 +3827,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -3581,9 +3885,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    NEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      NEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -3595,9 +3903,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -3719,9 +4031,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -3733,9 +4049,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -3787,9 +4107,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -3801,9 +4125,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -3855,9 +4183,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    NEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      NEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -3869,9 +4201,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -3993,9 +4329,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -4007,9 +4347,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -4061,9 +4405,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -4075,9 +4423,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -4129,9 +4481,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    EXCLUSIVE
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      EXCLUSIVE
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -4143,9 +4499,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -4267,9 +4627,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -4281,9 +4645,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -4335,9 +4703,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    NEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      NEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -4349,9 +4721,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    REVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      REVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -4403,9 +4779,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="article-info css-1wte5n0"
                 >
                   <span
-                    class="css-ciimpt"
+                    class="css-6tvr2h"
                   >
-                    BREAKING
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      BREAKING
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"
@@ -4417,9 +4797,13 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     />
                   </div>
                   <span
-                    class="css-1kanhs9"
+                    class="css-1basb1c"
                   >
-                    INTERVIEW
+                    <div
+                      class="css-gb5m6n"
+                    >
+                      INTERVIEW
+                    </div>
                   </span>
                   <div
                     class="css-p44zak"

--- a/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -56,9 +56,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  NEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    NEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -70,9 +74,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -167,9 +175,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -181,9 +193,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -292,9 +308,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -306,9 +326,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -403,9 +427,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -417,9 +445,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -535,9 +567,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -549,9 +585,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -646,9 +686,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  NEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    NEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -660,9 +704,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -771,9 +819,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -785,9 +837,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -882,9 +938,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -896,9 +956,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1023,9 +1087,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  NEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    NEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1037,9 +1105,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1134,9 +1206,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1148,9 +1224,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1259,9 +1339,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1273,9 +1357,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1370,9 +1458,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1384,9 +1476,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1502,9 +1598,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1516,9 +1616,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1613,9 +1717,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  NEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    NEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1627,9 +1735,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1738,9 +1850,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1752,9 +1868,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1849,9 +1969,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1863,9 +1987,13 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -1990,9 +2118,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  NEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    NEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2004,9 +2136,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2101,9 +2237,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2115,9 +2255,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2226,9 +2370,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2240,9 +2388,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2337,9 +2489,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2351,9 +2507,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2469,9 +2629,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2483,9 +2647,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2580,9 +2748,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  NEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    NEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2594,9 +2766,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2705,9 +2881,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2719,9 +2899,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2816,9 +3000,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2830,9 +3018,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2957,9 +3149,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  NEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    NEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -2971,9 +3167,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3068,9 +3268,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3082,9 +3286,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3193,9 +3401,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3207,9 +3419,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3304,9 +3520,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3318,9 +3538,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3436,9 +3660,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3450,9 +3678,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3547,9 +3779,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  NEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    NEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3561,9 +3797,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3672,9 +3912,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3686,9 +3930,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3783,9 +4031,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3797,9 +4049,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3924,9 +4180,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  NEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    NEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -3938,9 +4198,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  PROFILE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    PROFILE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4035,9 +4299,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4049,9 +4317,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4160,9 +4432,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4174,9 +4450,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4271,9 +4551,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4285,9 +4569,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4403,9 +4691,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4417,9 +4709,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4514,9 +4810,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  NEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    NEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4528,9 +4828,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4639,9 +4943,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  EXCLUSIVE
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    EXCLUSIVE
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4653,9 +4961,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  REVIEW
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    REVIEW
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4750,9 +5062,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                 class="article-info css-1wte5n0"
               >
                 <span
-                  class="css-ciimpt"
+                  class="css-6tvr2h"
                 >
-                  UPDATED
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    UPDATED
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"
@@ -4764,9 +5080,13 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                   />
                 </div>
                 <span
-                  class="css-1kanhs9"
+                  class="css-1basb1c"
                 >
-                  Q&A
+                  <div
+                    class="css-gb5m6n"
+                  >
+                    Q&A
+                  </div>
                 </span>
                 <div
                   class="css-p44zak"


### PR DESCRIPTION
### Description

Reverts changes to article tile info to unblock other PRs.

### Checklist

- [X] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?
