### PR TITLE
feat(TMRX-1671): fix hamburger menu alignment

### DIFF
--- a/packages/ts-newskit/src/components/navigation/global-nav/HamburgerMenuContainer.tsx
+++ b/packages/ts-newskit/src/components/navigation/global-nav/HamburgerMenuContainer.tsx
@@ -10,7 +10,7 @@ const MenuDrawer = styled.div<{ open: boolean; isLoggedIn?: boolean }>`
   width: 100%;
   height: 100%;
   @media screen and (min-width: 768px) {
-    width: 320px;
+    width: 322px;
     top: 60px;
   }
 `;

--- a/packages/ts-newskit/src/components/navigation/global-nav/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/navigation/global-nav/__tests__/__snapshots__/index.test.tsx.snap
@@ -1023,7 +1023,7 @@ exports[`GlobalNavWithCustomDrawer matches snapshot when logged in 1`] = `
     data-testid="overlay"
   />
   <div
-    class="css-1mosdy0"
+    class="css-1led2la"
   >
     <nav
       aria-label="menu-vertical"
@@ -4624,7 +4624,7 @@ exports[`GlobalNavWithCustomDrawer matches snapshot when logged out 1`] = `
     data-testid="overlay"
   />
   <div
-    class="css-16ui3d2"
+    class="css-1mpsryh"
   >
     <nav
       aria-label="menu-vertical"


### PR DESCRIPTION
### Description

On desktop hamburger menu should align with ‘The Times’ branding (including the border)
Expand width of hamburger to match logo (including border) rather than reduce logo width

[JIRA-1671](https://nidigitalsolutions.jira.com/browse/TMRX-1671)

### Checklist

- [X] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

**Before**
<img width="888" alt="Screenshot 2023-12-14 at 15 19 26" src="https://github.com/newsuk/times-components/assets/142982056/ded63dd1-0104-4314-b02a-3e666aeff1cd">

**After**
<img width="938" alt="Screenshot 2023-12-14 at 15 19 06" src="https://github.com/newsuk/times-components/assets/142982056/8b3cef59-dc0d-4d97-bf73-b489b46e0b84">


