### PR TITLE
chore(TMP-663): Bump sonarcloud orb version to the latest one.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
         resource_class: small
 
 orbs:
-  sonarcloud: sonarsource/sonarcloud@1.0.3
+  sonarcloud: sonarsource/sonarcloud@2.0.0
 
 commands:
     install-dependencies:


### PR DESCRIPTION
### Description

```
The version of Java (11.0.11) used to run this analysis is deprecated, and SonarCloud no longer supports it. Please upgrade to Java 17 or later.
As a temporary measure, you can set the property 'sonar.scanner.force-deprecated-java-version' to 'true' to continue using Java 11.0.11
This workaround will only be effective until January 28, 2024. After this date, all scans using the deprecated Java 11 will fail.
ERROR: 
ERROR: Re-run SonarScanner using the -X switch to enable full debug logging.
https://app.circleci.com/pipelines/github/newsuk/cps-content-render/74737/workflows/4631d25f-a097-4e58-b9b7-f478fd9d37d9/jobs/444196
````

<b>Acceptance Criteria</b>
<div>
Update SonarCloud Orbs version
</div>

[TMP-663](https://nidigitalsolutions.jira.com/browse/TMP-663)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMP-663]: https://nidigitalsolutions.jira.com/browse/TMP-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ