### PR TITLE
feat(TMRX-0000): disable summary for mobile

### DIFF
--- a/packages/ts-newskit/src/slices/lead-story-4/mobile.tsx
+++ b/packages/ts-newskit/src/slices/lead-story-4/mobile.tsx
@@ -23,6 +23,11 @@ export const LeadStory4Mobile = ({
   articlesFrom5To9,
   article234
 }: LeadStory4Mobile) => {
+  const articlesWithDisabledSummary = articlesFrom5To9.map(item => ({
+    ...item,
+    isSummaryEnabled: false
+  }));
+
   return (
     <LeadStoryContainer marginBlockEnd="space000">
       <StackItem
@@ -72,7 +77,7 @@ export const LeadStory4Mobile = ({
       </FullWidthBlock>
       <BlockItem>
         <ArticleStackLarge
-          articles={articlesFrom5To9}
+          articles={articlesWithDisabledSummary}
           clickHandler={clickHandler}
         />
       </BlockItem>


### PR DESCRIPTION
### Description

This PR is an initial change for Lead Story 5. Given the similarity between Lead Story 5 and Lead Story 4, this pull request is focused on disabling scrollable article summaries in Lead Story 4 for mobile devices

[JIRA-1234](https://nidigitalsolutions.jira.com/browse/JIRA-1234)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
before 

<img width="584" alt="Screenshot 2023-12-07 at 09 28 47" src="https://github.com/newsuk/times-components/assets/116718171/059e7cfe-5d74-4cef-88c9-ddf635001f88">
after

<img width="568" alt="Screenshot 2023-12-07 at 09 28 58" src="https://github.com/newsuk/times-components/assets/116718171/68555c03-5116-44ba-989a-409ac316f301">
