### PR TITLE
fix(TMRX-1800): add padding between image and label

### DIFF
--- a/packages/ts-newskit/src/components/slices/article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/article/index.tsx
@@ -11,7 +11,8 @@ import {
 import {
   CardHeadlineLink,
   FullWidthBlock,
-  FullWidthGridLayoutItem
+  FullWidthGridLayoutItem,
+  StyledSpan
 } from '../shared-styles';
 import { TagAndFlag } from '../shared/tag-and-flag';
 import {
@@ -176,7 +177,7 @@ export const Article = ({
             area="media"
             aria-label="article-lead-image"
             className="article-image"
-            marginBlockEnd={hasCaptionOrCredits ? 'space000' : 'space020'}
+            marginBlockEnd={hasCaptionOrCredits ? 'space000' : 'space040'}
           >
             {image}
           </FullWidthGridLayoutItem>
@@ -197,7 +198,7 @@ export const Article = ({
       <CardContent alignContent="start">
         {images &&
           !imageRight &&
-          images.caption &&
+          hasCaptionOrCredits &&
           !hideImage && (
             <TextBlock
               marginBlockStart="space020"
@@ -206,6 +207,11 @@ export const Article = ({
               typographyPreset="editorialCaption010"
             >
               {images.caption}
+              {images.credits && (
+                <StyledSpan hasCaption={hasCaption}>
+                  {images.credits}
+                </StyledSpan>
+              )}
             </TextBlock>
           )}
 

--- a/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
               >
                 <div
                   aria-label="article-lead-image"
-                  class="article-image css-cxo30k"
+                  class="article-image css-9wrjbw"
                 >
                   <a
                     href="/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
@@ -667,7 +667,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
               >
                 <div
                   aria-label="article-lead-image"
-                  class="article-image css-cxo30k"
+                  class="article-image css-9wrjbw"
                 >
                   <a
                     href="/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"

--- a/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -53,6 +53,11 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                     class="css-lg4krt"
                   >
                     Sarcacens an inclusive club? They didnt look
+                    <span
+                      class="css-15rs040"
+                    >
+                      Gareth Fuller/Press Association
+                    </span>
                   </p>
                   <div
                     class="article-info css-1fjzok1"
@@ -206,6 +211,11 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                     class="css-lg4krt"
                   >
                     Sarcacens an inclusive club? They didnt look
+                    <span
+                      class="css-15rs040"
+                    >
+                      Gareth Fuller/Press Association
+                    </span>
                   </p>
                   <div
                     class="article-info css-1fjzok1"
@@ -1412,6 +1422,11 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                     class="css-lg4krt"
                   >
                     Sarcacens an inclusive club? They didnt look
+                    <span
+                      class="css-15rs040"
+                    >
+                      Gareth Fuller/Press Association
+                    </span>
                   </p>
                   <div
                     class="article-info css-1fjzok1"
@@ -1565,6 +1580,11 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                     class="css-lg4krt"
                   >
                     Sarcacens an inclusive club? They didnt look
+                    <span
+                      class="css-15rs040"
+                    >
+                      Gareth Fuller/Press Association
+                    </span>
                   </p>
                   <div
                     class="article-info css-1fjzok1"

--- a/packages/ts-newskit/src/slices/lead-story-4/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-4/__tests__/__snapshots__/index.test.tsx.snap
@@ -2231,6 +2231,11 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -2365,6 +2370,11 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -2457,6 +2467,11 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -7318,6 +7333,11 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -7452,6 +7472,11 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -7544,6 +7569,11 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -12405,6 +12435,11 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -12539,6 +12574,11 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -12631,6 +12671,11 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -17492,6 +17537,11 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -17626,6 +17676,11 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -17718,6 +17773,11 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -22579,6 +22639,11 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -22713,6 +22778,11 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"
@@ -22805,6 +22875,11 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       class="css-lg4krt"
                     >
                       Sarcacens an inclusive club? They didnt look out for me
+                      <span
+                        class="css-15rs040"
+                      >
+                        Gareth Fuller/Press Association
+                      </span>
                     </p>
                     <div
                       class="article-info css-1fjzok1"

--- a/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
           >
             <div
               aria-label="article-lead-image"
-              class="article-image css-cxo30k"
+              class="article-image css-9wrjbw"
             >
               <a
                 href="/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
@@ -548,7 +548,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
           >
             <div
               aria-label="article-lead-image"
-              class="article-image css-cxo30k"
+              class="article-image css-9wrjbw"
             >
               <a
                 href="/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
@@ -1072,7 +1072,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
           >
             <div
               aria-label="article-lead-image"
-              class="article-image css-cxo30k"
+              class="article-image css-9wrjbw"
             >
               <a
                 href="/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
@@ -1587,7 +1587,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
           >
             <div
               aria-label="article-lead-image"
-              class="article-image css-cxo30k"
+              class="article-image css-9wrjbw"
             >
               <a
                 href="/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
@@ -2111,7 +2111,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
           >
             <div
               aria-label="article-lead-image"
-              class="article-image css-cxo30k"
+              class="article-image css-9wrjbw"
             >
               <a
                 href="/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
@@ -2626,7 +2626,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
           >
             <div
               aria-label="article-lead-image"
-              class="article-image css-cxo30k"
+              class="article-image css-9wrjbw"
             >
               <a
                 href="/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
@@ -3150,7 +3150,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
           >
             <div
               aria-label="article-lead-image"
-              class="article-image css-cxo30k"
+              class="article-image css-9wrjbw"
             >
               <a
                 href="/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
@@ -3665,7 +3665,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
           >
             <div
               aria-label="article-lead-image"
-              class="article-image css-cxo30k"
+              class="article-image css-9wrjbw"
             >
               <a
                 href="/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
@@ -4189,7 +4189,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
           >
             <div
               aria-label="article-lead-image"
-              class="article-image css-cxo30k"
+              class="article-image css-9wrjbw"
             >
               <a
                 href="/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"
@@ -4704,7 +4704,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
           >
             <div
               aria-label="article-lead-image"
-              class="article-image css-cxo30k"
+              class="article-image css-9wrjbw"
             >
               <a
                 href="/article/harry-and-meghan-s-new-project-to-make-boys-less-toxic-nk5n3h70m"


### PR DESCRIPTION
### Description

Acceptance Criteria

Padding is added between lead image and label

Use padding dimensions used between images and labels within other tiles

Review other slices to check for repetition of the issue 
[JIRA-1800](https://nidigitalsolutions.jira.com/browse/TMRX-1800)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.
