### PR TITLE
fix(TMRX-1879): list view ads not loading

### DIFF
--- a/packages/responsive/package.json
+++ b/packages/responsive/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "dependencies": {
-    "@times-components/ts-styleguide": "1.50.4",
+    "@times-components/ts-styleguide": "1.50.5",
     "@times-components/utils": "6.17.0",
     "prop-types": "15.7.2"
   },

--- a/packages/ts-newskit/src/components/slices/slice-header/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/slice-header/__tests__/__snapshots__/index.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Render Header should render a snapshot 1`] = `
         class="css-dtd8ey"
       >
         <div
-          class="css-1w57ntt"
+          class="css-sy3cfj"
         >
           <div
             class="css-16p0gc"
@@ -79,7 +79,7 @@ exports[`Render Header should render a snapshot with tagline 1`] = `
         class="css-dtd8ey"
       >
         <div
-          class="css-1w57ntt"
+          class="css-sy3cfj"
         >
           <div
             class="css-16p0gc"

--- a/packages/ts-newskit/src/components/slices/slice-header/styles.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/styles.tsx
@@ -43,7 +43,7 @@ export const SliceHeaderContainer = styled(Stack)`
 
 export const TitleBarContainer = styled(Stack)`
   max-width: 760px;
-  ${getMediaQueryFromTheme('lg')} {
+  ${getMediaQueryFromTheme('xl')} {
     max-width: 840px;
   }
 `;

--- a/packages/ts-newskit/src/slices/list-view-slice/__tests__/desktop.test.tsx
+++ b/packages/ts-newskit/src/slices/list-view-slice/__tests__/desktop.test.tsx
@@ -16,8 +16,9 @@ const defaultProps = {
   handlePageChange,
   onPageChange,
   totalItems: 11,
-  StickyAd: SectionAd,
-  SectionAd
+  SectionAd,
+  SectionAdMob: SectionAd,
+  StickyAd: SectionAd
 };
 
 describe('Render ListViewSliceDesktop', () => {

--- a/packages/ts-newskit/src/slices/list-view-slice/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/slices/list-view-slice/__tests__/index.test.tsx
@@ -15,7 +15,8 @@ const defaultProps = {
   handlePageChange,
   totalItems: 10,
   StickyAd: SectionAd,
-  SectionAd
+  SectionAd,
+  SectionAdMob: SectionAd
 };
 
 describe('Render List View Slice', () => {

--- a/packages/ts-newskit/src/slices/list-view-slice/__tests__/mobile.test.tsx
+++ b/packages/ts-newskit/src/slices/list-view-slice/__tests__/mobile.test.tsx
@@ -14,8 +14,9 @@ const defaultProps = {
   clickHandler: mockClickHandler,
   handlePageChange,
   totalItems: 12,
+  SectionAd,
   StickyAd: SectionAd,
-  SectionAd
+  SectionAdMob: SectionAd
 };
 
 describe('Render ListViewSliceMobile', () => {

--- a/packages/ts-newskit/src/slices/list-view-slice/index.tsx
+++ b/packages/ts-newskit/src/slices/list-view-slice/index.tsx
@@ -21,6 +21,7 @@ export type ListViewSliceProps = {
   isLoading?: boolean;
   StickyAd: React.FunctionComponent;
   SectionAd: React.FunctionComponent;
+  SectionAdMob: React.FunctionComponent;
 };
 export const ListViewSlice = ({
   leadArticles,
@@ -32,7 +33,8 @@ export const ListViewSlice = ({
   totalItems,
   isLoading = false,
   StickyAd,
-  SectionAd
+  SectionAd,
+  SectionAdMob
 }: ListViewSliceProps) => {
   const modifiedLeadArticles = leadArticles.map(item => ({
     ...item,
@@ -50,7 +52,8 @@ export const ListViewSlice = ({
     totalItems,
     isLoading,
     StickyAd,
-    SectionAd
+    SectionAd,
+    SectionAdMob
   };
   return (
     <CustomBlockLayout>

--- a/packages/ts-newskit/src/slices/list-view-slice/list-view-slice.stories.mdx
+++ b/packages/ts-newskit/src/slices/list-view-slice/list-view-slice.stories.mdx
@@ -26,11 +26,11 @@ This takes in a series of props, as below, to display the part of the slices.
 ## View Component
 Please click the 'Canvas' tab for a better viewing experience, where you can update the props and review at the different breakpoints by clicking the preview icon and selecting from our list of pre-defined breakpoints (XS, SM, MD, LG and XL).
 
-export const ListViewSliceStory = ({ leadArticles, theme, gridOverlay, clickHandler, articleWithAdSlot, currentPage, itemsPerPage, totalItems, isLoading, handlePageChange, onPageChange, StickyAd, SectionAd }) => (
+export const ListViewSliceStory = ({ leadArticles, theme, gridOverlay, clickHandler, articleWithAdSlot, currentPage, itemsPerPage, totalItems, isLoading, handlePageChange, onPageChange, StickyAd, SectionAd, SectionAdMob }) => (
   <TCThemeProvider theme={theme}>
     <>
       <GridOverlay show={gridOverlay} />
-      <ListViewSlice {...{ leadArticles, clickHandler, articleWithAdSlot, currentPage, itemsPerPage, totalItems, isLoading, handlePageChange, onPageChange, StickyAd, SectionAd }} />
+      <ListViewSlice {...{ leadArticles, clickHandler, articleWithAdSlot, currentPage, itemsPerPage, totalItems, isLoading, handlePageChange, onPageChange, StickyAd, SectionAd, SectionAdMob }} />
     </>
   </TCThemeProvider>
 );
@@ -57,7 +57,8 @@ ListViewSliceStory.args = {
       console.log("ON PAGE CHANGE")
     },
     StickyAd: SectionAd,
-    SectionAd: SectionAd
+    SectionAd: SectionAd,
+    SectionAdMob: SectionAd
   }}
   argTypes={{
     theme: {

--- a/packages/ts-newskit/src/slices/list-view-slice/mobile.tsx
+++ b/packages/ts-newskit/src/slices/list-view-slice/mobile.tsx
@@ -18,7 +18,7 @@ export const ListViewSliceMobile = ({
   isLoading,
   itemsPerPage = 10,
   totalItems,
-  SectionAd
+  SectionAdMob
 }: ListViewSliceProps) => {
   const renderLoadMoreButton = currentPage * itemsPerPage < totalItems;
   const adSlots = [Math.ceil(itemsPerPage / 2)];
@@ -67,7 +67,7 @@ export const ListViewSliceMobile = ({
                 )}
               {renderAds && (
                 <Block marginBlock="space040">
-                  <SectionAd />
+                  <SectionAdMob />
                 </Block>
               )}
             </Fragment>

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="css-1xlmj6j"
                   >
                     <div
-                      class="css-1w57ntt"
+                      class="css-sy3cfj"
                     >
                       <div
                         class="css-16p0gc"
@@ -316,7 +316,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="css-1xlmj6j"
                   >
                     <div
-                      class="css-1w57ntt"
+                      class="css-sy3cfj"
                     >
                       <div
                         class="css-16p0gc"
@@ -597,7 +597,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="css-1xlmj6j"
                   >
                     <div
-                      class="css-1w57ntt"
+                      class="css-sy3cfj"
                     >
                       <div
                         class="css-16p0gc"
@@ -878,7 +878,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                     class="css-1xlmj6j"
                   >
                     <div
-                      class="css-1w57ntt"
+                      class="css-sy3cfj"
                     >
                       <div
                         class="css-16p0gc"
@@ -1173,7 +1173,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="css-1xlmj6j"
                 >
                   <div
-                    class="css-1w57ntt"
+                    class="css-sy3cfj"
                   >
                     <div
                       class="css-16p0gc"
@@ -1454,7 +1454,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="css-1xlmj6j"
                 >
                   <div
-                    class="css-1w57ntt"
+                    class="css-sy3cfj"
                   >
                     <div
                       class="css-16p0gc"
@@ -1735,7 +1735,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="css-1xlmj6j"
                 >
                   <div
-                    class="css-1w57ntt"
+                    class="css-sy3cfj"
                   >
                     <div
                       class="css-16p0gc"
@@ -2016,7 +2016,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                   class="css-1xlmj6j"
                 >
                   <div
-                    class="css-1w57ntt"
+                    class="css-sy3cfj"
                   >
                     <div
                       class="css-16p0gc"
@@ -2323,7 +2323,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="css-1xlmj6j"
                   >
                     <div
-                      class="css-1w57ntt"
+                      class="css-sy3cfj"
                     >
                       <div
                         class="css-16p0gc"
@@ -2604,7 +2604,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="css-1xlmj6j"
                   >
                     <div
-                      class="css-1w57ntt"
+                      class="css-sy3cfj"
                     >
                       <div
                         class="css-16p0gc"
@@ -2885,7 +2885,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="css-1xlmj6j"
                   >
                     <div
-                      class="css-1w57ntt"
+                      class="css-sy3cfj"
                     >
                       <div
                         class="css-16p0gc"
@@ -3166,7 +3166,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                     class="css-1xlmj6j"
                   >
                     <div
-                      class="css-1w57ntt"
+                      class="css-sy3cfj"
                     >
                       <div
                         class="css-16p0gc"
@@ -3461,7 +3461,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="css-1xlmj6j"
                 >
                   <div
-                    class="css-1w57ntt"
+                    class="css-sy3cfj"
                   >
                     <div
                       class="css-16p0gc"
@@ -3742,7 +3742,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="css-1xlmj6j"
                 >
                   <div
-                    class="css-1w57ntt"
+                    class="css-sy3cfj"
                   >
                     <div
                       class="css-16p0gc"
@@ -4023,7 +4023,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="css-1xlmj6j"
                 >
                   <div
-                    class="css-1w57ntt"
+                    class="css-sy3cfj"
                   >
                     <div
                       class="css-16p0gc"
@@ -4304,7 +4304,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                   class="css-1xlmj6j"
                 >
                   <div
-                    class="css-1w57ntt"
+                    class="css-sy3cfj"
                   >
                     <div
                       class="css-16p0gc"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@times-components/schema": "0.7.4",
-    "@times-components/ts-styleguide": "1.50.4",
+    "@times-components/ts-styleguide": "1.50.5",
     "apollo-cache-inmemory": "1.5.1",
     "apollo-client": "2.5.1",
     "apollo-link": "1.2.4",


### PR DESCRIPTION
### Description

Add `useBreakpointKey` hook to conditionally render mobile/desktop views

* Updated to add new slot (`SectionAdMob`) for mobile, instead of using `usebreakpointKey` hook
[TMRX-1879](https://nidigitalsolutions.jira.com/browse/TMRX-1879)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMRX-1879]: https://nidigitalsolutions.jira.com/browse/TMRX-1879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ