### PR TITLE
feat(TMRX-1826): update pagination, spacing and make byline clickable

### DIFF
--- a/packages/ts-newskit/src/components/slices/lead-article/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/lead-article/__tests__/__snapshots__/index.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Render Component one should render a snapshot 1`] = `
         data-testid="divider"
       />
       <div
-        class="article-info css-1fjzok1"
+        class="article-info css-t0h780"
       >
         <span
           class="css-7b9bzx"

--- a/packages/ts-newskit/src/components/slices/lead-article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-article/index.tsx
@@ -45,7 +45,10 @@ export interface LeadArticleProps {
   isListView?: boolean;
   imageTop?: boolean;
   isLeadImage?: boolean;
-  byline?: string;
+  byline?: {
+    name: string;
+    slug?: string;
+  };
   hasTopBorder?: boolean;
   contentTop?: boolean;
   contentWidth?: MQ<string> | string;
@@ -224,7 +227,7 @@ export const LeadArticle = ({
           contentType={contentType}
           expirableFlags={expirableFlags}
           label={label}
-          marginBlockEnd="space020"
+          marginBlockEnd="space030"
         />
         <CardHeadlineLink
           href={url}

--- a/packages/ts-newskit/src/components/slices/shared/tag-and-flag.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/tag-and-flag.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Block, TextBlock, Divider } from 'newskit';
+import { Block, TextBlock, Divider, LinkInline } from 'newskit';
 import { ContainerInline, TextLink } from '../shared-styles';
 import { TagAndFlagProps } from '../../../slices/types';
 
@@ -27,11 +27,20 @@ export const TagAndFlag = ({
 }: TagAndFlagProps) => {
   const hasTag = tag && tag.label;
   const hasFlag = flag && flag !== '';
-  const hasbyline = byline && byline !== '';
+  const hasbyline = byline && byline.name !== '';
 
   if (!hasTag && !hasFlag && !hasbyline) {
     return null;
   }
+
+  const defaultStylePreset = (xsStyle: string, mdStyle: string) =>
+    flagOverrides && flagOverrides.stylePreset
+      ? flagOverrides.stylePreset
+      : { xs: xsStyle, md: mdStyle };
+  const defaultTypographyPreset = (xsStyle: string, mdStyle: string) =>
+    flagOverrides && flagOverrides.typographyPreset
+      ? flagOverrides.typographyPreset
+      : { xs: xsStyle, md: mdStyle };
 
   return (
     <Block marginBlockStart={marginBlockStart} data-testid="tag-and-flag">
@@ -56,37 +65,45 @@ export const TagAndFlag = ({
       {isListView &&
         byline && (
           <TagAndFlagWrapper>
-            <TextBlock
-              typographyPreset={
-                flagOverrides && flagOverrides.typographyPreset
-                  ? flagOverrides.typographyPreset
-                  : { xs: 'utilityButton010', md: 'utilityButton005' }
-              }
-              stylePreset={
-                flagOverrides && flagOverrides.stylePreset
-                  ? flagOverrides.stylePreset
-                  : { xs: 'inkNonEssential', md: 'inkSubtle' }
-              }
-              as="span"
-            >
-              {byline}
-            </TextBlock>
+            {byline.slug ? (
+              <LinkInline
+                overrides={{
+                  typographyPreset: defaultTypographyPreset(
+                    'utilityButton010',
+                    'utilityButton005'
+                  ),
+                  stylePreset: defaultStylePreset(
+                    'inkNonEssential',
+                    'inkSubtle'
+                  )
+                }}
+                href={`/profile/${byline.slug}`}
+              >
+                {byline.name}
+              </LinkInline>
+            ) : (
+              <TextBlock
+                typographyPreset={defaultTypographyPreset(
+                  'utilityButton010',
+                  'utilityButton005'
+                )}
+                stylePreset={defaultStylePreset('inkNonEssential', 'inkSubtle')}
+                as="span"
+              >
+                {byline.name}
+              </TextBlock>
+            )}
           </TagAndFlagWrapper>
         )}
 
       {flag && (
         <TagAndFlagWrapper>
           <TextBlock
-            typographyPreset={
-              flagOverrides && flagOverrides.typographyPreset
-                ? flagOverrides.typographyPreset
-                : { xs: 'utilityMeta010', md: 'utilityMeta005' }
-            }
-            stylePreset={
-              flagOverrides && flagOverrides.stylePreset
-                ? flagOverrides.stylePreset
-                : { xs: 'inkNonEssential', md: 'inkSubtle' }
-            }
+            typographyPreset={defaultTypographyPreset(
+              'utilityMeta010',
+              'utilityMeta005'
+            )}
+            stylePreset={defaultStylePreset('inkNonEssential', 'inkSubtle')}
             as="span"
           >
             {flag}

--- a/packages/ts-newskit/src/components/slices/shared/tag-and-flag.tsx
+++ b/packages/ts-newskit/src/components/slices/shared/tag-and-flag.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Block, TextBlock, Divider, LinkInline } from 'newskit';
+import { Block, TextBlock, Divider, LinkInline, MQ } from 'newskit';
 import { ContainerInline, TextLink } from '../shared-styles';
 import { TagAndFlagProps } from '../../../slices/types';
 
@@ -33,14 +33,14 @@ export const TagAndFlag = ({
     return null;
   }
 
-  const defaultStylePreset = (xsStyle: string, mdStyle: string) =>
+  const defaultStylePreset = (preset: MQ<string>) =>
     flagOverrides && flagOverrides.stylePreset
       ? flagOverrides.stylePreset
-      : { xs: xsStyle, md: mdStyle };
-  const defaultTypographyPreset = (xsStyle: string, mdStyle: string) =>
+      : preset;
+  const defaultTypographyPreset = (preset: MQ<string>) =>
     flagOverrides && flagOverrides.typographyPreset
       ? flagOverrides.typographyPreset
-      : { xs: xsStyle, md: mdStyle };
+      : preset;
 
   return (
     <Block marginBlockStart={marginBlockStart} data-testid="tag-and-flag">
@@ -68,14 +68,14 @@ export const TagAndFlag = ({
             {byline.slug ? (
               <LinkInline
                 overrides={{
-                  typographyPreset: defaultTypographyPreset(
-                    'utilityButton010',
-                    'utilityButton005'
-                  ),
-                  stylePreset: defaultStylePreset(
-                    'inkNonEssential',
-                    'inkSubtle'
-                  )
+                  typographyPreset: defaultTypographyPreset({
+                    xs: 'utilityButton010',
+                    md: 'utilityButton005'
+                  }),
+                  stylePreset: defaultStylePreset({
+                    xs: 'inkNonEssential',
+                    md: 'inkSubtle'
+                  })
                 }}
                 href={`/profile/${byline.slug}`}
               >
@@ -83,11 +83,14 @@ export const TagAndFlag = ({
               </LinkInline>
             ) : (
               <TextBlock
-                typographyPreset={defaultTypographyPreset(
-                  'utilityButton010',
-                  'utilityButton005'
-                )}
-                stylePreset={defaultStylePreset('inkNonEssential', 'inkSubtle')}
+                typographyPreset={defaultTypographyPreset({
+                  xs: 'utilityButton010',
+                  md: 'utilityButton005'
+                })}
+                stylePreset={defaultStylePreset({
+                  xs: 'inkNonEssential',
+                  md: 'inkSubtle'
+                })}
                 as="span"
               >
                 {byline.name}
@@ -99,11 +102,14 @@ export const TagAndFlag = ({
       {flag && (
         <TagAndFlagWrapper>
           <TextBlock
-            typographyPreset={defaultTypographyPreset(
-              'utilityMeta010',
-              'utilityMeta005'
-            )}
-            stylePreset={defaultStylePreset('inkNonEssential', 'inkSubtle')}
+            typographyPreset={defaultTypographyPreset({
+              xs: 'utilityMeta010',
+              md: 'utilityMeta005'
+            })}
+            stylePreset={defaultStylePreset({
+              xs: 'inkNonEssential',
+              md: 'inkSubtle'
+            })}
             as="span"
           >
             {flag}

--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -212,7 +212,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                   data-testid="divider"
                 />
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -1516,7 +1516,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -1679,7 +1679,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                   data-testid="divider"
                 />
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"

--- a/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                     class="css-gpke1l"
                   >
                     <div
-                      class="article-info css-1fjzok1"
+                      class="article-info css-t0h780"
                     >
                       <span
                         class="css-7b9bzx"
@@ -237,7 +237,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                     class="css-gpke1l"
                   >
                     <div
-                      class="article-info css-1fjzok1"
+                      class="article-info css-t0h780"
                     >
                       <span
                         class="css-7b9bzx"
@@ -1458,7 +1458,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                     class="css-gpke1l"
                   >
                     <div
-                      class="article-info css-1fjzok1"
+                      class="article-info css-t0h780"
                     >
                       <span
                         class="css-7b9bzx"
@@ -1625,7 +1625,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                     class="css-gpke1l"
                   >
                     <div
-                      class="article-info css-1fjzok1"
+                      class="article-info css-t0h780"
                     >
                       <span
                         class="css-7b9bzx"

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -256,7 +256,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -352,7 +352,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -485,7 +485,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -9066,7 +9066,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -9162,7 +9162,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -9295,7 +9295,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -17876,7 +17876,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -17972,7 +17972,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -18105,7 +18105,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -26686,7 +26686,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -26782,7 +26782,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -26915,7 +26915,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -35496,7 +35496,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -35592,7 +35592,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -35725,7 +35725,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/article-stacks.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/article-stacks.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -155,7 +155,7 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -325,7 +325,7 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
               class="css-gpke1l"
             >
               <div
-                class="article-info css-1fjzok1"
+                class="article-info css-t0h780"
               >
                 <span
                   class="css-ciimpt"
@@ -486,7 +486,7 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
               class="css-gpke1l"
             >
               <div
-                class="article-info css-1fjzok1"
+                class="article-info css-t0h780"
               >
                 <span
                   class="css-ciimpt"
@@ -624,7 +624,7 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -751,7 +751,7 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -921,7 +921,7 @@ exports[`Render ArticleStack renders with passed width 1`] = `
               class="css-gpke1l"
             >
               <div
-                class="article-info css-1fjzok1"
+                class="article-info css-t0h780"
               >
                 <span
                   class="css-ciimpt"
@@ -1082,7 +1082,7 @@ exports[`Render ArticleStack renders with passed width 1`] = `
               class="css-gpke1l"
             >
               <div
-                class="article-info css-1fjzok1"
+                class="article-info css-t0h780"
               >
                 <span
                   class="css-ciimpt"

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -216,7 +216,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -365,7 +365,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="css-gpke1l"
                       >
                         <div
-                          class="article-info css-1fjzok1"
+                          class="article-info css-t0h780"
                         >
                           <span
                             class="css-ciimpt"
@@ -492,7 +492,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         class="css-gpke1l"
                       >
                         <div
-                          class="article-info css-1fjzok1"
+                          class="article-info css-t0h780"
                         >
                           <span
                             class="css-ciimpt"
@@ -662,7 +662,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -823,7 +823,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -8811,7 +8811,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -8973,7 +8973,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -9122,7 +9122,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-gpke1l"
                       >
                         <div
-                          class="article-info css-1fjzok1"
+                          class="article-info css-t0h780"
                         >
                           <span
                             class="css-ciimpt"
@@ -9249,7 +9249,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-gpke1l"
                       >
                         <div
-                          class="article-info css-1fjzok1"
+                          class="article-info css-t0h780"
                         >
                           <span
                             class="css-ciimpt"
@@ -9419,7 +9419,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -9580,7 +9580,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -17568,7 +17568,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -17730,7 +17730,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -17879,7 +17879,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-gpke1l"
                       >
                         <div
-                          class="article-info css-1fjzok1"
+                          class="article-info css-t0h780"
                         >
                           <span
                             class="css-ciimpt"
@@ -18006,7 +18006,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-gpke1l"
                       >
                         <div
-                          class="article-info css-1fjzok1"
+                          class="article-info css-t0h780"
                         >
                           <span
                             class="css-ciimpt"
@@ -18176,7 +18176,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -18337,7 +18337,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -26325,7 +26325,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -26487,7 +26487,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-7b9bzx"
@@ -26636,7 +26636,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-gpke1l"
                       >
                         <div
-                          class="article-info css-1fjzok1"
+                          class="article-info css-t0h780"
                         >
                           <span
                             class="css-ciimpt"
@@ -26763,7 +26763,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         class="css-gpke1l"
                       >
                         <div
-                          class="article-info css-1fjzok1"
+                          class="article-info css-t0h780"
                         >
                           <span
                             class="css-ciimpt"
@@ -26933,7 +26933,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -27094,7 +27094,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"

--- a/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -166,7 +166,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -293,7 +293,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -407,7 +407,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -534,7 +534,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -648,7 +648,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -807,7 +807,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
               class="css-gpke1l"
             >
               <div
-                class="article-info css-1fjzok1"
+                class="article-info css-t0h780"
               >
                 <span
                   class="css-ciimpt"
@@ -8784,7 +8784,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -8898,7 +8898,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -9025,7 +9025,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -9139,7 +9139,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -9266,7 +9266,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -9380,7 +9380,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -9539,7 +9539,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
               class="css-gpke1l"
             >
               <div
-                class="article-info css-1fjzok1"
+                class="article-info css-t0h780"
               >
                 <span
                   class="css-ciimpt"
@@ -17516,7 +17516,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -17630,7 +17630,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -17757,7 +17757,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -17871,7 +17871,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -17998,7 +17998,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -18112,7 +18112,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -18271,7 +18271,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
               class="css-gpke1l"
             >
               <div
-                class="article-info css-1fjzok1"
+                class="article-info css-t0h780"
               >
                 <span
                   class="css-ciimpt"
@@ -26248,7 +26248,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -26362,7 +26362,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -26489,7 +26489,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -26603,7 +26603,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -26730,7 +26730,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -26844,7 +26844,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -27003,7 +27003,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
               class="css-gpke1l"
             >
               <div
-                class="article-info css-1fjzok1"
+                class="article-info css-t0h780"
               >
                 <span
                   class="css-ciimpt"
@@ -34980,7 +34980,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -35094,7 +35094,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -35221,7 +35221,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -35335,7 +35335,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -35462,7 +35462,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -35576,7 +35576,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -35735,7 +35735,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
               class="css-gpke1l"
             >
               <div
-                class="article-info css-1fjzok1"
+                class="article-info css-t0h780"
               >
                 <span
                   class="css-ciimpt"

--- a/packages/ts-newskit/src/slices/lead-story-4/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-4/__tests__/__snapshots__/index.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -2080,7 +2080,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -5146,7 +5146,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -7167,7 +7167,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -10233,7 +10233,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -12254,7 +12254,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -15320,7 +15320,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -17341,7 +17341,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -20407,7 +20407,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"
@@ -22428,7 +22428,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                 class="css-gpke1l"
               >
                 <div
-                  class="article-info css-1fjzok1"
+                  class="article-info css-t0h780"
                 >
                   <span
                     class="css-ciimpt"

--- a/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/desktop.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/desktop.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -249,7 +249,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -437,7 +437,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -625,7 +625,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -803,7 +803,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -1009,7 +1009,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -1197,7 +1197,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -1375,7 +1375,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -1563,7 +1563,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -1741,7 +1741,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -1907,34 +1907,6 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
             <button
               aria-disabled="true"
               class="css-hu5lgw"
-              data-testid="pagination-first-item"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="css-1my36lh-EmotionIconBase ex0cdmw0"
-                fill="currentColor"
-                focusable="false"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"
-                />
-                <path
-                  d="M24 24H0V0h24v24z"
-                  fill="none"
-                />
-              </svg>
-            </button>
-          </li>
-          <li
-            class="css-1o2fxxh"
-          >
-            <button
-              aria-disabled="true"
-              class="css-hu5lgw"
               data-testid="pagination-prev-item"
               disabled=""
               type="button"
@@ -2021,33 +1993,6 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                 />
                 <path
                   d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
-                />
-              </svg>
-            </button>
-          </li>
-          <li
-            class="css-1o2fxxh"
-          >
-            <button
-              aria-label="go to last page"
-              class="css-bi08xr"
-              data-testid="pagination-last-item"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="css-1my36lh-EmotionIconBase ex0cdmw0"
-                fill="currentColor"
-                focusable="false"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M0 0h24v24H0V0z"
-                  fill="none"
-                />
-                <path
-                  d="M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"
                 />
               </svg>
             </button>

--- a/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/index.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -167,11 +167,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -269,7 +278,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -369,11 +378,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -471,7 +489,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -571,11 +589,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -673,7 +700,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -773,11 +800,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -865,7 +901,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -965,11 +1001,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -1085,7 +1130,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -1185,11 +1230,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -1287,7 +1341,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -1479,7 +1533,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -1579,11 +1633,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -1681,7 +1744,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -1781,11 +1844,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -1873,7 +1945,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -1973,11 +2045,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -2047,34 +2128,6 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
             <ul
               class="css-wx88k6"
             >
-              <li
-                class="css-1o2fxxh"
-              >
-                <button
-                  aria-disabled="true"
-                  class="css-hu5lgw"
-                  data-testid="pagination-first-item"
-                  disabled=""
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-1my36lh-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"
-                    />
-                    <path
-                      d="M24 24H0V0h24v24z"
-                      fill="none"
-                    />
-                  </svg>
-                </button>
-              </li>
               <li
                 class="css-1o2fxxh"
               >
@@ -2152,34 +2205,6 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                   </svg>
                 </button>
               </li>
-              <li
-                class="css-1o2fxxh"
-              >
-                <button
-                  aria-disabled="true"
-                  class="css-hu5lgw"
-                  data-testid="pagination-last-item"
-                  disabled=""
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-1my36lh-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0 0h24v24H0V0z"
-                      fill="none"
-                    />
-                    <path
-                      d="M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"
-                    />
-                  </svg>
-                </button>
-              </li>
             </ul>
           </nav>
         </div>
@@ -2233,7 +2258,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -2333,11 +2358,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -2414,7 +2448,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -2514,11 +2548,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -2595,7 +2638,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -2695,11 +2738,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -2776,7 +2828,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -2876,11 +2928,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -2957,7 +3018,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -3057,11 +3118,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -3141,7 +3211,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -3241,11 +3311,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -3322,7 +3401,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -3503,7 +3582,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -3603,11 +3682,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -3684,7 +3772,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -3784,11 +3872,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -3865,7 +3962,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -3965,11 +4062,20 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -4072,7 +4178,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -4172,11 +4278,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -4274,7 +4389,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -4374,11 +4489,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -4476,7 +4600,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -4576,11 +4700,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -4678,7 +4811,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -4778,11 +4911,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -4870,7 +5012,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -4970,11 +5112,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -5090,7 +5241,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -5190,11 +5341,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -5292,7 +5452,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -5484,7 +5644,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -5584,11 +5744,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -5686,7 +5855,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -5786,11 +5955,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -5878,7 +6056,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -5978,11 +6156,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -6052,34 +6239,6 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
             <ul
               class="css-wx88k6"
             >
-              <li
-                class="css-1o2fxxh"
-              >
-                <button
-                  aria-disabled="true"
-                  class="css-hu5lgw"
-                  data-testid="pagination-first-item"
-                  disabled=""
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-1my36lh-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"
-                    />
-                    <path
-                      d="M24 24H0V0h24v24z"
-                      fill="none"
-                    />
-                  </svg>
-                </button>
-              </li>
               <li
                 class="css-1o2fxxh"
               >
@@ -6157,34 +6316,6 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   </svg>
                 </button>
               </li>
-              <li
-                class="css-1o2fxxh"
-              >
-                <button
-                  aria-disabled="true"
-                  class="css-hu5lgw"
-                  data-testid="pagination-last-item"
-                  disabled=""
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-1my36lh-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0 0h24v24H0V0z"
-                      fill="none"
-                    />
-                    <path
-                      d="M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"
-                    />
-                  </svg>
-                </button>
-              </li>
             </ul>
           </nav>
         </div>
@@ -6238,7 +6369,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -6338,11 +6469,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -6419,7 +6559,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -6519,11 +6659,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -6600,7 +6749,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -6700,11 +6849,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -6781,7 +6939,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -6881,11 +7039,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -6962,7 +7129,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -7062,11 +7229,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -7146,7 +7322,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -7246,11 +7422,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -7327,7 +7512,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -7508,7 +7693,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -7608,11 +7793,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -7689,7 +7883,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -7789,11 +7983,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -7870,7 +8073,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -7970,11 +8173,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -8077,7 +8289,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -8177,11 +8389,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -8279,7 +8500,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -8379,11 +8600,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -8481,7 +8711,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -8581,11 +8811,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -8683,7 +8922,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -8783,11 +9022,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -8875,7 +9123,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -8975,11 +9223,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -9095,7 +9352,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -9195,11 +9452,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -9297,7 +9563,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -9489,7 +9755,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -9589,11 +9855,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -9691,7 +9966,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -9791,11 +10066,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -9883,7 +10167,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -9983,11 +10267,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -10057,34 +10350,6 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
             <ul
               class="css-wx88k6"
             >
-              <li
-                class="css-1o2fxxh"
-              >
-                <button
-                  aria-disabled="true"
-                  class="css-hu5lgw"
-                  data-testid="pagination-first-item"
-                  disabled=""
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-1my36lh-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"
-                    />
-                    <path
-                      d="M24 24H0V0h24v24z"
-                      fill="none"
-                    />
-                  </svg>
-                </button>
-              </li>
               <li
                 class="css-1o2fxxh"
               >
@@ -10162,34 +10427,6 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   </svg>
                 </button>
               </li>
-              <li
-                class="css-1o2fxxh"
-              >
-                <button
-                  aria-disabled="true"
-                  class="css-hu5lgw"
-                  data-testid="pagination-last-item"
-                  disabled=""
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-1my36lh-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0 0h24v24H0V0z"
-                      fill="none"
-                    />
-                    <path
-                      d="M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"
-                    />
-                  </svg>
-                </button>
-              </li>
             </ul>
           </nav>
         </div>
@@ -10243,7 +10480,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -10343,11 +10580,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -10424,7 +10670,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -10524,11 +10770,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -10605,7 +10860,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -10705,11 +10960,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -10786,7 +11050,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -10886,11 +11150,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -10967,7 +11240,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -11067,11 +11340,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -11151,7 +11433,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -11251,11 +11533,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -11332,7 +11623,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -11513,7 +11804,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -11613,11 +11904,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -11694,7 +11994,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -11794,11 +12094,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -11875,7 +12184,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -11975,11 +12284,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -12082,7 +12400,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -12182,11 +12500,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -12284,7 +12611,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -12384,11 +12711,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -12486,7 +12822,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -12586,11 +12922,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -12688,7 +13033,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -12788,11 +13133,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -12880,7 +13234,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -12980,11 +13334,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -13100,7 +13463,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -13200,11 +13563,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -13302,7 +13674,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -13494,7 +13866,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -13594,11 +13966,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -13696,7 +14077,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -13796,11 +14177,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -13888,7 +14278,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -13988,11 +14378,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -14062,34 +14461,6 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
             <ul
               class="css-wx88k6"
             >
-              <li
-                class="css-1o2fxxh"
-              >
-                <button
-                  aria-disabled="true"
-                  class="css-hu5lgw"
-                  data-testid="pagination-first-item"
-                  disabled=""
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-1my36lh-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"
-                    />
-                    <path
-                      d="M24 24H0V0h24v24z"
-                      fill="none"
-                    />
-                  </svg>
-                </button>
-              </li>
               <li
                 class="css-1o2fxxh"
               >
@@ -14167,34 +14538,6 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   </svg>
                 </button>
               </li>
-              <li
-                class="css-1o2fxxh"
-              >
-                <button
-                  aria-disabled="true"
-                  class="css-hu5lgw"
-                  data-testid="pagination-last-item"
-                  disabled=""
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-1my36lh-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0 0h24v24H0V0z"
-                      fill="none"
-                    />
-                    <path
-                      d="M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"
-                    />
-                  </svg>
-                </button>
-              </li>
             </ul>
           </nav>
         </div>
@@ -14248,7 +14591,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -14348,11 +14691,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -14429,7 +14781,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -14529,11 +14881,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -14610,7 +14971,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -14710,11 +15071,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -14791,7 +15161,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -14891,11 +15261,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -14972,7 +15351,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -15072,11 +15451,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -15156,7 +15544,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -15256,11 +15644,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -15337,7 +15734,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -15518,7 +15915,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -15618,11 +16015,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -15699,7 +16105,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -15799,11 +16205,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -15880,7 +16295,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -15980,11 +16395,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -16087,7 +16511,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -16187,11 +16611,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -16289,7 +16722,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -16389,11 +16822,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -16491,7 +16933,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -16591,11 +17033,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -16693,7 +17144,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -16793,11 +17244,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -16885,7 +17345,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -16985,11 +17445,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -17105,7 +17574,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -17205,11 +17674,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -17307,7 +17785,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -17499,7 +17977,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -17599,11 +18077,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -17701,7 +18188,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -17801,11 +18288,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -17893,7 +18389,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                       class="css-gpke1l"
                     >
                       <div
-                        class="article-info css-1fjzok1"
+                        class="article-info css-t0h780"
                       >
                         <span
                           class="css-ciimpt"
@@ -17993,11 +18489,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                             data-testid="divider"
                           />
                         </div>
-                        <span
-                          class="css-4z8vdx"
+                        <a
+                          class="css-1z0urni"
+                          href="/profile/ibrahim"
                         >
-                          ibrahim
-                        </span>
+                          <span
+                            class="css-17x5lw"
+                          >
+                            <span
+                              class="css-qx2986"
+                            >
+                              ibrahim
+                            </span>
+                          </span>
+                        </a>
                         <div
                           class="css-p44zak"
                         >
@@ -18067,34 +18572,6 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
             <ul
               class="css-wx88k6"
             >
-              <li
-                class="css-1o2fxxh"
-              >
-                <button
-                  aria-disabled="true"
-                  class="css-hu5lgw"
-                  data-testid="pagination-first-item"
-                  disabled=""
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-1my36lh-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"
-                    />
-                    <path
-                      d="M24 24H0V0h24v24z"
-                      fill="none"
-                    />
-                  </svg>
-                </button>
-              </li>
               <li
                 class="css-1o2fxxh"
               >
@@ -18172,34 +18649,6 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   </svg>
                 </button>
               </li>
-              <li
-                class="css-1o2fxxh"
-              >
-                <button
-                  aria-disabled="true"
-                  class="css-hu5lgw"
-                  data-testid="pagination-last-item"
-                  disabled=""
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="css-1my36lh-EmotionIconBase ex0cdmw0"
-                    fill="currentColor"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0 0h24v24H0V0z"
-                      fill="none"
-                    />
-                    <path
-                      d="M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"
-                    />
-                  </svg>
-                </button>
-              </li>
             </ul>
           </nav>
         </div>
@@ -18253,7 +18702,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -18353,11 +18802,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -18434,7 +18892,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -18534,11 +18992,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -18615,7 +19082,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -18715,11 +19182,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -18796,7 +19272,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -18896,11 +19372,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -18977,7 +19462,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -19077,11 +19562,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -19161,7 +19655,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -19261,11 +19755,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -19342,7 +19845,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -19523,7 +20026,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -19623,11 +20126,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -19704,7 +20216,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -19804,11 +20316,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >
@@ -19885,7 +20406,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                   class="css-gpke1l"
                 >
                   <div
-                    class="article-info css-1fjzok1"
+                    class="article-info css-t0h780"
                   >
                     <span
                       class="css-ciimpt"
@@ -19985,11 +20506,20 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                         data-testid="divider"
                       />
                     </div>
-                    <span
-                      class="css-4z8vdx"
+                    <a
+                      class="css-1z0urni"
+                      href="/profile/ibrahim"
                     >
-                      ibrahim
-                    </span>
+                      <span
+                        class="css-17x5lw"
+                      >
+                        <span
+                          class="css-qx2986"
+                        >
+                          ibrahim
+                        </span>
+                      </span>
+                    </a>
                     <div
                       class="css-p44zak"
                     >

--- a/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/mobile.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/mobile.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
             class="css-gpke1l"
           >
             <div
-              class="article-info css-1fjzok1"
+              class="article-info css-t0h780"
             >
               <span
                 class="css-ciimpt"
@@ -215,7 +215,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
             class="css-gpke1l"
           >
             <div
-              class="article-info css-1fjzok1"
+              class="article-info css-t0h780"
             >
               <span
                 class="css-ciimpt"
@@ -382,7 +382,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
             class="css-gpke1l"
           >
             <div
-              class="article-info css-1fjzok1"
+              class="article-info css-t0h780"
             >
               <span
                 class="css-ciimpt"
@@ -549,7 +549,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
             class="css-gpke1l"
           >
             <div
-              class="article-info css-1fjzok1"
+              class="article-info css-t0h780"
             >
               <span
                 class="css-ciimpt"
@@ -716,7 +716,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
             class="css-gpke1l"
           >
             <div
-              class="article-info css-1fjzok1"
+              class="article-info css-t0h780"
             >
               <span
                 class="css-ciimpt"
@@ -886,7 +886,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
             class="css-gpke1l"
           >
             <div
-              class="article-info css-1fjzok1"
+              class="article-info css-t0h780"
             >
               <span
                 class="css-ciimpt"
@@ -1053,7 +1053,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
             class="css-gpke1l"
           >
             <div
-              class="article-info css-1fjzok1"
+              class="article-info css-t0h780"
             >
               <span
                 class="css-ciimpt"
@@ -1220,7 +1220,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
             class="css-gpke1l"
           >
             <div
-              class="article-info css-1fjzok1"
+              class="article-info css-t0h780"
             >
               <span
                 class="css-ciimpt"
@@ -1387,7 +1387,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
             class="css-gpke1l"
           >
             <div
-              class="article-info css-1fjzok1"
+              class="article-info css-t0h780"
             >
               <span
                 class="css-ciimpt"
@@ -1554,7 +1554,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
             class="css-gpke1l"
           >
             <div
-              class="article-info css-1fjzok1"
+              class="article-info css-t0h780"
             >
               <span
                 class="css-ciimpt"

--- a/packages/ts-newskit/src/slices/list-view-slice/__tests__/desktop.test.tsx
+++ b/packages/ts-newskit/src/slices/list-view-slice/__tests__/desktop.test.tsx
@@ -40,15 +40,6 @@ describe('Render ListViewSliceDesktop', () => {
 });
 
 describe('ListViewSliceDesktop pagination', () => {
-  it('does not triggers when clicking first item and on first page', () => {
-    const { getByTestId } = renderComponent(
-      <ListViewSliceDesktop {...defaultProps} />
-    );
-    const paginationButton = getByTestId('pagination-first-item');
-    fireEvent.click(paginationButton);
-    expect(handlePageChange).not.toHaveBeenCalled();
-    expect(onPageChange).not.toHaveBeenCalled();
-  });
   it('does not triggers when clicking previous and on first page', () => {
     const { getByTestId } = renderComponent(
       <ListViewSliceDesktop {...defaultProps} />
@@ -58,14 +49,6 @@ describe('ListViewSliceDesktop pagination', () => {
     expect(handlePageChange).not.toHaveBeenCalled();
   });
 
-  it('does trigger when clicking first item and NOT on first page', () => {
-    const { getByTestId } = renderComponent(
-      <ListViewSliceDesktop {...defaultProps} currentPage={2} />
-    );
-    const paginationButton = getByTestId('pagination-first-item');
-    fireEvent.click(paginationButton);
-    expect(handlePageChange).toHaveBeenCalledWith(1);
-  });
   it('does trigger when clicking previous and NOT on first page', () => {
     const { getByTestId } = renderComponent(
       <ListViewSliceDesktop {...defaultProps} currentPage={2} />
@@ -80,16 +63,6 @@ describe('ListViewSliceDesktop pagination', () => {
       <ListViewSliceDesktop {...defaultProps} />
     );
     const paginationButton = getByTestId('pagination-next-item');
-    fireEvent.click(paginationButton);
-    expect(handlePageChange).toHaveBeenCalledWith(2);
-    expect(onPageChange).toHaveBeenCalled();
-  });
-
-  it('triggers correctly when clicking last item', () => {
-    const { getByTestId } = renderComponent(
-      <ListViewSliceDesktop {...defaultProps} />
-    );
-    const paginationButton = getByTestId('pagination-last-item');
     fireEvent.click(paginationButton);
     expect(handlePageChange).toHaveBeenCalledWith(2);
     expect(onPageChange).toHaveBeenCalled();

--- a/packages/ts-newskit/src/slices/list-view-slice/data.json
+++ b/packages/ts-newskit/src/slices/list-view-slice/data.json
@@ -52,7 +52,10 @@
       },
       "flag": "The Times",
       "datePublished": "2023-12-11T16:00:00.000Z",
-      "byline": "ibrahim"
+      "byline": {
+        "name": "ibrahim",
+        "slug": "ibrahim"
+      }
     },
 
     {
@@ -107,7 +110,10 @@
       },
       "flag": "The Times",
       "datePublished": "2023-04-11T16:00:00.000Z",
-      "byline": "ibrahim"
+      "byline": {
+        "name": "ibrahim",
+        "slug": "ibrahim"
+      }
     },
     {
       "hasVideo": false,
@@ -161,7 +167,10 @@
       },
       "flag": "The Sunday Times",
       "datePublished": "2023-02-11T16:00:00.000Z",
-      "byline": "ibrahim"
+      "byline": {
+        "name": "ibrahim",
+        "slug": "ibrahim"
+      }
     },
     {
       "hasVideo": false,
@@ -215,7 +224,10 @@
       },
       "flag": "The Times",
       "datePublished": "2023-11-11T16:00:00.000Z",
-      "byline": "ibrahim"
+      "byline": {
+        "name": "ibrahim",
+        "slug": "ibrahim"
+      }
     },
     {
       "hasVideo": false,
@@ -269,7 +281,10 @@
       },
       "flag": "The Sunday Times",
       "datePublished": "2023-11-11T16:00:00.000Z",
-      "byline": "ibrahim"
+      "byline": {
+        "name": "ibrahim",
+        "slug": "ibrahim"
+      }
     },
     {
       "hasVideo": false,
@@ -323,7 +338,10 @@
       },
       "flag": "The Times",
       "datePublished": "2023-10-11T16:00:00.000Z",
-      "byline": "ibrahim"
+      "byline": {
+        "name": "ibrahim",
+        "slug": "ibrahim"
+      }
     },
     {
       "hasVideo": false,
@@ -377,7 +395,9 @@
       },
       "flag": "The Sunday Times",
       "datePublished": "2023-09-11T16:00:00.000Z",
-      "byline": "ibrahim kurhan"
+      "byline": {
+        "name": "ibrahim kurhan"
+      }
     },
     {
       "hasVideo": false,
@@ -432,7 +452,10 @@
       "flag": "The Times",
 
       "datePublished": "2023-09-11T16:00:00.000Z",
-      "byline": "ibrahim"
+      "byline": {
+        "name": "ibrahim",
+        "slug": "ibrahim"
+      }
     },
     {
       "hasVideo": false,
@@ -486,7 +509,10 @@
       },
       "flag": "The Times",
       "datePublished": "2023-06-11T16:00:00.000Z",
-      "byline": "ibrahim"
+      "byline": {
+        "name": "ibrahim",
+        "slug": "ibrahim"
+      }
     },
     {
       "hasVideo": false,
@@ -540,7 +566,10 @@
       },
       "flag": "The Times",
       "datePublished": "2023-06-11T16:00:00.000Z",
-      "byline": "ibrahim"
+      "byline": {
+        "name": "ibrahim",
+        "slug": "ibrahim"
+      }
     }
   ]
 }

--- a/packages/ts-newskit/src/slices/list-view-slice/pagination.tsx
+++ b/packages/ts-newskit/src/slices/list-view-slice/pagination.tsx
@@ -1,9 +1,7 @@
 import {
-  PaginationFirstItem,
   PaginationPrevItem,
   PaginationItems,
-  PaginationNextItem,
-  PaginationLastItem
+  PaginationNextItem
 } from 'newskit';
 import React from 'react';
 import { StyledPagination, StyledPaginationButton } from './styles';
@@ -36,16 +34,11 @@ export const Paginations = ({
       page={currentPage}
       onPageChange={onPageChange}
     >
-      <PaginationFirstItem
-        overrides={{ stylePreset: 'interfaceBrand010' }}
-        onClick={() => handlePageChange(1)}
-      />
       <PaginationPrevItem
         overrides={{ stylePreset: 'interfaceBrand010' }}
         onClick={() => handlePageChange(currentPage - 1)}
       />
       <PaginationItems
-        truncation
         siblings={2}
         boundaries={1}
         overrides={{
@@ -76,10 +69,6 @@ export const Paginations = ({
       <PaginationNextItem
         overrides={{ stylePreset: 'interfaceBrand010' }}
         onClick={() => handlePageChange(currentPage + 1)}
-      />
-      <PaginationLastItem
-        overrides={{ stylePreset: 'interfaceBrand010' }}
-        onClick={() => handlePageChange(Math.ceil(totalItems / pageSize))}
       />
     </StyledPagination>
   );

--- a/packages/ts-newskit/src/slices/types.ts
+++ b/packages/ts-newskit/src/slices/types.ts
@@ -55,7 +55,10 @@ export type TagAndFlagProps = {
     typographyPreset?: MQ<string> | string;
     stylePreset?: MQ<string> | string;
   };
-  byline?: string;
+  byline?: {
+    name: string;
+    slug?: string;
+  };
   isListView?: boolean;
   tag?: {
     label: string;


### PR DESCRIPTION
### Description

TMRX-1822: Conditionally render a link for the byline, which will bring viewer to  journalists profile page when clicked
TMRX-1828: Increase spacing between label and headline from 8px to 12px in LeadArticle component
TMRX-1829: Update pagination to remove first/last and truncated navigation buttons to mitigate performance related issues in Render with current paginated data from TPA. This will be reintroduced once CP team has updated data response and query to utilise de-duped cursor based paginated data.

[TMRX-1826](https://nidigitalsolutions.jira.com/browse/TMRX-1826)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMRX-1826]: https://nidigitalsolutions.jira.com/browse/TMRX-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ