### PR TITLE
fix(TMRX-1806): remove byline from tag and flag

### DIFF
--- a/packages/ts-newskit/src/components/slices/lead-article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-article/index.tsx
@@ -41,6 +41,7 @@ export interface LeadArticleProps {
     label: string;
     href: string;
   };
+  isListView?: boolean;
   imageTop?: boolean;
   isLeadImage?: boolean;
   byline?: string;
@@ -79,6 +80,7 @@ export const LeadArticle = ({
     imageTop,
     hasTopBorder = true,
     contentTop,
+    isListView,
     contentWidth,
     isLeadImage,
     columnGap,
@@ -234,7 +236,7 @@ export const LeadArticle = ({
         <TagAndFlag
           tag={tag}
           flag={flag}
-          byline={byline}
+          byline={isListView ? byline : ''}
           marginBlockStart={tagAndFlagMarginBlockStart}
         />
         <UnorderedListItems listData={listData} clickHandler={clickHandler} />

--- a/packages/ts-newskit/src/components/slices/lead-article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-article/index.tsx
@@ -107,6 +107,7 @@ export const LeadArticle = ({
     imageWithCorrectRatio.url !== '';
 
   const hasCaption = !!(images && images.caption);
+
   const hasCredits = !!(images && images.credits);
 
   const hasCaptionOrCredits = hasCaption || hasCredits;

--- a/packages/ts-newskit/src/components/slices/lead-article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-article/index.tsx
@@ -237,7 +237,8 @@ export const LeadArticle = ({
         <TagAndFlag
           tag={tag}
           flag={flag}
-          byline={isListView ? byline : ''}
+          byline={byline}
+          isListView={isListView}
           marginBlockStart={tagAndFlagMarginBlockStart}
         />
         <UnorderedListItems listData={listData} clickHandler={clickHandler} />

--- a/packages/ts-newskit/src/components/slices/shared/tag-and-flag.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/tag-and-flag.tsx
@@ -22,7 +22,8 @@ export const TagAndFlag = ({
   flagOverrides,
   tag,
   marginBlockStart = 'space000',
-  byline
+  byline,
+  isListView
 }: TagAndFlagProps) => {
   const hasTag = tag && tag.label;
   const hasFlag = flag && flag !== '';
@@ -52,25 +53,26 @@ export const TagAndFlag = ({
           </TagAndFlagWrapper>
         )}
 
-      {byline && (
-        <TagAndFlagWrapper>
-          <TextBlock
-            typographyPreset={
-              flagOverrides && flagOverrides.typographyPreset
-                ? flagOverrides.typographyPreset
-                : { xs: 'utilityButton010', md: 'utilityButton005' }
-            }
-            stylePreset={
-              flagOverrides && flagOverrides.stylePreset
-                ? flagOverrides.stylePreset
-                : { xs: 'inkNonEssential', md: 'inkSubtle' }
-            }
-            as="span"
-          >
-            {byline}
-          </TextBlock>
-        </TagAndFlagWrapper>
-      )}
+      {isListView &&
+        byline && (
+          <TagAndFlagWrapper>
+            <TextBlock
+              typographyPreset={
+                flagOverrides && flagOverrides.typographyPreset
+                  ? flagOverrides.typographyPreset
+                  : { xs: 'utilityButton010', md: 'utilityButton005' }
+              }
+              stylePreset={
+                flagOverrides && flagOverrides.stylePreset
+                  ? flagOverrides.stylePreset
+                  : { xs: 'inkNonEssential', md: 'inkSubtle' }
+              }
+              as="span"
+            >
+              {byline}
+            </TextBlock>
+          </TagAndFlagWrapper>
+        )}
 
       {flag && (
         <TagAndFlagWrapper>

--- a/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/desktop.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/desktop.test.tsx.snap
@@ -162,20 +162,6 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-4z8vdx"
-                    >
-                      ibrahim
-                    </span>
-                    <div
-                      class="css-p44zak"
-                    >
-                      <hr
-                        aria-hidden="true"
-                        class="css-15kf7hd"
-                        data-testid="divider"
-                      />
-                    </div>
-                    <span
                       class="css-1selp7x"
                     >
                       The Times
@@ -354,20 +340,6 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                         </span>
                       </span>
                     </a>
-                    <div
-                      class="css-p44zak"
-                    >
-                      <hr
-                        aria-hidden="true"
-                        class="css-15kf7hd"
-                        data-testid="divider"
-                      />
-                    </div>
-                    <span
-                      class="css-4z8vdx"
-                    >
-                      ibrahim
-                    </span>
                     <div
                       class="css-p44zak"
                     >
@@ -566,20 +538,6 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-4z8vdx"
-                    >
-                      ibrahim
-                    </span>
-                    <div
-                      class="css-p44zak"
-                    >
-                      <hr
-                        aria-hidden="true"
-                        class="css-15kf7hd"
-                        data-testid="divider"
-                      />
-                    </div>
-                    <span
                       class="css-1selp7x"
                     >
                       The Sunday Times
@@ -768,20 +726,6 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-4z8vdx"
-                    >
-                      ibrahim
-                    </span>
-                    <div
-                      class="css-p44zak"
-                    >
-                      <hr
-                        aria-hidden="true"
-                        class="css-15kf7hd"
-                        data-testid="divider"
-                      />
-                    </div>
-                    <span
                       class="css-1selp7x"
                     >
                       The Times
@@ -950,20 +894,6 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                         </span>
                       </span>
                     </a>
-                    <div
-                      class="css-p44zak"
-                    >
-                      <hr
-                        aria-hidden="true"
-                        class="css-15kf7hd"
-                        data-testid="divider"
-                      />
-                    </div>
-                    <span
-                      class="css-4z8vdx"
-                    >
-                      ibrahim
-                    </span>
                     <div
                       class="css-p44zak"
                     >
@@ -1180,20 +1110,6 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-4z8vdx"
-                    >
-                      ibrahim
-                    </span>
-                    <div
-                      class="css-p44zak"
-                    >
-                      <hr
-                        aria-hidden="true"
-                        class="css-15kf7hd"
-                        data-testid="divider"
-                      />
-                    </div>
-                    <span
                       class="css-1selp7x"
                     >
                       The Times
@@ -1382,20 +1298,6 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-4z8vdx"
-                    >
-                      ibrahim kurhan
-                    </span>
-                    <div
-                      class="css-p44zak"
-                    >
-                      <hr
-                        aria-hidden="true"
-                        class="css-15kf7hd"
-                        data-testid="divider"
-                      />
-                    </div>
-                    <span
                       class="css-1selp7x"
                     >
                       The Sunday Times
@@ -1564,20 +1466,6 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                         </span>
                       </span>
                     </a>
-                    <div
-                      class="css-p44zak"
-                    >
-                      <hr
-                        aria-hidden="true"
-                        class="css-15kf7hd"
-                        data-testid="divider"
-                      />
-                    </div>
-                    <span
-                      class="css-4z8vdx"
-                    >
-                      ibrahim
-                    </span>
                     <div
                       class="css-p44zak"
                     >
@@ -1776,20 +1664,6 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                       />
                     </div>
                     <span
-                      class="css-4z8vdx"
-                    >
-                      ibrahim
-                    </span>
-                    <div
-                      class="css-p44zak"
-                    >
-                      <hr
-                        aria-hidden="true"
-                        class="css-15kf7hd"
-                        data-testid="divider"
-                      />
-                    </div>
-                    <span
                       class="css-1selp7x"
                     >
                       The Times
@@ -1958,20 +1832,6 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                         </span>
                       </span>
                     </a>
-                    <div
-                      class="css-p44zak"
-                    >
-                      <hr
-                        aria-hidden="true"
-                        class="css-15kf7hd"
-                        data-testid="divider"
-                      />
-                    </div>
-                    <span
-                      class="css-4z8vdx"
-                    >
-                      ibrahim
-                    </span>
                     <div
                       class="css-p44zak"
                     >

--- a/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/mobile.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/mobile.test.tsx.snap
@@ -149,20 +149,6 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                 />
               </div>
               <span
-                class="css-4z8vdx"
-              >
-                ibrahim
-              </span>
-              <div
-                class="css-p44zak"
-              >
-                <hr
-                  aria-hidden="true"
-                  class="css-15kf7hd"
-                  data-testid="divider"
-                />
-              </div>
-              <span
                 class="css-1selp7x"
               >
                 The Times
@@ -320,20 +306,6 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                   </span>
                 </span>
               </a>
-              <div
-                class="css-p44zak"
-              >
-                <hr
-                  aria-hidden="true"
-                  class="css-15kf7hd"
-                  data-testid="divider"
-                />
-              </div>
-              <span
-                class="css-4z8vdx"
-              >
-                ibrahim
-              </span>
               <div
                 class="css-p44zak"
               >
@@ -511,20 +483,6 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                 />
               </div>
               <span
-                class="css-4z8vdx"
-              >
-                ibrahim
-              </span>
-              <div
-                class="css-p44zak"
-              >
-                <hr
-                  aria-hidden="true"
-                  class="css-15kf7hd"
-                  data-testid="divider"
-                />
-              </div>
-              <span
                 class="css-1selp7x"
               >
                 The Sunday Times
@@ -692,20 +650,6 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                 />
               </div>
               <span
-                class="css-4z8vdx"
-              >
-                ibrahim
-              </span>
-              <div
-                class="css-p44zak"
-              >
-                <hr
-                  aria-hidden="true"
-                  class="css-15kf7hd"
-                  data-testid="divider"
-                />
-              </div>
-              <span
                 class="css-1selp7x"
               >
                 The Times
@@ -863,20 +807,6 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                   </span>
                 </span>
               </a>
-              <div
-                class="css-p44zak"
-              >
-                <hr
-                  aria-hidden="true"
-                  class="css-15kf7hd"
-                  data-testid="divider"
-                />
-              </div>
-              <span
-                class="css-4z8vdx"
-              >
-                ibrahim
-              </span>
               <div
                 class="css-p44zak"
               >
@@ -1057,20 +987,6 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                 />
               </div>
               <span
-                class="css-4z8vdx"
-              >
-                ibrahim
-              </span>
-              <div
-                class="css-p44zak"
-              >
-                <hr
-                  aria-hidden="true"
-                  class="css-15kf7hd"
-                  data-testid="divider"
-                />
-              </div>
-              <span
                 class="css-1selp7x"
               >
                 The Times
@@ -1228,20 +1144,6 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                   </span>
                 </span>
               </a>
-              <div
-                class="css-p44zak"
-              >
-                <hr
-                  aria-hidden="true"
-                  class="css-15kf7hd"
-                  data-testid="divider"
-                />
-              </div>
-              <span
-                class="css-4z8vdx"
-              >
-                ibrahim kurhan
-              </span>
               <div
                 class="css-p44zak"
               >
@@ -1419,20 +1321,6 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                 />
               </div>
               <span
-                class="css-4z8vdx"
-              >
-                ibrahim
-              </span>
-              <div
-                class="css-p44zak"
-              >
-                <hr
-                  aria-hidden="true"
-                  class="css-15kf7hd"
-                  data-testid="divider"
-                />
-              </div>
-              <span
                 class="css-1selp7x"
               >
                 The Times
@@ -1600,20 +1488,6 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                 />
               </div>
               <span
-                class="css-4z8vdx"
-              >
-                ibrahim
-              </span>
-              <div
-                class="css-p44zak"
-              >
-                <hr
-                  aria-hidden="true"
-                  class="css-15kf7hd"
-                  data-testid="divider"
-                />
-              </div>
-              <span
                 class="css-1selp7x"
               >
                 The Times
@@ -1771,20 +1645,6 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                   </span>
                 </span>
               </a>
-              <div
-                class="css-p44zak"
-              >
-                <hr
-                  aria-hidden="true"
-                  class="css-15kf7hd"
-                  data-testid="divider"
-                />
-              </div>
-              <span
-                class="css-4z8vdx"
-              >
-                ibrahim
-              </span>
               <div
                 class="css-p44zak"
               >

--- a/packages/ts-newskit/src/slices/list-view-slice/index.tsx
+++ b/packages/ts-newskit/src/slices/list-view-slice/index.tsx
@@ -34,7 +34,8 @@ export const ListViewSlice = ({
   const modifiedLeadArticles = leadArticles.map(item => ({
     ...item,
     headlineTypographyPreset: 'editorialHeadline020',
-    isLeadImage: false
+    isLeadImage: false,
+    isListView: true
   }));
 
   const sliceProps = {

--- a/packages/ts-newskit/src/slices/types.ts
+++ b/packages/ts-newskit/src/slices/types.ts
@@ -56,6 +56,7 @@ export type TagAndFlagProps = {
     stylePreset?: MQ<string> | string;
   };
   byline?: string;
+  isListView?: boolean;
   tag?: {
     label: string;
     href: string;


### PR DESCRIPTION
### Description

the byline is currently appearing in the Tag and Flag section below the summary or short summary. The byline should be removed specifically from these sections, excluding the List View slice.

Acceptance Criteria

Byline should not be displayed in the Tag and Flag section(below the summary , short summary or headline) in slices other than the List View.
[JIRA-1806](https://nidigitalsolutions.jira.com/browse/TMRX-1806)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
