### PR TITLE
fix(TMRX-1745): Fix ads on list view slice

### DIFF
--- a/packages/ad/src/ad-container.js
+++ b/packages/ad/src/ad-container.js
@@ -8,7 +8,7 @@ const AdContainer = ({ slotName, style }) => {
   const adMap = {
     header: "ad-header",
     "inline-ad": "ad-article-inline",
-    articleListAd: "inline-ad",
+    articleListAd: "ad-article-inline",
     pixel: "ad-pixel",
     pixelteads: "ad-pixelteads",
     pixelskin: "ad-pixelskin",

--- a/packages/ssr/__tests__/helpers/author-profile-helper.js
+++ b/packages/ssr/__tests__/helpers/author-profile-helper.js
@@ -36,7 +36,7 @@ export default (options = {}) => {
     });
 
     it("loads inline-ad", () => {
-      expect(cy.get("#inline-ad")).to.exist;
+      expect(cy.get("#ad-article-inline")).to.exist;
     });
 
     it("navigates between article pages", () => {

--- a/packages/ssr/__tests__/helpers/topic-helper.js
+++ b/packages/ssr/__tests__/helpers/topic-helper.js
@@ -39,7 +39,7 @@ export default (options = {}) => {
     });
 
     it("loads inline-ad", () => {
-      expect(cy.get("#inline-ad")).to.exist;
+      expect(cy.get("#ad-article-inline")).to.exist;
     });
 
     it("navigates between article pages", () => {


### PR DESCRIPTION
### Description

The commercial team are expecting `ad-article-inline` as the id of the ad container on topic and author pages that use the articleList component. 

[TMRX-1745](https://nidigitalsolutions.jira.com/browse/TMRX-1745)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMRX-1745]: https://nidigitalsolutions.jira.com/browse/TMRX-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ