### PR TITLE
fix(TMRX-1550): newsletter puff not appearing in irish sport section

### DIFF
--- a/packages/article-skeleton/src/contentModifiers/newsletter-puff.js
+++ b/packages/article-skeleton/src/contentModifiers/newsletter-puff.js
@@ -102,7 +102,7 @@ const newslettersBySection = [
     })
   },
   {
-    section: "irish-sport",
+    section: "irish sport",
     payload: setNewsletterPayload({
       code: "TNL-152",
       headline: "Best of Times Ireland newsletter:",


### PR DESCRIPTION
### Description

Automated newsletter puff is not showing the article under Irish Sport section.

[JIRA-1550](https://nidigitalsolutions.jira.com/browse/TMRX-1550)


### Checklist

- [X] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

![Screenshot 2023-11-30 at 13 01 35](https://github.com/newsuk/times-components/assets/142982056/a277ce00-cd6e-4e83-963d-85eaefe84aa4)

