### PR TITLE
spike(TMRX-1710): add breadcrumb from TPA data

### DIFF
--- a/packages/article-main-standard/package.json
+++ b/packages/article-main-standard/package.json
@@ -63,6 +63,7 @@
     "@times-components/date-publication": "0.28.1",
     "@times-components/responsive": "0.17.1",
     "@times-components/ts-components": "1.81.7",
+    "@times-components/ts-newskit": "1.146.1",
     "@times-components/ts-styleguide": "1.48.1",
     "@times-components/user-state": "0.5.11",
     "@times-components/utils": "6.16.21",

--- a/packages/article-main-standard/src/article-main-standard.js
+++ b/packages/article-main-standard/src/article-main-standard.js
@@ -18,6 +18,7 @@ import {
   LeadAsset,
   MetaContainer
 } from "./styles/responsive";
+import { Breadcrumb, TCThemeProvider } from "@times-components/ts-newskit";
 
 const renderCaption = ({ caption }) => (
   <LeadAssetCaptionContainer>
@@ -35,6 +36,7 @@ class ArticlePage extends Component {
     const { article } = this.props;
     const {
       bylines,
+      categoryConnection,
       hasVideo,
       headline,
       expirableFlags,
@@ -53,6 +55,9 @@ class ArticlePage extends Component {
       <Fragment>
         <HeaderTopContainer>
           <HeaderContainer>
+            <TCThemeProvider>
+              <Breadcrumb data={categoryConnection.nodes} />
+            </TCThemeProvider>
             <ArticleHeader
               flags={expirableFlags}
               hasVideo={hasVideo}

--- a/packages/article-skeleton/src/head.js
+++ b/packages/article-skeleton/src/head.js
@@ -256,6 +256,7 @@ function Head({
   swgProductId
 }) {
   const {
+    categoryConnection,
     descriptionMarkup,
     headline,
     leadAsset,
@@ -406,6 +407,19 @@ function Head({
     articleSection: sectionname,
     articleId: id
   };
+
+  const breadcrumbJsonLD = categoryConnection.nodes.length 
+    ? {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": categoryConnection.nodes.map((breadcrumb, breadcrumbIndex) => ({
+          "@type": "ListItem",
+          "position": breadcrumbIndex + 1,
+          "name": breadcrumb.title,
+          "item": `https://thetimes.co.uk/${breadcrumb.slug}`
+        }))
+      }
+    : null;
   const isSyndicatedArticle = SYNDICATED_ARTICLE_IDS.includes(article.id);
 
   return (
@@ -452,6 +466,11 @@ function Head({
             {videoJsonLD && (
               <script type="application/ld+json">
                 {JSON.stringify(videoJsonLD)}
+              </script>
+            )}
+            {breadcrumbJsonLD && (
+              <script type="application/ld+json">
+                {JSON.stringify(breadcrumbJsonLD)}
               </script>
             )}
           </Helmet>

--- a/packages/provider-queries/src/article_props.graphql
+++ b/packages/provider-queries/src/article_props.graphql
@@ -14,6 +14,12 @@ fragment articleProps on Article {
       }
     }
   }
+  categoryConnection(desc: true) {
+    nodes {
+      slug
+      title
+    }
+  }
   hasVideo
   headline
   id

--- a/packages/provider-queries/src/article_web.graphql
+++ b/packages/provider-queries/src/article_web.graphql
@@ -152,6 +152,12 @@ fragment articleProps on Article {
       }
     }
   }
+  categoryConnection(desc: true) {
+    nodes {
+      slug
+      title
+    }
+  }
   hasVideo
   headline
   id

--- a/packages/provider-test-tools/fixtures/article.json
+++ b/packages/provider-test-tools/fixtures/article.json
@@ -1395,6 +1395,18 @@
       "expiryTime": "2030-03-13T13:00:00.000Z"
     }
   ],
+  "categoryConnection": {
+    "nodes": [
+      {
+        "slug": "sport",
+        "title": "Sport"
+      },
+      {
+        "slug": "football",
+        "title": "Football"
+      }
+    ]
+  },
   "hasVideo": true,
   "headline": "Exclusive interview: the cyclist Geraint Thomas on Welsh pride, drugs cheats and winning the Tour de France",
   "keywords": ["Supplement", "In", "Depth", "Template", "Style"],


### PR DESCRIPTION
### Description

Spike to review implementation of Breadcrumbs on article pages.
- uses `categoryConnection` field from TPA article data
- implementation for adding schema for Breadcrumbs on article pages

[TMRX-1710](https://nidigitalsolutions.jira.com/browse/TMRX-1710)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.
